### PR TITLE
Fix session cancel leaving user stuck on /sessions/new

### DIFF
--- a/crates/intrada-web/src/views/session_new.rs
+++ b/crates/intrada-web/src/views/session_new.rs
@@ -41,8 +41,13 @@ pub fn SessionNewView() -> impl IntoView {
                 );
             }
             "idle" => {
-                // If building was cancelled, go back to sessions
-                // But don't navigate on initial mount — only if we were building
+                navigate(
+                    "/sessions",
+                    NavigateOptions {
+                        replace: true,
+                        ..Default::default()
+                    },
+                );
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- When clicking Cancel on an empty setlist, the `CancelBuilding` event correctly resets state to `idle`, but the effect handler in `session_new.rs` had an empty match arm — no navigation occurred
- User was left stuck on `/sessions/new` in an idle state with no way forward
- Added the missing `navigate("/sessions")` call, matching the pattern already used in `session_active.rs` and `session_summary.rs`

## Test plan
- [x] All 218 tests pass (`cargo test`)
- [x] No clippy warnings
- [ ] Manual: navigate to /sessions/new, click Cancel without adding items — should redirect to /sessions
- [ ] Manual: add items, then click Cancel — should redirect to /sessions
- [ ] Manual: add items, click Start Session — should still work as before

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)