### PR TITLE
Add migration tests and eliminate dual-schema source of truth

### DIFF
--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -1,63 +1,10 @@
 use libsql::Connection;
 
-/// Raw SQL statements for each migration (used by tests that skip libsql_migration).
-pub const MIGRATION_SQL: &[&str] = &[
-    "CREATE TABLE IF NOT EXISTS pieces (
-        id TEXT PRIMARY KEY NOT NULL,
-        title TEXT NOT NULL,
-        composer TEXT NOT NULL,
-        key_signature TEXT,
-        tempo_marking TEXT,
-        tempo_bpm INTEGER,
-        notes TEXT,
-        tags TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );",
-    "CREATE TABLE IF NOT EXISTS exercises (
-        id TEXT PRIMARY KEY NOT NULL,
-        title TEXT NOT NULL,
-        composer TEXT,
-        category TEXT,
-        key_signature TEXT,
-        tempo_marking TEXT,
-        tempo_bpm INTEGER,
-        notes TEXT,
-        tags TEXT NOT NULL DEFAULT '[]',
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-    );",
-    "CREATE TABLE IF NOT EXISTS sessions (
-        id TEXT PRIMARY KEY NOT NULL,
-        session_notes TEXT,
-        started_at TEXT NOT NULL,
-        completed_at TEXT NOT NULL,
-        total_duration_secs INTEGER NOT NULL,
-        completion_status TEXT NOT NULL
-    );",
-    "CREATE TABLE IF NOT EXISTS setlist_entries (
-        id TEXT PRIMARY KEY NOT NULL,
-        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-        item_id TEXT NOT NULL,
-        item_title TEXT NOT NULL,
-        item_type TEXT NOT NULL,
-        position INTEGER NOT NULL,
-        duration_secs INTEGER NOT NULL,
-        status TEXT NOT NULL,
-        notes TEXT,
-        score INTEGER
-    );",
-    "CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
-];
-
-/// Run migrations directly via SQL (for testing with in-memory databases).
-pub async fn run_migrations_sql(conn: &Connection) -> Result<(), Box<dyn std::error::Error>> {
-    for sql in MIGRATION_SQL {
-        conn.execute(sql, ()).await?;
-    }
-    Ok(())
-}
-
+/// Single source of truth for all database migrations.
+///
+/// Each entry is `(name, sql)` where `sql` must contain exactly ONE SQL statement.
+/// Production uses `run_migrations()` (via libsql_migration tracking).
+/// Tests use `run_migrations_direct()` (raw execution, same SQL).
 const MIGRATIONS: &[(&str, &str)] = &[
     (
         "0001_create_pieces",
@@ -125,6 +72,7 @@ const MIGRATIONS: &[(&str, &str)] = &[
     ),
 ];
 
+/// Run migrations via libsql_migration (production path — tracks applied state).
 pub async fn run_migrations(conn: &Connection) -> Result<(), Box<dyn std::error::Error>> {
     for (id, sql) in MIGRATIONS {
         let result = libsql_migration::content::migrate(conn, id.to_string(), sql.to_string())
@@ -141,4 +89,41 @@ pub async fn run_migrations(conn: &Connection) -> Result<(), Box<dyn std::error:
         }
     }
     Ok(())
+}
+
+/// Run migrations via direct SQL execution (test path — no tracking overhead).
+///
+/// Uses the same `MIGRATIONS` source as `run_migrations()` to guarantee
+/// tests and production always execute identical SQL.
+pub async fn run_migrations_direct(conn: &Connection) -> Result<(), Box<dyn std::error::Error>> {
+    for (_id, sql) in MIGRATIONS {
+        conn.execute(sql, ()).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Guard: every migration must contain exactly one SQL statement.
+    ///
+    /// libsql_migration silently ignores all but the first statement in a
+    /// multi-statement migration. This test catches that mistake at compile
+    /// time rather than discovering it in production.
+    #[test]
+    fn each_migration_contains_single_statement() {
+        for (name, sql) in MIGRATIONS {
+            // Strip trailing whitespace and the final semicolon, then check
+            // for any remaining semicolons — which would indicate multiple
+            // statements were bundled together.
+            let trimmed = sql.trim().trim_end_matches(';').trim();
+            assert!(
+                !trimmed.contains(';'),
+                "Migration '{name}' contains multiple SQL statements. \
+                 libsql_migration only executes the first statement. \
+                 Split this into separate migrations."
+            );
+        }
+    }
 }

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -22,7 +22,7 @@ pub async fn setup_test_app() -> Router {
 
     let conn = db.connect().expect("Failed to connect to test database");
 
-    migrations::run_migrations_sql(&conn)
+    migrations::run_migrations_direct(&conn)
         .await
         .expect("Failed to run migrations");
 

--- a/crates/intrada-api/tests/migrations_test.rs
+++ b/crates/intrada-api/tests/migrations_test.rs
@@ -1,0 +1,126 @@
+use intrada_api::migrations;
+
+/// Helper: create a fresh local SQLite database and return a connection.
+async fn fresh_db() -> libsql::Connection {
+    let tmp_dir = std::env::temp_dir();
+    let db_path = tmp_dir.join(format!("intrada_migration_test_{}.db", ulid::Ulid::new()));
+
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("Failed to build test database");
+
+    db.connect().expect("Failed to connect to test database")
+}
+
+/// Test the production migration path (libsql_migration) creates all expected tables.
+#[tokio::test]
+async fn run_migrations_creates_all_tables() {
+    let conn = fresh_db().await;
+
+    migrations::run_migrations(&conn)
+        .await
+        .expect("run_migrations should succeed on fresh database");
+
+    // Query sqlite_master for all user-created tables (excluding libsql_migration internals).
+    let mut rows = conn
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '\\__%' ESCAPE '\\' ORDER BY name",
+            (),
+        )
+        .await
+        .expect("Failed to query sqlite_master");
+
+    let mut tables: Vec<String> = Vec::new();
+    while let Some(row) = rows.next().await.expect("Failed to read row") {
+        let name: String = row.get(0).expect("Failed to get table name");
+        tables.push(name);
+    }
+
+    assert!(
+        tables.contains(&"pieces".to_string()),
+        "Missing 'pieces' table. Found: {tables:?}"
+    );
+    assert!(
+        tables.contains(&"exercises".to_string()),
+        "Missing 'exercises' table. Found: {tables:?}"
+    );
+    assert!(
+        tables.contains(&"sessions".to_string()),
+        "Missing 'sessions' table. Found: {tables:?}"
+    );
+    assert!(
+        tables.contains(&"setlist_entries".to_string()),
+        "Missing 'setlist_entries' table. Found: {tables:?}"
+    );
+}
+
+/// Test that the score column exists on setlist_entries after migrations.
+#[tokio::test]
+async fn run_migrations_adds_score_column() {
+    let conn = fresh_db().await;
+
+    migrations::run_migrations(&conn)
+        .await
+        .expect("run_migrations should succeed");
+
+    // PRAGMA table_info returns one row per column.
+    let mut rows = conn
+        .query("PRAGMA table_info(setlist_entries)", ())
+        .await
+        .expect("Failed to query table_info");
+
+    let mut columns: Vec<String> = Vec::new();
+    while let Some(row) = rows.next().await.expect("Failed to read row") {
+        let name: String = row.get(1).expect("Failed to get column name");
+        columns.push(name);
+    }
+
+    assert!(
+        columns.contains(&"score".to_string()),
+        "Missing 'score' column on setlist_entries. Found: {columns:?}"
+    );
+}
+
+/// Test that running migrations twice is idempotent (no errors on second run).
+#[tokio::test]
+async fn run_migrations_is_idempotent() {
+    let conn = fresh_db().await;
+
+    migrations::run_migrations(&conn)
+        .await
+        .expect("First run should succeed");
+
+    migrations::run_migrations(&conn)
+        .await
+        .expect("Second run should succeed (idempotent)");
+}
+
+/// Test that the index on setlist_entries.session_id exists after migrations.
+#[tokio::test]
+async fn run_migrations_creates_index() {
+    let conn = fresh_db().await;
+
+    migrations::run_migrations(&conn)
+        .await
+        .expect("run_migrations should succeed");
+
+    let mut rows = conn
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='setlist_entries'",
+            (),
+        )
+        .await
+        .expect("Failed to query indexes");
+
+    let mut indexes: Vec<String> = Vec::new();
+    while let Some(row) = rows.next().await.expect("Failed to read row") {
+        let name: String = row.get(0).expect("Failed to get index name");
+        indexes.push(name);
+    }
+
+    assert!(
+        indexes.contains(&"idx_setlist_entries_session_id".to_string()),
+        "Missing index 'idx_setlist_entries_session_id'. Found: {indexes:?}"
+    );
+}


### PR DESCRIPTION
Three layers of protection against the multi-statement migration bug:

1. Single source of truth: remove duplicate MIGRATION_SQL array; both production (run_migrations) and tests (run_migrations_direct) now read from the same MIGRATIONS constant.

2. Single-statement guard: unit test asserts every migration entry contains exactly one SQL statement, failing immediately if someone bundles multiple statements.

3. Production path tests: 4 integration tests exercise run_migrations() (the libsql_migration code path) against a real SQLite database — verifying all tables, columns, indexes, and idempotency.