### PR TITLE
Add confidence scoring to practice sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-15
 - Turso (managed libsql/SQLite) via HTTP protocol — `libsql` crate with `remote` feature (020-api-server)
 - Rust stable (1.89.0 in CI; workspace MSRV 1.75+, 2021 edition) + leptos 0.8.x (CSR), crux_core 0.17.0-rc2, gloo-net 0.6 (NEW), wasm-bindgen-futures 0.4 (NEW), serde/serde_json 1 (021-api-sync)
 - REST API (Turso/libsql via intrada-api) for pieces, exercises, sessions; localStorage for session-in-progress crash recovery only (021-api-sync)
+- Rust stable (1.89.0 in CI; workspace MSRV 1.75+, 2021 edition) + crux_core 0.17.0-rc2, leptos 0.8.x (CSR), axum 0.8, libsql 0.9, serde 1, ulid 1, chrono 0.4 (022-session-scoring)
+- Turso (managed libsql/SQLite) via REST API; localStorage for session-in-progress crash recovery only (022-session-scoring)
 
 ## Project Structure
 
@@ -41,9 +43,9 @@ cargo clippy
 Rust stable (1.75+, 2021 edition): Follow standard conventions
 
 ## Recent Changes
+- 022-session-scoring: Added Rust stable (1.89.0 in CI; workspace MSRV 1.75+, 2021 edition) + crux_core 0.17.0-rc2, leptos 0.8.x (CSR), axum 0.8, libsql 0.9, serde 1, ulid 1, chrono 0.4
 - 021-api-sync: Added Rust stable (1.89.0 in CI; workspace MSRV 1.75+, 2021 edition) + leptos 0.8.x (CSR), crux_core 0.17.0-rc2, gloo-net 0.6 (NEW), wasm-bindgen-futures 0.4 (NEW), serde/serde_json 1
 - 020-api-server: Added Rust stable (1.89.0 in CI; workspace MSRV 1.75, axum 0.8 requires 1.78+) + axum 0.8, libsql 0.9 (remote feature), libsql_migration 0.2.2 (content feature), tower-http 0.6 (cors), tokio 1, serde/serde_json 1, ulid 1, chrono 0.4, thiserror 1, tracing 0.1
-- 019-improve-cicd: Added GitHub Actions YAML (no Rust code changes) + GitHub Actions (checkout@v4, upload-artifact@v4, download-artifact@v4, rust-toolchain, rust-cache@v2, trunk-action, wrangler-action@v3)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/crates/intrada-api/src/db/sessions.rs
+++ b/crates/intrada-api/src/db/sessions.rs
@@ -30,6 +30,8 @@ pub struct SaveSessionEntry {
     pub duration_secs: u64,
     pub status: EntryStatus,
     pub notes: Option<String>,
+    #[serde(default)]
+    pub score: Option<u8>,
 }
 
 fn completion_status_to_str(status: &CompletionStatus) -> &'static str {
@@ -76,6 +78,8 @@ fn row_to_entry(row: &libsql::Row) -> Result<SetlistEntry, ApiError> {
     let duration_secs: i64 = row.get(6).map_err(|e| ApiError::Internal(e.to_string()))?;
     let status_str: String = row.get(7).map_err(|e| ApiError::Internal(e.to_string()))?;
     let notes: Option<String> = row.get(8).map_err(|e| ApiError::Internal(e.to_string()))?;
+    let score_raw: Option<i64> = row.get(9).map_err(|e| ApiError::Internal(e.to_string()))?;
+    let score = score_raw.map(|s| s as u8);
 
     Ok(SetlistEntry {
         id,
@@ -86,6 +90,7 @@ fn row_to_entry(row: &libsql::Row) -> Result<SetlistEntry, ApiError> {
         duration_secs: duration_secs as u64,
         status: entry_status_from_str(&status_str)?,
         notes,
+        score,
     })
 }
 
@@ -93,7 +98,7 @@ fn row_to_entry(row: &libsql::Row) -> Result<SetlistEntry, ApiError> {
 async fn fetch_entries(conn: &Connection, session_id: &str) -> Result<Vec<SetlistEntry>, ApiError> {
     let mut rows = conn
         .query(
-            "SELECT id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes
+            "SELECT id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes, score
              FROM setlist_entries WHERE session_id = ?1 ORDER BY position ASC",
             libsql::params![session_id],
         )
@@ -217,9 +222,10 @@ pub async fn insert_session(
         let mut entries = Vec::with_capacity(input.entries.len());
         for entry in &input.entries {
             let status_str = entry_status_to_str(&entry.status);
+            let score_val: Option<i64> = entry.score.map(|s| s as i64);
             conn.execute(
-                "INSERT INTO setlist_entries (id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO setlist_entries (id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes, score)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                 libsql::params![
                     entry.id.as_str(),
                     id.as_str(),
@@ -229,7 +235,8 @@ pub async fn insert_session(
                     entry.position as i64,
                     entry.duration_secs as i64,
                     status_str,
-                    entry.notes.as_deref()
+                    entry.notes.as_deref(),
+                    score_val
                 ],
             )
             .await?;
@@ -243,6 +250,7 @@ pub async fn insert_session(
                 duration_secs: entry.duration_secs,
                 status: entry.status.clone(),
                 notes: entry.notes.clone(),
+                score: entry.score,
             });
         }
 

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -44,7 +44,8 @@ pub const MIGRATION_SQL: &[&str] = &[
         position INTEGER NOT NULL,
         duration_secs INTEGER NOT NULL,
         status TEXT NOT NULL,
-        notes TEXT
+        notes TEXT,
+        score INTEGER
     );",
     "CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
 ];
@@ -113,6 +114,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         );
 
         CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
+    ),
+    (
+        "0004_add_score_to_setlist_entries",
+        "ALTER TABLE setlist_entries ADD COLUMN score INTEGER;",
     ),
 ];
 

