### PR TITLE
Pin Rust 1.89.0 in CI and declare MSRV 1.75 in Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  RUST_VERSION: "1.89.0"
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
@@ -21,8 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
@@ -32,8 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
@@ -58,8 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
         with:
@@ -101,7 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
       - run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+package.rust-version = "1.75"
 
 [workspace.dependencies]
 crux_core = "0.17.0-rc2"

--- a/crates/intrada-core/Cargo.toml
+++ b/crates/intrada-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-core"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 crux_core = { workspace = true }

--- a/crates/intrada-web/Cargo.toml
+++ b/crates/intrada-web/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-web"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 intrada-core = { path = "../intrada-core" }


### PR DESCRIPTION
## Summary

- Pin all CI jobs to Rust **1.89.0** via a single `RUST_VERSION` env var (was `@stable` which floats)
- Declare `rust-version = "1.75"` in workspace `Cargo.toml`, inherited by both crates
- Switch from `dtolnay/rust-toolchain@stable` to `@master` with explicit toolchain version

## Why

CI was using `@stable` which silently upgrades whenever a new Rust release drops. This can cause surprise breakages and makes builds non-reproducible. Pinning to a specific version means upgrades are intentional. The MSRV in `Cargo.toml` ensures cargo warns if someone tries to build on too old a toolchain.

## Test plan

- [x] CI passes on this PR (validates the `@master` + explicit toolchain approach works)
- [x] `cargo test` passes locally
- [x] `cargo clippy -- -D warnings` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)