### PR TITLE
Replace SQLite with JSON file persistence (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-08
 - N/A (in-memory stub data; no persistence changes) (007-crux-leptos-upgrade)
 - Rust stable (1.75+, 2021 edition) + leptos 0.8.x (CSR), leptos_router 0.8.x, crux_core 0.17.0-rc2 (workspace), tailwindcss v4 (standalone CLI), trunk 0.21.x, console_error_panic_hook, wasm-bindgen, ulid, chrono, send_wrapper 0.6, getrandom 0.3 (008-url-routing)
 - Rust stable (1.75+, 2021 edition) + leptos 0.7 (CSR), leptos_router 0.8, crux_core 0.17.0-rc2 (workspace), send_wrapper 0.6, tailwindcss v4 (standalone CLI), trunk 0.21.x (009-unified-library-form)
+- Rust stable (1.75+, 2021 edition) + crux_core 0.17.0-rc2, serde_json 1, web-sys (with Storage+Window features), dirs 5 (011-json-persistence)
+- JSON files (CLI: `~/.local/share/intrada/library.json`), localStorage (web: `intrada:library` key) (011-json-persistence)
 
 - Rust stable (1.75+, 2021 edition) + rusqlite (bundled), clap 4.5 (derive), ulid, serde, thiserror, anyhow, chrono (001-music-library)
 
@@ -38,9 +40,9 @@ cargo clippy
 Rust stable (1.75+, 2021 edition): Follow standard conventions
 
 ## Recent Changes
+- 011-json-persistence: Added Rust stable (1.75+, 2021 edition) + crux_core 0.17.0-rc2, serde_json 1, web-sys (with Storage+Window features), dirs 5
+- 011-json-persistence: Added Rust stable (1.75+, 2021 edition) + crux_core 0.17.0-rc2, serde_json 1, web-sys (with Storage+Window features), dirs 5
 - 009-unified-library-form: Added Rust stable (1.75+, 2021 edition) + leptos 0.7 (CSR), leptos_router 0.8, crux_core 0.17.0-rc2 (workspace), send_wrapper 0.6, tailwindcss v4 (standalone CLI), trunk 0.21.x
-- 008-url-routing: Added Rust stable (1.75+, 2021 edition) + leptos 0.8.x (CSR), leptos_router 0.8.x, crux_core 0.17.0-rc2 (workspace), tailwindcss v4 (standalone CLI), trunk 0.21.x, console_error_panic_hook, wasm-bindgen, ulid, chrono, send_wrapper 0.6, getrandom 0.3
-- 007-crux-leptos-upgrade: Added Rust stable (1.75+, 2021 edition) + crux_core 0.17.0-rc2 (unchanged), leptos 0.7 → 0.8 (upgrade), send_wrapper 0.6 (unchanged)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1731451909bde27714eacba19c2566362a7f35224f52b153d3f42cf60f72472"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,16 +680,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
+name = "fastrand"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -897,9 +889,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -915,15 +904,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -1142,8 +1122,8 @@ dependencies = [
  "crux_core",
  "dirs",
  "intrada-core",
- "rusqlite",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1170,8 +1150,10 @@ dependencies = [
  "leptos",
  "leptos_router",
  "send_wrapper",
+ "serde_json",
  "ulid",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1393,21 +1375,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1602,12 +1579,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1901,20 +1872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +1884,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2221,6 +2191,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,12 +2418,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ serde_json = "1"
 ulid = "1"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-rusqlite = { version = "0.31", features = ["bundled"] }
 clap = { version = "4.5", features = ["derive"] }
 anyhow = "1"
 dirs = "5"

--- a/crates/intrada-cli/Cargo.toml
+++ b/crates/intrada-cli/Cargo.toml
@@ -10,9 +10,11 @@ path = "src/main.rs"
 [dependencies]
 intrada-core = { path = "../intrada-core" }
 crux_core = { workspace = true }
-rusqlite = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/intrada-cli/src/main.rs
+++ b/crates/intrada-cli/src/main.rs
@@ -13,7 +13,7 @@ use intrada_core::Event;
 
 use crate::display::{print_error, print_item_detail, print_item_list, print_success};
 use crate::shell::Shell;
-use crate::storage::SqliteStore;
+use crate::storage::JsonStore;
 
 #[derive(Parser)]
 #[command(name = "intrada", about = "A music practice library manager")]
@@ -159,7 +159,7 @@ enum AddCommands {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let store = SqliteStore::new()?;
+    let store = JsonStore::new()?;
     let shell = Shell::new(store);
     let vm = shell.load_data()?;
 

--- a/crates/intrada-cli/src/shell.rs
+++ b/crates/intrada-cli/src/shell.rs
@@ -3,15 +3,15 @@ use crux_core::Core;
 use intrada_core::app::{Effect, StorageEffect};
 use intrada_core::{Event, Intrada, ViewModel};
 
-use crate::storage::SqliteStore;
+use crate::storage::JsonStore;
 
 pub struct Shell {
     core: Core<Intrada>,
-    store: SqliteStore,
+    store: JsonStore,
 }
 
 impl Shell {
-    pub fn new(store: SqliteStore) -> Self {
+    pub fn new(store: JsonStore) -> Self {
         Self {
             core: Core::new(),
             store,
@@ -69,21 +69,23 @@ mod tests {
     use intrada_core::domain::piece::PieceEvent;
     use intrada_core::domain::types::CreatePiece;
 
-    fn test_shell() -> Shell {
-        let store = SqliteStore::new_in_memory().unwrap();
-        Shell::new(store)
+    fn test_shell() -> (Shell, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("library.json");
+        let store = JsonStore::new_with_path(path);
+        (Shell::new(store), dir)
     }
 
     #[test]
     fn test_load_empty_data() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         let vm = shell.load_data().unwrap();
         assert!(vm.items.is_empty());
     }
 
     #[test]
     fn test_add_piece_round_trip() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
         let vm = shell
@@ -101,18 +103,16 @@ mod tests {
         assert_eq!(vm.items[0].title, "Clair de Lune");
         assert!(vm.error.is_none());
 
-        // Verify persisted — create a new shell with same store
-        // (can't reuse store, but verify via load_data which re-reads model)
-        // Instead, verify the view is correct
         let vm2 = shell.run(Event::ClearError).unwrap();
         assert_eq!(vm2.items.len(), 1);
     }
 
     #[test]
-    fn test_add_piece_persists_to_db() {
-        let store = SqliteStore::new_in_memory().unwrap();
+    fn test_add_piece_persists_to_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("library.json");
+        let store = JsonStore::new_with_path(path);
 
-        // Add via shell
         let shell = Shell::new(store);
         shell.load_data().unwrap();
         shell
@@ -126,21 +126,17 @@ mod tests {
             })))
             .unwrap();
 
-        // Verify in DB by loading again
+        // Reload from JSON file to verify persistence
         let vm = shell.load_data().unwrap();
-        // DataLoaded replaces model, so we get only what's in DB
         assert_eq!(vm.items.len(), 1);
         assert_eq!(vm.items[0].title, "Sonata");
     }
 
-    // --- T042: Unicode handling ---
-
     #[test]
     fn test_unicode_piece_round_trip() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
-        // Add piece with Unicode characters in title and composer
         let vm = shell
             .run(Event::Piece(PieceEvent::Add(CreatePiece {
                 title: "Ménuet in G".to_string(),
@@ -157,7 +153,7 @@ mod tests {
         assert_eq!(vm.items[0].title, "Ménuet in G");
         assert_eq!(vm.items[0].subtitle, "Dvořák");
 
-        // Reload from SQLite to verify round-trip
+        // Reload from JSON to verify round-trip
         let vm2 = shell.load_data().unwrap();
         assert_eq!(vm2.items.len(), 1);
         assert_eq!(vm2.items[0].title, "Ménuet in G");
@@ -175,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_unicode_exercise_round_trip() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
         let vm = shell
@@ -201,38 +197,33 @@ mod tests {
         assert_eq!(vm2.items[0].tags, vec!["größe".to_string()]);
     }
 
-    // --- T043: Edge cases ---
-
     #[test]
     fn test_field_length_at_boundary() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
-        // Title at max (500 chars) — should succeed
         let vm = shell
             .run(Event::Piece(PieceEvent::Add(CreatePiece {
                 title: "x".repeat(500),
-                composer: "y".repeat(200), // composer at max
+                composer: "y".repeat(200),
                 key: None,
                 tempo: None,
-                notes: Some("z".repeat(5000)), // notes at max
-                tags: vec!["t".repeat(100)],   // tag at max
+                notes: Some("z".repeat(5000)),
+                tags: vec!["t".repeat(100)],
             })))
             .unwrap();
         assert!(vm.error.is_none());
         assert_eq!(vm.items.len(), 1);
 
-        // Verify persisted correctly
         let vm2 = shell.load_data().unwrap();
         assert_eq!(vm2.items[0].title.len(), 500);
     }
 
     #[test]
     fn test_field_length_over_boundary() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
-        // Title over max (501 chars) — should fail
         let vm = shell
             .run(Event::Piece(PieceEvent::Add(CreatePiece {
                 title: "x".repeat(501),
@@ -249,12 +240,12 @@ mod tests {
 
     #[test]
     fn test_validation_error_surfaces() {
-        let shell = test_shell();
+        let (shell, _dir) = test_shell();
         shell.load_data().unwrap();
 
         let vm = shell
             .run(Event::Piece(PieceEvent::Add(CreatePiece {
-                title: "".to_string(), // invalid: empty title
+                title: "".to_string(),
                 composer: "Debussy".to_string(),
                 key: None,
                 tempo: None,

--- a/crates/intrada-cli/src/storage.rs
+++ b/crates/intrada-cli/src/storage.rs
@@ -1,15 +1,15 @@
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
 use intrada_core::domain::exercise::Exercise;
 use intrada_core::domain::piece::Piece;
-use intrada_core::domain::types::Tempo;
-use rusqlite::{params, Connection};
+use intrada_core::LibraryData;
 
-pub struct SqliteStore {
-    conn: Connection,
+pub struct JsonStore {
+    path: PathBuf,
 }
 
-impl SqliteStore {
+impl JsonStore {
     pub fn new() -> Result<Self> {
         let data_dir = dirs::data_local_dir()
             .context("Could not determine local data directory")?
@@ -17,306 +17,101 @@ impl SqliteStore {
         std::fs::create_dir_all(&data_dir)
             .with_context(|| format!("Could not create data directory: {}", data_dir.display()))?;
 
-        let db_path = data_dir.join("library.db");
-        let conn = Connection::open(&db_path)
-            .with_context(|| format!("Could not open database: {}", db_path.display()))?;
-
-        let store = Self { conn };
-        store.initialize_schema()?;
-        Ok(store)
+        Ok(Self {
+            path: data_dir.join("library.json"),
+        })
     }
 
     #[cfg(test)]
-    pub fn new_in_memory() -> Result<Self> {
-        let conn = Connection::open_in_memory()?;
-        let store = Self { conn };
-        store.initialize_schema()?;
-        Ok(store)
-    }
-
-    fn initialize_schema(&self) -> Result<()> {
-        self.conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS pieces (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                composer TEXT NOT NULL,
-                key TEXT,
-                tempo_marking TEXT,
-                tempo_bpm INTEGER,
-                notes TEXT,
-                tags TEXT NOT NULL DEFAULT '[]',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            );
-            CREATE TABLE IF NOT EXISTS exercises (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                composer TEXT,
-                category TEXT,
-                key TEXT,
-                tempo_marking TEXT,
-                tempo_bpm INTEGER,
-                notes TEXT,
-                tags TEXT NOT NULL DEFAULT '[]',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            );",
-        )?;
-        Ok(())
+    pub fn new_with_path(path: PathBuf) -> Self {
+        Self { path }
     }
 
     pub fn load_all(&self) -> Result<(Vec<Piece>, Vec<Exercise>)> {
-        let pieces = self.load_pieces()?;
-        let exercises = self.load_exercises()?;
-        Ok((pieces, exercises))
-    }
-
-    fn load_pieces(&self) -> Result<Vec<Piece>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, title, composer, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at FROM pieces"
-        )?;
-
-        let pieces = stmt.query_map([], |row| {
-            let tags_str: String = row.get(7)?;
-            let created_str: String = row.get(8)?;
-            let updated_str: String = row.get(9)?;
-            let tempo_marking: Option<String> = row.get(4)?;
-            let tempo_bpm: Option<u16> = row.get(5)?;
-
-            Ok(PieceRow {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                composer: row.get(2)?,
-                key: row.get(3)?,
-                tempo_marking,
-                tempo_bpm,
-                notes: row.get(6)?,
-                tags_str,
-                created_str,
-                updated_str,
-            })
-        })?;
-
-        let mut result = Vec::new();
-        for row in pieces {
-            let row = row?;
-            result.push(piece_from_row(row)?);
+        if !self.path.exists() {
+            return Ok((Vec::new(), Vec::new()));
         }
-        Ok(result)
-    }
 
-    fn load_exercises(&self) -> Result<Vec<Exercise>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id, title, composer, category, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at FROM exercises"
-        )?;
+        let contents = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("Could not read {}", self.path.display()))?;
 
-        let exercises = stmt.query_map([], |row| {
-            let tags_str: String = row.get(8)?;
-            let created_str: String = row.get(9)?;
-            let updated_str: String = row.get(10)?;
-            let tempo_marking: Option<String> = row.get(5)?;
-            let tempo_bpm: Option<u16> = row.get(6)?;
+        let data: LibraryData = serde_json::from_str(&contents)
+            .with_context(|| format!("Invalid JSON in {}", self.path.display()))?;
 
-            Ok(ExerciseRow {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                composer: row.get(2)?,
-                category: row.get(3)?,
-                key: row.get(4)?,
-                tempo_marking,
-                tempo_bpm,
-                notes: row.get(7)?,
-                tags_str,
-                created_str,
-                updated_str,
-            })
-        })?;
-
-        let mut result = Vec::new();
-        for row in exercises {
-            let row = row?;
-            result.push(exercise_from_row(row)?);
-        }
-        Ok(result)
+        Ok((data.pieces, data.exercises))
     }
 
     pub fn save_piece(&self, piece: &Piece) -> Result<()> {
-        let tags_json = serde_json::to_string(&piece.tags)?;
-        let (tempo_marking, tempo_bpm) = split_tempo(&piece.tempo);
-
-        self.conn.execute(
-            "INSERT INTO pieces (id, title, composer, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            params![
-                piece.id,
-                piece.title,
-                piece.composer,
-                piece.key,
-                tempo_marking,
-                tempo_bpm,
-                piece.notes,
-                tags_json,
-                piece.created_at.to_rfc3339(),
-                piece.updated_at.to_rfc3339(),
-            ],
-        )?;
-        Ok(())
+        let mut data = self.read_library()?;
+        data.pieces.push(piece.clone());
+        self.write_library(&data)
     }
 
     pub fn save_exercise(&self, exercise: &Exercise) -> Result<()> {
-        let tags_json = serde_json::to_string(&exercise.tags)?;
-        let (tempo_marking, tempo_bpm) = split_tempo(&exercise.tempo);
-
-        self.conn.execute(
-            "INSERT INTO exercises (id, title, composer, category, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
-            params![
-                exercise.id,
-                exercise.title,
-                exercise.composer,
-                exercise.category,
-                exercise.key,
-                tempo_marking,
-                tempo_bpm,
-                exercise.notes,
-                tags_json,
-                exercise.created_at.to_rfc3339(),
-                exercise.updated_at.to_rfc3339(),
-            ],
-        )?;
-        Ok(())
+        let mut data = self.read_library()?;
+        data.exercises.push(exercise.clone());
+        self.write_library(&data)
     }
 
     pub fn update_piece(&self, piece: &Piece) -> Result<()> {
-        let tags_json = serde_json::to_string(&piece.tags)?;
-        let (tempo_marking, tempo_bpm) = split_tempo(&piece.tempo);
-
-        self.conn.execute(
-            "UPDATE pieces SET title=?1, composer=?2, key=?3, tempo_marking=?4, tempo_bpm=?5, notes=?6, tags=?7, updated_at=?8 WHERE id=?9",
-            params![
-                piece.title,
-                piece.composer,
-                piece.key,
-                tempo_marking,
-                tempo_bpm,
-                piece.notes,
-                tags_json,
-                piece.updated_at.to_rfc3339(),
-                piece.id,
-            ],
-        )?;
-        Ok(())
+        let mut data = self.read_library()?;
+        if let Some(existing) = data.pieces.iter_mut().find(|p| p.id == piece.id) {
+            *existing = piece.clone();
+        }
+        self.write_library(&data)
     }
 
     pub fn update_exercise(&self, exercise: &Exercise) -> Result<()> {
-        let tags_json = serde_json::to_string(&exercise.tags)?;
-        let (tempo_marking, tempo_bpm) = split_tempo(&exercise.tempo);
-
-        self.conn.execute(
-            "UPDATE exercises SET title=?1, composer=?2, category=?3, key=?4, tempo_marking=?5, tempo_bpm=?6, notes=?7, tags=?8, updated_at=?9 WHERE id=?10",
-            params![
-                exercise.title,
-                exercise.composer,
-                exercise.category,
-                exercise.key,
-                tempo_marking,
-                tempo_bpm,
-                exercise.notes,
-                tags_json,
-                exercise.updated_at.to_rfc3339(),
-                exercise.id,
-            ],
-        )?;
-        Ok(())
+        let mut data = self.read_library()?;
+        if let Some(existing) = data.exercises.iter_mut().find(|e| e.id == exercise.id) {
+            *existing = exercise.clone();
+        }
+        self.write_library(&data)
     }
 
     pub fn delete_item(&self, id: &str) -> Result<()> {
-        self.conn
-            .execute("DELETE FROM pieces WHERE id=?1", params![id])?;
-        self.conn
-            .execute("DELETE FROM exercises WHERE id=?1", params![id])?;
+        let mut data = self.read_library()?;
+        data.pieces.retain(|p| p.id != id);
+        data.exercises.retain(|e| e.id != id);
+        self.write_library(&data)
+    }
+
+    fn read_library(&self) -> Result<LibraryData> {
+        if !self.path.exists() {
+            return Ok(LibraryData::default());
+        }
+        let contents = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("Could not read {}", self.path.display()))?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("Invalid JSON in {}", self.path.display()))
+    }
+
+    fn write_library(&self, data: &LibraryData) -> Result<()> {
+        let json = serde_json::to_string_pretty(data)?;
+
+        // Atomic write: write to temp file in same directory, then rename.
+        let dir = self.path.parent().unwrap_or_else(|| Path::new("."));
+        let tmp_path = dir.join(".library.json.tmp");
+        std::fs::write(&tmp_path, &json)
+            .with_context(|| format!("Could not write temp file: {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &self.path)
+            .with_context(|| format!("Could not rename temp file to {}", self.path.display()))?;
+
         Ok(())
     }
-}
-
-fn split_tempo(tempo: &Option<Tempo>) -> (Option<&str>, Option<u16>) {
-    match tempo {
-        Some(t) => (t.marking.as_deref(), t.bpm),
-        None => (None, None),
-    }
-}
-
-fn parse_timestamp(s: &str) -> Result<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(s)
-        .map(|dt| dt.with_timezone(&Utc))
-        .with_context(|| format!("Invalid timestamp: {s}"))
-}
-
-struct PieceRow {
-    id: String,
-    title: String,
-    composer: String,
-    key: Option<String>,
-    tempo_marking: Option<String>,
-    tempo_bpm: Option<u16>,
-    notes: Option<String>,
-    tags_str: String,
-    created_str: String,
-    updated_str: String,
-}
-
-struct ExerciseRow {
-    id: String,
-    title: String,
-    composer: Option<String>,
-    category: Option<String>,
-    key: Option<String>,
-    tempo_marking: Option<String>,
-    tempo_bpm: Option<u16>,
-    notes: Option<String>,
-    tags_str: String,
-    created_str: String,
-    updated_str: String,
-}
-
-fn piece_from_row(row: PieceRow) -> Result<Piece> {
-    let tags: Vec<String> = serde_json::from_str(&row.tags_str)
-        .with_context(|| format!("Invalid tags JSON for piece {}", row.id))?;
-
-    Ok(Piece {
-        id: row.id,
-        title: row.title,
-        composer: row.composer,
-        key: row.key,
-        tempo: Tempo::from_parts(row.tempo_marking, row.tempo_bpm),
-        notes: row.notes,
-        tags,
-        created_at: parse_timestamp(&row.created_str)?,
-        updated_at: parse_timestamp(&row.updated_str)?,
-    })
-}
-
-fn exercise_from_row(row: ExerciseRow) -> Result<Exercise> {
-    let tags: Vec<String> = serde_json::from_str(&row.tags_str)
-        .with_context(|| format!("Invalid tags JSON for exercise {}", row.id))?;
-
-    Ok(Exercise {
-        id: row.id,
-        title: row.title,
-        composer: row.composer,
-        category: row.category,
-        key: row.key,
-        tempo: Tempo::from_parts(row.tempo_marking, row.tempo_bpm),
-        notes: row.notes,
-        tags,
-        created_at: parse_timestamp(&row.created_str)?,
-        updated_at: parse_timestamp(&row.updated_str)?,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use intrada_core::Tempo;
+
+    fn temp_store() -> (JsonStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("library.json");
+        (JsonStore::new_with_path(path), dir)
+    }
 
     fn make_piece() -> Piece {
         let now = Utc::now();
@@ -354,7 +149,7 @@ mod tests {
 
     #[test]
     fn test_save_and_load_piece() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let piece = make_piece();
         store.save_piece(&piece).unwrap();
 
@@ -374,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_save_and_load_exercise() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let exercise = make_exercise();
         store.save_exercise(&exercise).unwrap();
 
@@ -394,7 +189,7 @@ mod tests {
 
     #[test]
     fn test_update_piece() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let mut piece = make_piece();
         store.save_piece(&piece).unwrap();
 
@@ -409,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_update_exercise() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let mut exercise = make_exercise();
         store.save_exercise(&exercise).unwrap();
 
@@ -424,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_delete_item() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let piece = make_piece();
         let exercise = make_exercise();
         store.save_piece(&piece).unwrap();
@@ -442,8 +237,8 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_database() {
-        let store = SqliteStore::new_in_memory().unwrap();
+    fn test_empty_store() {
+        let (store, _dir) = temp_store();
         let (pieces, exercises) = store.load_all().unwrap();
         assert!(pieces.is_empty());
         assert!(exercises.is_empty());
@@ -451,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_piece_with_no_optional_fields() {
-        let store = SqliteStore::new_in_memory().unwrap();
+        let (store, _dir) = temp_store();
         let now = Utc::now();
         let piece = Piece {
             id: "p2".to_string(),
@@ -471,5 +266,39 @@ mod tests {
         assert_eq!(pieces[0].tempo, None);
         assert_eq!(pieces[0].notes, None);
         assert!(pieces[0].tags.is_empty());
+    }
+
+    #[test]
+    fn test_missing_file_returns_empty() {
+        let (store, _dir) = temp_store();
+        // File doesn't exist yet
+        let (pieces, exercises) = store.load_all().unwrap();
+        assert!(pieces.is_empty());
+        assert!(exercises.is_empty());
+    }
+
+    #[test]
+    fn test_malformed_json_returns_error() {
+        let (store, _dir) = temp_store();
+        std::fs::write(&store.path, "{ not valid json !!!").unwrap();
+
+        let result = store.load_all();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unknown_fields_deserialise_ok() {
+        let (store, _dir) = temp_store();
+        let json = r#"{
+            "pieces": [],
+            "exercises": [],
+            "future_field": "some value",
+            "another_unknown": 42
+        }"#;
+        std::fs::write(&store.path, json).unwrap();
+
+        let (pieces, exercises) = store.load_all().unwrap();
+        assert!(pieces.is_empty());
+        assert!(exercises.is_empty());
     }
 }

--- a/crates/intrada-core/src/domain/mod.rs
+++ b/crates/intrada-core/src/domain/mod.rs
@@ -4,4 +4,6 @@ pub mod types;
 
 pub use exercise::{Exercise, ExerciseEvent};
 pub use piece::{Piece, PieceEvent};
-pub use types::{CreateExercise, CreatePiece, ListQuery, Tempo, UpdateExercise, UpdatePiece};
+pub use types::{
+    CreateExercise, CreatePiece, LibraryData, ListQuery, Tempo, UpdateExercise, UpdatePiece,
+};

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -1,5 +1,19 @@
 use serde::{Deserialize, Serialize};
 
+use super::exercise::Exercise;
+use super::piece::Piece;
+
+/// Top-level serialisation unit for `library.json` / `intrada:library`.
+///
+/// Both CLI and web shells share this format for persistence.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct LibraryData {
+    #[serde(default)]
+    pub pieces: Vec<Piece>,
+    #[serde(default)]
+    pub exercises: Vec<Exercise>,
+}
+
 /// Tempo representation with optional marking (e.g. "Allegro") and BPM.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Tempo {

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -8,7 +8,7 @@ pub use app::{Effect, Event, Intrada, StorageEffect};
 pub use domain::exercise::{Exercise, ExerciseEvent};
 pub use domain::piece::{Piece, PieceEvent};
 pub use domain::types::{
-    CreateExercise, CreatePiece, ListQuery, Tempo, UpdateExercise, UpdatePiece,
+    CreateExercise, CreatePiece, LibraryData, ListQuery, Tempo, UpdateExercise, UpdatePiece,
 };
 pub use error::LibraryError;
 pub use model::{LibraryItemView, Model, ViewModel};

--- a/crates/intrada-web/Cargo.toml
+++ b/crates/intrada-web/Cargo.toml
@@ -14,3 +14,5 @@ chrono = { workspace = true }
 ulid = { workspace = true }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 send_wrapper = "0.6.0"
+serde_json = { workspace = true }
+web-sys = { version = "0.3", features = ["Window", "Storage"] }

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -10,8 +10,7 @@ use send_wrapper::SendWrapper;
 use intrada_core::{Event, Intrada, ViewModel};
 
 use crate::components::{AppFooter, AppHeader};
-use crate::core_bridge::process_effects;
-use crate::data::create_stub_data;
+use crate::core_bridge::{load_library_data, process_effects};
 use crate::types::SharedCore;
 use crate::views::{
     AddLibraryItemForm, DetailView, EditLibraryItemForm, LibraryListView, NotFoundView,
@@ -22,10 +21,10 @@ pub fn App() -> impl IntoView {
     let core: SharedCore = SendWrapper::new(Rc::new(RefCell::new(Core::<Intrada>::new())));
     let view_model = RwSignal::new(ViewModel::default());
 
-    // Initialize: load stub data on mount
+    // Initialize: load from localStorage (or seed stub data on first run)
     {
         let core_ref = core.borrow();
-        let (pieces, exercises) = create_stub_data();
+        let (pieces, exercises) = load_library_data();
         let effects = core_ref.process_event(Event::DataLoaded { pieces, exercises });
         process_effects(&core_ref, effects, &view_model);
     }

--- a/crates/intrada-web/src/core_bridge.rs
+++ b/crates/intrada-web/src/core_bridge.rs
@@ -1,9 +1,71 @@
+use std::cell::RefCell;
+
 use crux_core::Core;
 use leptos::prelude::{RwSignal, Set};
 
-use intrada_core::{Effect, Event, Intrada, StorageEffect, ViewModel};
+use intrada_core::{Effect, Event, Intrada, LibraryData, StorageEffect, ViewModel};
 
 use crate::data::create_stub_data;
+
+const STORAGE_KEY: &str = "intrada:library";
+
+thread_local! {
+    static LIBRARY: RefCell<LibraryData> = RefCell::new(LibraryData::default());
+}
+
+fn get_local_storage() -> Option<web_sys::Storage> {
+    web_sys::window()?.local_storage().ok()?
+}
+
+fn load_from_local_storage() -> LibraryData {
+    let Some(storage) = get_local_storage() else {
+        return LibraryData::default();
+    };
+
+    match storage.get_item(STORAGE_KEY) {
+        Ok(Some(json)) => serde_json::from_str(&json).unwrap_or_default(),
+        _ => LibraryData::default(),
+    }
+}
+
+fn save_to_local_storage(data: &LibraryData) {
+    let Some(storage) = get_local_storage() else {
+        return;
+    };
+
+    match serde_json::to_string(data) {
+        Ok(json) => {
+            if storage.set_item(STORAGE_KEY, &json).is_err() {
+                web_sys::console::warn_1(
+                    &"intrada: localStorage write failed (storage may be full)".into(),
+                );
+            }
+        }
+        Err(e) => {
+            web_sys::console::warn_1(
+                &format!("intrada: failed to serialise library data: {e}").into(),
+            );
+        }
+    }
+}
+
+/// Load library data from localStorage (or seed with stub data on first run).
+///
+/// Called by `App()` during initialisation, mirroring the CLI shell's `load_data()`.
+pub fn load_library_data() -> (Vec<intrada_core::Piece>, Vec<intrada_core::Exercise>) {
+    let mut data = load_from_local_storage();
+
+    // If localStorage was empty, seed with stub data
+    if data.pieces.is_empty() && data.exercises.is_empty() {
+        let (pieces, exercises) = create_stub_data();
+        data.pieces = pieces;
+        data.exercises = exercises;
+        save_to_local_storage(&data);
+    }
+
+    LIBRARY.with(|lib| *lib.borrow_mut() = data.clone());
+    (data.pieces, data.exercises)
+}
 
 /// Process effects returned by the Crux core.
 pub fn process_effects(
@@ -16,15 +78,52 @@ pub fn process_effects(
             Effect::Render(_) => {}
             Effect::Storage(boxed_request) => match &boxed_request.operation {
                 StorageEffect::LoadAll => {
-                    let (pieces, exercises) = create_stub_data();
+                    let (pieces, exercises) = load_library_data();
                     let inner_effects = core.process_event(Event::DataLoaded { pieces, exercises });
                     process_effects(core, inner_effects, view_model);
                 }
-                StorageEffect::SavePiece(_)
-                | StorageEffect::SaveExercise(_)
-                | StorageEffect::UpdatePiece(_)
-                | StorageEffect::UpdateExercise(_)
-                | StorageEffect::DeleteItem { .. } => {}
+                StorageEffect::SavePiece(piece) => {
+                    LIBRARY.with(|lib| {
+                        let mut data = lib.borrow_mut();
+                        data.pieces.push(piece.clone());
+                        save_to_local_storage(&data);
+                    });
+                }
+                StorageEffect::SaveExercise(exercise) => {
+                    LIBRARY.with(|lib| {
+                        let mut data = lib.borrow_mut();
+                        data.exercises.push(exercise.clone());
+                        save_to_local_storage(&data);
+                    });
+                }
+                StorageEffect::UpdatePiece(piece) => {
+                    LIBRARY.with(|lib| {
+                        let mut data = lib.borrow_mut();
+                        if let Some(existing) = data.pieces.iter_mut().find(|p| p.id == piece.id) {
+                            *existing = piece.clone();
+                        }
+                        save_to_local_storage(&data);
+                    });
+                }
+                StorageEffect::UpdateExercise(exercise) => {
+                    LIBRARY.with(|lib| {
+                        let mut data = lib.borrow_mut();
+                        if let Some(existing) =
+                            data.exercises.iter_mut().find(|e| e.id == exercise.id)
+                        {
+                            *existing = exercise.clone();
+                        }
+                        save_to_local_storage(&data);
+                    });
+                }
+                StorageEffect::DeleteItem { id } => {
+                    LIBRARY.with(|lib| {
+                        let mut data = lib.borrow_mut();
+                        data.pieces.retain(|p| p.id != *id);
+                        data.exercises.retain(|e| e.id != *id);
+                        save_to_local_storage(&data);
+                    });
+                }
             },
         }
     }

--- a/specs/011-json-persistence/data-model.md
+++ b/specs/011-json-persistence/data-model.md
@@ -1,0 +1,98 @@
+# Data Model: JSON File Persistence
+
+**Feature**: 011-json-persistence | **Date**: 2026-02-14
+
+## Entities
+
+### LibraryData (NEW)
+
+Top-level serialisation unit for both `library.json` (CLI) and `intrada:library` (web localStorage).
+
+```rust
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct LibraryData {
+    #[serde(default)]
+    pub pieces: Vec<Piece>,
+    #[serde(default)]
+    pub exercises: Vec<Exercise>,
+}
+```
+
+**Location**: `crates/intrada-core/src/domain/types.rs` (shared between shells)
+
+**JSON format**:
+```json
+{
+  "pieces": [
+    {
+      "id": "01HYK...",
+      "title": "Clair de Lune",
+      "composer": "Claude Debussy",
+      "key": "Db Major",
+      "tempo": { "marking": "Andante", "bpm": 66 },
+      "notes": "Third movement of Suite bergamasque",
+      "tags": ["impressionist", "piano"],
+      "created_at": "2026-02-14T10:30:00Z",
+      "updated_at": "2026-02-14T10:30:00Z"
+    }
+  ],
+  "exercises": [
+    {
+      "id": "01HYK...",
+      "title": "Hanon No. 1",
+      "composer": "Charles-Louis Hanon",
+      "category": "Technique",
+      "key": "C Major",
+      "tempo": { "marking": "Moderato", "bpm": 108 },
+      "notes": "The Virtuoso Pianist — Exercise 1",
+      "tags": ["technique", "warm-up"],
+      "created_at": "2026-02-14T10:30:00Z",
+      "updated_at": "2026-02-14T10:30:00Z"
+    }
+  ]
+}
+```
+
+### Piece (UNCHANGED)
+
+Existing struct in `crates/intrada-core/src/domain/piece.rs`. Already has `#[derive(Serialize, Deserialize)]`. No changes needed.
+
+### Exercise (UNCHANGED)
+
+Existing struct in `crates/intrada-core/src/domain/exercise.rs`. Already has `#[derive(Serialize, Deserialize)]`. No changes needed.
+
+### Tempo (UNCHANGED)
+
+Existing struct in `crates/intrada-core/src/domain/types.rs`. Already has `#[derive(Serialize, Deserialize)]`. No changes needed.
+
+## Schema Evolution Strategy
+
+New optional fields added to `Piece`, `Exercise`, or `LibraryData` MUST use `#[serde(default)]`:
+
+```rust
+// Example future addition:
+pub struct Piece {
+    // ... existing fields ...
+    #[serde(default)]
+    pub difficulty: Option<u8>,  // Added in v2 — old files load fine
+}
+```
+
+Unknown fields in the JSON are silently ignored by serde_json (default behaviour). No `#[serde(deny_unknown_fields)]` anywhere.
+
+## Storage Locations
+
+| Shell | Path/Key | Format |
+|-------|----------|--------|
+| CLI | `~/.local/share/intrada/library.json` | Pretty-printed JSON |
+| Web | `localStorage["intrada:library"]` | Compact JSON |
+
+## Future Domain Files
+
+The segmented approach supports future domains without structural changes:
+
+| Domain | CLI File | Web Key | Load Strategy |
+|--------|----------|---------|---------------|
+| Library | `library.json` | `intrada:library` | Eager (on startup) |
+| Sessions | `sessions.json` | `intrada:sessions` | On demand (future) |
+| Goals | `goals.json` | `intrada:goals` | On demand (future) |

--- a/specs/011-json-persistence/plan.md
+++ b/specs/011-json-persistence/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: JSON File Persistence
+
+**Branch**: `011-json-persistence` | **Date**: 2026-02-14 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-json-persistence/spec.md`
+
+## Summary
+
+Replace the SQLite persistence layer in the CLI shell with JSON file storage (`library.json`) and add localStorage persistence to the web shell (`intrada:library` key). The core's `StorageEffect` enum is unchanged — only the shell-side storage implementations change. Remove the `rusqlite` dependency entirely.
+
+## Technical Context
+
+**Language/Version**: Rust stable (1.75+, 2021 edition)
+**Primary Dependencies**: crux_core 0.17.0-rc2, serde_json 1, web-sys (with Storage+Window features), dirs 5
+**Storage**: JSON files (CLI: `~/.local/share/intrada/library.json`), localStorage (web: `intrada:library` key)
+**Testing**: `cargo test` (unit tests in storage.rs, shell.rs; existing core tests unchanged)
+**Target Platform**: CLI (macOS/Linux), WASM (browser via trunk)
+**Project Type**: Workspace with 3 crates (core, cli, web)
+**Performance Goals**: N/A — single-user local app, file I/O is negligible
+**Constraints**: Atomic writes for CLI (temp file + rename). localStorage 5MB limit (log warning on failure, don't crash).
+**Scale/Scope**: Single user, hundreds of items max. Full-file rewrite on each save is acceptable.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | PASS | Single-responsibility: `JsonStore` replaces `SqliteStore` with same public API. No dead code — SQLite code fully removed, not commented out. |
+| II. Testing Standards | PASS | All existing CLI tests adapted to JSON backend. New tests for round-trip serialisation, missing file, malformed JSON. Tests use temp dirs, not real XDG path. |
+| III. UX Consistency | PASS | No user-facing behaviour changes. CLI commands identical. Web app gains persistence (improvement, not inconsistency). |
+| IV. Performance | PASS | Full-file rewrite is <1ms for expected data sizes. No N+1 or over-fetching concerns. |
+
+**Post-Phase 1 re-check**: PASS — no new patterns introduced. `LibraryData` struct is a plain serde container, no abstractions.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-json-persistence/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── intrada-core/
+│   └── src/
+│       └── domain/
+│           └── types.rs          # Add LibraryData struct (shared serialisation unit)
+├── intrada-cli/
+│   ├── Cargo.toml                # Remove rusqlite, keep serde_json
+│   └── src/
+│       ├── storage.rs            # REWRITE: JsonStore replaces SqliteStore
+│       ├── shell.rs              # UPDATE: use JsonStore instead of SqliteStore
+│       └── main.rs               # MINOR: update store construction
+└── intrada-web/
+    ├── Cargo.toml                # Add web-sys with Storage+Window features
+    └── src/
+        ├── core_bridge.rs        # UPDATE: persist to/from localStorage (localStorage logic inlined here)
+        └── data.rs               # KEEP: stub data still used for first-run seeding
+```
+
+**Workspace Cargo.toml**: Remove `rusqlite` from `[workspace.dependencies]`.
+
+**Structure Decision**: Existing 3-crate workspace structure is preserved. No new crates. The `LibraryData` struct lives in `intrada-core` because both shells need it.
+
+## File Change Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `Cargo.toml` (workspace) | EDIT | Remove `rusqlite` from workspace dependencies |
+| `crates/intrada-core/src/domain/types.rs` | EDIT | Add `LibraryData` struct |
+| `crates/intrada-core/src/lib.rs` | EDIT | Re-export `LibraryData` |
+| `crates/intrada-cli/Cargo.toml` | EDIT | Remove `rusqlite` dependency |
+| `crates/intrada-cli/src/storage.rs` | REWRITE | `JsonStore` replacing `SqliteStore` |
+| `crates/intrada-cli/src/shell.rs` | EDIT | Update type references from `SqliteStore` to `JsonStore` |
+| `crates/intrada-cli/src/main.rs` | EDIT | Update store construction |
+| `crates/intrada-web/Cargo.toml` | EDIT | Add `web-sys` with features, add `serde_json` |
+| `crates/intrada-web/src/core_bridge.rs` | EDIT | Add localStorage read/write for all StorageEffect variants |
+| `crates/intrada-web/src/app.rs` | EDIT | Load from localStorage on init instead of always using stub data |
+| `crates/intrada-web/src/data.rs` | KEEP | Unchanged — stub data used for first-run seeding |

--- a/specs/011-json-persistence/quickstart.md
+++ b/specs/011-json-persistence/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: JSON File Persistence
+
+**Feature**: 011-json-persistence | **Date**: 2026-02-14
+
+## Verification Commands
+
+```bash
+# Run all tests (core + CLI + web compile check)
+cargo test
+
+# Run only CLI tests
+cargo test -p intrada-cli
+
+# Run only core tests
+cargo test -p intrada-core
+
+# Check for clippy warnings
+cargo clippy -- -D warnings
+
+# Verify rusqlite is gone from the dependency tree
+cargo tree -p intrada-cli | grep -i sqlite && echo "FAIL: rusqlite still present" || echo "OK: rusqlite removed"
+
+# Build web shell (requires trunk + wasm target)
+cd crates/intrada-web && trunk build
+```
+
+## Manual Verification — CLI
+
+```bash
+# 1. Remove any existing data to start fresh
+rm -f ~/.local/share/intrada/library.json
+
+# 2. Add a piece
+cargo run -p intrada-cli -- add piece "Clair de Lune" "Debussy" --key "Db Major"
+
+# 3. Verify the JSON file was created
+cat ~/.local/share/intrada/library.json | python3 -m json.tool
+
+# 4. List items (should show the piece)
+cargo run -p intrada-cli -- list
+
+# 5. Add an exercise
+cargo run -p intrada-cli -- add exercise "Hanon No. 1"
+
+# 6. Verify both items in JSON
+cat ~/.local/share/intrada/library.json | python3 -m json.tool
+
+# 7. Delete the piece, verify it's removed from JSON
+cargo run -p intrada-cli -- delete <piece-id>
+cat ~/.local/share/intrada/library.json | python3 -m json.tool
+```
+
+## Manual Verification — Web
+
+```bash
+# 1. Start the web app
+cd crates/intrada-web && trunk serve
+
+# 2. Open http://localhost:8080 in browser
+
+# 3. First load: stub data should appear and be persisted
+#    Check: DevTools → Application → Local Storage → intrada:library
+
+# 4. Add a new piece via the form
+
+# 5. Refresh the page — the new piece should still be there
+#    (plus the original stub data, minus any deleted items)
+
+# 6. Clear localStorage and refresh — stub data should reappear
+```

--- a/specs/011-json-persistence/research.md
+++ b/specs/011-json-persistence/research.md
@@ -1,0 +1,48 @@
+# Research: JSON File Persistence
+
+**Feature**: 011-json-persistence | **Date**: 2026-02-14
+
+## R1: Atomic file writes in Rust
+
+**Decision**: Write to a temp file in the same directory, then `std::fs::rename()` to the target path.
+
+**Rationale**: `rename()` is atomic on POSIX filesystems when source and target are on the same filesystem. Writing to a temp file in the same directory guarantees this. The `tempfile` crate is unnecessary — `std::fs::write` to a `.tmp` suffix then `rename` is sufficient for this use case.
+
+**Alternatives considered**:
+- `tempfile` crate: Adds a dependency for something achievable in 3 lines of std code.
+- Write-in-place: Risk of data corruption if the process is killed mid-write.
+
+## R2: localStorage API in WASM/Leptos
+
+**Decision**: Use `web_sys::window().unwrap().local_storage().unwrap().unwrap()` directly via `web-sys` with the `Storage` feature. No additional crate needed.
+
+**Rationale**: `web-sys` is already a transitive dependency of `leptos` and `wasm-bindgen`. Adding `gloo-storage` would introduce another dependency for a trivial wrapper around `localStorage.getItem()` / `setItem()`. Direct `web-sys` usage is 5-10 lines of code.
+
+**Alternatives considered**:
+- `gloo-storage` crate: Clean API but adds a dependency. The `gloo` ecosystem is in flux with version fragmentation.
+- `wasm-bindgen` raw JS interop: Lower-level than needed when `web-sys` already exposes the API.
+
+## R3: JSON pretty-print vs compact
+
+**Decision**: Use `serde_json::to_string_pretty()` for CLI file output. Compact format for localStorage (via `serde_json::to_string()`).
+
+**Rationale**: CLI users may inspect `library.json` manually — pretty-printed JSON is friendlier. localStorage has a 5MB limit, so compact is better. The serialisation format difference doesn't matter since both deserialise identically.
+
+**Alternatives considered**:
+- Compact everywhere: Harder for users to debug by inspecting the file.
+- Pretty everywhere: Wastes localStorage space unnecessarily.
+
+## R4: serde_json handling of unknown fields
+
+**Decision**: No configuration needed. `serde_json::from_str` ignores unknown fields by default when deserialising into a struct. This is the standard serde behaviour.
+
+**Rationale**: Schema evolution via `#[serde(default)]` on new optional fields plus default unknown-field-ignoring means old clients can read newer files and newer clients can read older files. No explicit `#[serde(deny_unknown_fields)]` should be added.
+
+## R5: web-sys features needed
+
+**Decision**: Enable `Storage`, `Window` features on `web-sys` in `intrada-web/Cargo.toml`.
+
+**Rationale**: `web-sys` gates each Web API behind feature flags to minimise WASM binary size. We need `Window` (for `window()`) and `Storage` (for `local_storage()`).
+
+**Alternatives considered**:
+- Feature flags are already the standard pattern for web-sys usage. No real alternatives.

--- a/specs/011-json-persistence/spec.md
+++ b/specs/011-json-persistence/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: JSON File Persistence
+
+**Feature Branch**: `011-json-persistence`
+**Created**: 2026-02-14
+**Status**: Draft
+**Input**: User description: "Replace SQLite persistence in the CLI shell with JSON file storage and add localStorage persistence to the web shell. Segmented file approach with separate files per data domain."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - CLI persists library data as JSON (Priority: P1)
+
+A musician using the CLI adds pieces and exercises. Their data persists between sessions as a JSON file at `~/.local/share/intrada/library.json` instead of a SQLite database. All existing CLI commands (add, list, show, edit, delete, tag, untag, search) work exactly as before — only the storage backend changes.
+
+**Why this priority**: This is the core change — replacing SQLite with JSON. Without this, nothing else matters.
+
+**Independent Test**: Run `intrada add piece`, exit, run `intrada list` — the added piece appears. Inspect `~/.local/share/intrada/library.json` to confirm it's valid JSON containing the piece.
+
+**Acceptance Scenarios**:
+
+1. **Given** no existing data directory, **When** the user runs any CLI command, **Then** the data directory is created and `library.json` is written (empty library if no data yet)
+2. **Given** a `library.json` with 3 pieces and 2 exercises, **When** the user runs `intrada list`, **Then** all 5 items are displayed
+3. **Given** a `library.json` with existing data, **When** the user adds a new piece, **Then** the piece is appended and `library.json` is rewritten with the new piece included
+4. **Given** a `library.json` with existing data, **When** the user edits an item, **Then** `library.json` is rewritten with the updated item
+5. **Given** a `library.json` with existing data, **When** the user deletes an item, **Then** `library.json` is rewritten without that item
+6. **Given** no `library.json` exists, **When** `LoadAll` is processed, **Then** an empty library is returned (no error)
+
+---
+
+### User Story 2 - Web shell persists library data to localStorage (Priority: P2)
+
+A musician using the web app adds items. Their data persists across page reloads via the browser's localStorage. The web shell uses the same JSON format as the CLI, stored under domain-specific keys (e.g. `intrada:library`).
+
+**Why this priority**: The web shell currently has no persistence — all data is lost on refresh. This makes the web app actually usable.
+
+**Independent Test**: Open the web app, add a piece, refresh the page — the piece is still there. Check `localStorage.getItem("intrada:library")` in the browser console to confirm valid JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** no localStorage key exists, **When** the web app loads, **Then** the stub data is used as a starting library and persisted to localStorage
+2. **Given** `intrada:library` exists in localStorage, **When** the web app loads, **Then** the persisted data is loaded (stub data is NOT used)
+3. **Given** the web app is running, **When** the user adds/edits/deletes an item, **Then** the `intrada:library` key is updated immediately
+4. **Given** corrupt or unparseable JSON in localStorage, **When** the web app loads, **Then** an empty library is used and the corrupt data is overwritten on next save
+
+---
+
+### Edge Cases
+
+- What happens when `library.json` is malformed? → CLI prints an error and exits; web shell falls back to empty library.
+- What happens when the filesystem is read-only or the data directory can't be created? → CLI returns an error via `anyhow`.
+- What happens when localStorage is full (5MB limit)? → Web shell logs a warning to console; the in-memory state remains correct even if persistence fails.
+- What happens when a future schema version adds new fields? → `#[serde(default)]` on new optional fields ensures old files load without migration.
+- What happens when two CLI processes write simultaneously? → Last write wins (acceptable for a single-user app).
+- What happens when `library.json` contains unknown fields from a newer version? → `serde_json` ignores unknown fields by default — the file loads fine.
+
+## Clarifications
+
+### Session 2026-02-14
+
+- Q: Should the CLI use atomic writes (temp file + rename) to prevent corruption on interrupted writes? → A: Yes, atomic write via temp file + rename.
+- Q: How should rusqlite be retained for the migrate command? → A: No migrate command needed — early development, no real user data at risk. Remove rusqlite entirely.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: CLI shell MUST read/write `library.json` at `~/.local/share/intrada/` (XDG data path, resolved via `dirs` crate as currently done)
+- **FR-002**: Web shell MUST read/write to `localStorage` under the key `intrada:library`
+- **FR-003**: Both shells MUST use the same JSON format: `{ "pieces": [...], "exercises": [...] }`
+- **FR-004**: On `StorageEffect::LoadAll`, the shell MUST read and deserialise the library file/key. If absent, return an empty library
+- **FR-005**: On `SavePiece`, `SaveExercise`, `UpdatePiece`, `UpdateExercise`, `DeleteItem`, the shell MUST update its in-memory collection and write the full library to storage. The CLI MUST use atomic writes (write to a temp file in the same directory, then rename) to prevent corruption on interrupted writes
+- **FR-006**: The `StorageEffect` enum in `intrada-core` MUST NOT change
+- **FR-007**: The `rusqlite` dependency MUST be removed from `intrada-cli` and the workspace entirely
+- **FR-008**: Schema evolution MUST be handled via `#[serde(default)]` on new optional fields — no explicit migration system needed
+- **FR-009**: The web shell MUST use stub data ONLY when no persisted data exists in localStorage
+- **FR-010**: The JSON file approach MUST accommodate future domain files (e.g. `sessions.json`, `goals.json`) without structural changes — each domain gets its own file/key
+
+### Key Entities
+
+- **LibraryData**: Top-level JSON structure containing `pieces: Vec<Piece>` and `exercises: Vec<Exercise>`. This is the serialisation unit for `library.json` / `intrada:library`.
+- **Piece**: Existing domain type (already has Serialize/Deserialize derives). No changes needed.
+- **Exercise**: Existing domain type (already has Serialize/Deserialize derives). No changes needed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing CLI tests continue to pass with the JSON backend
+- **SC-002**: All existing web shell functionality works with localStorage persistence
+- **SC-003**: Data round-trips correctly: CLI write → CLI read, web write → web read, CLI write → manual inspection of JSON
+- **SC-004**: `rusqlite` no longer appears anywhere in `Cargo.lock`
+- **SC-005**: Adding a new optional field to `Piece` or `Exercise` with `#[serde(default)]` loads old JSON files without error

--- a/specs/011-json-persistence/tasks.md
+++ b/specs/011-json-persistence/tasks.md
@@ -1,0 +1,146 @@
+# Tasks: JSON File Persistence
+
+**Input**: Design documents from `/specs/011-json-persistence/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Included — existing CLI tests must be adapted and new persistence tests added.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Exact file paths included in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add shared `LibraryData` type and update workspace dependencies
+
+- [x] T001 Add `LibraryData` struct with `#[serde(default)]` fields in `crates/intrada-core/src/domain/types.rs`
+- [x] T002 Re-export `LibraryData` from `crates/intrada-core/src/lib.rs`
+- [x] T003 Verify `cargo test -p intrada-core` passes (no core changes beyond the new struct)
+
+---
+
+## Phase 2: User Story 1 — CLI persists library data as JSON (Priority: P1)
+
+**Goal**: Replace SQLite with JSON file persistence. All existing CLI commands work identically — only the storage backend changes.
+
+**Independent Test**: `cargo test -p intrada-cli` passes. Run `intrada add piece`, exit, run `intrada list` — added piece appears. Inspect `~/.local/share/intrada/library.json` for valid JSON.
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Rewrite `crates/intrada-cli/src/storage.rs`: replace `SqliteStore` with `JsonStore` implementing `new()`, `new_with_path()` (for tests), `load_all()`, `save_piece()`, `save_exercise()`, `update_piece()`, `update_exercise()`, `delete_item()`, and private `write_library()` using atomic writes (temp file + rename) with `serde_json::to_string_pretty()`
+- [x] T005 [US1] Update `crates/intrada-cli/src/shell.rs`: change `SqliteStore` → `JsonStore` in struct definition, constructor, and imports
+- [x] T006 [US1] Update `crates/intrada-cli/src/main.rs`: change store construction from `SqliteStore::new()` to `JsonStore::new()`
+- [x] T007 [US1] Remove `rusqlite` from `crates/intrada-cli/Cargo.toml`
+- [x] T008 [US1] Remove `rusqlite` from workspace `Cargo.toml` `[workspace.dependencies]`
+- [x] T009 [US1] Adapt all existing tests in `crates/intrada-cli/src/storage.rs`: replace `SqliteStore::new_in_memory()` with `JsonStore::new_with_path(tempdir)` using `tempfile` or `std::env::temp_dir()` for test isolation. Cover: save/load piece, save/load exercise, update piece, update exercise, delete item, empty store, piece with no optional fields
+- [x] T010 [US1] Adapt all existing tests in `crates/intrada-cli/src/shell.rs`: update `test_shell()` helper to use `JsonStore::new_with_path(tempdir)`. Ensure load_data, add_piece_round_trip, add_piece_persists, unicode round-trips, boundary tests, and validation tests all pass
+- [x] T011 [US1] Add new test in `crates/intrada-cli/src/storage.rs`: missing file returns empty library (no error)
+- [x] T012 [US1] Add new test in `crates/intrada-cli/src/storage.rs`: malformed JSON file returns an error
+- [x] T013 [US1] Add new test in `crates/intrada-cli/src/storage.rs`: JSON with unknown fields deserialises successfully (schema forward-compatibility)
+- [x] T014 [US1] Run `cargo test -p intrada-cli` — all tests pass
+- [x] T015 [US1] Run `cargo clippy -- -D warnings` — zero warnings across workspace
+
+**Checkpoint**: CLI fully functional with JSON persistence. All existing tests pass. `rusqlite` gone from dependency tree.
+
+---
+
+## Phase 3: User Story 2 — Web shell persists library data to localStorage (Priority: P2)
+
+**Goal**: Add localStorage persistence to the web shell. Data survives page reloads. Stub data used only on first run.
+
+**Independent Test**: Open web app, add a piece, refresh — piece persists. Check `localStorage.getItem("intrada:library")` in browser console.
+
+### Implementation for User Story 2
+
+- [x] T016 [P] [US2] Add `web-sys` dependency with `Storage` and `Window` features, and `serde_json` (workspace) to `crates/intrada-web/Cargo.toml`
+- [x] T017 [US2] Update `crates/intrada-web/src/core_bridge.rs`: maintain an in-memory `LibraryData` (loaded once on init). On `StorageEffect::LoadAll`, read `intrada:library` from localStorage, deserialise as `LibraryData`, fall back to stub data if key absent or JSON corrupt, store in the in-memory copy. On `SavePiece`/`SaveExercise`/`UpdatePiece`/`UpdateExercise`/`DeleteItem`, mutate the in-memory `LibraryData` (push/replace/remove) and write back to localStorage as compact JSON via `serde_json::to_string()`. Log warning to console if `setItem` fails (localStorage full).
+- [x] T018 [US2] Update `crates/intrada-web/src/app.rs`: remove direct `create_stub_data()` call from `App()` init — instead, send a `LoadAll`-triggering event or rely on the existing `StorageEffect::LoadAll` flow in `core_bridge.rs` to handle first-load logic (stub data vs persisted data)
+- [x] T019 [US2] Run `trunk build` in `crates/intrada-web/` — compiles to WASM without errors
+- [x] T020 [US2] Run `cargo clippy -- -D warnings` — zero warnings across workspace
+
+**Checkpoint**: Web shell persists to localStorage. Stub data appears on first load, persisted data on subsequent loads. All commands (add/edit/delete) survive page refresh.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across the full workspace
+
+- [x] T021 Run full `cargo test` — all tests pass across all 3 crates
+- [x] T022 Verify `rusqlite` absent from `Cargo.lock`: `cargo tree -p intrada-cli | grep -i sqlite` returns nothing
+- [x] T023 Run quickstart.md manual verification steps for CLI (add piece, inspect JSON, list, add exercise, delete)
+- [ ] T024 Run quickstart.md manual verification steps for web (trunk serve, add piece, refresh, check localStorage)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **US1 (Phase 2)**: Depends on Phase 1 (needs `LibraryData` type)
+- **US2 (Phase 3)**: Depends on Phase 1 (needs `LibraryData` type). Independent of US1 (different crate).
+- **Polish (Phase 4)**: Depends on Phases 2 and 3 both complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 1 only. No dependency on US2.
+- **User Story 2 (P2)**: Depends on Phase 1 only. No dependency on US1. Can be developed in parallel with US1.
+
+### Within Each User Story
+
+- Storage implementation before shell/main updates
+- Shell updates before test adaptation
+- All tests passing before checkpoint
+
+### Parallel Opportunities
+
+- **T016** (web Cargo.toml) can run in parallel with any US1 task (different crate)
+- **US1 and US2** can be developed in parallel after Phase 1 completes (different crates, no shared files)
+- **T011, T012, T013** (new storage tests) can run in parallel with each other
+
+---
+
+## Parallel Example: User Story 1 + User Story 2
+
+```text
+# After Phase 1 (Setup) completes:
+
+# Stream A — US1 (CLI):
+T004 → T005 + T006 + T007 + T008 (parallel, different files) → T009 + T010 (parallel) → T011 + T012 + T013 (parallel) → T014 → T015
+
+# Stream B — US2 (Web):
+T016 → T017 → T018 → T019 → T020
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T003)
+2. Complete Phase 2: User Story 1 (T004–T015)
+3. **STOP and VALIDATE**: `cargo test -p intrada-cli` passes, `rusqlite` gone
+4. CLI is fully functional with JSON persistence
+
+### Incremental Delivery
+
+1. Phase 1 → Setup complete
+2. Phase 2 → CLI JSON persistence working (MVP)
+3. Phase 3 → Web localStorage persistence working
+4. Phase 4 → Full verification, ready for PR
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [US1]/[US2] labels map tasks to specific user stories
+- US1 and US2 are fully independent (different crates) — can be parallelised
+- Commit after each phase checkpoint
+- `data.rs` (stub data) is unchanged — still used for first-run seeding in web shell


### PR DESCRIPTION
## Summary
- **CLI shell**: Replaces `rusqlite`/SQLite with a plain JSON file (`library.json`) using atomic writes (temp file + rename) for crash safety
- **Web shell**: Adds full `localStorage` persistence — all CRUD operations now survive page reloads
- **Shared format**: New `LibraryData` struct in `intrada-core` with `#[serde(default)]` for forward-compatible schema evolution
- **Dependency removal**: `rusqlite` fully removed from workspace — simplifies builds and eliminates native C dependency

## Changes

### intrada-core
- Added `LibraryData` struct (shared serialisation unit for both shells)
- Re-exported from `domain/mod.rs` and `lib.rs`

### intrada-cli
- Rewrote `storage.rs`: `SqliteStore` → `JsonStore` with pretty-printed JSON and atomic writes
- Updated `shell.rs` and `main.rs` imports
- Removed `rusqlite` dependency, added `tempfile` as dev-dependency
- 10 storage tests + 8 shell integration tests (incl. Unicode round-trip, boundary validation)

### intrada-web
- Implemented localStorage persistence in `core_bridge.rs` for all `StorageEffect` variants
- Thread-local `RefCell<LibraryData>` for in-memory state
- Auto-seeds stub data on first run, persists all subsequent changes
- Updated `app.rs` init to load from localStorage

### Workspace
- Removed `rusqlite` from `[workspace.dependencies]`

## Test plan
- [x] `cargo test` — 89 tests pass (68 core + 21 CLI)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo check -p intrada-web --target wasm32-unknown-unknown` — compiles
- [x] CLI quickstart: `intrada add piece`, `intrada list`, inspect `library.json`
- [x] Verify `rusqlite` fully removed: `cargo tree -p intrada-cli | grep sqlite` returns nothing
- [ ] Web manual verification: `trunk serve`, add/edit/delete items, refresh page to confirm persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)