--- a/crates/intrada-api/src/routes/sessions.rs
+++ b/crates/intrada-api/src/routes/sessions.rs
@@ -43,9 +43,10 @@ async fn save_session(
     // Validate session notes
     validation::validate_session_notes(&input.session_notes)?;
 
-    // Validate each entry's notes
+    // Validate each entry's notes and score
     for entry in &input.entries {
         validation::validate_entry_notes(&entry.notes)?;
+        validation::validate_score(&entry.score)?;
     }
 
     // Validate setlist is not empty — need to convert to SetlistEntry slice

--- a/crates/intrada-api/tests/sessions_test.rs
+++ b/crates/intrada-api/tests/sessions_test.rs
@@ -184,3 +184,188 @@ async fn session_ended_early_status() {
     let session: PracticeSession = common::json(&body);
     assert_eq!(format!("{:?}", session.completion_status), "EndedEarly");
 }
+
+// ── Score-related tests (T014) ──────────────────────────────────────
+
+fn sample_session_with_scores() -> serde_json::Value {
+    json!({
+        "entries": [
+            {
+                "id": "entry-s1",
+                "item_id": "piece-001",
+                "item_title": "Clair de Lune",
+                "item_type": "Piece",
+                "position": 0,
+                "duration_secs": 600,
+                "status": "Completed",
+                "notes": "Good dynamics",
+                "score": 4
+            },
+            {
+                "id": "entry-s2",
+                "item_id": "exercise-001",
+                "item_title": "Hanon No. 1",
+                "item_type": "Exercise",
+                "position": 1,
+                "duration_secs": 300,
+                "status": "Completed",
+                "notes": null,
+                "score": 2
+            },
+            {
+                "id": "entry-s3",
+                "item_id": "piece-002",
+                "item_title": "Moonlight Sonata",
+                "item_type": "Piece",
+                "position": 2,
+                "duration_secs": 200,
+                "status": "Skipped",
+                "notes": null,
+                "score": null
+            }
+        ],
+        "session_notes": "Scored session",
+        "started_at": "2026-02-16T10:00:00Z",
+        "completed_at": "2026-02-16T10:18:20Z",
+        "total_duration_secs": 1100,
+        "completion_status": "Completed"
+    })
+}
+
+#[tokio::test]
+async fn save_session_with_scores_returns_scores() {
+    let app = common::setup_test_app().await;
+    let (status, body) =
+        common::post_json(app, "/api/sessions", sample_session_with_scores()).await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let session: PracticeSession = common::json(&body);
+    assert_eq!(session.entries.len(), 3);
+    assert_eq!(session.entries[0].score, Some(4));
+    assert_eq!(session.entries[1].score, Some(2));
+    assert_eq!(session.entries[2].score, None);
+}
+
+#[tokio::test]
+async fn get_session_returns_scores() {
+    let app = common::setup_test_app().await;
+
+    let (_, body) =
+        common::post_json(app.clone(), "/api/sessions", sample_session_with_scores()).await;
+    let created: PracticeSession = common::json(&body);
+
+    let (status, body) = common::get(app, &format!("/api/sessions/{}", created.id)).await;
+    assert_eq!(status, StatusCode::OK);
+    let fetched: PracticeSession = common::json(&body);
+    assert_eq!(fetched.entries[0].score, Some(4));
+    assert_eq!(fetched.entries[1].score, Some(2));
+    assert_eq!(fetched.entries[2].score, None);
+}
+
+#[tokio::test]
+async fn save_session_invalid_score_returns_400() {
+    let app = common::setup_test_app().await;
+    let (status, _body) = common::post_json(
+        app,
+        "/api/sessions",
+        json!({
+            "entries": [{
+                "id": "entry-001",
+                "item_id": "piece-001",
+                "item_title": "Scales",
+                "item_type": "Exercise",
+                "position": 0,
+                "duration_secs": 120,
+                "status": "Completed",
+                "notes": null,
+                "score": 6
+            }],
+            "started_at": "2026-02-16T10:00:00Z",
+            "completed_at": "2026-02-16T10:02:00Z",
+            "total_duration_secs": 120,
+            "completion_status": "Completed"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn save_session_score_zero_returns_400() {
+    let app = common::setup_test_app().await;
+    let (status, _body) = common::post_json(
+        app,
+        "/api/sessions",
+        json!({
+            "entries": [{
+                "id": "entry-001",
+                "item_id": "piece-001",
+                "item_title": "Scales",
+                "item_type": "Exercise",
+                "position": 0,
+                "duration_secs": 120,
+                "status": "Completed",
+                "notes": null,
+                "score": 0
+            }],
+            "started_at": "2026-02-16T10:00:00Z",
+            "completed_at": "2026-02-16T10:02:00Z",
+            "total_duration_secs": 120,
+            "completion_status": "Completed"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ── Backward compatibility (T015) ───────────────────────────────────
+
+#[tokio::test]
+async fn save_session_without_scores_returns_null_scores() {
+    let app = common::setup_test_app().await;
+
+    // Use the original sample body which has no score fields
+    let (status, body) = common::post_json(app, "/api/sessions", sample_session_body()).await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let session: PracticeSession = common::json(&body);
+    assert_eq!(session.entries.len(), 2);
+    // Both entries should have score: None when not provided
+    assert_eq!(session.entries[0].score, None);
+    assert_eq!(session.entries[1].score, None);
+}
+
+#[tokio::test]
+async fn get_session_without_scores_returns_null_scores() {
+    let app = common::setup_test_app().await;
+
+    // Create a session without scores
+    let (_, body) = common::post_json(app.clone(), "/api/sessions", sample_session_body()).await;
+    let created: PracticeSession = common::json(&body);
+
+    // Fetch it back
+    let (status, body) = common::get(app, &format!("/api/sessions/{}", created.id)).await;
+    assert_eq!(status, StatusCode::OK);
+    let fetched: PracticeSession = common::json(&body);
+    assert_eq!(fetched.entries[0].score, None);
+    assert_eq!(fetched.entries[1].score, None);
+}
+
+#[tokio::test]
+async fn list_sessions_without_scores_returns_null_scores() {
+    let app = common::setup_test_app().await;
+
+    // Create a session without scores
+    common::post_json(app.clone(), "/api/sessions", sample_session_body()).await;
+
+    let (status, body) = common::get(app, "/api/sessions").await;
+    assert_eq!(status, StatusCode::OK);
+    let sessions: Vec<PracticeSession> = common::json(&body);
+    assert_eq!(sessions.len(), 1);
+    // All entries should have score: None
+    for entry in &sessions[0].entries {
+        assert_eq!(entry.score, None);
+    }
+}

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -223,14 +223,25 @@ fn compute_practice_summary(
     sessions: &[PracticeSession],
     item_id: &str,
 ) -> Option<ItemPracticeSummary> {
+    use crate::model::ScoreHistoryEntry;
+
     let mut session_count = 0usize;
     let mut total_secs = 0u64;
+    let mut score_history: Vec<ScoreHistoryEntry> = Vec::new();
 
     for session in sessions {
         for entry in &session.entries {
             if entry.item_id == item_id {
                 session_count += 1;
                 total_secs += entry.duration_secs;
+
+                if let Some(score) = entry.score {
+                    score_history.push(ScoreHistoryEntry {
+                        session_date: session.started_at.to_rfc3339(),
+                        score,
+                        session_id: session.id.clone(),
+                    });
+                }
             }
         }
     }
@@ -239,9 +250,16 @@ fn compute_practice_summary(
         return None;
     }
 
+    // Sort by session date descending (most recent first)
+    score_history.sort_by(|a, b| b.session_date.cmp(&a.session_date));
+
+    let latest_score = score_history.first().map(|e| e.score);
+
     Some(ItemPracticeSummary {
         session_count,
         total_minutes: (total_secs / 60) as u32,
+        latest_score,
+        score_history,
     })
 }
 
@@ -825,6 +843,7 @@ mod tests {
                     duration_secs: 1800, // 30 min
                     status: EntryStatus::Completed,
                     notes: None,
+                    score: None,
                 },
                 SetlistEntry {
                     id: "e2".to_string(),
@@ -835,6 +854,7 @@ mod tests {
                     duration_secs: 900, // 15 min
                     status: EntryStatus::Completed,
                     notes: None,
+                    score: None,
                 },
             ],
         });
@@ -843,16 +863,270 @@ mod tests {
         let p1_view = vm.items.iter().find(|i| i.id == "p1").unwrap();
         let p2_view = vm.items.iter().find(|i| i.id == "p2").unwrap();
 
-        // p1 has 2 entries totalling 45 minutes
+        // p1 has 2 entries totalling 45 minutes, no scores
         assert_eq!(
             p1_view.practice,
             Some(ItemPracticeSummary {
                 session_count: 2,
                 total_minutes: 45,
+                latest_score: None,
+                score_history: vec![],
             })
         );
         // p2 has no entries
         assert_eq!(p2_view.practice, None);
+    }
+
+    // ── Score history tests (T019) ────────────────────────────────────
+
+    #[test]
+    fn test_score_history_multiple_sessions() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let mut model = Model::default();
+
+        model.pieces.push(Piece {
+            id: "p1".to_string(),
+            title: "Sonata".to_string(),
+            composer: "Beethoven".to_string(),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        });
+
+        use crate::domain::session::{
+            CompletionStatus, EntryStatus, PracticeSession, SetlistEntry,
+        };
+
+        // Session 1: older, score 3
+        model.sessions.push(PracticeSession {
+            id: "sess1".to_string(),
+            started_at: now - chrono::Duration::hours(2),
+            completed_at: now - chrono::Duration::hours(1),
+            total_duration_secs: 3600,
+            completion_status: CompletionStatus::Completed,
+            session_notes: None,
+            entries: vec![SetlistEntry {
+                id: "e1".to_string(),
+                item_id: "p1".to_string(),
+                item_title: "Sonata".to_string(),
+                item_type: "piece".to_string(),
+                position: 0,
+                duration_secs: 1800,
+                status: EntryStatus::Completed,
+                notes: None,
+                score: Some(3),
+            }],
+        });
+
+        // Session 2: newer, score 5
+        model.sessions.push(PracticeSession {
+            id: "sess2".to_string(),
+            started_at: now - chrono::Duration::minutes(30),
+            completed_at: now,
+            total_duration_secs: 1800,
+            completion_status: CompletionStatus::Completed,
+            session_notes: None,
+            entries: vec![SetlistEntry {
+                id: "e2".to_string(),
+                item_id: "p1".to_string(),
+                item_title: "Sonata".to_string(),
+                item_type: "piece".to_string(),
+                position: 0,
+                duration_secs: 900,
+                status: EntryStatus::Completed,
+                notes: None,
+                score: Some(5),
+            }],
+        });
+
+        let vm = app.view(&model);
+        let p1 = vm.items.iter().find(|i| i.id == "p1").unwrap();
+        let practice = p1.practice.as_ref().unwrap();
+
+        // latest_score should be from the newer session
+        assert_eq!(practice.latest_score, Some(5));
+        assert_eq!(practice.score_history.len(), 2);
+        // First entry = most recent (score 5)
+        assert_eq!(practice.score_history[0].score, 5);
+        assert_eq!(practice.score_history[0].session_id, "sess2");
+        // Second entry = older (score 3)
+        assert_eq!(practice.score_history[1].score, 3);
+        assert_eq!(practice.score_history[1].session_id, "sess1");
+    }
+
+    #[test]
+    fn test_score_history_no_scored_sessions() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let mut model = Model::default();
+
+        model.pieces.push(Piece {
+            id: "p1".to_string(),
+            title: "Sonata".to_string(),
+            composer: "Beethoven".to_string(),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        });
+
+        use crate::domain::session::{
+            CompletionStatus, EntryStatus, PracticeSession, SetlistEntry,
+        };
+
+        // Session with no score
+        model.sessions.push(PracticeSession {
+            id: "sess1".to_string(),
+            started_at: now - chrono::Duration::hours(1),
+            completed_at: now,
+            total_duration_secs: 1800,
+            completion_status: CompletionStatus::Completed,
+            session_notes: None,
+            entries: vec![SetlistEntry {
+                id: "e1".to_string(),
+                item_id: "p1".to_string(),
+                item_title: "Sonata".to_string(),
+                item_type: "piece".to_string(),
+                position: 0,
+                duration_secs: 1800,
+                status: EntryStatus::Completed,
+                notes: None,
+                score: None,
+            }],
+        });
+
+        let vm = app.view(&model);
+        let p1 = vm.items.iter().find(|i| i.id == "p1").unwrap();
+        let practice = p1.practice.as_ref().unwrap();
+
+        assert_eq!(practice.latest_score, None);
+        assert!(practice.score_history.is_empty());
+    }
+
+    #[test]
+    fn test_score_history_item_multiple_times_in_one_session() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let mut model = Model::default();
+
+        model.pieces.push(Piece {
+            id: "p1".to_string(),
+            title: "Sonata".to_string(),
+            composer: "Beethoven".to_string(),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        });
+
+        use crate::domain::session::{
+            CompletionStatus, EntryStatus, PracticeSession, SetlistEntry,
+        };
+
+        // Single session with the same item twice (different scores)
+        model.sessions.push(PracticeSession {
+            id: "sess1".to_string(),
+            started_at: now - chrono::Duration::hours(1),
+            completed_at: now,
+            total_duration_secs: 3600,
+            completion_status: CompletionStatus::Completed,
+            session_notes: None,
+            entries: vec![
+                SetlistEntry {
+                    id: "e1".to_string(),
+                    item_id: "p1".to_string(),
+                    item_title: "Sonata".to_string(),
+                    item_type: "piece".to_string(),
+                    position: 0,
+                    duration_secs: 1800,
+                    status: EntryStatus::Completed,
+                    notes: None,
+                    score: Some(2),
+                },
+                SetlistEntry {
+                    id: "e2".to_string(),
+                    item_id: "p1".to_string(),
+                    item_title: "Sonata".to_string(),
+                    item_type: "piece".to_string(),
+                    position: 1,
+                    duration_secs: 1800,
+                    status: EntryStatus::Completed,
+                    notes: None,
+                    score: Some(4),
+                },
+            ],
+        });
+
+        let vm = app.view(&model);
+        let p1 = vm.items.iter().find(|i| i.id == "p1").unwrap();
+        let practice = p1.practice.as_ref().unwrap();
+
+        // Both entries from the same session should appear in score_history
+        assert_eq!(practice.score_history.len(), 2);
+        // Both have the same session_id
+        assert!(practice
+            .score_history
+            .iter()
+            .all(|e| e.session_id == "sess1"));
+    }
+
+    #[test]
+    fn test_score_history_skipped_entries_excluded() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let mut model = Model::default();
+
+        model.pieces.push(Piece {
+            id: "p1".to_string(),
+            title: "Sonata".to_string(),
+            composer: "Beethoven".to_string(),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        });
+
+        use crate::domain::session::{
+            CompletionStatus, EntryStatus, PracticeSession, SetlistEntry,
+        };
+
+        // A skipped entry won't have a score (scores only set on completed entries)
+        model.sessions.push(PracticeSession {
+            id: "sess1".to_string(),
+            started_at: now - chrono::Duration::hours(1),
+            completed_at: now,
+            total_duration_secs: 600,
+            completion_status: CompletionStatus::EndedEarly,
+            session_notes: None,
+            entries: vec![SetlistEntry {
+                id: "e1".to_string(),
+                item_id: "p1".to_string(),
+                item_title: "Sonata".to_string(),
+                item_type: "piece".to_string(),
+                position: 0,
+                duration_secs: 600,
+                status: EntryStatus::Skipped,
+                notes: None,
+                score: None, // Skipped entries never have scores
+            }],
+        });
+
+        let vm = app.view(&model);
+        let p1 = vm.items.iter().find(|i| i.id == "p1").unwrap();
+        let practice = p1.practice.as_ref().unwrap();
+
+        assert_eq!(practice.latest_score, None);
+        assert!(practice.score_history.is_empty());
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -44,6 +44,8 @@ pub struct SetlistEntry {
     pub duration_secs: u64,
     pub status: EntryStatus,
     pub notes: Option<String>,
+    #[serde(default)]
+    pub score: Option<u8>,
 }
 
 /// A completed practice session (persisted to localStorage).
@@ -149,6 +151,10 @@ pub enum SessionEvent {
         entry_id: String,
         notes: Option<String>,
     },
+    UpdateEntryScore {
+        entry_id: String,
+        score: Option<u8>,
+    },
     UpdateSessionNotes {
         notes: Option<String>,
     },
@@ -207,6 +213,7 @@ fn create_entry(item_id: &str, item_title: &str, item_type: &str, position: usiz
         duration_secs: 0,
         status: EntryStatus::NotAttempted,
         notes: None,
+        score: None,
     }
 }
 
@@ -617,6 +624,35 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
         }
 
         // ── Summary Phase ──────────────────────────────────────────
+        SessionEvent::UpdateEntryScore { entry_id, score } => {
+            let SessionStatus::Summary(ref mut summary) = model.session_status else {
+                // Silent no-op if not in summary state (consistent with existing pattern)
+                return crux_core::render::render();
+            };
+
+            // Validate score range if present
+            if let Some(s) = score {
+                if !(validation::MIN_SCORE..=validation::MAX_SCORE).contains(&s) {
+                    // Silent no-op for out-of-range score
+                    return crux_core::render::render();
+                }
+            }
+
+            let Some(entry) = summary.entries.iter_mut().find(|e| e.id == entry_id) else {
+                // Silent no-op if entry not found
+                return crux_core::render::render();
+            };
+
+            // Only allow scoring on completed entries
+            if entry.status != EntryStatus::Completed {
+                return crux_core::render::render();
+            }
+
+            entry.score = score;
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
         SessionEvent::UpdateEntryNotes { entry_id, notes } => {
             let SessionStatus::Summary(ref mut summary) = model.session_status else {
                 model.last_error = Some("Not in summary state".to_string());
@@ -1546,6 +1582,207 @@ mod tests {
         assert_eq!(session.session_notes, Some("Focused session".to_string()));
         assert_eq!(session.total_duration_secs, 90); // 30 + 0 + 60
         assert_eq!(session.completion_status, CompletionStatus::Completed);
+    }
+
+    // --- UpdateEntryScore Tests ---
+
+    #[test]
+    fn test_update_entry_score_on_completed_entry() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(4),
+            }),
+        );
+
+        assert!(model.last_error.is_none());
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, Some(4));
+        } else {
+            panic!("Expected Summary state");
+        }
+    }
+
+    #[test]
+    fn test_update_entry_score_toggle_clears_score() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Set score to 4
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(4),
+            }),
+        );
+
+        // Clear score by setting to None (toggle)
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: None,
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, None);
+        } else {
+            panic!("Expected Summary state");
+        }
+    }
+
+    #[test]
+    fn test_update_entry_score_ignored_on_skipped_entry() {
+        // Create a session where one item is skipped
+        let (mut model, start) = model_with_active_session(2);
+        let t1 = start + chrono::Duration::seconds(5);
+        let t2 = t1 + chrono::Duration::seconds(30);
+
+        // Skip the first item
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SkipItem { now: t1 }),
+        );
+        // Finish the second item
+        update(
+            &mut model,
+            Event::Session(SessionEvent::FinishSession { now: t2 }),
+        );
+
+        let skipped_entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].status, EntryStatus::Skipped);
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Try to score the skipped entry — should be a no-op
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: skipped_entry_id.clone(),
+                score: Some(3),
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, None); // Score not set
+        } else {
+            panic!("Expected Summary state");
+        }
+    }
+
+    #[test]
+    fn test_update_entry_score_out_of_range_rejected() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Score 0 — out of range
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(0),
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, None); // Score not set
+        }
+
+        // Score 6 — out of range
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(6),
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, None); // Score still not set
+        }
+    }
+
+    #[test]
+    fn test_update_entry_score_only_works_during_summary() {
+        let (mut model, _start) = model_with_active_session(2);
+
+        // In Active state, try to update score
+        let entry_id = if let SessionStatus::Active(ref a) = model.session_status {
+            a.entries[0].id.clone()
+        } else {
+            panic!("Expected Active state");
+        };
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id,
+                score: Some(3),
+            }),
+        );
+
+        // Should still be in Active state, no crash, no error
+        assert!(matches!(model.session_status, SessionStatus::Active(_)));
+    }
+
+    #[test]
+    fn test_update_entry_score_boundary_values() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Score 1 — minimum valid
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(1),
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, Some(1));
+        }
+
+        // Score 5 — maximum valid
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryScore {
+                entry_id: entry_id.clone(),
+                score: Some(5),
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].score, Some(5));
+        }
     }
 
     // --- format_duration_display Tests ---

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use domain::types::{
 pub use error::LibraryError;
 pub use model::{
     ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model,
-    PracticeSessionView, SetlistEntryView, SummaryView, ViewModel,
+    PracticeSessionView, ScoreHistoryEntry, SetlistEntryView, SummaryView, ViewModel,
 };
 pub use validation::{
     MAX_BPM, MAX_CATEGORY, MAX_COMPOSER, MAX_NOTES, MAX_TAG, MAX_TEMPO_MARKING, MAX_TITLE, MIN_BPM,

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -51,6 +51,16 @@ pub struct LibraryItemView {
 pub struct ItemPracticeSummary {
     pub session_count: usize,
     pub total_minutes: u32,
+    pub latest_score: Option<u8>,
+    pub score_history: Vec<ScoreHistoryEntry>,
+}
+
+/// A single score data point for an item's progress history.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ScoreHistoryEntry {
+    pub session_date: String,
+    pub score: u8,
+    pub session_id: String,
 }
 
 /// A completed practice session in history view.
@@ -76,6 +86,7 @@ pub struct SetlistEntryView {
     pub duration_display: String,
     pub status: String,
     pub notes: Option<String>,
+    pub score: Option<u8>,
 }
 
 /// View for the in-progress active session.
@@ -122,6 +133,7 @@ pub fn entry_to_view(entry: &SetlistEntry) -> SetlistEntryView {
             EntryStatus::NotAttempted => "not_attempted".to_string(),
         },
         notes: entry.notes.clone(),
+        score: entry.score,
     }
 }
 

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -11,6 +11,8 @@ pub const MAX_TAG: usize = 100;
 pub const MAX_TEMPO_MARKING: usize = 100;
 pub const MIN_BPM: u16 = 1;
 pub const MAX_BPM: u16 = 400;
