### PR TITLE
Prevent duplicate submissions by disabling buttons during API requests

### DIFF
--- a/crates/intrada-web/src/components/button.rs
+++ b/crates/intrada-web/src/components/button.rs
@@ -22,23 +22,51 @@ impl ButtonVariant {
 }
 
 /// Shared button component with consistent styling per variant.
+///
+/// When `disabled` is true, the button is visually dimmed, shows a
+/// `not-allowed` cursor, and ignores click events.
+/// When `loading` is true, a small spinner is prepended to the label
+/// and the button is also treated as disabled.
 #[component]
 pub fn Button(
     variant: ButtonVariant,
     #[prop(optional)] on_click: Option<Callback<ev::MouseEvent>>,
     #[prop(default = "button")] button_type: &'static str,
+    #[prop(optional, into)] disabled: Signal<bool>,
+    #[prop(optional, into)] loading: Signal<bool>,
     children: Children,
 ) -> impl IntoView {
+    let is_disabled = Signal::derive(move || disabled.get() || loading.get());
+
     view! {
         <button
             type=button_type
-            class=variant.classes()
+            class=move || {
+                let base = variant.classes();
+                if is_disabled.get() {
+                    format!("{base} opacity-50 cursor-not-allowed")
+                } else {
+                    base.to_string()
+                }
+            }
+            disabled=is_disabled
             on:click=move |ev| {
-                if let Some(cb) = &on_click {
-                    cb.run(ev);
+                if !is_disabled.get() {
+                    if let Some(cb) = &on_click {
+                        cb.run(ev);
+                    }
                 }
             }
         >
+            {move || {
+                if loading.get() {
+                    Some(view! {
+                        <span class="animate-spin rounded-full h-4 w-4 border-2 border-current border-t-transparent" aria-hidden="true"></span>
+                    })
+                } else {
+                    None
+                }
+            }}
             {children()}
         </button>
     }

--- a/crates/intrada-web/src/views/add_form.rs
+++ b/crates/intrada-web/src/views/add_form.rs
@@ -185,7 +185,13 @@ pub fn AddLibraryItemForm() -> impl IntoView {
 
                         // Buttons
                         <div class="flex flex-col sm:flex-row gap-3 pt-2">
-                            <Button variant=ButtonVariant::Primary button_type="submit">"Save"</Button>
+                            <Button
+                                variant=ButtonVariant::Primary
+                                button_type="submit"
+                                loading=Signal::derive(move || is_submitting.get())
+                            >
+                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
+                            </Button>
                             <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
                                 navigate_cancel("/", NavigateOptions::default());
                             })>"Cancel"</Button>

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -81,7 +81,10 @@ pub fn DetailView() -> impl IntoView {
                                 "Are you sure you want to delete this item? This action cannot be undone."
                             </p>
                             <div class="flex gap-3">
-                                <Button variant=ButtonVariant::Danger on_click=Callback::new(move |_| {
+                                <Button
+                                    variant=ButtonVariant::Danger
+                                    loading=Signal::derive(move || is_submitting.get())
+                                    on_click=Callback::new(move |_| {
                                         let event = if item_type_del == "piece" {
                                             Event::Piece(PieceEvent::Delete { id: id_del.clone() })
                                         } else {
@@ -92,7 +95,7 @@ pub fn DetailView() -> impl IntoView {
                                         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                                         navigate_del("/", NavigateOptions { replace: true, ..Default::default() });
                                     })>
-                                    "Confirm Delete"
+                                    {move || if is_submitting.get() { "Deleting\u{2026}" } else { "Confirm Delete" }}
                                 </Button>
                                 <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| { show_delete_confirm.set(false); })>
                                     "Cancel"
@@ -212,7 +215,11 @@ pub fn DetailView() -> impl IntoView {
                 <A href=edit_href attr:class="w-full sm:w-auto inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 motion-safe:transition-colors min-h-[44px]">
                     "Edit"
                 </A>
-                <Button variant=ButtonVariant::DangerOutline on_click=Callback::new(move |_| { show_delete_confirm.set(true); })>
+                <Button
+                    variant=ButtonVariant::DangerOutline
+                    disabled=Signal::derive(move || is_submitting.get())
+                    on_click=Callback::new(move |_| { show_delete_confirm.set(true); })
+                >
                     "Delete"
                 </Button>
             </div>

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -238,7 +238,13 @@ pub fn EditLibraryItemForm() -> impl IntoView {
 
                         // Buttons
                         <div class="flex flex-col sm:flex-row gap-3 pt-2">
-                            <Button variant=ButtonVariant::Primary button_type="submit">"Save"</Button>
+                            <Button
+                                variant=ButtonVariant::Primary
+                                button_type="submit"
+                                loading=Signal::derive(move || is_submitting.get())
+                            >
+                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
+                            </Button>
                             <Button variant=ButtonVariant::Secondary on_click={
                                 let cancel_href = cancel_href.clone();
                                 let navigate = navigate.clone();

--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -98,13 +98,17 @@ fn SessionRow(
                         <div>
                             <p class="text-sm text-red-300 mb-3">"Delete this session? This cannot be undone."</p>
                             <div class="flex gap-2">
-                                <Button variant=ButtonVariant::Danger on_click=Callback::new(move |_| {
-                                    let event = Event::Session(SessionEvent::DeleteSession { id: id_del.clone() });
-                                    let core_ref = core_del.borrow();
-                                    let effects = core_ref.process_event(event);
-                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                })>
-                                    "Confirm Delete"
+                                <Button
+                                    variant=ButtonVariant::Danger
+                                    loading=Signal::derive(move || is_submitting.get())
+                                    on_click=Callback::new(move |_| {
+                                        let event = Event::Session(SessionEvent::DeleteSession { id: id_del.clone() });
+                                        let core_ref = core_del.borrow();
+                                        let effects = core_ref.process_event(event);
+                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                    })
+                                >
+                                    {move || if is_submitting.get() { "Deleting\u{2026}" } else { "Confirm Delete" }}
                                 </Button>
                                 <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
                                     confirm_delete.set(false);


### PR DESCRIPTION
The is_submitting signal was already being toggled in core_bridge but no buttons reacted to it, allowing users to double-click Save or Delete while an API call was in-flight.

- Add disabled and loading props to the shared Button component
- Show spinner + "Saving…" on form submit buttons while submitting
- Show spinner + "Deleting…" on delete confirm buttons while deleting
- Disable the Delete trigger button during in-flight requests
- Use Signal<bool> instead of deprecated MaybeSignal<bool>