### PR TITLE
Improve form UX: helper text, disabled states, accessibility

### DIFF
--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -69,6 +69,8 @@ pub fn SessionSummary() -> impl IntoView {
                                         let core_score_inner = core_score.clone();
                                         let is_completed = entry.status == "completed";
                                         let current_score = entry.score;
+                                        let notes_label = format!("Notes for {}", entry.item_title);
+                                        let notes_input_id = format!("entry-notes-{}", entry.id);
                                         let status_label = match entry.status.as_str() {
                                             "completed" => "✓",
                                             "skipped" => "⊘",
@@ -90,8 +92,12 @@ pub fn SessionSummary() -> impl IntoView {
                                                     <span class="text-sm text-gray-400">{entry.duration_display}</span>
                                                 </div>
                                                 <div>
+                                                    <label class="sr-only" for=notes_input_id.clone()>
+                                                        {notes_label}
+                                                    </label>
                                                     <input
                                                         type="text"
+                                                        id=notes_input_id
                                                         placeholder="Add notes for this item..."
                                                         class="w-full rounded border border-white/20 bg-white/10 text-white placeholder-gray-400 px-2 py-1 text-sm focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400"
                                                         bind:value=entry_notes
@@ -124,9 +130,13 @@ pub fn SessionSummary() -> impl IntoView {
                                                                 } else {
                                                                     "w-9 h-9 rounded-full text-sm font-semibold bg-white/10 text-white/60 hover:bg-white/20 hover:text-white transition-all duration-150"
                                                                 };
+                                                                let aria_label = format!("Rate confidence {} out of 5", n);
+                                                                let aria_pressed = if is_selected { "true" } else { "false" };
                                                                 view! {
                                                                     <button
                                                                         class=btn_class
+                                                                        aria-label=aria_label
+                                                                        aria-pressed=aria_pressed
                                                                         on:click=move |_| {
                                                                             // Toggle: if same score is clicked, clear it
                                                                             let new_score = if current_score == Some(n) { None } else { Some(n) };

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -89,19 +89,40 @@ pub fn SetlistBuilder() -> impl IntoView {
                 }}
             </Card>
 
+            // Error display (above buttons so it's visible without scrolling)
+            {move || {
+                let vm = view_model.get();
+                vm.error.map(|err| {
+                    view! {
+                        <p class="text-sm text-red-400">{err}</p>
+                    }
+                })
+            }}
+
             // Action buttons
             <div class="flex gap-3">
                 {
                     let core_start = core_actions.clone();
                     let core_cancel = core_actions.clone();
+                    let setlist_empty = Signal::derive(move || {
+                        let vm = view_model.get();
+                        match &vm.building_setlist {
+                            Some(setlist) => setlist.entries.is_empty(),
+                            None => true,
+                        }
+                    });
                     view! {
-                        <Button variant=ButtonVariant::Primary on_click=Callback::new(move |_| {
-                            let now = chrono::Utc::now();
-                            let event = Event::Session(SessionEvent::StartSession { now });
-                            let core_ref = core_start.borrow();
-                            let effects = core_ref.process_event(event);
-                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                        })>
+                        <Button
+                            variant=ButtonVariant::Primary
+                            disabled=setlist_empty
+                            on_click=Callback::new(move |_| {
+                                let now = chrono::Utc::now();
+                                let event = Event::Session(SessionEvent::StartSession { now });
+                                let core_ref = core_start.borrow();
+                                let effects = core_ref.process_event(event);
+                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                            })
+                        >
                             "Start Session"
                         </Button>
                         <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
@@ -115,16 +136,6 @@ pub fn SetlistBuilder() -> impl IntoView {
                     }
                 }
             </div>
-
-            // Error display
-            {move || {
-                let vm = view_model.get();
-                vm.error.map(|err| {
-                    view! {
-                        <p class="text-sm text-red-400">{err}</p>
-                    }
-                })
-            }}
 
             // Library items to add
             <Card>

--- a/crates/intrada-web/src/components/text_area.rs
+++ b/crates/intrada-web/src/components/text_area.rs
@@ -11,6 +11,7 @@ pub fn TextArea(
     label: &'static str,
     value: RwSignal<String>,
     #[prop(default = 3)] rows: u32,
+    #[prop(optional)] hint: Option<&'static str>,
     field_name: &'static str,
     errors: RwSignal<HashMap<String, String>>,
 ) -> impl IntoView {
@@ -23,6 +24,9 @@ pub fn TextArea(
             <label class="block text-sm font-medium text-gray-200 mb-1" for=id>
                 {label}
             </label>
+            {hint.map(|h| view! {
+                <p class="text-xs text-gray-400 mb-1">{h}</p>
+            })}
             <textarea
                 id=id
                 rows=rows_str

--- a/crates/intrada-web/src/components/text_field.rs
+++ b/crates/intrada-web/src/components/text_field.rs
@@ -12,6 +12,7 @@ pub fn TextField(
     value: RwSignal<String>,
     #[prop(default = false)] required: bool,
     #[prop(optional)] placeholder: Option<&'static str>,
+    #[prop(optional)] hint: Option<&'static str>,
     field_name: &'static str,
     errors: RwSignal<HashMap<String, String>>,
     #[prop(default = "text")] input_type: &'static str,
@@ -24,6 +25,9 @@ pub fn TextField(
             <label class="block text-sm font-medium text-gray-200 mb-1" for=id>
                 {label}
             </label>
+            {hint.map(|h| view! {
+                <p class="text-xs text-gray-400 mb-1">{h}</p>
+            })}
             <input
                 id=id
                 type=input_type

--- a/crates/intrada-web/src/views/add_form.rs
+++ b/crates/intrada-web/src/views/add_form.rs
@@ -152,7 +152,7 @@ pub fn AddLibraryItemForm() -> impl IntoView {
                                 }.into_any()
                             } else {
                                 view! {
-                                    <TextField id="add-composer" label="Composer" value=composer field_name="composer" errors=errors />
+                                    <TextField id="add-composer" label="Composer (optional)" value=composer field_name="composer" errors=errors />
                                 }.into_any()
                             }
                         }}
@@ -169,7 +169,7 @@ pub fn AddLibraryItemForm() -> impl IntoView {
                         }}
 
                         // Key (optional — shared)
-                        <TextField id="add-key" label="Key" value=key_sig placeholder="e.g. C Major, Db Minor" field_name="key" errors=errors />
+                        <TextField id="add-key" label="Key" value=key_sig hint="e.g. C Major, Db Minor" field_name="key" errors=errors />
 
                         // Tempo: marking + BPM on one row (shared)
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -178,10 +178,10 @@ pub fn AddLibraryItemForm() -> impl IntoView {
                         </div>
 
                         // Notes (optional — shared)
-                        <TextArea id="add-notes" label="Notes" value=notes field_name="notes" errors=errors />
+                        <TextArea id="add-notes" label="Notes" value=notes hint="Practice notes, goals, or reminders" field_name="notes" errors=errors />
 
                         // Tags (shared)
-                        <TextField id="add-tags" label="Tags" value=tags_input placeholder="Comma-separated, e.g. classical, piano" field_name="tags" errors=errors />
+                        <TextField id="add-tags" label="Tags" value=tags_input hint="Comma-separated" placeholder="e.g. classical, piano" field_name="tags" errors=errors />
 
                         // Buttons
                         <div class="flex flex-col sm:flex-row gap-3 pt-2">

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -208,7 +208,7 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                             }.into_any()
                         } else {
                             view! {
-                                <TextField id="edit-composer" label="Composer" value=composer field_name="composer" errors=errors />
+                                <TextField id="edit-composer" label="Composer (optional)" value=composer field_name="composer" errors=errors />
                             }.into_any()
                         }}
 
@@ -222,7 +222,7 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                         }}
 
                         // Key (optional — shared)
-                        <TextField id="edit-key" label="Key" value=key_sig placeholder="e.g. C Major, Db Minor" field_name="key" errors=errors />
+                        <TextField id="edit-key" label="Key" value=key_sig hint="e.g. C Major, Db Minor" field_name="key" errors=errors />
 
                         // Tempo: marking + BPM on one row (shared)
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -231,10 +231,10 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                         </div>
 
                         // Notes (optional — shared)
-                        <TextArea id="edit-notes" label="Notes" value=notes field_name="notes" errors=errors />
+                        <TextArea id="edit-notes" label="Notes" value=notes hint="Practice notes, goals, or reminders" field_name="notes" errors=errors />
 
                         // Tags (shared)
-                        <TextField id="edit-tags" label="Tags" value=tags_input placeholder="Comma-separated, e.g. classical, piano" field_name="tags" errors=errors />
+                        <TextField id="edit-tags" label="Tags" value=tags_input hint="Comma-separated" placeholder="e.g. classical, piano" field_name="tags" errors=errors />
 
                         // Buttons
                         <div class="flex flex-col sm:flex-row gap-3 pt-2">


### PR DESCRIPTION
## Summary
- Add `hint` prop to `TextField` and `TextArea` components for persistent helper text below labels
- Add hints to Key, Notes, and Tags fields in both add and edit forms; label Composer as "(optional)" on Exercise tab
- Disable Start Session button when setlist is empty; move error message above action buttons for visibility
- Add `sr-only` labels to entry notes inputs, `aria-label` and `aria-pressed` to confidence score buttons in session summary

## Test plan
- [x] All 218 tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [ ] Manual: verify helper text visible below labels on add/edit forms
- [ ] Manual: verify Composer shows "(optional)" on Exercise tab
- [ ] Manual: verify Start Session button is disabled when setlist is empty
- [ ] Manual: verify error message appears above buttons in setlist builder
- [ ] Manual: screen reader testing for session summary score buttons

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)