### PR TITLE
Add Analytics link to desktop header navigation

### DIFF
--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -20,6 +20,11 @@ pub fn AppHeader() -> impl IntoView {
         path.starts_with("/sessions")
     };
 
+    let is_analytics_active = move || {
+        let path = location.pathname.get();
+        path.starts_with("/analytics")
+    };
+
     view! {
         <header class="bg-gray-900/60 supports-backdrop:backdrop-blur-md border-b border-white/10" role="banner">
             <div class="max-w-4xl mx-auto px-4 sm:px-6 py-4 sm:py-5 flex items-center justify-between">
@@ -55,6 +60,19 @@ pub fn AppHeader() -> impl IntoView {
                         attr:aria-current=move || if is_sessions_active() { Some("page") } else { None }
                     >
                         "Sessions"
+                    </A>
+                    <A
+                        href="/analytics"
+                        attr:class=move || {
+                            if is_analytics_active() {
+                                "text-sm font-medium text-indigo-300 motion-safe:transition-colors"
+                            } else {
+                                "text-sm font-medium text-gray-300 hover:text-white motion-safe:transition-colors"
+                            }
+                        }
+                        attr:aria-current=move || if is_analytics_active() { Some("page") } else { None }
+                    >
+                        "Analytics"
                     </A>
                 </nav>
             </div>


### PR DESCRIPTION
## Summary
- Add missing Analytics link to the desktop header nav bar
- The Analytics page was only reachable from the mobile bottom tab bar — desktop users had no way to navigate to it
- Uses the same active-state styling pattern (indigo-300 highlight, aria-current) as Library and Sessions links

Closes #80

## Test plan
- [ ] Desktop: verify Library, Sessions, and Analytics links all appear in the header
- [ ] Verify Analytics link highlights when on `/analytics` route
- [ ] Mobile: confirm bottom tab bar still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)