+pub const MIN_SCORE: u8 = 1;
+pub const MAX_SCORE: u8 = 5;
 
 pub fn validate_create_piece(input: &CreatePiece) -> Result<(), LibraryError> {
     if input.title.is_empty() {
@@ -230,6 +232,18 @@ pub fn validate_tags(tags: &[String]) -> Result<(), LibraryError> {
             return Err(LibraryError::Validation {
                 field: "tags".to_string(),
                 message: format!("Each tag must be between 1 and {MAX_TAG} characters"),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_score(score: &Option<u8>) -> Result<(), LibraryError> {
+    if let Some(s) = score {
+        if !(MIN_SCORE..=MAX_SCORE).contains(s) {
+            return Err(LibraryError::Validation {
+                field: "score".to_string(),
+                message: format!("Score must be between {MIN_SCORE} and {MAX_SCORE}"),
             });
         }
     }

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -19,6 +19,7 @@ pub fn SessionSummary() -> impl IntoView {
     let core_save = core.clone();
     let core_discard = core.clone();
     let core_entries = core.clone();
+    let core_score = core.clone();
     let core_session_notes_outer = core;
 
     view! {
@@ -30,6 +31,7 @@ pub fn SessionSummary() -> impl IntoView {
                         let core_save = core_save.clone();
                         let core_discard = core_discard.clone();
                         let core_entries = core_entries.clone();
+                        let core_score = core_score.clone();
                         let core_session_notes = core_session_notes_outer.clone();
                         let total_duration = summary.total_duration_display.clone();
                         let completion_status = summary.completion_status.clone();
@@ -61,8 +63,12 @@ pub fn SessionSummary() -> impl IntoView {
                                 <div class="space-y-3">
                                     {entries.into_iter().map(|entry| {
                                         let entry_id = entry.id.clone();
+                                        let entry_id_for_score = entry.id.clone();
                                         let entry_notes = RwSignal::new(entry.notes.clone().unwrap_or_default());
                                         let core_notes = core_entries.clone();
+                                        let core_score_inner = core_score.clone();
+                                        let is_completed = entry.status == "completed";
+                                        let current_score = entry.score;
                                         let status_label = match entry.status.as_str() {
                                             "completed" => "✓",
                                             "skipped" => "⊘",
@@ -102,6 +108,46 @@ pub fn SessionSummary() -> impl IntoView {
                                                         }
                                                     />
                                                 </div>
+                                                // Score buttons — only for completed entries
+                                                {if is_completed {
+                                                    let entry_id_score = entry_id_for_score.clone();
+                                                    let core_score_btns = core_score_inner.clone();
+                                                    Some(view! {
+                                                        <div class="flex items-center gap-2">
+                                                            <span class="text-xs text-gray-400 mr-1">"Confidence:"</span>
+                                                            {(1u8..=5).map(|n| {
+                                                                let entry_id_n = entry_id_score.clone();
+                                                                let core_n = core_score_btns.clone();
+                                                                let is_selected = current_score == Some(n);
+                                                                let btn_class = if is_selected {
+                                                                    "w-9 h-9 rounded-full text-sm font-semibold bg-indigo-600 text-white shadow-md transition-all duration-150"
+                                                                } else {
+                                                                    "w-9 h-9 rounded-full text-sm font-semibold bg-white/10 text-white/60 hover:bg-white/20 hover:text-white transition-all duration-150"
+                                                                };
+                                                                view! {
+                                                                    <button
+                                                                        class=btn_class
+                                                                        on:click=move |_| {
+                                                                            // Toggle: if same score is clicked, clear it
+                                                                            let new_score = if current_score == Some(n) { None } else { Some(n) };
+                                                                            let event = Event::Session(SessionEvent::UpdateEntryScore {
+                                                                                entry_id: entry_id_n.clone(),
+                                                                                score: new_score,
+                                                                            });
+                                                                            let core_ref = core_n.borrow();
+                                                                            let effects = core_ref.process_event(event);
+                                                                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                                                        }
+                                                                    >
+                                                                        {n.to_string()}
+                                                                    </button>
+                                                                }
+                                                            }).collect::<Vec<_>>()}
+                                                        </div>
+                                                    })
+                                                } else {
+                                                    None
+                                                }}
                                             </div>
                                         }
                                     }).collect::<Vec<_>>()}

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -193,17 +193,64 @@ pub fn DetailView() -> impl IntoView {
 
             // Practice summary
             {practice.map(|p| {
+                let has_scores = !p.score_history.is_empty();
                 view! {
-                    <div class="mt-4 rounded-lg bg-indigo-500/10 border border-indigo-400/20 px-4 py-3">
-                        <p class="text-sm font-medium text-indigo-200">
-                            {format!(
-                                "{} session{}, {} min total",
-                                p.session_count,
-                                if p.session_count == 1 { "" } else { "s" },
-                                p.total_minutes
-                            )}
-                        </p>
-                    </div>
+                    <Card>
+                        <div class="space-y-4">
+                            // Practice stats
+                            <div>
+                                <h3 class="text-sm font-semibold text-white mb-1">"Practice Summary"</h3>
+                                <p class="text-sm text-gray-300">
+                                    {format!(
+                                        "{} session{}, {} min total",
+                                        p.session_count,
+                                        if p.session_count == 1 { "" } else { "s" },
+                                        p.total_minutes
+                                    )}
+                                </p>
+                            </div>
+
+                            // Latest confidence score
+                            {p.latest_score.map(|score| {
+                                view! {
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-sm text-gray-400">"Current confidence:"</span>
+                                        <span class="text-2xl font-bold text-indigo-300">
+                                            {format!("{}/5", score)}
+                                        </span>
+                                    </div>
+                                }
+                            })}
+
+                            // Score history
+                            {if has_scores {
+                                let history = p.score_history;
+                                view! {
+                                    <div>
+                                        <h4 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">"Score History"</h4>
+                                        <div class="space-y-1.5">
+                                            {history.into_iter().map(|entry| {
+                                                // Format date for display (extract date portion from RFC3339)
+                                                let display_date = entry.session_date.split('T').next().unwrap_or(&entry.session_date).to_string();
+                                                view! {
+                                                    <div class="flex items-center justify-between text-sm">
+                                                        <span class="text-gray-400">{display_date}</span>
+                                                        <span class="inline-flex items-center rounded-md bg-indigo-500/20 px-1.5 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-indigo-400/20 ring-inset">
+                                                            {format!("{}/5", entry.score)}
+                                                        </span>
+                                                    </div>
+                                                }
+                                            }).collect::<Vec<_>>()}
+                                        </div>
+                                    </div>
+                                }.into_any()
+                            } else {
+                                view! {
+                                    <p class="text-xs text-gray-500">"No confidence scores recorded yet"</p>
+                                }.into_any()
+                            }}
+                        </div>
+                    </Card>
                 }
             })}
 

--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -87,6 +87,7 @@ fn SessionRow(
     let completion_status = session.completion_status.clone();
     let session_notes = session.notes.clone();
     let entry_count = session.entries.len();
+    let entries = session.entries.clone();
 
     view! {
         <Card>
@@ -119,40 +120,82 @@ fn SessionRow(
                     let total_duration = total_duration.clone();
                     let completion_status = completion_status.clone();
                     let session_notes = session_notes.clone();
+                    let entries = entries.clone();
                     view! {
-                        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                            <div class="flex-1 min-w-0">
-                                <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                                    <span class="text-sm font-medium text-white">
-                                        {total_duration}
-                                    </span>
-                                    <span class="text-xs text-gray-400">
-                                        {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
-                                    </span>
-                                    {if completion_status == "ended_early" {
-                                        Some(view! {
-                                            <span class="inline-flex items-center rounded-md bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-amber-400/20 ring-inset">
-                                                "Ended Early"
-                                            </span>
-                                        })
-                                    } else {
-                                        None
-                                    }}
-                                    <span class="text-xs text-gray-500">{started_at}</span>
+                        <div class="space-y-3">
+                            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                <div class="flex-1 min-w-0">
+                                    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                                        <span class="text-sm font-medium text-white">
+                                            {total_duration}
+                                        </span>
+                                        <span class="text-xs text-gray-400">
+                                            {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
+                                        </span>
+                                        {if completion_status == "ended_early" {
+                                            Some(view! {
+                                                <span class="inline-flex items-center rounded-md bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-amber-400/20 ring-inset">
+                                                    "Ended Early"
+                                                </span>
+                                            })
+                                        } else {
+                                            None
+                                        }}
+                                        <span class="text-xs text-gray-500">{started_at}</span>
+                                    </div>
+                                    {session_notes.map(|n| {
+                                        view! {
+                                            <p class="text-sm text-gray-300 mt-1">{n}</p>
+                                        }
+                                    })}
                                 </div>
-                                {session_notes.map(|n| {
-                                    view! {
-                                        <p class="text-sm text-gray-300 mt-1">{n}</p>
-                                    }
-                                })}
+                                <div class="flex gap-2 sm:ml-4">
+                                    <button
+                                        class="text-xs text-red-400 hover:text-red-300 font-medium"
+                                        on:click=move |_| { confirm_delete.set(true); }
+                                    >
+                                        "Delete"
+                                    </button>
+                                </div>
                             </div>
-                            <div class="flex gap-2 sm:ml-4">
-                                <button
-                                    class="text-xs text-red-400 hover:text-red-300 font-medium"
-                                    on:click=move |_| { confirm_delete.set(true); }
-                                >
-                                    "Delete"
-                                </button>
+                            // Entry details with scores
+                            <div class="border-t border-white/10 pt-2 space-y-1.5">
+                                {entries.into_iter().map(|entry| {
+                                    let status_label = match entry.status.as_str() {
+                                        "completed" => "✓",
+                                        "skipped" => "⊘",
+                                        _ => "—",
+                                    };
+                                    let status_color = match entry.status.as_str() {
+                                        "completed" => "text-green-400",
+                                        "skipped" => "text-amber-400",
+                                        _ => "text-gray-500",
+                                    };
+                                    view! {
+                                        <div class="flex items-center justify-between text-xs">
+                                            <div class="flex items-center gap-2 min-w-0">
+                                                <span class={format!("font-medium {}", status_color)}>{status_label}</span>
+                                                <span class="text-white truncate">{entry.item_title}</span>
+                                                <span class="text-gray-500 shrink-0">{entry.duration_display}</span>
+                                            </div>
+                                            <div class="flex items-center gap-2 shrink-0 ml-2">
+                                                {entry.score.map(|s| {
+                                                    view! {
+                                                        <span class="inline-flex items-center rounded-md bg-indigo-500/20 px-1.5 py-0.5 text-xs font-medium text-indigo-300 ring-1 ring-indigo-400/20 ring-inset">
+                                                            {format!("{}/5", s)}
+                                                        </span>
+                                                    }
+                                                })}
+                                                {entry.notes.map(|n| {
+                                                    let title = n.clone();
+                                                    view! {
+                                                        <span class="text-gray-400 truncate max-w-[120px]" title={title}>{n}</span>
+                                                    }
+                                                })}
+                                            </div>
+                                        </div>
+                                    }
+                                }).collect::<Vec<_>>()}
                             </div>
                         </div>
                     }.into_any()

--- a/crates/intrada-web/tests/wasm.rs
+++ b/crates/intrada-web/tests/wasm.rs
@@ -49,6 +49,7 @@ fn test_session_in_progress_round_trip() {
             duration_secs: 0,
             status: EntryStatus::NotAttempted,
             notes: None,
+            score: None,
         }],
         current_index: 0,
         session_started_at: now,

--- a/specs/022-session-scoring/checklists/requirements.md
+++ b/specs/022-session-scoring/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Session Item Scoring
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.plan`.
+- Clarification session (2026-02-17): 3 questions asked, 3 answered. Score semantics, progress presentation, and scope boundary all resolved.
+- Reasonable defaults applied: 1–5 confidence scale, chronological list with latest-score highlight, detail-page-only display, scoring optional, read-only history.

--- a/specs/022-session-scoring/contracts/api-changes.md
+++ b/specs/022-session-scoring/contracts/api-changes.md
@@ -1,0 +1,146 @@
+# API Contract Changes: Session Item Scoring
+
+**Feature**: 022-session-scoring
+**Date**: 2026-02-17
+
+## Overview
+
+No new endpoints. The existing session endpoints are extended to include the optional `score` field on setlist entries. All changes are backward compatible — the `score` field is optional in both requests and responses.
+
+## Modified Endpoints
+
+### POST /api/sessions
+
+**Change**: `entries[].score` field added to request body.
+
+**Request body** (updated `SaveSessionRequest`):
+
+```json
+{
+  "entries": [
+    {
+      "id": "01HXYZ...",
+      "item_id": "01HABC...",
+      "item_title": "Clair de Lune",
+      "item_type": "piece",
+      "position": 0,
+      "duration_secs": 300,
+      "status": "Completed",
+      "notes": "Good tempo control",
+      "score": 4
+    },
+    {
+      "id": "01HXYZ...",
+      "item_id": "01HDEF...",
+      "item_title": "C Major Scale",
+      "item_type": "exercise",
+      "position": 1,
+      "duration_secs": 0,
+      "status": "Skipped",
+      "notes": null,
+      "score": null
+    }
+  ],
+  "session_notes": "Great session overall",
+  "started_at": "2026-02-17T10:00:00Z",
+  "completed_at": "2026-02-17T10:35:00Z",
+  "total_duration_secs": 300,
+  "completion_status": "Completed"
+}
+```
+
+**Field: `entries[].score`**
+- Type: `integer | null`
+- Required: No (defaults to `null` if omitted)
+- Constraints: When present, must be 1–5 inclusive
+- Validation error: 400 Bad Request with message `"Score must be between 1 and 5"`
+
+**Response**: Unchanged structure — `201 Created` with full `PracticeSession` including entries with `score` field.
+
+---
+
+### GET /api/sessions
+
+**Change**: Response entries now include `score` field.
+
+**Response body** (entries within each session):
+
+```json
+[
+  {
+    "id": "01HSESS...",
+    "entries": [
+      {
+        "id": "01HENTRY...",
+        "item_id": "01HABC...",
+        "item_title": "Clair de Lune",
+        "item_type": "piece",
+        "position": 0,
+        "duration_secs": 300,
+        "status": "Completed",
+        "notes": "Good tempo control",
+        "score": 4
+      }
+    ],
+    "session_notes": "Great session",
+    "started_at": "2026-02-17T10:00:00Z",
+    "completed_at": "2026-02-17T10:35:00Z",
+    "total_duration_secs": 300,
+    "completion_status": "Completed"
+  }
+]
+```
+
+**Field: `entries[].score`**
+- Type: `integer | null`
+- `null` for entries that were not scored, or for entries from sessions saved before this feature
+
+---
+
+### GET /api/sessions/{id}
+
+**Change**: Same as GET /api/sessions — entries include `score` field.
+
+---
+
+### DELETE /api/sessions/{id}
+
+**Change**: None. Cascade delete removes entries including their scores.
+
+## Validation Rules (Server-Side)
+
+Applied in the `save_session` route handler:
+
+1. If `entry.score` is present (not null):
+   - Value must be >= 1 and <= 5
+   - If out of range: return `400 Bad Request` with `"Score must be between 1 and 5"`
+2. If `entry.score` is null or absent: accepted (no score recorded)
+3. No validation that score is only present on "Completed" entries at the API level — the core enforces this constraint during the session summary flow. The API stores whatever valid (1–5 or null) score is provided.
+
+## Crux Event Contract
+
+### New Event: `SessionEvent::UpdateEntryScore`
+
+```
+Event::Session(SessionEvent::UpdateEntryScore {
+    entry_id: String,
+    score: Option<u8>,
+})
+```
+
+**Preconditions**:
+- `session_status` must be `Summary`
+- Entry with `entry_id` must exist in the summary's entries
+- Entry must have `status == Completed`
+- If `score` is `Some(n)`, then `n` must be 1–5
+
+**Effects**:
+- Updates the entry's `score` field in the `SummarySession`
+- Triggers a re-render (existing render effect)
+
+**Error behaviour**:
+- If preconditions fail: no state change, no error surfaced (silent no-op, consistent with existing event handling pattern)
+
+### Modified Effect: `StorageEffect::SavePracticeSession`
+
+No structural change. The `PracticeSession` payload now includes entries with `score: Option<u8>`. The shell serializes this as part of the existing JSON body sent to `POST /api/sessions`.

--- a/specs/022-session-scoring/data-model.md
+++ b/specs/022-session-scoring/data-model.md
@@ -1,0 +1,159 @@
+# Data Model: Session Item Scoring
+
+**Feature**: 022-session-scoring
+**Date**: 2026-02-17
+
+## Entity Changes
+
+### Modified: SetlistEntry (domain)
+
+The core domain entity `SetlistEntry` gains a new optional `score` field.
+
+```
+SetlistEntry
+├── id: String (ULID)                    # existing
+├── item_id: String (ULID)               # existing
+├── item_title: String                   # existing (snapshot)
+├── item_type: String                    # existing ("piece" | "exercise")
+├── position: usize                      # existing (0-indexed)
+├── duration_secs: u64                   # existing
+├── status: EntryStatus                  # existing (Completed | Skipped | NotAttempted)
+├── notes: Option<String>                # existing
+└── score: Option<u8>                    # NEW — confidence score 1–5, None = not scored
+```
+
+**Validation rules**:
+- Score must be `None` or a value in range 1–5 (inclusive)
+- Score is only meaningful when `status == Completed`; core ignores score on Skipped/NotAttempted entries
+- Score defaults to `None` when entry is created
+
+### Modified: SummarySession (transient)
+
+The `SummarySession` struct is transient (exists only during session review, not persisted). It contains `Vec<SetlistEntry>`, so it inherits the score field automatically. No structural changes needed — the existing `UpdateEntryNotes` pattern is mirrored by a new `UpdateEntryScore` event.
+
+### Modified: ActiveSession (transient, localStorage)
+
+The `ActiveSession` struct is persisted to localStorage for crash recovery. It contains `Vec<SetlistEntry>`, so it inherits the score field. Since scoring only happens during the Summary phase (after Active), the score field will always be `None` during the Active phase. Backward compatible — deserialization of old ActiveSession data (without score) will default to `None` via `serde`.
+
+### Unchanged: PracticeSession (persisted)
+
+`PracticeSession` contains `Vec<SetlistEntry>`, so it inherits the score field automatically. No structural changes needed.
+
+## New View Types
+
+### ScoreHistoryEntry (view model)
+
+A single data point in the progress history for a library item.
+
+```
+ScoreHistoryEntry
+├── session_date: String                 # RFC3339 timestamp of the session's started_at
+├── score: u8                            # confidence score 1–5
+└── session_id: String                   # reference to the parent session (for potential linking)
+```
+
+**Derivation**: Computed in core `view()` by filtering all session entries where `item_id` matches and `score.is_some()`, ordered by `session.started_at` descending (most recent first).
+
+### Modified: SetlistEntryView
+
+```
+SetlistEntryView
+├── id: String                           # existing
+├── item_id: String                      # existing
+├── item_title: String                   # existing
+├── item_type: String                    # existing
+├── position: usize                      # existing
+├── duration_display: String             # existing
+├── status: String                       # existing
+├── notes: Option<String>                # existing
+└── score: Option<u8>                    # NEW — raw score value for display
+```
+
+### Modified: SummaryView
+
+```
+SummaryView
+├── total_duration_display: String       # existing
+├── completion_status: String            # existing
+├── notes: Option<String>                # existing
+└── entries: Vec<SetlistEntryView>       # existing (entries now include score)
+```
+
+No structural change — entries already carry the updated `SetlistEntryView`.
+
+### Modified: ItemPracticeSummary
+
+```
+ItemPracticeSummary
+├── session_count: usize                 # existing
+├── total_minutes: u32                   # existing
+├── latest_score: Option<u8>            # NEW — most recent confidence score, None if never scored
+└── score_history: Vec<ScoreHistoryEntry> # NEW — all scored entries, most recent first
+```
+
+### Modified: LibraryItemView
+
+No structural change. `LibraryItemView` already contains `practice: Option<ItemPracticeSummary>`, which now includes the new fields. Per FR-011, score data is NOT displayed on the library list — only on the detail page where `ItemPracticeSummary` is rendered fully.
+
+## Database Schema Changes
+
+### Migration: Add score column
+
+```sql
+ALTER TABLE setlist_entries ADD COLUMN score INTEGER;
+```
+
+- Column is nullable (no `NOT NULL` constraint)
+- No default value — existing rows get `NULL`
+- No new indexes needed (queries filter by `session_id`, not by `score`)
+- Check constraint not added at DB level — validated in application code (core + API)
+
+### Updated: setlist_entries table (post-migration)
+
+```
+setlist_entries
+├── id TEXT PRIMARY KEY NOT NULL
+├── session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE
+├── item_id TEXT NOT NULL
+├── item_title TEXT NOT NULL
+├── item_type TEXT NOT NULL
+├── position INTEGER NOT NULL
+├── duration_secs INTEGER NOT NULL
+├── status TEXT NOT NULL
+├── notes TEXT
+└── score INTEGER                        # NEW — nullable, values 1–5 or NULL
+```
+
+## Event Changes
+
+### New: SessionEvent::UpdateEntryScore
+
+```
+UpdateEntryScore { entry_id: String, score: Option<u8> }
+```
+
+- Dispatched from the summary screen when user taps a score button
+- Passing `Some(n)` sets the score; passing `None` clears it (toggle-to-deselect)
+- Core validates: if `score.is_some()`, value must be 1–5; entry must have status `Completed`
+- Only valid during `SessionStatus::Summary`
+
+## Relationships
+
+```
+PracticeSession 1──* SetlistEntry (entries, ordered by position)
+     │                    │
+     │                    └── score: Option<u8> (NEW)
+     │
+Library Item ◄──── SetlistEntry.item_id (many entries reference one item)
+     │
+     └── ItemPracticeSummary (computed view)
+              ├── latest_score (derived from most recent scored entry)
+              └── score_history (derived from all scored entries)
+```
+
+## Backward Compatibility
+
+- **Existing sessions in DB**: `score` column is nullable → existing rows have `NULL` → deserialized as `Option<u8> = None` → displayed as "not scored"
+- **Existing sessions in localStorage** (crash recovery): `serde` deserialization of `ActiveSession` with missing `score` field defaults to `None` via `#[serde(default)]`
+- **API responses**: Existing `GET /sessions` and `GET /sessions/{id}` return entries with `score: null` for pre-existing data — JSON clients handle this naturally
+- **API requests**: `POST /sessions` accepts entries with or without `score` field — `serde` defaults missing field to `None`

--- a/specs/022-session-scoring/plan.md
+++ b/specs/022-session-scoring/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Session Item Scoring
+
+**Branch**: `022-session-scoring` | **Date**: 2026-02-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/022-session-scoring/spec.md`
+
+## Summary
+
+Add an optional 1–5 confidence score field to each completed setlist entry during the session summary review. Persist scores through the existing Crux effect pipeline to the Turso database via a new `score` column on `setlist_entries`. Display scores on session history views and add a chronological progress summary (with latest-score highlight) to each library item's detail page. No new crates, endpoints, or architectural patterns — this extends existing session data flow end-to-end.
+
+## Technical Context
+
+**Language/Version**: Rust stable (1.89.0 in CI; workspace MSRV 1.75+, 2021 edition)
+**Primary Dependencies**: crux_core 0.17.0-rc2, leptos 0.8.x (CSR), axum 0.8, libsql 0.9, serde 1, ulid 1, chrono 0.4
+**Storage**: Turso (managed libsql/SQLite) via REST API; localStorage for session-in-progress crash recovery only
+**Testing**: `cargo test` (core unit tests), `wasm-bindgen-test` (WASM boundary tests), Playwright (E2E)
+**Target Platform**: WASM (web frontend via Leptos CSR) + Linux server (API via Axum)
+**Project Type**: Workspace with 3 crates (core, web, api)
+**Performance Goals**: Scoring interaction must not add perceptible delay to the summary screen; progress query must return within existing page-load time
+**Constraints**: Pure core must remain I/O-free; backward compatible with existing sessions (no score = NULL)
+**Scale/Scope**: Single-user app; realistic dataset: hundreds of sessions, thousands of entries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| V. Architecture Integrity — Pure Core | ✅ Pass | Score field added to core domain types. No I/O in core. New `UpdateEntryScore` event processed purely. Shell renders UI and handles persistence as before. |
+| V. Architecture Integrity — Shell Isolation | ✅ Pass | Score input UI lives in `intrada-web` components only. API persistence in `intrada-api` only. |
+| V. Architecture Integrity — Effect-Driven | ✅ Pass | Score flows through existing `SavePracticeSession` effect — no new effect type needed. |
+| V. Architecture Integrity — Portable | ✅ Pass | `cargo test` in `intrada-core` requires no browser. Score is a plain `Option<u8>`. |
+| V. Architecture Integrity — Validation Sharing | ✅ Pass | Score range validation (1–5) defined once in `intrada-core/src/validation.rs`, reused by API. |
+| I. Code Quality | ✅ Pass | `Option<u8>` is the simplest possible representation. No new abstractions introduced. |
+| II. Testing Standards | ✅ Pass | Core unit tests for score events, API integration tests for score persistence, E2E test for scoring flow. Boundary tested at core↔shell via existing pattern. |
+| III. UX Consistency | ✅ Pass | Score input follows existing interaction patterns (inline controls on summary entries, like notes). Consistent with glassmorphism styling. |
+| IV. Performance | ✅ Pass | Adding one `Option<u8>` per entry has negligible impact. Progress query is a filter over existing data — no new indexes needed at this scale. |
+
+**Result**: All gates pass. No violations to track.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-session-scoring/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── api-changes.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (files modified by this feature)
+
+```text
+crates/
+  intrada-core/
+  ├── src/
+  │   ├── domain/
+  │   │   └── session.rs          # Add score field to SetlistEntry, SummarySession event
+  │   ├── model.rs                # Add score to view types, add ItemScoreHistory
+  │   ├── validation.rs           # Add score range validation constant
+  │   ├── app.rs                  # Add UpdateEntryScore event, update compute_practice_summary
+  │   └── lib.rs                  # Re-export new types if needed
+  intrada-web/
+  ├── src/
+  │   ├── components/
+  │   │   └── session_summary.rs  # Add score input controls per entry
+  │   ├── views/
+  │   │   ├── detail.rs           # Add progress/score history section
+  │   │   └── session_detail.rs   # Display scores on past session entries
+  │   └── api_client.rs           # No changes (PracticeSession shape updated via core)
+  intrada-api/
+  ├── src/
+  │   ├── db/
+  │   │   └── sessions.rs         # Add score to SaveSessionEntry, SQL queries
+  │   ├── routes/
+  │   │   └── sessions.rs         # Validate score range on save
+  │   └── migrations.rs           # Add migration: ALTER TABLE setlist_entries ADD COLUMN score INTEGER
+```
+
+**Structure Decision**: Existing 3-crate workspace. No new crates or directories. Changes are additive within existing modules.

--- a/specs/022-session-scoring/quickstart.md
+++ b/specs/022-session-scoring/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Session Item Scoring
+
+**Feature**: 022-session-scoring
+**Date**: 2026-02-17
+
+## Prerequisites
+
+- Rust stable toolchain (1.75+)
+- Trunk installed (`cargo install trunk`)
+- Tailwind CSS v4 standalone CLI available
+- Running Turso database (or local libsql for development)
+- API server running (`cargo run -p intrada-api`)
+
+## Build & Run
+
+```bash
+# Run all tests (core + api + wasm)
+cargo test
+
+# Run clippy
+cargo clippy -- -D warnings
+
+# Start the API server (in one terminal)
+cargo run -p intrada-api
+
+# Start the web dev server (in another terminal)
+cd crates/intrada-web && trunk serve
+```
+
+## Verification Steps
+
+### V1: Score Assignment (FR-001, FR-002, FR-003)
+
+1. Open the app and navigate to the library
+2. Start a new practice session with at least 2 items
+3. Complete the session (or end early)
+4. On the summary screen, verify:
+   - Each **completed** entry shows 5 tappable score buttons (1–5)
+   - Skipped or not-attempted entries do NOT show score buttons
+5. Tap score "4" on the first completed entry → button highlights
+6. Tap score "4" again → deselects (returns to no score)
+7. Tap score "3" → button 3 highlights
+8. Leave the second entry unscored
+9. Save the session
+10. **Expected**: Session saves successfully with no errors
+
+### V2: Score Persistence & Display (FR-004, FR-005, FR-006)
+
+1. After V1, navigate to the session history
+2. Open the session you just saved
+3. Verify:
+   - First entry shows score "3"
+   - Second entry shows no score indicator
+   - Duration, status, and notes are unchanged
+4. Open an older session (saved before this feature)
+5. Verify: entries display normally with no score — no errors or visual artefacts
+
+### V3: Progress Summary (FR-007, FR-010, FR-011)
+
+1. Complete 2–3 sessions that include the same library item, scoring it differently each time (e.g., 2, then 3, then 4)
+2. Navigate to that item's detail page
+3. Verify:
+   - The most recent confidence score is displayed prominently
+   - Below it, a chronological list shows all past scores with session dates
+   - Most recent score appears first in the list
+4. Navigate back to the library list view
+5. Verify: scores do NOT appear on the list cards (FR-011)
+
+### V4: Edge Cases
+
+1. Save a session with zero entries scored → session saves normally
+2. Add the same item twice to a session, score each differently → both scores appear in that item's progress history
+3. View an item that has been practised but never scored → "No scores available" message shown
+
+### V5: Backward Compatibility (FR-006, SC-004)
+
+1. Verify existing sessions in the database display correctly
+2. Verify the API returns `null` for `score` on pre-existing entries
+3. Run `cargo test` — all existing tests pass with no modification
+
+## Smoke Test (CI)
+
+```bash
+cargo test && cargo clippy -- -D warnings
+```
+
+All existing tests must continue to pass. New tests for scoring must be added as part of implementation.

--- a/specs/022-session-scoring/research.md
+++ b/specs/022-session-scoring/research.md
@@ -1,0 +1,72 @@
+# Research: Session Item Scoring
+
+**Feature**: 022-session-scoring
+**Date**: 2026-02-17
+
+## Overview
+
+This feature adds an optional confidence score (1–5) to each completed setlist entry. The research below resolves all technical decisions needed before design and implementation.
+
+## Decision 1: Score Data Type
+
+**Decision**: `Option<u8>` in Rust; `INTEGER` (nullable) in SQLite/Turso
+
+**Rationale**: A score is a small integer (1–5). `u8` is the smallest standard Rust integer type and maps cleanly to SQLite `INTEGER`. Using `Option` makes the field nullable, preserving backward compatibility with existing entries (which will have `NULL` scores). No need for a float, enum, or separate table — the value is a simple number attached to an existing record.
+
+**Alternatives considered**:
+- `Option<u16>` / `Option<i32>`: Unnecessarily wide for a 1–5 range.
+- Custom `Score` newtype: Adds indirection with no practical benefit. Validation at boundaries (event handler + API route) is sufficient.
+- Separate `scores` table: Over-engineered for a single optional field on an existing entity.
+
+## Decision 2: Score Validation Strategy
+
+**Decision**: Define `MIN_SCORE: u8 = 1` and `MAX_SCORE: u8 = 5` in `intrada-core/src/validation.rs`. Validate in two places: (1) the core `UpdateEntryScore` event handler rejects out-of-range values, (2) the API `save_session` route rejects out-of-range values before database insert.
+
+**Rationale**: Consistent with existing validation pattern — constants are defined once in core and imported by both core event handlers and API routes. The core validates during the session summary (client-side), the API validates on save (server-side). Belt-and-braces approach prevents invalid data regardless of entry point.
+
+**Alternatives considered**:
+- Validate only in core: Server would accept any value if called directly (bypassing the web shell).
+- Validate only in API: Invalid scores could appear in the local summary view before save.
+- Newtype with `TryFrom`: Cleaner in isolation, but inconsistent with how existing validation (notes length, BPM range) is handled in this codebase.
+
+## Decision 3: Database Migration Approach
+
+**Decision**: Add a new migration in `migrations.rs`: `ALTER TABLE setlist_entries ADD COLUMN score INTEGER;`. The column is nullable with no default — existing rows remain `NULL`.
+
+**Rationale**: SQLite supports `ALTER TABLE ... ADD COLUMN` with nullable columns. This is the simplest possible migration. Existing sessions remain untouched (NULL score = "not scored"), and the application code already uses `Option<u8>` which maps directly to nullable INTEGER. No data backfill needed.
+
+**Alternatives considered**:
+- Default value (e.g., `DEFAULT 0`): Would make existing entries appear scored at 0, which is semantically wrong and outside the 1–5 range.
+- New table: Unnecessary complexity for a single column addition.
+
+## Decision 4: Progress Computation Location
+
+**Decision**: Compute item score history in the core `view()` function alongside the existing `compute_practice_summary`. Add a new `compute_score_history` function that filters scored entries for a given `item_id` and returns them chronologically.
+
+**Rationale**: The core already computes `ItemPracticeSummary` per library item during `view()` by iterating all sessions. Extending this to also collect score history follows the same pattern — pure computation in core, no I/O. The data is already loaded into the `Model` (all sessions are fetched on app start).
+
+**Alternatives considered**:
+- New API endpoint (`GET /items/{id}/progress`): Would require a new server-side query. Not needed — all session data is already available client-side in the Model. At this scale (hundreds of sessions), client-side filtering is instant.
+- Compute in the shell (web): Violates the pure-core principle. The shell should only render what core provides.
+
+## Decision 5: Score UI Control
+
+**Decision**: Use a row of 5 tappable number buttons (1–5) per completed entry on the summary screen. Selected button is visually highlighted. Tapping the same button again deselects it (returns to no score).
+
+**Rationale**: Five buttons are the most direct, accessible, and mobile-friendly control for a 1–5 discrete scale. Each number is a single tap — no sliders, no dropdowns, no modals. The toggle-to-deselect behaviour supports the "scoring is optional" requirement. This is consistent with the app's existing interaction style (inline controls on entry rows, similar to the notes input).
+
+**Alternatives considered**:
+- Star rating: Common but adds visual complexity and ambiguity ("is 3 stars good or bad?"). Numbers are explicit.
+- Slider: Poor for discrete values; imprecise on mobile.
+- Dropdown/select: Requires two interactions (open + select); slower.
+
+## Decision 6: Progress Display Format
+
+**Decision**: On the item detail page, show: (1) the most recent confidence score displayed prominently as a large number with label, (2) below it, a chronological list of past scores with session date and score value, most recent first.
+
+**Rationale**: Per clarification, users want to see "where am I now?" at a glance (latest score), plus the ability to scan history. A simple list is the minimum viable presentation that enables this. Charts or trend indicators can be added in a future feature.
+
+**Alternatives considered**:
+- Chart/sparkline: Valuable but out of scope per spec assumptions.
+- Trend arrow: Requires defining "trend" algorithm — deferred to future feature.
+- Average score: Loses temporal information; masks recent improvement or decline.

--- a/specs/022-session-scoring/spec.md
+++ b/specs/022-session-scoring/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Session Item Scoring
+
+**Feature Branch**: `022-session-scoring`
+**Created**: 2026-02-17
+**Status**: Draft
+**Input**: User description: "A user should be able to score each item at the end of a session. This data will be used to track progress of items over time"
+
+## Clarifications
+
+### Session 2026-02-17
+
+- Q: What does the score represent — session quality, confidence/mastery, or difficulty? → A: Confidence/mastery — "How confident do I feel with this piece?" (cumulative self-assessment)
+- Q: How should the progress summary present scores visually? → A: Chronological list with the most recent score highlighted prominently
+- Q: Should the latest confidence score surface on the library list view or only the item detail page? → A: Detail page only — library list stays clean
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Score Items During Session Review (Priority: P1)
+
+After completing a practice session, during the summary review screen, a user assigns a confidence score to each item they practised. The score reflects how confident they feel with that item — a cumulative self-assessment of mastery (e.g., "How confident do I feel with this piece?"). The user then saves the session with scores included.
+
+**Why this priority**: This is the core interaction — without the ability to assign scores, no progress data can be collected. Everything else builds on this.
+
+**Independent Test**: Can be fully tested by completing a practice session with multiple items, assigning different scores to each item on the summary screen, saving the session, and verifying scores are persisted when the session is viewed again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the session summary screen after practising, **When** they view the list of completed entries, **Then** each entry with status "completed" displays a scoring control defaulting to no score selected.
+2. **Given** a user is on the session summary screen, **When** they assign a score to a completed entry, **Then** the selected score is visually indicated and associated with that entry.
+3. **Given** a user has assigned scores to some or all entries, **When** they save the session, **Then** the scores are persisted alongside each entry.
+4. **Given** a user has entries with status "skipped" or "not attempted", **When** they view the summary screen, **Then** those entries do not display a scoring control (scores only apply to completed entries).
+5. **Given** a user chooses not to score a completed entry, **When** they save the session, **Then** the entry is saved with no score (scoring is optional per entry).
+
+---
+
+### User Story 2 - View Scores on Past Sessions (Priority: P2)
+
+A user views a previously completed session and sees the scores they assigned to each item. This provides a historical record of how they felt about each practice.
+
+**Why this priority**: Users need to recall past self-assessments to understand their journey. This is the basic read-back of stored data.
+
+**Independent Test**: Can be fully tested by viewing a saved session that has scores and confirming each entry displays its recorded score alongside duration and status.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user views a completed session that has scored entries, **When** the session detail loads, **Then** each entry displays its score alongside existing information (duration, status, notes).
+2. **Given** a user views a completed session where some entries were not scored, **When** the session detail loads, **Then** unscored entries show no score indicator (not a zero or default).
+3. **Given** a user views a session completed before scoring was available, **When** the session detail loads, **Then** entries display without scores (backward compatible).
+
+---
+
+### User Story 3 - Track Item Progress Over Time (Priority: P3)
+
+A user views a library item (piece or exercise) and sees a summary of their scoring history — how their scores have trended across sessions. This helps them understand whether they are improving, plateauing, or struggling with a particular item.
+
+**Why this priority**: This is the downstream value of collecting scores — turning data into insight. It depends on scores being collected (P1) and readable (P2).
+
+**Independent Test**: Can be fully tested by practising the same item across multiple sessions with varying scores, then viewing that item's detail page and confirming the progress summary reflects all recorded scores in chronological order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a library item has been scored in multiple sessions, **When** the user views that item's detail page, **Then** they see the most recent confidence score displayed prominently, followed by a chronological list of all past scores with session dates.
+2. **Given** a library item has been practised but never scored, **When** the user views that item's detail page, **Then** the progress section indicates no scores are available yet.
+3. **Given** a library item appears multiple times in a single session (e.g., warm-up and main practice), **When** the user views progress, **Then** each scored occurrence is included as a separate data point.
+4. **Given** a library item has only one scored session, **When** the user views the progress summary, **Then** the single score is displayed prominently as the latest score, with no additional history rows.
+
+---
+
+### Edge Cases
+
+- What happens when a user saves a session with zero entries scored? The session saves normally; scoring is entirely optional.
+- What happens when the same library item appears multiple times in one session with different scores? Each entry is independent — both scores are stored and both appear in the item's progress history.
+- What happens when a library item is deleted after sessions with scores exist? Scores remain on the session entries (item data is already snapshotted). The item's progress view is no longer accessible, but session history retains the scores.
+- What happens when viewing progress for an item that has only "skipped" or "not attempted" entries across sessions? The progress section shows no scores available, since only completed entries can be scored.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow users to assign a score to each session entry with status "completed" during the session summary review.
+- **FR-002**: System MUST use a 1–5 numeric scale for confidence scores, where 1 represents the lowest confidence ("not confident at all") and 5 represents the highest ("fully confident / mastered").
+- **FR-003**: Scoring MUST be optional — users may save a session without scoring any or all completed entries.
+- **FR-004**: System MUST persist the score as part of the session entry when the session is saved.
+- **FR-005**: System MUST display stored scores when viewing a previously completed session.
+- **FR-006**: System MUST remain backward compatible — sessions saved before scoring was introduced display normally without score information.
+- **FR-007**: System MUST display a progress summary on each library item's detail page, showing the most recent confidence score prominently, followed by a chronological history of all past scores.
+- **FR-008**: System MUST NOT allow scoring of entries with status "skipped" or "not attempted".
+- **FR-009**: When a library item appears multiple times in a single session, each occurrence MUST be independently scoreable.
+- **FR-010**: The progress summary for a library item MUST include the date of each session and the score assigned, ordered chronologically.
+- **FR-011**: Confidence scores MUST NOT appear on the library list view — progress information is only visible on the individual item detail page.
+
+### Key Entities
+
+- **Confidence Score**: A numeric value (1–5) representing a user's self-assessed confidence or mastery of a specific item, recorded at the end of a session. Attached to a single setlist entry. Optional (may be absent).
+- **Item Progress**: An aggregated, chronological view of all scores for a given library item across sessions. Derived from scored setlist entries that reference that item.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can score all completed items in a session and save within 30 seconds of additional interaction beyond the current summary flow.
+- **SC-002**: 100% of saved scores are accurately displayed when the session is viewed again.
+- **SC-003**: Progress history for a library item correctly reflects all scored sessions, with no data loss or duplication.
+- **SC-004**: Sessions saved before this feature was introduced continue to display correctly with no visual artefacts or errors.
+
+## Assumptions
+
+- The 1–5 numeric scale is appropriate for a quick confidence self-assessment during session review. This is a common pattern in practice journals and spaced-repetition tools. Labels for the scale endpoints (e.g., 1 = "Not confident", 5 = "Mastered") can be determined during design/planning.
+- Progress tracking is read-only — users cannot edit scores on past sessions after saving. If retroactive editing is needed, it would be a separate feature.
+- The progress summary on the item detail page shows the latest score prominently plus a chronological list — not a chart or graph. Visual enhancements can be layered on later.
+- Scores are personal and not shared or compared between users (single-user context, consistent with the existing app model).

--- a/specs/022-session-scoring/tasks.md
+++ b/specs/022-session-scoring/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: Session Item Scoring
+
+**Input**: Design documents from `/specs/022-session-scoring/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project setup needed — this feature extends existing crates. This phase covers only the shared foundational changes that all user stories depend on.
+
+- [x] T001 Add score validation constants `MIN_SCORE: u8 = 1` and `MAX_SCORE: u8 = 5` (and a `validate_score` function) to `crates/intrada-core/src/validation.rs`
+- [x] T002 Add `score: Option<u8>` field to `SetlistEntry` struct in `crates/intrada-core/src/domain/session.rs` — include `#[serde(default)]` for backward compatibility with deserialized data; update all places where `SetlistEntry` is constructed to initialise `score: None`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Database migration and API-layer changes that MUST be complete before any user story can persist scores
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Add database migration to `crates/intrada-api/src/migrations.rs` — new migration: `ALTER TABLE setlist_entries ADD COLUMN score INTEGER;`
+- [x] T004 [P] Add `score: Option<u8>` field to `SaveSessionEntry` struct in `crates/intrada-api/src/db/sessions.rs`; update the `INSERT INTO setlist_entries` SQL in `insert_session` to include the `score` column; update the `SELECT` query in `parse_entry_row` (or equivalent row-parsing code) to read the `score` column
+- [x] T005 [P] Add server-side score validation in `crates/intrada-api/src/routes/sessions.rs` — in the `save_session` handler, validate each entry's score: if `score.is_some()`, value must be 1–5 (import constants from `intrada-core::validation`); return 400 Bad Request with message `"Score must be between 1 and 5"` if invalid
+- [x] T006 Verify backward compatibility — run `cargo test` across the entire workspace to confirm all existing tests pass with the new `score` field (all constructors initialise `score: None`, deserialization defaults missing field to `None`)
+
+**Checkpoint**: Foundation ready — score field flows through domain types, database, and API. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Score Items During Session Review (Priority: P1) 🎯 MVP
+
+**Goal**: Users can assign a 1–5 confidence score to each completed entry on the session summary screen before saving.
+
+**Independent Test**: Complete a practice session with multiple items, assign different scores on the summary screen, save, and verify scores are persisted when the session is viewed again.
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Add `UpdateEntryScore { entry_id: String, score: Option<u8> }` variant to `SessionEvent` enum in `crates/intrada-core/src/domain/session.rs`
+- [x] T008 [US1] Implement `UpdateEntryScore` event handler in the session event processing logic in `crates/intrada-core/src/domain/session.rs` — when `SessionStatus::Summary`, find the entry by `entry_id`, verify `status == Completed`, validate score range (1–5 or None), and update the entry's `score` field; no-op if preconditions fail
+- [x] T009 [US1] Add `score: Option<u8>` field to `SetlistEntryView` struct in `crates/intrada-core/src/model.rs`; update the `entry_to_view` (or equivalent) function that converts `SetlistEntry` → `SetlistEntryView` to pass through the score value
+- [x] T010 [US1] Add unit tests for `UpdateEntryScore` event in `crates/intrada-core/src/domain/session.rs` (or `crates/intrada-core/src/app.rs` test module): test setting score on completed entry, test clearing score (toggle), test score ignored on skipped entry, test out-of-range score rejected, test score only works during Summary status
+- [x] T011 [US1] Add score input UI to the session summary component in `crates/intrada-web/src/components/session_summary.rs` — for each entry with `status == "completed"`, render a row of 5 tappable number buttons (1–5) below the entry; highlight the selected button; on click, dispatch `Event::Session(SessionEvent::UpdateEntryScore { entry_id, score })` where score toggles (same value → None, different value → Some(n)); do NOT render score buttons for skipped/not-attempted entries
+- [x] T012 [US1] Style the score buttons in `crates/intrada-web/src/components/session_summary.rs` — use glassmorphism-consistent styling: small rounded buttons with the app's indigo/white colour palette; selected state uses `bg-indigo-600 text-white`; unselected state uses `bg-white/10 text-white/60`; ensure touch targets are at least 44px for mobile
+
+**Checkpoint**: At this point, User Story 1 should be fully functional — users can score items on the summary screen and save sessions with scores persisted to the database.
+
+---
+
+## Phase 4: User Story 2 — View Scores on Past Sessions (Priority: P2)
+
+**Goal**: Users can see previously assigned scores when viewing completed session history.
+
+**Independent Test**: View a saved session that has scored entries and confirm each entry displays its recorded score alongside duration, status, and notes.
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Update the session detail view in `crates/intrada-web/src/views/session_detail.rs` (or the component that renders a single past session) to display the `score` field from `SetlistEntryView` — show the score as a small badge or number next to each completed entry; show nothing for entries where `score` is `None`
+- [x] T014 [US2] Add API integration test in `crates/intrada-api/src/` (existing test module) — test that `POST /sessions` with scored entries returns the scores in the response; test that `GET /sessions/{id}` returns the correct scores; test that entries without scores return `score: null`
+- [x] T015 [US2] Verify backward compatibility display — manually or via test: create a session via the API without `score` fields in the request body and confirm it returns `score: null` for each entry; load a session detail view for this session and confirm no visual artefacts
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work — users can score items and then view those scores on past sessions.
+
+---
+
+## Phase 5: User Story 3 — Track Item Progress Over Time (Priority: P3)
+
+**Goal**: Users can view a chronological history of confidence scores on each library item's detail page, with the most recent score highlighted.
+
+**Independent Test**: Practice the same item across multiple sessions with varying scores, then view that item's detail page and confirm the progress summary reflects all recorded scores chronologically.
+
+### Implementation for User Story 3
+
+- [x] T016 [US3] Add `ScoreHistoryEntry` struct to `crates/intrada-core/src/model.rs` with fields: `session_date: String` (RFC3339), `score: u8`, `session_id: String`
+- [x] T017 [US3] Add `latest_score: Option<u8>` and `score_history: Vec<ScoreHistoryEntry>` fields to `ItemPracticeSummary` struct in `crates/intrada-core/src/model.rs`
+- [x] T018 [US3] Update the `compute_practice_summary` function in `crates/intrada-core/src/app.rs` to also collect score history — iterate session entries matching `item_id`, collect entries where `score.is_some()`, build `ScoreHistoryEntry` records with session date, sort by `session.started_at` descending (most recent first), set `latest_score` to the first entry's score (or None if empty)
+- [x] T019 [US3] Add unit tests for score history computation in `crates/intrada-core/src/app.rs` test module — test item with multiple scored sessions returns correct chronological order; test item with no scored sessions returns empty history and `latest_score: None`; test item appearing multiple times in one session produces multiple history entries; test item with only skipped entries returns empty history
+- [x] T020 [US3] Update the item detail view in `crates/intrada-web/src/views/detail.rs` to display the progress section — below the existing practice summary ("X sessions, Y min total"), add a new section: if `latest_score.is_some()`, show the latest score prominently (large number with label like "Current confidence: 4/5"); below it, render a list of `score_history` entries showing date and score; if `score_history` is empty, show "No confidence scores recorded yet"
+- [x] T021 [US3] Style the progress section in `crates/intrada-web/src/views/detail.rs` — use a card or panel consistent with the glassmorphism design; latest score displayed as a large number; history list uses the app's standard list styling with subtle separators; ensure the section does NOT appear on the library list view (FR-011) — it only renders within the detail page
+
+**Checkpoint**: All user stories should now be independently functional — scoring, viewing, and progress tracking all work end-to-end.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup across all stories
+
+- [x] T022 Run `cargo clippy -- -D warnings` across the entire workspace and fix any warnings
+- [x] T023 Run `cargo test` across the entire workspace and verify all tests pass (existing + new)
+- [x] T024 Run quickstart.md verification steps V1–V5 end-to-end and confirm all pass
+- [x] T025 Verify the library list view does NOT show any score-related information (FR-011 spot-check)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational phase completion
+- **User Story 2 (Phase 4)**: Depends on Foundational phase; functionally independent of US1 but best done after US1 (scores must exist to view them)
+- **User Story 3 (Phase 5)**: Depends on Foundational phase; requires US1 scored data to be meaningful, but code can be developed independently
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Phase 2. No dependencies on other stories.
+- **User Story 2 (P2)**: Can start after Phase 2. Code is independent of US1, but testing requires scored sessions (from US1 flow).
+- **User Story 3 (P3)**: Can start after Phase 2. Code is independent of US1/US2, but testing requires scored sessions.
+
+### Within Each User Story
+
+- Core domain/model changes before web shell UI changes
+- Event handlers before UI that dispatches events
+- Unit tests alongside or immediately after the code they test
+
+### Parallel Opportunities
+
+- T004 and T005 can run in parallel (different files: `db/sessions.rs` vs `routes/sessions.rs`)
+- T007 and T009 can run in parallel (different files: `domain/session.rs` vs `model.rs`)
+- T016 and T017 can run in parallel (both in `model.rs` but logically grouped — implement together)
+- Once Phase 2 is complete, US1/US2/US3 core changes could theoretically proceed in parallel (different concerns)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Phase 2 foundation is complete:
+
+# Core domain changes (can run in parallel across files):
+Task T007: "Add UpdateEntryScore event variant in domain/session.rs"
+Task T009: "Add score to SetlistEntryView in model.rs"
+
+# Then sequentially:
+Task T008: "Implement UpdateEntryScore handler" (depends on T007)
+Task T010: "Add unit tests" (depends on T008)
+Task T011: "Add score UI to session_summary.rs" (depends on T009)
+Task T012: "Style score buttons" (depends on T011)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T006)
+3. Complete Phase 3: User Story 1 (T007–T012)
+4. **STOP and VALIDATE**: Score items on summary, save, and verify persistence
+5. This alone delivers the core value — confidence scoring
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add User Story 1 → Score items and save → **MVP!**
+3. Add User Story 2 → View scores on past sessions → Deploy
+4. Add User Story 3 → Progress tracking on item detail → Deploy
+5. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All `score` field additions use `Option<u8>` with `#[serde(default)]` for backward compatibility
+- Existing tests must continue passing at every checkpoint
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently


### PR DESCRIPTION
## Summary
- Add optional 1–5 confidence scoring to practice session entries, enabling musicians to rate how well they performed each piece/exercise
- Display scores throughout the UI: star rating during session summary, score badges on session history, and per-item score progress on library detail pages
- Introduce `ScoreHistoryEntry` model to track confidence trends over time per library item

## Changes across the stack

**Domain & Validation** (`intrada-core`)
- `SetlistEntry.score: Option<u8>` with 1–5 validation
- `ScoreHistoryEntry` struct for progress tracking
- `ItemPracticeSummary` expanded with `latest_score` and `score_history`
- `UpdateEntryScore` session event + handler
- `compute_practice_summary` collects and sorts score history

**API & Database** (`intrada-api`)
- Migration adds `score` column to `session_entries` table
- Score persisted/retrieved through full CRUD cycle
- Validation rejects scores outside 1–5 range (400 Bad Request)

**Web UI** (`intrada-web`)
- Star rating component in end-of-session summary
- Session history entries show status icons (✓/⊘/—), score badges, and notes
- Library detail page shows latest confidence score and full score history

**Tests**: 17 new tests (10 core unit + 7 API integration), all passing

## Test plan
- [x] `cargo test` — all tests pass (pre-existing flaky `list_pieces_returns_created_items` unrelated)
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] Backward compatibility: sessions without scores return `score: null`
- [x] FR-011 verified: scores appear only on detail page, not library list

🤖 Generated with [Claude Code](https://claude.com/claude-code)