### PR TITLE
Add Shuttle API server with REST endpoints for pieces and exercises

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-15
 - localStorage (web: `intrada:sessions` key for completed sessions, `intrada:session-in-progress` key for crash recovery) (015-rework-sessions)
 - Rust stable (1.75+, 2021 edition) + leptos 0.8.x (CSR), crux_core 0.17.0-rc2, Tailwind CSS v4 (standalone CLI v4.1.18), trunk 0.21.x (016-glassmorphism-responsive)
 - N/A (no storage changes — visual only) (016-glassmorphism-responsive)
+- Rust stable (1.75+ workspace minimum; axum 0.8 requires 1.78+) + shuttle-runtime 0.57, shuttle-axum 0.57, axum 0.8, sqlx 0.8 (Postgres), tower-http 0.6 (fs), intrada-core (workspace) (017-shuttle-api-deploy)
+- Shuttle-managed Postgres via `shuttle-shared-db` (zero-config, auto-provisioned) (017-shuttle-api-deploy)
 
 ## Project Structure
 
@@ -35,9 +37,9 @@ cargo clippy
 Rust stable (1.75+, 2021 edition): Follow standard conventions
 
 ## Recent Changes
+- 017-shuttle-api-deploy: Added Rust stable (1.75+ workspace minimum; axum 0.8 requires 1.78+) + shuttle-runtime 0.57, shuttle-axum 0.57, axum 0.8, sqlx 0.8 (Postgres), tower-http 0.6 (fs), intrada-core (workspace)
 - 016-glassmorphism-responsive: Added Rust stable (1.75+, 2021 edition) + leptos 0.8.x (CSR), crux_core 0.17.0-rc2, Tailwind CSS v4 (standalone CLI v4.1.18), trunk 0.21.x
 - 015-rework-sessions: Added Rust stable (1.75+, 2021 edition) + crux_core 0.17.0-rc2 (workspace), leptos 0.8.x (CSR), leptos_router 0.8.x, web-sys (Storage+Window), wasm-bindgen, serde/serde_json 1, ulid 1, chrono 0.4, send_wrapper 0.6
-- 015-rework-sessions: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "attribute-derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +123,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +185,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -127,6 +206,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -142,6 +224,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -176,6 +264,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -241,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +425,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -353,7 +487,7 @@ version = "0.8.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c18ba1052a1f28c97e3595e5a64496921953b3945cf7537e0544f93b36735e74"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "heck",
  "proc-macro-error",
  "proc-macro2",
@@ -373,12 +507,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -396,11 +554,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.115",
 ]
