### PR TITLE
Add Cloudflare Workers deployment for WASM hosting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  RUST_VERSION: "1.89.0"
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "wasm"
+      - uses: jetli/trunk-action@v0.5.1
+      - name: Install Tailwind CSS v4 standalone CLI
+        run: |
+          curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.18/tailwindcss-linux-x64
+          chmod +x tailwindcss-linux-x64
+          mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+      - name: Build WASM
+        working-directory: crates/intrada-web
+        run: trunk build --release
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,5 @@
+export default {
+  async fetch(request, env) {
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "intrada"
+main = "./worker.js"
+compatibility_date = "2026-02-15"
+
+[assets]
+directory = "crates/intrada-web/dist"
+not_found_handling = "single-page-application"


### PR DESCRIPTION
## Summary
- Adds `wrangler.toml` with SPA fallback routing for client-side navigation (leptos_router)
- Adds minimal `worker.js` passthrough that delegates to Cloudflare's static assets binding
- Adds `.github/workflows/deploy.yml` CD workflow that builds WASM with `trunk build --release` and deploys via `cloudflare/wrangler-action@v3` on push to `main`

## Background
Shuttle.rs (our original hosting target from PR #20) is shutting down — login broken, projects being deleted. This pivots to Cloudflare Workers with Static Assets as the first step of the decomposed Tier 2 architecture. The app continues using localStorage with no code changes.

## Setup required
Two GitHub repository secrets must be configured before the deploy workflow succeeds:
1. `CLOUDFLARE_API_TOKEN` — create at https://dash.cloudflare.com/profile/api-tokens with "Edit Cloudflare Workers" permissions
2. `CLOUDFLARE_ACCOUNT_ID` — found on the Cloudflare dashboard sidebar

## Test plan
- [ ] `cargo test` — all 142 tests pass (no code changes)
- [ ] `cargo clippy -- -D warnings` — zero warnings
- [ ] CI passes on PR
- [ ] After merge + secrets configured: visit `https://intrada.<account>.workers.dev`
- [ ] Home page loads with pieces/exercises
- [ ] Client-side routing works (navigate, refresh — no 404)
- [ ] localStorage persistence works (add item, refresh, still there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)