### PR TITLE
Fix migration multi-statement bug causing missing setlist_entries table

### DIFF
--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -99,9 +99,11 @@ const MIGRATIONS: &[(&str, &str)] = &[
             completed_at TEXT NOT NULL,
             total_duration_secs INTEGER NOT NULL,
             completion_status TEXT NOT NULL
-        );
-
-        CREATE TABLE IF NOT EXISTS setlist_entries (
+        );",
+    ),
+    (
+        "0004_create_setlist_entries",
+        "CREATE TABLE IF NOT EXISTS setlist_entries (
             id TEXT PRIMARY KEY NOT NULL,
             session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
             item_id TEXT NOT NULL,
@@ -111,12 +113,14 @@ const MIGRATIONS: &[(&str, &str)] = &[
             duration_secs INTEGER NOT NULL,
             status TEXT NOT NULL,
             notes TEXT
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
+        );",
     ),
     (
-        "0004_add_score_to_setlist_entries",
+        "0005_index_setlist_entries_session_id",
+        "CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
+    ),
+    (
+        "0006_add_score_to_setlist_entries",
         "ALTER TABLE setlist_entries ADD COLUMN score INTEGER;",
     ),
 ];


### PR DESCRIPTION
## Summary
- Fix production migration failure where `setlist_entries` table was never created on Turso
- `libsql_migration` executes each migration as a single SQL statement, but migration `0003` contained three semicolon-separated statements — only the first (`CREATE TABLE sessions`) ran
- Split into individual migrations: `0003` (sessions), `0004` (setlist_entries), `0005` (index), `0006` (score column)

## Root cause
Migration `0003_create_sessions` bundled three SQL statements:
1. `CREATE TABLE sessions` ✅ ran
2. `CREATE TABLE setlist_entries` ❌ silently skipped
3. `CREATE INDEX` ❌ silently skipped

The `libsql_migration::content::migrate` function only executes the first statement, so the `setlist_entries` table was never created in the production Turso database.

## Test plan
- [x] All 45 API tests pass
- [x] Existing databases with `0003` already applied will pick up new `0004`–`0006` on next deploy
- [x] New databases create all tables correctly via sequential single-statement migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)