@@ -420,6 +589,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,13 +617,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "2.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229850a212cd9b84d4f0290ad9d294afc0ae70fccaa8949dbe8b43ffafa1e20c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "diesel_derives",
+ "itoa",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcc26599f590c7e5b182a05061cfb445f216bb069df72eb31f38cffde8ca598"
+dependencies = [
+ "diesel",
+ "futures-core",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b96984c469425cb577bf6f17121ecb3e4fe1e81de5d8f780dd372802858d756"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "dsl_auto_type",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+dependencies = [
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -452,16 +688,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
+name = "dsl_auto_type"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+dependencies = [
+ "darling 0.20.11",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "either_of"
@@ -484,6 +743,27 @@ name = "erased"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1731451909bde27714eacba19c2566362a7f35224f52b153d3f42cf60f72472"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "event-listener"
@@ -559,10 +839,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -623,6 +926,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +991,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -747,6 +1074,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +1104,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -766,6 +1114,39 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -778,6 +1159,39 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html-escape"
@@ -799,6 +1213,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hydration_context"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +1265,72 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "throw_error",
+]
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -975,6 +1496,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "intrada-api"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "intrada-core",
+ "serde",
+ "serde_json",
+ "shuttle-axum",
+ "shuttle-runtime",
+ "shuttle-shared-db",
+ "sqlx",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+]
+
+[[package]]
 name = "intrada-core"
 version = "0.1.0"
 dependencies = [
@@ -1006,6 +1547,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1585,15 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1214,6 +1780,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,10 +1857,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicov"
@@ -1277,6 +1911,17 @@ checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1297,7 +1942,43 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1318,6 +1999,24 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1372,7 +2071,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1390,10 +2089,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1426,6 +2153,62 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1535,6 +2318,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,12 +2411,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1588,7 +2447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1664,6 +2532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +2568,93 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "rstml"
@@ -1723,10 +2687,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1735,6 +2740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scoped-futures"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b24aae2d0636530f359e9d5ef0c04669d11c5e756699b27a6a6d845d8329091"
+dependencies = [
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1748,6 +2762,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -1802,6 +2820,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2848,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1880,6 +2921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,10 +2943,169 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shuttle-api-client"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50014d2c881895e2f18c412d07a945f8dadd2a40171af2773e29aebc306555f5"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "headers",
+ "http",
+ "percent-encoding",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "shuttle-common",
+ "tokio",
+ "tokio-tungstenite",
+ "url",
+]
+
+[[package]]
+name = "shuttle-axum"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8689ba948b46f56ba52ac6fcbd68cd07807e79a5f6b1e2bf35c4be1d1eaf4620"
+dependencies = [
+ "axum",
+ "shuttle-runtime",
+]
+
+[[package]]
+name = "shuttle-codegen"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31ffbf347a3d18a548e27b77608c6052ce293b053624e23938916325ac13bb1"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "shuttle-ifc",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "shuttle-common"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5f589b53bec1c0b993883d7a5a80111fcc6a1cbe6220f712ea504c748e83e6"
+dependencies = [
+ "chrono",
+ "http",
+ "semver",
+ "serde",
+ "serde_json",
+ "strum",
+ "typeshare",
+ "zeroize",
+]
+
+[[package]]
+name = "shuttle-ifc"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec9f79ae871e02182b8dd3fed894a44afee58c4549e5252e9c3a6acbaece3a"
+dependencies = [
+ "proc-macro2",
+ "shuttle-common",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "shuttle-runtime"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613d6fd24bb70d4c173989d6b7882b5b6bffdafd679223f5a76171369aadcf01"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "serde",
+ "serde_json",
+ "shuttle-api-client",
+ "shuttle-codegen",
+ "shuttle-common",
+ "shuttle-service",
+ "strfmt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "shuttle-service"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8400f4ec61f959d696a3ec73ac9de798185999b3d8bf7c79b7e745ba44a14"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "shuttle-common",
+ "strfmt",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "shuttle-shared-db"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11916c7bae646e82c3441fbbcbc1451686fcbabe6cc38553bd06f32104cd797e"
+dependencies = [
+ "async-trait",
+ "diesel-async",
+ "serde",
+ "serde_json",
+ "shuttle-service",
+ "sqlx",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -1916,6 +3127,232 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.115",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1930,10 +3367,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strfmt"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fdc163db75f7b5ffa3daf0c5a7136fb0d4b2f35523cd1769da05e034159feb"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1969,6 +3450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +3467,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.115",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2054,6 +3565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "throw_error"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +3590,125 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami 2.1.1",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2101,6 +3740,162 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -2150,20 +3945,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typeshare"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1bf9fe204f358ffea7f8f779b53923a20278b3ab8e8d97962c5e1b3a54edb7"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621963e302416b389a1ec177397e9e62de849a78bd8205d428608553def75350"
+dependencies = [
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "ulid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "web-time",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2189,6 +4033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +4049,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-width"
@@ -2224,6 +4080,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +4105,30 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
 ]
 
 [[package]]
@@ -2255,6 +4147,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2445,12 +4352,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite 1.0.2",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2495,6 +4443,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,12 +4473,225 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2699,6 +4871,12 @@ dependencies = [
  "syn 2.0.115",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Shuttle.toml
+++ b/Shuttle.toml
@@ -1,0 +1,5 @@
+name = "intrada"
+crate = "crates/intrada-api"
+
+[build]
+assets = ["crates/intrada-web/dist/*"]

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "intrada-api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+intrada-core = { path = "../intrada-core" }
+
+shuttle-runtime = "0.57"
+shuttle-axum = "0.57"
+shuttle-shared-db = { version = "0.57", features = ["postgres", "sqlx"] }
+
+axum = "0.8"
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
+tower-http = { version = "0.6", features = ["fs"] }
+tokio = { version = "1", features = ["macros"] }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+ulid = { workspace = true }
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/intrada-api/migrations/001_create_pieces.sql
+++ b/crates/intrada-api/migrations/001_create_pieces.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS pieces (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    composer TEXT NOT NULL,
+    key TEXT,
+    tempo_marking TEXT,
+    tempo_bpm SMALLINT CHECK (tempo_bpm IS NULL OR (tempo_bpm >= 1 AND tempo_bpm <= 400)),
+    notes TEXT,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);

--- a/crates/intrada-api/migrations/002_create_exercises.sql
+++ b/crates/intrada-api/migrations/002_create_exercises.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS exercises (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    composer TEXT,
+    category TEXT,
+    key TEXT,
+    tempo_marking TEXT,
+    tempo_bpm SMALLINT CHECK (tempo_bpm IS NULL OR (tempo_bpm >= 1 AND tempo_bpm <= 400)),
+    notes TEXT,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);

--- a/crates/intrada-api/migrations/003_create_sessions.sql
+++ b/crates/intrada-api/migrations/003_create_sessions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS practice_sessions (
+    id TEXT PRIMARY KEY,
+    session_notes TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ NOT NULL,
+    total_duration_secs BIGINT NOT NULL CHECK (total_duration_secs >= 0),
+    completion_status TEXT NOT NULL CHECK (completion_status IN ('completed', 'ended_early'))
+);
+
+CREATE TABLE IF NOT EXISTS setlist_entries (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES practice_sessions(id) ON DELETE CASCADE,
+    item_id TEXT NOT NULL,
+    item_title TEXT NOT NULL,
+    item_type TEXT NOT NULL CHECK (item_type IN ('piece', 'exercise')),
+    position INTEGER NOT NULL CHECK (position >= 0),
+    duration_secs BIGINT NOT NULL CHECK (duration_secs >= 0),
+    status TEXT NOT NULL CHECK (status IN ('completed', 'skipped', 'not_attempted')),
+    notes TEXT
+);
+
+CREATE INDEX idx_setlist_entries_session_id ON setlist_entries(session_id);

--- a/crates/intrada-api/src/db/exercises.rs
+++ b/crates/intrada-api/src/db/exercises.rs
@@ -1,0 +1,158 @@
+use chrono::Utc;
+use sqlx::{PgPool, Row};
+
+use intrada_core::{CreateExercise, Exercise, Tempo, UpdateExercise};
+
+use crate::error::ApiError;
+
+pub async fn insert_exercise(pool: &PgPool, input: &CreateExercise) -> Result<Exercise, ApiError> {
+    let id = ulid::Ulid::new().to_string();
+    let now = Utc::now();
+    let (tempo_marking, tempo_bpm) = flatten_tempo(&input.tempo);
+
+    sqlx::query(
+        "INSERT INTO exercises (id, title, composer, category, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+    )
+    .bind(&id)
+    .bind(&input.title)
+    .bind(&input.composer)
+    .bind(&input.category)
+    .bind(&input.key)
+    .bind(&tempo_marking)
+    .bind(tempo_bpm)
+    .bind(&input.notes)
+    .bind(&input.tags)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(Exercise {
+        id,
+        title: input.title.clone(),
+        composer: input.composer.clone(),
+        category: input.category.clone(),
+        key: input.key.clone(),
+        tempo: input.tempo.clone(),
+        notes: input.notes.clone(),
+        tags: input.tags.clone(),
+        created_at: now,
+        updated_at: now,
+    })
+}
+
+pub async fn list_exercises(pool: &PgPool) -> Result<Vec<Exercise>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, title, composer, category, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at
+         FROM exercises ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(row_to_exercise).collect())
+}
+
+pub async fn get_exercise(pool: &PgPool, id: &str) -> Result<Option<Exercise>, ApiError> {
+    let row = sqlx::query(
+        "SELECT id, title, composer, category, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at
+         FROM exercises WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(row_to_exercise))
+}
+
+pub async fn update_exercise(
+    pool: &PgPool,
+    id: &str,
+    input: &UpdateExercise,
+) -> Result<Option<Exercise>, ApiError> {
+    let existing = get_exercise(pool, id).await?;
+    let Some(mut exercise) = existing else {
+        return Ok(None);
+    };
+
+    if let Some(ref title) = input.title {
+        exercise.title = title.clone();
+    }
+    if let Some(ref composer) = input.composer {
+        exercise.composer = composer.clone();
+    }
+    if let Some(ref category) = input.category {
+        exercise.category = category.clone();
+    }
+    if let Some(ref key) = input.key {
+        exercise.key = key.clone();
+    }
+    if let Some(ref tempo) = input.tempo {
+        exercise.tempo = tempo.clone();
+    }
+    if let Some(ref notes) = input.notes {
+        exercise.notes = notes.clone();
+    }
+    if let Some(ref tags) = input.tags {
+        exercise.tags = tags.clone();
+    }
+    exercise.updated_at = Utc::now();
+
+    let (tempo_marking, tempo_bpm) = flatten_tempo(&exercise.tempo);
+
+    sqlx::query(
+        "UPDATE exercises
+         SET title = $2, composer = $3, category = $4, key = $5, tempo_marking = $6, tempo_bpm = $7,
+             notes = $8, tags = $9, updated_at = $10
+         WHERE id = $1",
+    )
+    .bind(&exercise.id)
+    .bind(&exercise.title)
+    .bind(&exercise.composer)
+    .bind(&exercise.category)
+    .bind(&exercise.key)
+    .bind(&tempo_marking)
+    .bind(tempo_bpm)
+    .bind(&exercise.notes)
+    .bind(&exercise.tags)
+    .bind(exercise.updated_at)
+    .execute(pool)
+    .await?;
+
+    Ok(Some(exercise))
+}
+
+pub async fn delete_exercise(pool: &PgPool, id: &str) -> Result<bool, ApiError> {
+    let result = sqlx::query("DELETE FROM exercises WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+fn row_to_exercise(row: sqlx::postgres::PgRow) -> Exercise {
+    let tempo_marking: Option<String> = row.get("tempo_marking");
+    let tempo_bpm: Option<i16> = row.get("tempo_bpm");
+    let tags: Vec<String> = row.get("tags");
+
+    Exercise {
+        id: row.get("id"),
+        title: row.get("title"),
+        composer: row.get("composer"),
+        category: row.get("category"),
+        key: row.get("key"),
+        tempo: Tempo::from_parts(tempo_marking, tempo_bpm.map(|v| v as u16)),
+        notes: row.get("notes"),
+        tags,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn flatten_tempo(tempo: &Option<Tempo>) -> (Option<String>, Option<i16>) {
+    match tempo {
+        Some(t) => (t.marking.clone(), t.bpm.map(|b| b as i16)),
+        None => (None, None),
+    }
+}

--- a/crates/intrada-api/src/db/mod.rs
+++ b/crates/intrada-api/src/db/mod.rs
@@ -1,0 +1,2 @@
+pub mod exercises;
+pub mod pieces;

--- a/crates/intrada-api/src/db/pieces.rs
+++ b/crates/intrada-api/src/db/pieces.rs
@@ -1,0 +1,151 @@
+use chrono::Utc;
+use sqlx::{PgPool, Row};
+
+use intrada_core::{CreatePiece, Piece, Tempo, UpdatePiece};
+
+use crate::error::ApiError;
+
+pub async fn insert_piece(pool: &PgPool, input: &CreatePiece) -> Result<Piece, ApiError> {
+    let id = ulid::Ulid::new().to_string();
+    let now = Utc::now();
+    let (tempo_marking, tempo_bpm) = flatten_tempo(&input.tempo);
+
+    sqlx::query(
+        "INSERT INTO pieces (id, title, composer, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(&id)
+    .bind(&input.title)
+    .bind(&input.composer)
+    .bind(&input.key)
+    .bind(&tempo_marking)
+    .bind(tempo_bpm)
+    .bind(&input.notes)
+    .bind(&input.tags)
+    .bind(now)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok(Piece {
+        id,
+        title: input.title.clone(),
+        composer: input.composer.clone(),
+        key: input.key.clone(),
+        tempo: input.tempo.clone(),
+        notes: input.notes.clone(),
+        tags: input.tags.clone(),
+        created_at: now,
+        updated_at: now,
+    })
+}
+
+pub async fn list_pieces(pool: &PgPool) -> Result<Vec<Piece>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, title, composer, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at
+         FROM pieces ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(row_to_piece).collect())
+}
+
+pub async fn get_piece(pool: &PgPool, id: &str) -> Result<Option<Piece>, ApiError> {
+    let row = sqlx::query(
+        "SELECT id, title, composer, key, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at
+         FROM pieces WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(row_to_piece))
+}
+
+pub async fn update_piece(
+    pool: &PgPool,
+    id: &str,
+    input: &UpdatePiece,
+) -> Result<Option<Piece>, ApiError> {
+    let existing = get_piece(pool, id).await?;
+    let Some(mut piece) = existing else {
+        return Ok(None);
+    };
+
+    if let Some(ref title) = input.title {
+        piece.title = title.clone();
+    }
+    if let Some(ref composer) = input.composer {
+        piece.composer = composer.clone();
+    }
+    if let Some(ref key) = input.key {
+        piece.key = key.clone();
+    }
+    if let Some(ref tempo) = input.tempo {
+        piece.tempo = tempo.clone();
+    }
+    if let Some(ref notes) = input.notes {
+        piece.notes = notes.clone();
+    }
+    if let Some(ref tags) = input.tags {
+        piece.tags = tags.clone();
+    }
+    piece.updated_at = Utc::now();
+
+    let (tempo_marking, tempo_bpm) = flatten_tempo(&piece.tempo);
+
+    sqlx::query(
+        "UPDATE pieces
+         SET title = $2, composer = $3, key = $4, tempo_marking = $5, tempo_bpm = $6,
+             notes = $7, tags = $8, updated_at = $9
+         WHERE id = $1",
+    )
+    .bind(&piece.id)
+    .bind(&piece.title)
+    .bind(&piece.composer)
+    .bind(&piece.key)
+    .bind(&tempo_marking)
+    .bind(tempo_bpm)
+    .bind(&piece.notes)
+    .bind(&piece.tags)
+    .bind(piece.updated_at)
+    .execute(pool)
+    .await?;
+
+    Ok(Some(piece))
+}
+
+pub async fn delete_piece(pool: &PgPool, id: &str) -> Result<bool, ApiError> {
+    let result = sqlx::query("DELETE FROM pieces WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+fn row_to_piece(row: sqlx::postgres::PgRow) -> Piece {
+    let tempo_marking: Option<String> = row.get("tempo_marking");
+    let tempo_bpm: Option<i16> = row.get("tempo_bpm");
+    let tags: Vec<String> = row.get("tags");
+
+    Piece {
+        id: row.get("id"),
+        title: row.get("title"),
+        composer: row.get("composer"),
+        key: row.get("key"),
+        tempo: Tempo::from_parts(tempo_marking, tempo_bpm.map(|v| v as u16)),
+        notes: row.get("notes"),
+        tags,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn flatten_tempo(tempo: &Option<Tempo>) -> (Option<String>, Option<i16>) {
+    match tempo {
+        Some(t) => (t.marking.clone(), t.bpm.map(|b| b as i16)),
+        None => (None, None),
+    }
+}

--- a/crates/intrada-api/src/error.rs
+++ b/crates/intrada-api/src/error.rs
@@ -1,0 +1,45 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use intrada_core::LibraryError;
+use serde_json::json;
+
+#[derive(Debug)]
+pub enum ApiError {
+    Validation(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            ApiError::Validation(msg) => (StatusCode::BAD_REQUEST, msg),
+            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
+            ApiError::Internal(msg) => {
+                tracing::error!("Internal error: {msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
+            }
+        };
+
+        let body = axum::Json(json!({ "error": message }));
+        (status, body).into_response()
+    }
+}
+
+impl From<LibraryError> for ApiError {
+    fn from(err: LibraryError) -> Self {
+        match err {
+            LibraryError::Validation { message, .. } => ApiError::Validation(message),
+            LibraryError::NotFound { id } => ApiError::NotFound(format!("Item not found: {id}")),
+        }
+    }
+}
+
+impl From<sqlx::Error> for ApiError {
+    fn from(err: sqlx::Error) -> Self {
+        ApiError::Internal(err.to_string())
+    }
+}

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -1,0 +1,20 @@
+mod db;
+mod error;
+mod routes;
+mod state;
+
+use sqlx::PgPool;
+use state::AppState;
+
+#[shuttle_runtime::main]
+async fn main(#[shuttle_shared_db::Postgres] pool: PgPool) -> shuttle_axum::ShuttleAxum {
+    sqlx::migrate!()
+        .run(&pool)
+        .await
+        .expect("Failed to run database migrations");
+
+    let state = AppState::new(pool);
+    let router = routes::api_router(state);
+
+    Ok(router.into())
+}

--- a/crates/intrada-api/src/routes/exercises.rs
+++ b/crates/intrada-api/src/routes/exercises.rs
@@ -1,0 +1,72 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+
+use intrada_core::{CreateExercise, Exercise, UpdateExercise};
+
+use crate::db;
+use crate::error::ApiError;
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_exercises).post(create_exercise))
+        .route(
+            "/{id}",
+            get(get_exercise)
+                .put(update_exercise)
+                .delete(delete_exercise),
+        )
+}
+
+async fn list_exercises(State(state): State<AppState>) -> Result<Json<Vec<Exercise>>, ApiError> {
+    let exercises = db::exercises::list_exercises(&state.pool).await?;
+    Ok(Json(exercises))
+}
+
+async fn get_exercise(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Exercise>, ApiError> {
+    let exercise = db::exercises::get_exercise(&state.pool, &id).await?;
+    match exercise {
+        Some(e) => Ok(Json(e)),
+        None => Err(ApiError::NotFound(format!("Exercise not found: {id}"))),
+    }
+}
+
+async fn create_exercise(
+    State(state): State<AppState>,
+    Json(input): Json<CreateExercise>,
+) -> Result<(StatusCode, Json<Exercise>), ApiError> {
+    intrada_core::validation::validate_create_exercise(&input)?;
+    let exercise = db::exercises::insert_exercise(&state.pool, &input).await?;
+    Ok((StatusCode::CREATED, Json(exercise)))
+}
+
+async fn update_exercise(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(input): Json<UpdateExercise>,
+) -> Result<Json<Exercise>, ApiError> {
+    intrada_core::validation::validate_update_exercise(&input)?;
+    let exercise = db::exercises::update_exercise(&state.pool, &id, &input).await?;
+    match exercise {
+        Some(e) => Ok(Json(e)),
+        None => Err(ApiError::NotFound(format!("Exercise not found: {id}"))),
+    }
+}
+
+async fn delete_exercise(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let deleted = db::exercises::delete_exercise(&state.pool, &id).await?;
+    if deleted {
+        Ok(Json(json!({ "message": "Exercise deleted" })))
+    } else {
+        Err(ApiError::NotFound(format!("Exercise not found: {id}")))
+    }
+}

--- a/crates/intrada-api/src/routes/health.rs
+++ b/crates/intrada-api/src/routes/health.rs
@@ -1,0 +1,13 @@
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/health", get(health_check))
+}
+
+async fn health_check() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -1,0 +1,18 @@
+mod exercises;
+mod health;
+mod pieces;
+
+use axum::Router;
+
+use crate::state::AppState;
+
+pub fn api_router(state: AppState) -> Router {
+    Router::new().nest("/api", api_routes()).with_state(state)
+}
+
+fn api_routes() -> Router<AppState> {
+    Router::new()
+        .merge(health::router())
+        .nest("/pieces", pieces::router())
+        .nest("/exercises", exercises::router())
+}

--- a/crates/intrada-api/src/routes/pieces.rs
+++ b/crates/intrada-api/src/routes/pieces.rs
@@ -1,0 +1,70 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+
+use intrada_core::{CreatePiece, Piece, UpdatePiece};
+
+use crate::db;
+use crate::error::ApiError;
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_pieces).post(create_piece))
+        .route(
+            "/{id}",
+            get(get_piece).put(update_piece).delete(delete_piece),
+        )
+}
+
+async fn list_pieces(State(state): State<AppState>) -> Result<Json<Vec<Piece>>, ApiError> {
+    let pieces = db::pieces::list_pieces(&state.pool).await?;
+    Ok(Json(pieces))
+}
+
+async fn get_piece(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Piece>, ApiError> {
+    let piece = db::pieces::get_piece(&state.pool, &id).await?;
+    match piece {
+        Some(p) => Ok(Json(p)),
+        None => Err(ApiError::NotFound(format!("Piece not found: {id}"))),
+    }
+}
+
+async fn create_piece(
+    State(state): State<AppState>,
+    Json(input): Json<CreatePiece>,
+) -> Result<(StatusCode, Json<Piece>), ApiError> {
+    intrada_core::validation::validate_create_piece(&input)?;
+    let piece = db::pieces::insert_piece(&state.pool, &input).await?;
+    Ok((StatusCode::CREATED, Json(piece)))
+}
+
+async fn update_piece(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(input): Json<UpdatePiece>,
+) -> Result<Json<Piece>, ApiError> {
+    intrada_core::validation::validate_update_piece(&input)?;
+    let piece = db::pieces::update_piece(&state.pool, &id, &input).await?;
+    match piece {
+        Some(p) => Ok(Json(p)),
+        None => Err(ApiError::NotFound(format!("Piece not found: {id}"))),
+    }
+}
+
+async fn delete_piece(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let deleted = db::pieces::delete_piece(&state.pool, &id).await?;
+    if deleted {
+        Ok(Json(json!({ "message": "Piece deleted" })))
+    } else {
+        Err(ApiError::NotFound(format!("Piece not found: {id}")))
+    }
+}

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -1,0 +1,12 @@
+use sqlx::PgPool;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: PgPool,
+}
+
+impl AppState {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}

--- a/specs/017-shuttle-api-deploy/checklists/requirements.md
+++ b/specs/017-shuttle-api-deploy/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Shuttle API Server & Database
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Database engine choice (Turso/LibSQL vs Shuttle Postgres) is intentionally deferred to the planning phase — this is documented in Assumptions and does not require clarification at the spec level.
+- Auth and offline-first sync are explicitly out of scope, documented in Assumptions as features 019 and 018 respectively.
+- All 16 checklist items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/017-shuttle-api-deploy/contracts/api.md
+++ b/specs/017-shuttle-api-deploy/contracts/api.md
@@ -1,0 +1,364 @@
+# API Contracts: Shuttle API Server
+
+**Feature**: 017-shuttle-api-deploy
+**Date**: 2026-02-15
+**Base URL**: `https://<app-name>.shuttleapp.rs`
+
+## Common Patterns
+
+### Content Type
+All API requests and responses use `Content-Type: application/json`.
+
+### Error Response Format
+All error responses follow a consistent shape:
+```json
+{
+  "error": "Human-readable error message"
+}
+```
+
+### Status Codes
+| Code | Meaning |
+|------|---------|
+| 200 | Success (read, update, delete) |
+| 201 | Created (new resource) |
+| 400 | Validation error (invalid input) |
+| 404 | Resource not found |
+| 500 | Internal server error |
+
+### ID Format
+All resource IDs are ULIDs (26-character, lexicographically sortable strings), generated server-side on creation.
+
+---
+
+## Health Check
+
+### `GET /api/health`
+
+Returns server health status.
+
+**Response** `200 OK`:
+```json
+{
+  "status": "ok"
+}
+```
+
+---
+
+## Pieces
+
+### `GET /api/pieces`
+
+List all pieces. Returns an array sorted by `created_at` descending (newest first).
+
+**Response** `200 OK`:
+```json
+[
+  {
+    "id": "01HQXYZ...",
+    "title": "Moonlight Sonata",
+    "composer": "Beethoven",
+    "key": "C# minor",
+    "tempo": {
+      "marking": "Adagio sostenuto",
+      "bpm": 52
+    },
+    "notes": "Focus on dynamics in the first movement",
+    "tags": ["classical", "sonata"],
+    "created_at": "2026-02-15T10:30:00Z",
+    "updated_at": "2026-02-15T10:30:00Z"
+  }
+]
+```
+
+### `GET /api/pieces/{id}`
+
+Get a single piece by ID.
+
+**Response** `200 OK`: Single piece object (same shape as array element above).
+
+**Response** `404 Not Found`:
+```json
+{
+  "error": "Piece not found: 01HQXYZ..."
+}
+```
+
+### `POST /api/pieces`
+
+Create a new piece. Server generates `id`, `created_at`, and `updated_at`.
+
+**Request Body** (maps to `CreatePiece`):
+```json
+{
+  "title": "Moonlight Sonata",
+  "composer": "Beethoven",
+  "key": "C# minor",
+  "tempo": {
+    "marking": "Adagio sostenuto",
+    "bpm": 52
+  },
+  "notes": "Focus on dynamics",
+  "tags": ["classical", "sonata"]
+}
+```
+
+**Required fields**: `title`, `composer`
+**Optional fields**: `key`, `tempo`, `notes`, `tags` (defaults to `[]`)
+
+**Response** `201 Created`: The created piece object with server-generated fields.
+
+**Response** `400 Bad Request`:
+```json
+{
+  "error": "Validation failed: title must be between 1 and 500 characters"
+}
+```
+
+### `PUT /api/pieces/{id}`
+
+Update an existing piece. Uses PATCH-style semantics (only provided fields are updated).
+
+**Request Body** (maps to `UpdatePiece`):
+```json
+{
+  "title": "Moonlight Sonata, Op. 27 No. 2",
+  "key": null,
+  "tempo": {
+    "marking": "Adagio sostenuto",
+    "bpm": 54
+  }
+}
+```
+
+**Three-state field semantics** (for optional fields like `key`, `tempo`, `notes`):
+- Field absent from JSON → field is not updated
+- Field present with value → field is set to new value
+- Field present with `null` → field is cleared
+
+**Response** `200 OK`: The updated piece object.
+
+**Response** `400 Bad Request`: Validation error.
+**Response** `404 Not Found`: Piece does not exist.
+
+### `DELETE /api/pieces/{id}`
+
+Delete a piece by ID.
+
+**Response** `200 OK`:
+```json
+{
+  "message": "Piece deleted"
+}
+```
+
+**Response** `404 Not Found`: Piece does not exist.
+
+---
+
+## Exercises
+
+### `GET /api/exercises`
+
+List all exercises. Returns an array sorted by `created_at` descending.
+
+**Response** `200 OK`:
+```json
+[
+  {
+    "id": "01HQABC...",
+    "title": "C Major Scale",
+    "composer": null,
+    "category": "Scales",
+    "key": "C major",
+    "tempo": {
+      "marking": null,
+      "bpm": 120
+    },
+    "notes": null,
+    "tags": ["scales", "technique"],
+    "created_at": "2026-02-15T10:30:00Z",
+    "updated_at": "2026-02-15T10:30:00Z"
+  }
+]
+```
+
+### `GET /api/exercises/{id}`
+
+Get a single exercise by ID.
+
+**Response** `200 OK`: Single exercise object.
+**Response** `404 Not Found`: Exercise does not exist.
+
+### `POST /api/exercises`
+
+Create a new exercise. Server generates `id`, `created_at`, and `updated_at`.
+
+**Request Body** (maps to `CreateExercise`):
+```json
+{
+  "title": "C Major Scale",
+  "composer": null,
+  "category": "Scales",
+  "key": "C major",
+  "tempo": {
+    "bpm": 120
+  },
+  "notes": null,
+  "tags": ["scales"]
+}
+```
+
+**Required fields**: `title`
+**Optional fields**: `composer`, `category`, `key`, `tempo`, `notes`, `tags` (defaults to `[]`)
+
+**Response** `201 Created`: The created exercise object.
+**Response** `400 Bad Request`: Validation error.
+
+### `PUT /api/exercises/{id}`
+
+Update an existing exercise. Same three-state PATCH semantics as pieces.
+
+**Request Body** (maps to `UpdateExercise`):
+```json
+{
+  "title": "C Major Scale (2 octaves)",
+  "category": null
+}
+```
+
+**Response** `200 OK`: The updated exercise object.
+**Response** `400 Bad Request`: Validation error.
+**Response** `404 Not Found`: Exercise does not exist.
+
+### `DELETE /api/exercises/{id}`
+
+Delete an exercise by ID.
+
+**Response** `200 OK`:
+```json
+{
+  "message": "Exercise deleted"
+}
+```
+
+**Response** `404 Not Found`: Exercise does not exist.
+
+---
+
+## Practice Sessions
+
+Sessions are **immutable once saved** — create and read only (no update or delete endpoints per FR-005).
+
+### `GET /api/sessions`
+
+List all practice sessions. Returns an array sorted by `completed_at` descending (most recent first).
+
+**Response** `200 OK`:
+```json
+[
+  {
+    "id": "01HQDEF...",
+    "entries": [
+      {
+        "id": "01HQGHI...",
+        "item_id": "01HQXYZ...",
+        "item_title": "Moonlight Sonata",
+        "item_type": "piece",
+        "position": 0,
+        "duration_secs": 1200,
+        "status": "completed",
+        "notes": "Good tempo control"
+      },
+      {
+        "id": "01HQJKL...",
+        "item_id": "01HQABC...",
+        "item_title": "C Major Scale",
+        "item_type": "exercise",
+        "position": 1,
+        "duration_secs": 300,
+        "status": "completed",
+        "notes": null
+      }
+    ],
+    "session_notes": "Focused session, good progress",
+    "started_at": "2026-02-15T09:00:00Z",
+    "completed_at": "2026-02-15T09:25:00Z",
+    "total_duration_secs": 1500,
+    "completion_status": "completed"
+  }
+]
+```
+
+### `GET /api/sessions/{id}`
+
+Get a single session by ID, including all setlist entries.
+
+**Response** `200 OK`: Single session object (same shape as array element above).
+**Response** `404 Not Found`: Session does not exist.
+
+### `POST /api/sessions`
+
+Save a completed practice session. The client sends the full session object (id, entries, timestamps generated client-side during the practice flow). The server validates and persists it.
+
+**Request Body** (maps to `PracticeSession`):
+```json
+{
+  "id": "01HQDEF...",
+  "entries": [
+    {
+      "id": "01HQGHI...",
+      "item_id": "01HQXYZ...",
+      "item_title": "Moonlight Sonata",
+      "item_type": "piece",
+      "position": 0,
+      "duration_secs": 1200,
+      "status": "completed",
+      "notes": "Good tempo control"
+    }
+  ],
+  "session_notes": "Focused session",
+  "started_at": "2026-02-15T09:00:00Z",
+  "completed_at": "2026-02-15T09:25:00Z",
+  "total_duration_secs": 1500,
+  "completion_status": "completed"
+}
+```
+
+**Validation**:
+- `entries` must have at least one entry (`validate_setlist_not_empty`)
+- `session_notes` max 5000 chars (`validate_session_notes`)
+- Each entry `notes` max 5000 chars (`validate_entry_notes`)
+- `completion_status` must be "completed" or "ended_early"
+- Each entry `status` must be "completed", "skipped", or "not_attempted"
+- Each entry `item_type` must be "piece" or "exercise"
+
+**Response** `201 Created`: The saved session object.
+**Response** `400 Bad Request`: Validation error.
+
+---
+
+## Web Shell API Integration
+
+### Data Flow
+
+1. **App loads**: Read localStorage cache → render immediately → fetch from API in background
+2. **API response arrives**: Update UI with fresh data → write to localStorage cache
+3. **User creates/edits/deletes**: Send API request → on success, update UI + localStorage cache
+4. **API error on write**: Show error message → keep local state intact → do not clear user input
+
+### localStorage Keys
+
+| Key | Content | Purpose |
+|-----|---------|---------|
+| `intrada:library` | `LibraryData` JSON | Cache of pieces + exercises |
+| `intrada:sessions` | `SessionsData` JSON | Cache of completed sessions |
+| `intrada:session-in-progress` | `ActiveSession` JSON | Crash recovery (localStorage-only, not sent to API) |
+
+### Cache Strategy
+
+- **Read**: localStorage first, then API fetch in background
+- **Write**: API first, then update localStorage on success
+- **Conflict**: Server is source of truth; background fetch replaces stale cache
+- **Offline**: Display cached data + show stale-data warning; writes fail with error message

--- a/specs/017-shuttle-api-deploy/data-model.md
+++ b/specs/017-shuttle-api-deploy/data-model.md
@@ -1,0 +1,206 @@
+# Data Model: Shuttle API Server & Database
+
+**Feature**: 017-shuttle-api-deploy
+**Date**: 2026-02-15
+**Source**: Domain types in `intrada-core/src/domain/`
+
+## Entity Relationship Diagram
+
+```text
+┌──────────────┐     ┌───────────────────┐
+│    pieces     │     │     exercises      │
+├──────────────┤     ├───────────────────┤
+│ id (PK)      │     │ id (PK)           │
+│ title        │     │ title             │
+│ composer     │     │ composer          │
+│ key          │     │ category          │
+│ tempo_marking│     │ key               │
+│ tempo_bpm    │     │ tempo_marking     │
+│ notes        │     │ tempo_bpm         │
+│ tags         │     │ notes             │
+│ created_at   │     │ tags              │
+│ updated_at   │     │ created_at        │
+└──────────────┘     │ updated_at        │
+                     └───────────────────┘
+
+┌───────────────────┐     ┌────────────────────┐
+│ practice_sessions │     │  setlist_entries    │
+├───────────────────┤     ├────────────────────┤
+│ id (PK)           │◄────│ session_id (FK)    │
+│ session_notes     │     │ id (PK)            │
+│ started_at        │     │ item_id            │
+│ completed_at      │     │ item_title         │
+│ total_duration_s  │     │ item_type          │
+│ completion_status │     │ position           │
+└───────────────────┘     │ duration_secs      │
+                          │ status             │
+                          │ notes              │
+                          └────────────────────┘
+```
+
+## Tables
+
+### `pieces`
+
+Maps to `intrada_core::Piece`. Composer is required for pieces.
+
+| Column | Type | Nullable | Constraints | Notes |
+|--------|------|----------|-------------|-------|
+| `id` | `TEXT` | NOT NULL | PRIMARY KEY | ULID string |
+| `title` | `TEXT` | NOT NULL | 1-500 chars | Validated by `validate_create_piece` |
+| `composer` | `TEXT` | NOT NULL | 1-200 chars | Required for pieces |
+| `key` | `TEXT` | NULL | | Musical key (e.g., "C major") |
+| `tempo_marking` | `TEXT` | NULL | | e.g., "Allegro" (max 100 chars) |
+| `tempo_bpm` | `SMALLINT` | NULL | 1-400 | Beats per minute |
+| `notes` | `TEXT` | NULL | max 5000 chars | Free-form notes |
+| `tags` | `TEXT[]` | NOT NULL | DEFAULT '{}' | Array of tag strings (each max 100 chars) |
+| `created_at` | `TIMESTAMPTZ` | NOT NULL | | UTC timestamp |
+| `updated_at` | `TIMESTAMPTZ` | NOT NULL | | UTC timestamp |
+
+**Design note**: The `Tempo` struct from core has two optional fields (`marking` and `bpm`). These are stored as two separate columns rather than a JSONB column, for queryability and simplicity. When both are NULL, the application interprets this as "no tempo set" (matching `Option<Tempo>` = `None`).
+
+### `exercises`
+
+Maps to `intrada_core::Exercise`. Composer is optional for exercises.
+
+| Column | Type | Nullable | Constraints | Notes |
+|--------|------|----------|-------------|-------|
+| `id` | `TEXT` | NOT NULL | PRIMARY KEY | ULID string |
+| `title` | `TEXT` | NOT NULL | 1-500 chars | Validated by `validate_create_exercise` |
+| `composer` | `TEXT` | NULL | 1-200 chars | Optional for exercises |
+| `category` | `TEXT` | NULL | 1-100 chars | e.g., "Scales", "Arpeggios" |
+| `key` | `TEXT` | NULL | | Musical key |
+| `tempo_marking` | `TEXT` | NULL | max 100 chars | e.g., "Andante" |
+| `tempo_bpm` | `SMALLINT` | NULL | 1-400 | Beats per minute |
+| `notes` | `TEXT` | NULL | max 5000 chars | Free-form notes |
+| `tags` | `TEXT[]` | NOT NULL | DEFAULT '{}' | Array of tag strings |
+| `created_at` | `TIMESTAMPTZ` | NOT NULL | | UTC timestamp |
+| `updated_at` | `TIMESTAMPTZ` | NOT NULL | | UTC timestamp |
+
+### `practice_sessions`
+
+Maps to `intrada_core::PracticeSession`. Immutable once saved (no update/delete endpoints per spec FR-005).
+
+| Column | Type | Nullable | Constraints | Notes |
+|--------|------|----------|-------------|-------|
+| `id` | `TEXT` | NOT NULL | PRIMARY KEY | ULID string |
+| `session_notes` | `TEXT` | NULL | max 5000 chars | Overall session notes |
+| `started_at` | `TIMESTAMPTZ` | NOT NULL | | When the session began |
+| `completed_at` | `TIMESTAMPTZ` | NOT NULL | | When the session ended |
+| `total_duration_secs` | `BIGINT` | NOT NULL | >= 0 | Total active practice time |
+| `completion_status` | `TEXT` | NOT NULL | 'completed' or 'ended_early' | Maps to `CompletionStatus` enum |
+
+### `setlist_entries`
+
+Maps to `intrada_core::SetlistEntry`. Child of `practice_sessions`.
+
+| Column | Type | Nullable | Constraints | Notes |
+|--------|------|----------|-------------|-------|
+| `id` | `TEXT` | NOT NULL | PRIMARY KEY | ULID string |
+| `session_id` | `TEXT` | NOT NULL | FK → practice_sessions.id, ON DELETE CASCADE | Parent session |
+| `item_id` | `TEXT` | NOT NULL | | Reference to piece/exercise ID |
+| `item_title` | `TEXT` | NOT NULL | | Snapshot of item title at practice time |
+| `item_type` | `TEXT` | NOT NULL | 'piece' or 'exercise' | Item type discriminator |
+| `position` | `INTEGER` | NOT NULL | >= 0 | Order within the setlist |
+| `duration_secs` | `BIGINT` | NOT NULL | >= 0 | Time spent on this item |
+| `status` | `TEXT` | NOT NULL | 'completed', 'skipped', or 'not_attempted' | Maps to `EntryStatus` enum |
+| `notes` | `TEXT` | NULL | max 5000 chars | Per-entry practice notes |
+
+**Ordering**: Entries within a session are ordered by `position` (set during session creation, immutable after save).
+
+## SQL Migrations
+
+### 001_create_pieces.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS pieces (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    composer TEXT NOT NULL,
+    key TEXT,
+    tempo_marking TEXT,
+    tempo_bpm SMALLINT CHECK (tempo_bpm IS NULL OR (tempo_bpm >= 1 AND tempo_bpm <= 400)),
+    notes TEXT,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+```
+
+### 002_create_exercises.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS exercises (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    composer TEXT,
+    category TEXT,
+    key TEXT,
+    tempo_marking TEXT,
+    tempo_bpm SMALLINT CHECK (tempo_bpm IS NULL OR (tempo_bpm >= 1 AND tempo_bpm <= 400)),
+    notes TEXT,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+```
+
+### 003_create_sessions.sql
+
+```sql
+CREATE TABLE IF NOT EXISTS practice_sessions (
+    id TEXT PRIMARY KEY,
+    session_notes TEXT,
+    started_at TIMESTAMPTZ NOT NULL,
+    completed_at TIMESTAMPTZ NOT NULL,
+    total_duration_secs BIGINT NOT NULL CHECK (total_duration_secs >= 0),
+    completion_status TEXT NOT NULL CHECK (completion_status IN ('completed', 'ended_early'))
+);
+
+CREATE TABLE IF NOT EXISTS setlist_entries (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES practice_sessions(id) ON DELETE CASCADE,
+    item_id TEXT NOT NULL,
+    item_title TEXT NOT NULL,
+    item_type TEXT NOT NULL CHECK (item_type IN ('piece', 'exercise')),
+    position INTEGER NOT NULL CHECK (position >= 0),
+    duration_secs BIGINT NOT NULL CHECK (duration_secs >= 0),
+    status TEXT NOT NULL CHECK (status IN ('completed', 'skipped', 'not_attempted')),
+    notes TEXT
+);
+
+CREATE INDEX idx_setlist_entries_session_id ON setlist_entries(session_id);
+```
+
+## Type Mapping: Rust ↔ Postgres
+
+| Rust Type | Postgres Type | Conversion Notes |
+|-----------|--------------|------------------|
+| `String` (ULID) | `TEXT` | Stored as string, generated by server |
+| `String` | `TEXT` | Direct mapping |
+| `Option<String>` | `TEXT` (nullable) | `None` → SQL NULL |
+| `Option<Tempo>` | `TEXT` + `SMALLINT` (nullable cols) | Flattened to `tempo_marking` + `tempo_bpm`; both NULL = None |
+| `Vec<String>` (tags) | `TEXT[]` | Postgres array; empty = `'{}'` |
+| `DateTime<Utc>` | `TIMESTAMPTZ` | sqlx handles chrono ↔ TIMESTAMPTZ automatically |
+| `u64` (duration) | `BIGINT` | Rust u64 fits in Postgres BIGINT |
+| `usize` (position) | `INTEGER` | Position values are small |
+| `EntryStatus` enum | `TEXT` | Stored as lowercase string ('completed', 'skipped', 'not_attempted') |
+| `CompletionStatus` enum | `TEXT` | Stored as lowercase string ('completed', 'ended_early') |
+| `Option<u16>` (BPM) | `SMALLINT` (nullable) | sqlx handles Option mapping |
+
+## Validation Rules (from intrada-core)
+
+All validation is performed server-side by calling `intrada_core::validation::*` functions before database writes. The same validation runs client-side in the Crux core.
+
+| Field | Rule | Constant |
+|-------|------|----------|
+| title | 1-500 characters | `MAX_TITLE = 500` |
+| composer | 1-200 characters | `MAX_COMPOSER = 200` |
+| category | 1-100 characters | `MAX_CATEGORY = 100` |
+| notes | 0-5000 characters | `MAX_NOTES = 5000` |
+| tag (each) | 1-100 characters | `MAX_TAG = 100` |
+| tempo_marking | 0-100 characters | `MAX_TEMPO_MARKING = 100` |
+| BPM | 1-400 | `MIN_BPM = 1`, `MAX_BPM = 400` |
+| session_notes | 0-5000 characters | `MAX_NOTES = 5000` |
+| entry_notes | 0-5000 characters | `MAX_NOTES = 5000` |
+| setlist entries | at least 1 entry | `validate_setlist_not_empty` |

--- a/specs/017-shuttle-api-deploy/plan.md
+++ b/specs/017-shuttle-api-deploy/plan.md
@@ -1,0 +1,128 @@
+# Implementation Plan: Shuttle API Server & Database
+
+**Branch**: `017-shuttle-api-deploy` | **Date**: 2026-02-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/017-shuttle-api-deploy/spec.md`
+
+## Summary
+
+Deploy the Intrada web app to Shuttle.rs with an Axum API server that serves the compiled WASM build as static files and provides REST CRUD endpoints for library items (pieces, exercises) and practice sessions. Data is persisted in Shuttle-managed Postgres via `shuttle-shared-db`. The web shell switches from localStorage-only persistence to API calls as the primary data source, keeping localStorage as a read cache for fast initial loads. The Crux core (`intrada-core`) remains untouched — only the web shell's storage layer changes. Single-user, no auth (auth deferred to feature 019).
+
+## Technical Context
+
+**Language/Version**: Rust stable (1.75+ workspace minimum; axum 0.8 requires 1.78+)
+**Primary Dependencies**: shuttle-runtime 0.57, shuttle-axum 0.57, axum 0.8, sqlx 0.8 (Postgres), tower-http 0.6 (fs), intrada-core (workspace)
+**Storage**: Shuttle-managed Postgres via `shuttle-shared-db` (zero-config, auto-provisioned)
+**Testing**: `cargo test` (unit + integration), contract tests for API endpoints, existing E2E tests (Playwright)
+**Target Platform**: Shuttle.rs (Linux container) for server; WASM (browser) for frontend
+**Project Type**: Web application (API server + WASM frontend served from same origin)
+**Performance Goals**: API response < 200ms, cached data display < 500ms, full page load < 5s
+**Constraints**: Single-user, no auth, no offline write queuing, free tier (0.5 GB DB, 1 GB egress)
+**Scale/Scope**: Single user, ~100s of library items, ~1000s of practice sessions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### I. Architecture Integrity ✅ PASS
+
+- **Pure Core**: `intrada-core` remains unchanged (FR-015). The new server crate imports domain types and validation only — no Crux events, effects, or state machine types.
+- **Shell Isolation**: Web shell changes are confined to the storage/data-access layer in `intrada-web`. The server (`intrada-api`) is a new shell that reuses core types.
+- **Effect-Driven Communication**: Not applicable to the server crate (server is not a Crux shell — it's a REST API that uses core types directly for validation and serialization).
+- **Portable by Design**: `intrada-core` continues to compile and test without WASM or browser dependencies.
+- **Validation Sharing**: Server reuses `intrada-core::validation::*` functions directly (FR-007). No duplication.
+
+### II. Code Quality ✅ PASS
+
+- Single responsibility: server crate handles HTTP/DB; core handles domain logic/validation.
+- Consistent style: `cargo clippy -- -D warnings`, `cargo fmt` applied to new crate.
+- No dead code: only types actually needed by the API are imported from core.
+
+### III. Testing Standards ✅ PASS
+
+- Server API endpoints tested via contract tests (HTTP request/response assertions).
+- Core unit tests (142+) remain unchanged and passing.
+- E2E tests updated to work against API-backed app.
+- Boundary: core↔server boundary tested via validation round-trips in contract tests.
+
+### IV. User Experience Consistency ✅ PASS
+
+- Error messages from API validation use the same `LibraryError` messages as the client.
+- Loading states: web shell shows cached data immediately, then refreshes from server.
+- No visual changes — only data source changes.
+
+### V. Performance Requirements ✅ PASS
+
+- WASM bundle size: no change (server is separate crate).
+- Cached data loads instantly from localStorage (< 500ms target).
+- Server responses expected < 200ms for single-user Postgres queries.
+
+### Post-Design Re-check ✅ PASS
+
+No violations introduced during Phase 1 design. The server crate adds a third workspace member but follows the existing `crates/*` pattern. All types imported from core are public and already exported.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-shuttle-api-deploy/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api.md           # REST API endpoint contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── intrada-core/          # Pure Crux core (unchanged)
+│   └── src/
+│       ├── app.rs
+│       ├── domain/
+│       ├── error.rs
+│       ├── model.rs
+│       └── validation.rs
+├── intrada-web/           # Web shell (Leptos CSR + WASM)
+│   └── src/
+│       ├── app.rs
+│       ├── core_bridge.rs # Modified: API calls + localStorage cache
+│       ├── components/
+│       └── views/
+└── intrada-api/           # NEW: Axum API server for Shuttle
+    ├── Cargo.toml
+    ├── src/
+    │   ├── main.rs        # Shuttle entry point (#[shuttle_runtime::main])
+    │   ├── routes/        # API route handlers
+    │   │   ├── mod.rs
+    │   │   ├── pieces.rs
+    │   │   ├── exercises.rs
+    │   │   ├── sessions.rs
+    │   │   └── health.rs
+    │   ├── db/            # Database access layer (sqlx queries)
+    │   │   ├── mod.rs
+    │   │   ├── pieces.rs
+    │   │   ├── exercises.rs
+    │   │   └── sessions.rs
+    │   ├── error.rs       # ApiError enum (IntoResponse impl)
+    │   └── state.rs       # AppState (PgPool wrapper)
+    └── migrations/        # SQL migrations (sqlx)
+        ├── 001_create_pieces.sql
+        ├── 002_create_exercises.sql
+        └── 003_create_sessions.sql
+
+Shuttle.toml               # NEW: Shuttle project configuration
+.github/workflows/ci.yml   # Modified: add deploy job
+e2e/                       # Existing: Playwright tests (may need config updates)
+```
+
+**Structure Decision**: New `crates/intrada-api/` server crate added to the workspace, following the existing `crates/*` pattern. The server imports `intrada-core` for domain types and validation. The web shell (`intrada-web`) is modified to use API calls instead of direct localStorage writes.
+
+## Complexity Tracking
+
+> No constitution violations to justify. The third workspace crate follows the established pattern and each crate has a clear single responsibility (core logic, web shell, API server).

--- a/specs/017-shuttle-api-deploy/quickstart.md
+++ b/specs/017-shuttle-api-deploy/quickstart.md
@@ -1,0 +1,128 @@
+# Quickstart: Shuttle API Server & Database
+
+**Feature**: 017-shuttle-api-deploy
+**Date**: 2026-02-15
+**Branch**: `017-shuttle-api-deploy`
+
+## Prerequisites
+
+- Rust stable (1.78+ for axum 0.8)
+- Docker (for local Shuttle Postgres)
+- `cargo-shuttle` CLI (`cargo install cargo-shuttle`)
+- Trunk (`cargo install trunk`)
+- `wasm32-unknown-unknown` target (`rustup target add wasm32-unknown-unknown`)
+
+## Local Development
+
+### 1. Build the WASM frontend
+
+```bash
+cd crates/intrada-web
+trunk build
+```
+
+This outputs to `crates/intrada-web/dist/`. Copy or symlink to where the API server expects it:
+
+```bash
+cp -r crates/intrada-web/dist crates/intrada-api/dist
+```
+
+### 2. Run the API server locally
+
+```bash
+cd crates/intrada-api
+cargo shuttle run
+```
+
+This will:
+- Start a local Postgres container via Docker
+- Run SQL migrations
+- Serve the API at `http://localhost:8000`
+- Serve the WASM app at `http://localhost:8000/`
+
+### 3. Verify the server is running
+
+```bash
+curl http://localhost:8000/api/health
+# Expected: {"status":"ok"}
+```
+
+## Verification Checklist
+
+Run these checks to confirm the feature is working correctly.
+
+### V1: Server starts and serves WASM app
+- [ ] `cargo shuttle run` starts without errors
+- [ ] Navigate to `http://localhost:8000/` in a browser
+- [ ] The Intrada web app loads and displays the home screen
+- [ ] Refreshing on a deep link (e.g., `/library`) returns the app (SPA routing works)
+
+### V2: Health endpoint
+- [ ] `GET /api/health` returns `{"status":"ok"}` with status 200
+
+### V3: Piece CRUD
+- [ ] `POST /api/pieces` with valid data returns 201 and the created piece
+- [ ] `GET /api/pieces` returns an array including the created piece
+- [ ] `GET /api/pieces/{id}` returns the specific piece
+- [ ] `PUT /api/pieces/{id}` updates the piece and returns 200
+- [ ] `DELETE /api/pieces/{id}` deletes the piece and returns 200
+- [ ] `POST /api/pieces` with empty title returns 400 with validation error
+- [ ] `GET /api/pieces/{nonexistent}` returns 404
+
+### V4: Exercise CRUD
+- [ ] `POST /api/exercises` with valid data returns 201
+- [ ] `GET /api/exercises` returns all exercises
+- [ ] `PUT /api/exercises/{id}` updates successfully
+- [ ] `DELETE /api/exercises/{id}` deletes successfully
+- [ ] Validation errors return 400
+
+### V5: Practice session persistence
+- [ ] `POST /api/sessions` with valid session data returns 201
+- [ ] `GET /api/sessions` returns all saved sessions with entries
+- [ ] `GET /api/sessions/{id}` returns a specific session with entries
+- [ ] Sessions with empty entries list are rejected with 400
+
+### V6: Web app uses API
+- [ ] Create a piece through the web UI → piece appears in library
+- [ ] Clear browser localStorage → reload → piece still appears (fetched from server)
+- [ ] Edit a piece → changes persist across browser clears
+- [ ] Delete a piece → piece is removed from server
+
+### V7: Local cache behaviour
+- [ ] On load, cached data appears before server response (inspect with slow connection or throttling)
+- [ ] After server fetch, UI updates if data differs from cache
+
+### V8: Existing tests pass
+- [ ] `cargo test` in workspace root — all tests pass (142+ unit tests)
+- [ ] `cargo clippy -- -D warnings` — zero warnings
+- [ ] E2E tests pass against the API-backed app (may require test infrastructure updates)
+
+### V9: CI/CD pipeline
+- [ ] CI workflow builds and tests the `intrada-api` crate
+- [ ] Deploy job uses `shuttle-hq/deploy-action@v2`
+- [ ] After merge to main, app is accessible at the Shuttle URL
+
+## Quick API Test Script
+
+```bash
+BASE="http://localhost:8000/api"
+
+# Health
+curl -s "$BASE/health" | jq .
+
+# Create a piece
+curl -s -X POST "$BASE/pieces" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Clair de Lune","composer":"Debussy","tags":["impressionist"]}' | jq .
+
+# List pieces
+curl -s "$BASE/pieces" | jq .
+
+# Create an exercise
+curl -s -X POST "$BASE/exercises" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Hanon No. 1","category":"Technique","tags":["warmup"]}' | jq .
+
+# List exercises
+curl -s "$BASE/exercises" | jq .
+```

--- a/specs/017-shuttle-api-deploy/research.md
+++ b/specs/017-shuttle-api-deploy/research.md
@@ -1,0 +1,132 @@
+# Research: Shuttle API Server & Database
+
+**Feature**: 017-shuttle-api-deploy
+**Date**: 2026-02-15
+**Status**: Complete
+
+## R1: Database Engine Selection
+
+**Decision**: Shuttle-managed Postgres via `shuttle-shared-db`
+
+**Rationale**: Zero-configuration provisioning — add a `#[shuttle_shared_db::Postgres]` parameter annotation and Shuttle auto-provisions a Postgres database on deploy. No external accounts, no token management, no secrets files for the DB connection. Returns a `sqlx::PgPool` directly. Local dev spins up a Docker Postgres container automatically via `cargo shuttle run`.
+
+**Alternatives considered**:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **shuttle-shared-db (Postgres)** ✅ | Zero-config, auto-provisioned, no external accounts, Docker local dev | Tied to Shuttle platform |
+| shuttle-turso (LibSQL) | Edge-hosted SQLite, portable if leaving Shuttle | Requires external Turso account, token management via Secrets.toml, more setup |
+
+**Free tier**: 0.5 GB shared database storage, 1 GB network egress — more than sufficient for a single-user music practice app.
+
+## R2: Web Framework & Static File Serving
+
+**Decision**: Axum 0.8 via `shuttle-axum`, with `tower-http` ServeDir for static WASM files
+
+**Rationale**: Axum is the de facto standard for Rust web APIs and has first-class Shuttle support. The SPA pattern uses `ServeDir::new("dist").fallback(ServeFile::new("dist/index.html"))` as a `fallback_service` on the outer Router, so API routes match first and unmatched paths fall through to the WASM app's client-side router.
+
+**Key versions**:
+- axum 0.8.8 (minimum Rust 1.78)
+- tower-http 0.6.x (compatible with axum 0.8; requires `fs` feature for ServeDir)
+- shuttle-runtime 0.57, shuttle-axum 0.57
+
+**SPA serving pattern**:
+```rust
+let spa = ServeDir::new("dist")
+    .fallback(ServeFile::new("dist/index.html"));
+
+let app = Router::new()
+    .nest("/api", api_router())
+    .fallback_service(spa);
+```
+
+**Key caveats**:
+- axum 0.8 uses `{param}` path syntax (not `:param`)
+- `.fallback()` preserves 200 status (correct for SPA); `.not_found_service()` forces 404 (wrong for SPA)
+- CORS is not needed when WASM app and API are served from same origin
+
+## R3: CI/CD Deployment Pipeline
+
+**Decision**: `shuttle-hq/deploy-action@v2` GitHub Action, triggered on merge to main
+
+**Rationale**: Official Shuttle GitHub Action with simple API key authentication. Integrates into existing CI workflow. Alternative is Shuttle's direct GitHub integration (auto-redeploy on push), but the Action approach gives explicit control over build/test gating.
+
+**Configuration**:
+```yaml
+- uses: shuttle-hq/deploy-action@v2
+  with:
+    shuttle-api-key: ${{ secrets.SHUTTLE_API_KEY }}
+    project-id: "proj_XXXXXXXXXXXX"
+```
+
+**Secrets required**: `SHUTTLE_API_KEY` stored in GitHub repository secrets.
+
+## R4: Core Type Reusability
+
+**Decision**: Server crate imports `intrada-core` directly — no refactoring needed
+
+**Rationale**: All domain types, DTOs, validation functions, and error types in intrada-core are cleanly separated from Crux. They carry no I/O, no async, no browser dependencies. The server crate can import and use them directly.
+
+**Reusable imports**:
+- Domain types: `Piece`, `Exercise`, `PracticeSession`, `SetlistEntry`, `Tempo`
+- Container types: `LibraryData`, `SessionsData`
+- Request DTOs: `CreatePiece`, `CreateExercise`, `UpdatePiece`, `UpdateExercise`
+- Error type: `LibraryError`
+- Query type: `ListQuery`
+- Validation: all `validate_*` functions and `MAX_*`/`MIN_*` constants
+
+**Not imported** (Crux-coupled): `Event`, `Effect`, `StorageEffect`, `Intrada` app, session state machine types, view model types.
+
+## R5: Error Handling Pattern
+
+**Decision**: Custom `ApiError` enum implementing axum's `IntoResponse`
+
+**Rationale**: Axum requires handlers to always produce a response. The pattern maps domain errors (`LibraryError`) to HTTP status codes and JSON error bodies. Handlers return `Result<impl IntoResponse, ApiError>`.
+
+**Mapping**:
+| Domain Error | HTTP Status | Response |
+|---|---|---|
+| `LibraryError::Validation(msg)` | 400 Bad Request | `{ "error": msg }` |
+| `LibraryError::NotFound(msg)` | 404 Not Found | `{ "error": msg }` |
+| Database/internal errors | 500 Internal Server Error | `{ "error": "Internal server error" }` |
+
+## R6: Project Structure
+
+**Decision**: New `crates/intrada-api/` server crate in the workspace
+
+**Rationale**: Follows the existing workspace pattern (`crates/*`). The server crate depends on `intrada-core` for types and validation, plus Shuttle/Axum/SQLx for the server runtime.
+
+**Dependencies**:
+```toml
+[dependencies]
+intrada-core = { path = "../intrada-core" }
+shuttle-runtime = "0.57"
+shuttle-axum = "0.57"
+shuttle-shared-db = { version = "0.57", features = ["postgres", "sqlx"] }
+axum = "0.8"
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
+tower-http = { version = "0.6", features = ["fs"] }
+tokio = { version = "1", features = ["macros"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+ulid = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+```
+
+## R7: Shuttle.toml & Build Assets
+
+**Decision**: Declare WASM build output as build assets in `Shuttle.toml`
+
+**Rationale**: Shuttle's `[build]` section copies declared assets into the runtime image. The Trunk-built WASM app output (in `dist/`) needs to be available at runtime for `ServeDir` to serve.
+
+**Configuration**:
+```toml
+name = "intrada"
+
+[build]
+assets = ["dist/*"]
+```
+
+**Build order**: Trunk builds the WASM app to `dist/`, then `cargo shuttle deploy` packages the server crate with `dist/` as build assets.

--- a/specs/017-shuttle-api-deploy/spec.md
+++ b/specs/017-shuttle-api-deploy/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Shuttle API Server & Database
+
+**Feature Branch**: `017-shuttle-api-deploy`
+**Created**: 2026-02-15
+**Status**: Draft
+**Input**: User description: "Deploy the Intrada web app to Shuttle.rs. Create an Axum API server that serves the static WASM build and provides REST CRUD endpoints for library items (pieces, exercises) and practice sessions. Choose between Turso (LibSQL) or Shuttle Postgres for the database during planning. Single-user, no auth for now (auth will be a separate follow-up feature). The web app should switch from localStorage to API calls as the primary data source, keeping localStorage as a read cache for fast initial loads. The Crux core remains untouched — only the web shell's storage layer changes. This is feature 017 in the roadmap, followed by 018 (offline-first sync) and 019 (auth)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Server-Persisted Library (Priority: P1)
+
+The user manages their music library (pieces and exercises) through the web app and all data is stored on the server rather than only in the browser. When they add a new piece, edit an exercise, or delete an item, the change is saved to the server's database and survives browser clears, device switches, or incognito sessions.
+
+**Why this priority**: Without server-side persistence the app remains browser-only, which is the core problem this feature solves. Every other story depends on the API and database being available.
+
+**Independent Test**: Can be fully tested by launching the deployed server, opening the web app, creating a piece, closing the browser, reopening it, and confirming the piece is still present.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has the web app open, **When** they add a new piece (title, composer, optional fields), **Then** the piece is saved to the server database and appears in the library list.
+2. **Given** a piece exists in the library, **When** the user edits its title, **Then** the updated title is persisted on the server and reflected in the UI.
+3. **Given** an exercise exists in the library, **When** the user deletes it, **Then** it is removed from the server database and no longer appears in the library list.
+4. **Given** the user has items in their library, **When** they clear browser storage and reload, **Then** all items are fetched from the server and displayed.
+
+---
+
+### User Story 2 — Server-Persisted Practice Sessions (Priority: P2)
+
+Completed practice sessions are saved to the server. The user can view their session history and it persists across browsers and devices.
+
+**Why this priority**: Practice sessions are the second major data type. Storing them server-side gives the user a durable practice log, but the app provides core value (library management) even without this.
+
+**Independent Test**: Can be tested by completing a practice session, verifying it appears in session history, clearing browser storage, and confirming it reloads from the server.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user completes a practice session, **When** the session summary is saved, **Then** the session is persisted to the server database.
+2. **Given** the user has past sessions stored on the server, **When** they view session history, **Then** all sessions are listed with correct dates, durations, and items practised.
+3. **Given** sessions exist on the server, **When** the user opens the app on a different browser, **Then** the full session history is available.
+
+---
+
+### User Story 3 — Static WASM Hosting (Priority: P3)
+
+The server hosts the compiled WASM web app as static files, so users access the app at a single URL without needing a separate CDN or static host.
+
+**Why this priority**: Simplifies deployment to a single service. The app is already functional locally; this story is about making it accessible over the internet.
+
+**Independent Test**: Can be tested by navigating to the deployed URL in a browser and confirming the app loads and renders correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server is running, **When** a user navigates to the root URL, **Then** the WASM app loads and displays the home screen.
+2. **Given** the app uses client-side routing, **When** the user refreshes on a deep link (e.g. `/library/abc123`), **Then** the server returns the app shell and client-side routing resolves the page.
+
+---
+
+### User Story 4 — Local Cache for Fast Loads (Priority: P4)
+
+The web app loads data from localStorage first for instant rendering, then refreshes from the server in the background. This gives the user a fast initial experience without a loading spinner on every page.
+
+**Why this priority**: This is a UX polish layer. The app works correctly without it (by fetching from the server on every load), but the cache makes the experience feel snappy.
+
+**Independent Test**: Can be tested by loading the app with a populated localStorage cache while on a slow connection, confirming data appears immediately, and then verifying the server data replaces it shortly after.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has previously loaded library data, **When** they reopen the app, **Then** cached data appears immediately while the server fetch happens in the background.
+2. **Given** the server has newer data than the local cache, **When** the background fetch completes, **Then** the UI updates to reflect the server's current state.
+3. **Given** the server is unreachable, **When** the app loads with cached data, **Then** the cached data is displayed and the user is informed that the data may be stale.
+
+---
+
+### Edge Cases
+
+- What happens when the server returns an error (500, network timeout) during a save operation? The user should see an error message and the data should not be lost from the local state.
+- What happens when the user submits invalid data (e.g. empty title)? Validation should occur client-side (existing Crux validation) before the API call is made, and the server should also reject invalid data.
+- What happens when the server database is empty on first deployment? The app should show an empty library with no errors.
+- What happens when the user creates items faster than the server can respond? Operations should be sequential per resource — the UI should prevent double submissions.
+- What happens if a delete request fails? The item should remain visible in the UI and an error should be shown.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a hosted server that serves the compiled WASM web application as static files at the root URL.
+- **FR-002**: The server MUST handle client-side routing by returning the app shell (index.html) for all non-API, non-static-asset URL paths.
+- **FR-003**: The system MUST provide REST API endpoints for creating, reading, updating, and deleting pieces.
+- **FR-004**: The system MUST provide REST API endpoints for creating, reading, updating, and deleting exercises.
+- **FR-005**: The system MUST provide REST API endpoints for creating and reading practice sessions (sessions are immutable once completed — no update or delete).
+- **FR-006**: The server MUST persist all data in a relational database.
+- **FR-007**: The server MUST validate all incoming data using the same rules as the client (title 1–500 chars, composer 1–200 chars, notes max 5000 chars, tags max 100 chars each, BPM 1–400, etc.).
+- **FR-008**: The server MUST return appropriate HTTP status codes: 200/201 for success, 400 for validation errors, 404 for not found, 500 for server errors.
+- **FR-009**: The server MUST return JSON responses for all API endpoints.
+- **FR-010**: The web app MUST use API calls as the primary data source for all CRUD operations instead of localStorage alone.
+- **FR-011**: The web app MUST write API responses to localStorage as a read cache so that subsequent page loads can display cached data before the server responds.
+- **FR-012**: The web app MUST fetch fresh data from the server after displaying cached data, and update the UI if the server data differs.
+- **FR-013**: The web app MUST show an error indicator when a server write operation fails, without losing the user's in-progress data.
+- **FR-014**: The system MUST operate as single-user with no authentication or access protection. All API endpoints are publicly accessible. All data belongs to one implicit user. (Auth will be added in feature 019.)
+- **FR-015**: The Crux core logic (intrada-core) MUST remain unchanged. Only the web shell's data access layer changes.
+- **FR-016**: The server MUST be deployable to the Shuttle.rs platform.
+- **FR-017**: The CI pipeline MUST build and test the server crate alongside existing crates.
+- **FR-018**: The CI pipeline MUST automatically deploy the application (WASM build + server) to Shuttle.rs on merge to main, after all tests pass.
+
+### Key Entities
+
+- **Piece**: A musical composition with title (required), composer (required), key, tempo (marking and/or BPM), notes, and tags. Identified by a ULID. Has created/updated timestamps.
+- **Exercise**: A practice exercise with title (required), optional composer, optional category, key, tempo, notes, and tags. Identified by a ULID. Has created/updated timestamps.
+- **PracticeSession**: A completed practice session containing a list of setlist entries, optional session notes, start/end times, total duration, and a completion status (completed or ended early). Identified by a ULID. Immutable once saved.
+- **SetlistEntry**: An individual item within a practice session, referencing a library item by ID and title, with position, duration, status (completed/skipped/not attempted), and optional notes.
+
+## Clarifications
+
+### Session 2026-02-15
+
+- Q: Should the publicly hosted API require any access protection (e.g. shared secret) before auth is added in feature 019? → A: No — fully open. The URL obscurity is sufficient for this phase; auth comes in 019.
+- Q: How should the application be deployed to Shuttle.rs — manually, via CI auto-deploy, or CI-built artifact with manual trigger? → A: CI auto-deploy. The CI pipeline builds the WASM and deploys to Shuttle automatically on merge to main.
+
+## Assumptions
+
+- The database engine (Turso/LibSQL or Shuttle Postgres) will be selected during the planning phase based on Shuttle.rs platform support, cost, and simplicity. This spec is intentionally database-agnostic.
+- No authentication or multi-user support is needed for this feature. Auth will be added in feature 019.
+- Offline write queuing is out of scope — if the server is unreachable during a write, the operation fails with an error. Offline-first sync will be added in feature 018.
+- The in-progress session state (crash recovery data in `intrada:session-in-progress`) remains localStorage-only. Only completed sessions are sent to the server.
+- Existing E2E tests may need minor updates to work against the API-backed app, but the core user flows should remain the same.
+- The WASM build output is embedded into or served alongside the API server as static files — there is no separate CDN or static hosting service.
+- The server does not need to handle high concurrency. Single-user, single-device access is the expected pattern for this phase.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The web app is accessible at a public URL and loads the full WASM application within 5 seconds on a standard broadband connection.
+- **SC-002**: All library CRUD operations (create, read, update, delete for pieces and exercises) round-trip through the server and persist across browser clears.
+- **SC-003**: Completed practice sessions are retrievable from the server after browser storage is cleared.
+- **SC-004**: The app displays cached data within 500 milliseconds of page load, before the server response arrives.
+- **SC-005**: All existing unit tests (142+) continue to pass unchanged (core logic is not modified).
+- **SC-006**: The server validates input and returns 400 errors for invalid data (e.g. empty title, BPM out of range) with a descriptive error message.
+- **SC-007**: All existing E2E user flows (14 tests) pass against the API-backed application (with test infrastructure updates as needed).
+- **SC-008**: Merging to main triggers an automated deployment to Shuttle.rs, and the updated application is accessible at the public URL within minutes.

--- a/specs/017-shuttle-api-deploy/tasks.md
+++ b/specs/017-shuttle-api-deploy/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: Shuttle API Server & Database
+
+**Input**: Design documents from `/specs/017-shuttle-api-deploy/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api.md, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the `intrada-api` crate, configure Shuttle, and set up the workspace
+
+- [ ] T001 Create `crates/intrada-api/` directory and `crates/intrada-api/Cargo.toml` with dependencies: shuttle-runtime 0.57, shuttle-axum 0.57, shuttle-shared-db 0.57 (postgres, sqlx), axum 0.8, sqlx 0.8 (runtime-tokio, postgres, chrono), tower-http 0.6 (fs), tokio 1 (macros), serde (workspace), serde_json (workspace), chrono (workspace), ulid (workspace), tracing 0.1, tracing-subscriber 0.3 (env-filter), intrada-core (path = "../intrada-core")
+- [ ] T002 Create Shuttle entry point in `crates/intrada-api/src/main.rs` with `#[shuttle_runtime::main]` function accepting `#[shuttle_shared_db::Postgres] pool: PgPool`, running migrations via `sqlx::migrate!()`, and returning the Axum router wrapped in `shuttle_axum::ShuttleAxum`
+- [ ] T003 Create `Shuttle.toml` at workspace root with `assets = ["crates/intrada-web/dist/*"]` and `crate = "crates/intrada-api"`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T004 Create `crates/intrada-api/src/state.rs` with `AppState` struct wrapping `sqlx::PgPool` (implements `Clone`) and constructor
+- [ ] T005 [P] Create `crates/intrada-api/src/error.rs` with `ApiError` enum (Validation, NotFound, Internal) implementing `axum::response::IntoResponse` — Validation→400 `{"error":"..."}`, NotFound→404 `{"error":"..."}`, Internal→500 `{"error":"Internal server error"}`; implement `From<intrada_core::LibraryError>` for ApiError
+- [ ] T006 [P] Create SQL migration `crates/intrada-api/migrations/001_create_pieces.sql` per data-model.md (pieces table with TEXT PK, TEXT NOT NULL title/composer, nullable key/tempo_marking/notes, SMALLINT tempo_bpm with CHECK 1-400, TEXT[] tags DEFAULT '{}', TIMESTAMPTZ created_at/updated_at)
+- [ ] T007 [P] Create SQL migration `crates/intrada-api/migrations/002_create_exercises.sql` per data-model.md (exercises table with TEXT PK, TEXT NOT NULL title, nullable composer/category/key/tempo_marking/notes, SMALLINT tempo_bpm with CHECK, TEXT[] tags DEFAULT '{}', TIMESTAMPTZ created_at/updated_at)
+- [ ] T008 [P] Create SQL migration `crates/intrada-api/migrations/003_create_sessions.sql` per data-model.md (practice_sessions table + setlist_entries table with FK ON DELETE CASCADE, CHECK constraints on completion_status/item_type/status, index on session_id)
+- [ ] T009 Create `crates/intrada-api/src/routes/mod.rs` with `api_router()` function that builds the nested `/api` router with health, pieces, exercises, and sessions sub-routers; create `crates/intrada-api/src/routes/health.rs` with `GET /health` handler returning `{"status":"ok"}`
+- [ ] T010 Create `crates/intrada-api/src/db/mod.rs` declaring the pieces, exercises, and sessions submodules
+
+**Checkpoint**: Foundation ready — migrations, error handling, routing skeleton, and app state in place
+
+---
+
+## Phase 3: User Story 1 — Server-Persisted Library (Priority: P1) MVP
+
+**Goal**: Full CRUD for pieces and exercises via REST API, persisted in Postgres
+
+**Independent Test**: Launch server, POST a piece via curl, GET /api/pieces to confirm it persists. Clear browser, reload — piece still present.
+
+### Implementation for User Story 1
+
+- [ ] T011 [P] [US1] Create `crates/intrada-api/src/db/pieces.rs` with functions: `insert_piece(pool, &CreatePiece) -> Piece`, `list_pieces(pool) -> Vec<Piece>`, `get_piece(pool, id) -> Option<Piece>`, `update_piece(pool, id, &UpdatePiece) -> Option<Piece>`, `delete_piece(pool, id) -> bool` — flatten Tempo to tempo_marking/tempo_bpm columns, handle TEXT[] tags, generate ULID + timestamps server-side
+- [ ] T012 [P] [US1] Create `crates/intrada-api/src/db/exercises.rs` with functions: `insert_exercise(pool, &CreateExercise) -> Exercise`, `list_exercises(pool) -> Vec<Exercise>`, `get_exercise(pool, id) -> Option<Exercise>`, `update_exercise(pool, id, &UpdateExercise) -> Option<Exercise>`, `delete_exercise(pool, id) -> bool` — same Tempo/tags pattern as pieces
+- [ ] T013 [US1] Create `crates/intrada-api/src/routes/pieces.rs` with handlers: `list_pieces` (GET /pieces), `get_piece` (GET /pieces/{id}), `create_piece` (POST /pieces — validate via `intrada_core::validation::validate_create_piece`, return 201), `update_piece` (PUT /pieces/{id} — validate via `validate_update_piece`, return 200), `delete_piece` (DELETE /pieces/{id} — return 200 or 404); register routes in `routes/mod.rs`
+- [ ] T014 [US1] Create `crates/intrada-api/src/routes/exercises.rs` with handlers: `list_exercises` (GET /exercises), `get_exercise` (GET /exercises/{id}), `create_exercise` (POST /exercises — validate via `validate_create_exercise`, return 201), `update_exercise` (PUT /exercises/{id} — validate via `validate_update_exercise`, return 200), `delete_exercise` (DELETE /exercises/{id} — return 200 or 404); register routes in `routes/mod.rs`
+- [ ] T015 [US1] Wire pieces and exercises routers into `api_router()` in `crates/intrada-api/src/routes/mod.rs` and verify the full CRUD flow compiles with `cargo check -p intrada-api`
+
+**Checkpoint**: Pieces and exercises CRUD endpoints functional. Test with curl/quickstart script against `cargo shuttle run`.
+
+---
+
+## Phase 4: User Story 2 — Server-Persisted Practice Sessions (Priority: P2)
+
+**Goal**: Create and read practice sessions via REST API (immutable once saved — no update/delete per FR-005)
+
+**Independent Test**: POST a session with entries via curl, GET /api/sessions to confirm it persists with all entries and correct ordering.
+
+### Implementation for User Story 2
+
+- [ ] T016 [P] [US2] Create `crates/intrada-api/src/db/sessions.rs` with functions: `insert_session(pool, &PracticeSession) -> PracticeSession` (inserts session + entries in a transaction, validates `completion_status`/`item_type`/`status` enums), `list_sessions(pool) -> Vec<PracticeSession>` (joins setlist_entries ordered by position), `get_session(pool, id) -> Option<PracticeSession>` (same join pattern)
+- [ ] T017 [US2] Create `crates/intrada-api/src/routes/sessions.rs` with handlers: `list_sessions` (GET /sessions), `get_session` (GET /sessions/{id}), `create_session` (POST /sessions — validate setlist not empty via `intrada_core::validation::validate_setlist_not_empty`, validate session_notes/entry_notes lengths, return 201); register routes in `routes/mod.rs`
+- [ ] T018 [US2] Wire sessions router into `api_router()` in `crates/intrada-api/src/routes/mod.rs` and verify full session create/read flow compiles
+
+**Checkpoint**: Sessions endpoint functional. Test with curl: create a session with entries, list sessions, get by ID.
+
+---
+
+## Phase 5: User Story 3 — Static WASM Hosting (Priority: P3)
+
+**Goal**: Serve the compiled WASM app as static files from the Axum server with SPA fallback routing
+
+**Independent Test**: Build WASM with trunk, run `cargo shuttle run`, navigate to `http://localhost:8000/` — app loads. Refresh on `/library` — app still loads (SPA fallback works).
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] Add static file serving to `crates/intrada-api/src/main.rs` using `tower_http::services::{ServeDir, ServeFile}` — configure the Axum router with `.fallback_service(ServeDir::new("dist").fallback(ServeFile::new("dist/index.html")))` so that API routes match first and all other paths return the SPA shell; ensure the `dist/` path resolves correctly for both local dev (`crates/intrada-web/dist/`) and Shuttle deployment (from `Shuttle.toml` assets)
+- [ ] T020 [US3] Verify SPA routing works: build WASM with `trunk build` in `crates/intrada-web/`, copy `dist/` to `crates/intrada-api/dist/`, run `cargo shuttle run`, and confirm root URL loads the app and deep links like `/library` return the app shell
+
+**Checkpoint**: Full app accessible at localhost:8000 — API endpoints under /api/, WASM app at all other paths.
+
+---
+
+## Phase 6: User Story 4 — Local Cache for Fast Loads (Priority: P4)
+
+**Goal**: Web shell uses API as primary data source with localStorage as read cache; cached data renders instantly, background fetch updates UI
+
+**Independent Test**: Load the app with populated localStorage on a throttled connection — cached data appears instantly. Clear localStorage, reload — data fetches from server. Disconnect server — cached data shown with stale warning.
+
+### Implementation for User Story 4
+
+- [ ] T021 [US4] Add HTTP client dependency to `crates/intrada-web/Cargo.toml`: `gloo-net` (for WASM-compatible fetch); add `wasm-bindgen-futures` if not already present for spawning async tasks
+- [ ] T022 [US4] Create `crates/intrada-web/src/api_client.rs` with async functions for all API operations: `fetch_pieces() -> Result<Vec<Piece>>`, `fetch_exercises() -> Result<Vec<Exercise>>`, `create_piece(&CreatePiece) -> Result<Piece>`, `update_piece(id, &UpdatePiece) -> Result<Piece>`, `delete_piece(id) -> Result<()>`, `create_exercise(&CreateExercise) -> Result<Exercise>`, `update_exercise(id, &UpdateExercise) -> Result<Exercise>`, `delete_exercise(id) -> Result<()>`, `fetch_sessions() -> Result<Vec<PracticeSession>>`, `save_session(&PracticeSession) -> Result<PracticeSession>` — use relative URLs (`/api/pieces`, etc.) since same-origin
+- [ ] T023 [US4] Modify `crates/intrada-web/src/core_bridge.rs` to implement the cache-first data flow: on `StorageEffect::LoadAll` → load from localStorage first (existing code) → fire `Event::DataLoaded` → spawn async background fetch from API → on API success, update thread-local state + localStorage cache + fire `Event::DataLoaded` again with fresh data; on `StorageEffect::LoadSessions` → same pattern for sessions
+- [ ] T024 [US4] Modify `crates/intrada-web/src/core_bridge.rs` to route write operations through API: on `StorageEffect::SavePiece` → call `api_client::create_piece()` → on success, update thread-local + localStorage; on `StorageEffect::UpdatePiece` → call `api_client::update_piece()` → update cache; on `StorageEffect::DeleteItem` → call `api_client::delete_piece()` or `delete_exercise()` → update cache; on `StorageEffect::SaveExercise` / `UpdateExercise` → same pattern; on `StorageEffect::SavePracticeSession` → call `api_client::save_session()`; on `StorageEffect::DeletePracticeSession` → keep localStorage-only deletion (no API endpoint per FR-005, sessions are immutable server-side) and log a console warning
+- [ ] T025 [US4] Add error handling to `crates/intrada-web/src/core_bridge.rs` for API failures: on network/server error during writes, log to console and fire an error event to the Crux core (or show a user-visible error via `web_sys::window().alert()`); on background fetch failure, keep cached data and log a warning; ensure in-progress data is never lost on API failure (FR-013)
+- [ ] T026 [US4] Remove stub data seeding from `crates/intrada-web/src/core_bridge.rs` — on first load with empty localStorage AND empty API response, show an empty library (no more `create_stub_data()` call); keep `crates/intrada-web/src/data.rs` for now but remove the call site
+
+**Checkpoint**: Web app loads cached data instantly, fetches from API in background, writes go through API first. Clear localStorage → data reloads from server. API down → cached data shown.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: CI/CD, testing, and deployment validation
+
+- [ ] T027 [P] Update `.github/workflows/ci.yml` to add a `deploy` job that: depends on `test`, `clippy`, `wasm-build`, and `e2e`; runs only on push to `main`; uses `shuttle-hq/deploy-action@v2` with `SHUTTLE_API_KEY` secret; set working directory to `crates/intrada-api`
+- [ ] T028 [P] Update `.github/workflows/ci.yml` to ensure the `test` and `clippy` jobs build and test `intrada-api` (already covered by workspace-level `cargo test` and `cargo clippy`)
+- [ ] T029 Run `cargo test` in workspace root — all existing tests (142+) must pass plus any new API crate compilation checks
+- [ ] T030 Run `cargo clippy -- -D warnings` — zero warnings across all crates including intrada-api
+- [ ] T031 Update E2E test infrastructure in `e2e/` to run against the API-backed app: configure Playwright to launch `cargo shuttle run` as the server (or point at the running instance), ensure the 14 existing E2E tests pass against the API server serving the WASM app (SC-007)
+- [ ] T032 Run the quickstart.md verification checklist (V1–V9): start server with `cargo shuttle run`, test health endpoint, test piece CRUD, test exercise CRUD, test session persistence, verify WASM app loads, verify SPA routing, verify cache behaviour
+- [ ] T033 Update `CLAUDE.md` by running `.specify/scripts/bash/update-agent-context.sh claude`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **US1 Library CRUD (Phase 3)**: Depends on Foundational (Phase 2)
+- **US2 Sessions (Phase 4)**: Depends on Foundational (Phase 2), can run in parallel with US1
+- **US3 WASM Hosting (Phase 5)**: Depends on Foundational (Phase 2), can run in parallel with US1/US2
+- **US4 Local Cache (Phase 6)**: Depends on US1 and US2 (needs API endpoints to exist before web shell can call them)
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2 — no dependencies on other stories
+- **US2 (P2)**: Can start after Phase 2 — no dependencies on other stories (can be parallel with US1)
+- **US3 (P3)**: Can start after Phase 2 — no dependencies on other stories (can be parallel with US1/US2)
+- **US4 (P4)**: Depends on US1 + US2 (needs API endpoints to exist for the web shell to call)
+
+### Within Each User Story
+
+- DB layer before route handlers (models before services)
+- Route handlers wire into router after DB functions exist
+- Compile check after wiring
+
+### Parallel Opportunities
+
+- T005, T006, T007, T008 can all run in parallel (different files, no dependencies)
+- T011 and T012 can run in parallel (pieces DB and exercises DB are independent files)
+- T016 can run in parallel with US1 tasks (sessions DB is a separate file)
+- T027 and T028 can run in parallel (CI config changes)
+
+---
+
+## Parallel Example: Phase 2 Foundation
+
+```bash
+# Launch all migration files + error module in parallel:
+Task: "Create error.rs in crates/intrada-api/src/error.rs"
+Task: "Create 001_create_pieces.sql migration"
+Task: "Create 002_create_exercises.sql migration"
+Task: "Create 003_create_sessions.sql migration"
+```
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch both DB modules in parallel:
+Task: "Create pieces DB layer in crates/intrada-api/src/db/pieces.rs"
+Task: "Create exercises DB layer in crates/intrada-api/src/db/exercises.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T003)
+2. Complete Phase 2: Foundational (T004–T010)
+3. Complete Phase 3: User Story 1 — Library CRUD (T011–T015)
+4. **STOP and VALIDATE**: Test piece/exercise CRUD with curl
+5. Can demo API-only (no web shell changes yet)
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 (Library CRUD) → Test with curl → MVP!
+3. Add US2 (Sessions) → Test with curl → Sessions work
+4. Add US3 (WASM Hosting) → App accessible at URL
+5. Add US4 (Local Cache) → Full integrated experience
+6. Polish → CI/CD, deploy, final validation
+
+### Task Summary
+
+- **Total tasks**: 33
+- **Phase 1 (Setup)**: 3 tasks
+- **Phase 2 (Foundational)**: 7 tasks (4 parallelizable)
+- **Phase 3 / US1 (Library CRUD)**: 5 tasks (2 parallelizable)
+- **Phase 4 / US2 (Sessions)**: 3 tasks (1 parallelizable)
+- **Phase 5 / US3 (WASM Hosting)**: 2 tasks
+- **Phase 6 / US4 (Local Cache)**: 6 tasks
+- **Phase 7 (Polish)**: 7 tasks (2 parallelizable)
+- **Suggested MVP scope**: Phases 1–3 (T001–T015) = 15 tasks
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- intrada-core remains completely unchanged (FR-015)
+- No auth — all endpoints are public (FR-014)
+- Session in-progress (`intrada:session-in-progress`) stays localStorage-only (not sent to API)


### PR DESCRIPTION
## Summary
- New `intrada-api` crate: Axum 0.8 REST server deployable to Shuttle.rs
- Full CRUD for pieces (`/api/pieces`) and exercises (`/api/exercises`) with validation via `intrada-core`
- Health check endpoint (`/api/health`)
- Postgres migrations for pieces, exercises, and sessions tables (sessions routes in follow-up PR)
- `ApiError` maps domain `LibraryError` to HTTP 400/404/500 with JSON error bodies
- `Shuttle.toml` configuration for deployment

## Steps to run locally

1. **Install Docker** (required for Shuttle's local Postgres):
   ```bash
   # macOS
   brew install --cask docker
   # Then start Docker Desktop
   ```

2. **Install Shuttle CLI**:
   ```bash
   cargo install shuttle
   ```

3. **Run the server**:
   ```bash
   cargo shuttle run
   ```
   This auto-provisions a local Postgres container, runs migrations, and starts the API at `http://localhost:8000`.

4. **Test with curl**:
   ```bash
   # Health check
   curl http://localhost:8000/api/health

   # Create a piece
   curl -X POST http://localhost:8000/api/pieces \
     -H "Content-Type: application/json" \
     -d '{"title":"Moonlight Sonata","composer":"Beethoven","tags":["classical"]}'

   # List pieces
   curl http://localhost:8000/api/pieces
   ```

## Steps to deploy

1. **Create a Shuttle account** at [console.shuttle.dev](https://console.shuttle.dev)
2. **Log in**: `shuttle login`
3. **Create the project**: `shuttle project create`
4. **Deploy**: `shuttle deploy`
5. **Set up CI auto-deploy** (follow-up): Add `SHUTTLE_API_KEY` secret to GitHub repo settings

## What's next (PR 2)
- Sessions REST endpoints (POST/GET only — immutable once saved)
- Static WASM hosting via `tower-http::ServeDir` with SPA fallback
- Web shell switches from localStorage-only to API calls + localStorage cache
- CI/CD auto-deploy job

## Test plan
- [x] `cargo check -p intrada-api` — zero warnings
- [x] `cargo test` — 142 tests pass (107 core + 35 web, core unchanged)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [ ] `cargo shuttle run` — server starts, migrations run, curl tests pass
- [ ] CI passes (test, clippy, fmt, wasm-build, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)