### PR TITLE
Improve local developer experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# intrada local development environment
+# Copy this file to .env and fill in your Turso credentials:
+#   cp .env.example .env
+
+# Turso database credentials (required for API server)
+TURSO_DATABASE_URL=libsql://intrada-YOUR_ORG.turso.io
+TURSO_AUTH_TOKEN=your-token-here
+
+# API server port (default: 3001, Fly.io sets 8080 in production)
+PORT=3001
+
+# CORS allowed origin (should match the Trunk dev server URL)
+ALLOWED_ORIGIN=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ release/
 .idea/
 *.log
 .env*
+!.env.example
 .DS_Store
 Thumbs.db
 *.tmp

--- a/README.md
+++ b/README.md
@@ -21,11 +21,43 @@ Intrada follows the Crux pure-core pattern: the core (`intrada-core`) contains a
 ## Prerequisites
 
 - Rust stable (2021 edition, 1.75+)
-- [Trunk](https://trunkrs.dev/) (for building and serving the web app)
+- [Trunk](https://trunkrs.dev/) (`cargo install trunk`)
+- [just](https://github.com/casey/just) (`brew install just` or `cargo install just`)
 
-## Getting started
+## Quick start
 
-All commands should be run from the project root (`intrada/`).
+```bash
+# 1. Set up environment
+cp .env.example .env
+# Edit .env with your Turso credentials
+
+# 2. Start both API and web dev servers
+just dev
+# → API on :3001, web on :8080 (proxies /api/* to API)
+
+# 3. Open http://localhost:8080
+```
+
+## Available commands
+
+Run `just` to see all commands. Key ones:
+
+```bash
+just dev        # Start API + web dev servers concurrently
+just dev-api    # Start only the API server
+just dev-web    # Start only the Trunk dev server
+just test       # Run all tests
+just lint       # Run clippy
+just fmt        # Format code
+just check      # Run test + clippy + format check
+just seed       # Seed development data (API must be running)
+just build      # Build WASM for production/E2E
+just e2e        # Build + run Playwright E2E tests
+```
+
+## Getting started (manual)
+
+If you prefer not to use `just`, all commands should be run from the project root:
 
 ```bash
 # Build all crates
@@ -41,11 +73,8 @@ cargo clippy
 ### Web app (local development)
 
 ```bash
-# Install trunk if you haven't already
-cargo install trunk
-
-# Serve the web app with hot reload
 trunk serve --config crates/intrada-web/Trunk.toml
+# → http://localhost:8080 (proxies /api/* to localhost:3001)
 ```
 
 ### API server (requires Turso credentials)
@@ -54,6 +83,7 @@ trunk serve --config crates/intrada-web/Trunk.toml
 export TURSO_DATABASE_URL="libsql://intrada-<your-org>.turso.io"
 export TURSO_AUTH_TOKEN="<your-token>"
 export ALLOWED_ORIGIN="http://localhost:8080"
+export PORT=3001
 
 cargo run -p intrada-api
 ```
@@ -66,7 +96,8 @@ To populate the API with realistic sample data (8 pieces, 5 exercises, ~25 pract
 
 ```bash
 # Requires: curl, jq
-bash scripts/seed-dev-data.sh
+just seed
+# or: bash scripts/seed-dev-data.sh
 ```
 
 This creates a realistic dataset with score progression, practice streaks, varied session lengths, and mixed completion statuses — useful for seeing how the library, session history, and analytics dashboard look with real data.

--- a/SETUP.md
+++ b/SETUP.md
@@ -131,6 +131,7 @@ fly deploy
 | `TURSO_AUTH_TOKEN` | `fly secrets set` | Token from `turso db tokens create` |
 | `ALLOWED_ORIGIN` | `fly secrets set` | Frontend URL (e.g. `https://intrada.xxx.workers.dev`) |
 | `RUST_LOG` | `fly.toml` [env] | `info` (already configured) |
+| `PORT` | `fly.toml` [env] | `8080` (production; defaults to `3001` locally) |
 
 ### Verify deployment
 
@@ -176,41 +177,73 @@ Add the output as the `FLY_API_TOKEN` secret in GitHub Actions.
 
 ## 5. Local Development
 
-### Frontend only (no API)
+### Prerequisites
+
+- Rust stable (1.75+)
+- [Trunk](https://trunkrs.dev/) (`cargo install trunk`)
+- [just](https://github.com/casey/just) (`brew install just` or `cargo install just`)
+
+### Quick start (recommended)
 
 ```bash
-cd crates/intrada-web
-trunk serve
-# Open http://localhost:8080
+# 1. Set up environment
+cp .env.example .env
+# Edit .env with your Turso credentials
+
+# 2. Start both API and web dev servers
+just dev
+# → API on :3001, web on :8080 (proxies /api/* to API)
+
+# 3. Open http://localhost:8080
 ```
 
-Uses localStorage — no API or database needed.
+The `just dev` command starts both servers concurrently. The Trunk dev server on port 8080 proxies all `/api/*` requests to the API server on port 3001, so the browser only talks to one origin (no CORS issues).
 
-### API server (requires Turso)
+### Manual setup (without just)
 
 ```bash
+# Terminal 1: API server (requires Turso credentials)
 export TURSO_DATABASE_URL="libsql://intrada-<your-org>.turso.io"
 export TURSO_AUTH_TOKEN="<your-token>"
 export ALLOWED_ORIGIN="http://localhost:8080"
+export PORT=3001
 
 cargo run -p intrada-api
-# Server starts on http://localhost:8080
+# → API on http://localhost:3001
+
+# Terminal 2: Web dev server
+trunk serve --config crates/intrada-web/Trunk.toml
+# → Web on http://localhost:8080 (proxies /api/* to :3001)
 ```
 
 ### Quick verification
 
 ```bash
-# Health check
+# Health check (via API directly)
+curl http://localhost:3001/api/health
+
+# Health check (via Trunk proxy)
 curl http://localhost:8080/api/health
 
 # Create a piece
-curl -X POST http://localhost:8080/api/pieces \
+curl -X POST http://localhost:3001/api/pieces \
   -H "Content-Type: application/json" \
   -d '{"title":"Clair de Lune","composer":"Debussy","tags":[]}'
 
 # List pieces
-curl http://localhost:8080/api/pieces
+curl http://localhost:3001/api/pieces
 ```
+
+### Seed data
+
+To populate the API with realistic sample data:
+
+```bash
+just seed
+# or: bash scripts/seed-dev-data.sh
+```
+
+See [README.md](README.md) for more seed options.
 
 ## Checklist
 

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -31,10 +31,13 @@ async fn main() {
     let state = AppState::new(db, allowed_origin);
     let router = routes::api_router(state);
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080")
-        .await
-        .expect("Failed to bind to port 8080");
+    let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());
+    let addr = format!("0.0.0.0:{port}");
 
-    tracing::info!("Server listening on 0.0.0.0:8080");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .unwrap_or_else(|_| panic!("Failed to bind to {addr}"));
+
+    tracing::info!("Server listening on {addr}");
     axum::serve(listener, router).await.expect("Server failed");
 }

--- a/crates/intrada-web/Trunk.toml
+++ b/crates/intrada-web/Trunk.toml
@@ -13,3 +13,9 @@ ignore = ["dist/"]
 stage = "pre_build"
 command = "tailwindcss"
 command_arguments = ["-i", "input.css", "-o", "tailwind-output.css"]
+
+# Proxy API requests to the backend server during development.
+# The web app makes requests to /api/* which Trunk forwards to the API server,
+# avoiding CORS issues entirely in local development.
+[[proxy]]
+backend = "http://localhost:3001/api/"

--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,7 @@ primary_region = 'lhr'
 
 [env]
   RUST_LOG = 'info'
+  PORT = '8080'
 
 [http_service]
   internal_port = 8080

--- a/justfile
+++ b/justfile
@@ -1,0 +1,52 @@
+set dotenv-load
+
+# Default: show available commands
+default:
+    @just --list
+
+# Start both API and web dev servers concurrently
+dev:
+    #!/usr/bin/env bash
+    set -e
+    trap 'kill 0' EXIT
+    cargo run -p intrada-api &
+    trunk serve --config crates/intrada-web/Trunk.toml &
+    wait
+
+# Start only the API server
+dev-api:
+    cargo run -p intrada-api
+
+# Start only the web dev server
+dev-web:
+    trunk serve --config crates/intrada-web/Trunk.toml
+
+# Run all tests
+test:
+    cargo test --workspace
+
+# Run clippy
+lint:
+    cargo clippy --workspace
+
+# Format code
+fmt:
+    cargo fmt --all
+
+# Check everything (test + lint + format check)
+check:
+    cargo test --workspace
+    cargo clippy --workspace
+    cargo fmt --all -- --check
+
+# Seed development data (API must be running)
+seed:
+    bash scripts/seed-dev-data.sh
+
+# Build WASM for production or E2E testing
+build:
+    trunk build --config crates/intrada-web/Trunk.toml
+
+# Run E2E tests (builds WASM first)
+e2e: build
+    cd e2e && npm install && npx playwright test --project=chromium

--- a/scripts/seed-dev-data.sh
+++ b/scripts/seed-dev-data.sh
@@ -2,7 +2,7 @@
 # seed-dev-data.sh — Populate the intrada API with realistic music practice data.
 #
 # Usage:
-#   bash scripts/seed-dev-data.sh              # seed into localhost:8080
+#   bash scripts/seed-dev-data.sh              # seed into localhost:3001 (API)
 #   bash scripts/seed-dev-data.sh --live       # seed into production (Fly.io)
 #   bash scripts/seed-dev-data.sh --clean      # delete all data first, then seed
 #   API_URL=https://... bash scripts/seed-dev-data.sh   # custom API URL
@@ -29,7 +29,7 @@ if [ "$LIVE" = true ]; then
   echo "   Press Enter to continue or Ctrl+C to abort..."
   read -r
 else
-  API_URL="${API_URL:-http://localhost:8080}"
+  API_URL="${API_URL:-http://localhost:3001}"
 fi
 
 # Check dependencies


### PR DESCRIPTION
## Summary

- **Fix port clash**: API server now defaults to port 3001 locally (configurable via `PORT` env var), while Trunk stays on 8080. Production (Fly.io) explicitly sets `PORT=8080`.
- **Add Trunk proxy**: `[[proxy]]` in `Trunk.toml` forwards `/api/*` requests to the API on :3001, eliminating CORS issues in local development.
- **Add `justfile`**: Single-command startup (`just dev`), plus `test`, `lint`, `fmt`, `check`, `seed`, `build`, and `e2e` commands. Loads `.env` automatically.
- **Add `.env.example`**: Template file with Turso credentials, port, and CORS origin — copy to `.env` and fill in.
- **Update documentation**: README quick start, available commands, and SETUP.md local development section all reflect the new workflow.

## Prerequisites

You'll need [just](https://github.com/casey/just) installed:

```bash
# macOS (Homebrew)
brew install just

# Or via Cargo
cargo install just

# Or via other package managers — see https://github.com/casey/just#installation
```

Also required (unchanged from before): Rust stable (1.75+) and [Trunk](https://trunkrs.dev/) (`cargo install trunk`).

## New developer workflow

```bash
# One-time setup
cp .env.example .env
# Edit .env with Turso credentials

# Start everything
just dev
# → API on :3001, web on :8080, proxy forwards /api/* to API

# Open http://localhost:8080
```

## Test plan

- [x] `cargo test --workspace` — 222 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] `just dev` starts both servers, API accessible via proxy at localhost:8080/api/health
- [ ] `just seed` populates data through the API on :3001
- [ ] Production deploy unaffected (Fly.io uses `PORT=8080` from `fly.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)