### PR TITLE
Fix form field spacing and soften input borders

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -36,7 +36,7 @@
   /* ── Border colours ── */
   --color-border-default: oklch(100% 0 0 / 10%);        /* white/10 — separators, list borders */
   --color-border-card: oklch(100% 0 0 / 15%);           /* white/15 — card borders (slightly visible) */
-  --color-border-input: oklch(100% 0 0 / 20%);          /* white/20 — form input borders */
+  --color-border-input: oklch(100% 0 0 / 12%);          /* white/12 — form input borders (subtle against glass cards) */
 
   /* ── Text colours ── */
   --color-text-primary: oklch(100% 0 0);                 /* white — headings, titles */

--- a/crates/intrada-web/src/views/add_form.rs
+++ b/crates/intrada-web/src/views/add_form.rs
@@ -55,7 +55,7 @@ pub fn AddLibraryItemForm() -> impl IntoView {
 
             <Card>
                 <form
-                    class="space-y-5"
+                    class="space-y-4"
                     on:submit=move |ev: ev::SubmitEvent| {
                         ev.prevent_default();
 
@@ -147,7 +147,7 @@ pub fn AddLibraryItemForm() -> impl IntoView {
                     />
 
                     // Tab panel content
-                    <div id="tabpanel-content" role="tabpanel">
+                    <div id="tabpanel-content" role="tabpanel" class="space-y-4">
                         // Title (required — shared)
                         <TextField id="add-title" label="Title *" value=title required=true field_name="title" errors=errors />
 

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -100,7 +100,7 @@ pub fn EditLibraryItemForm() -> impl IntoView {
 
             <Card>
                 <form
-                    class="space-y-5"
+                    class="space-y-4"
                     on:submit={
                         let item_id = item_id.clone();
                         move |ev: ev::SubmitEvent| {
@@ -204,7 +204,7 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                     />
 
                     // Tab panel content
-                    <div id="tabpanel-content" role="tabpanel">
+                    <div id="tabpanel-content" role="tabpanel" class="space-y-4">
                         // Title (required — shared)
                         <TextField id="edit-title" label="Title *" value=title required=true field_name="title" errors=errors />
 


### PR DESCRIPTION
## Summary
- Reduce input border opacity from `white/20` to `white/12` so form fields don't visually clash with the glass card border
- Add `space-y-4` to the tabpanel content div so fields have consistent vertical gaps
- Unify form spacing to `space-y-4` throughout both add and edit forms

## Test plan
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes with zero warnings
- [ ] All 137 core tests pass
- [ ] Visual check: form fields no longer show double-border effect against the card edge
- [ ] Visual check: consistent spacing between all form fields (labels, hints, inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)