### PR TITLE
Add 16 new E2E tests for routines, analytics, edit form, and session flows

### DIFF
--- a/e2e/fixtures/api-mock.ts
+++ b/e2e/fixtures/api-mock.ts
@@ -11,8 +11,10 @@ import {
   Piece,
   Exercise,
   PracticeSession,
+  Routine,
   createSeedPieces,
   createSeedExercises,
+  createSeedRoutines,
 } from "./seed-data";
 
 const API_BASE = "https://intrada-api.fly.dev";
@@ -27,6 +29,7 @@ export interface MockStore {
   pieces: Piece[];
   exercises: Exercise[];
   sessions: PracticeSession[];
+  routines: Routine[];
 }
 
 async function setupApiMock(page: Page, store: MockStore) {
@@ -230,6 +233,105 @@ async function setupApiMock(page: Page, store: MockStore) {
       }
     }
 
+    // ---- Routines ----
+    if (path === "/api/routines" && method === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(store.routines),
+      });
+    }
+
+    if (path === "/api/routines" && method === "POST") {
+      const body = request.postDataJSON();
+      const now = new Date().toISOString();
+      const routine: Routine = {
+        id: generateId(),
+        name: body.name,
+        entries: (body.entries ?? []).map(
+          (e: { item_id: string; item_title: string; item_type: string }, i: number) => ({
+            id: generateId(),
+            item_id: e.item_id,
+            item_title: e.item_title,
+            item_type: e.item_type,
+            position: i,
+          })
+        ),
+        created_at: now,
+        updated_at: now,
+      };
+      store.routines.push(routine);
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify(routine),
+      });
+    }
+
+    const routineMatch = path.match(/^\/api\/routines\/(.+)$/);
+    if (routineMatch) {
+      const id = routineMatch[1];
+      if (method === "GET") {
+        const routine = store.routines.find((r) => r.id === id);
+        if (!routine) {
+          return route.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "Not found" }),
+          });
+        }
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(routine),
+        });
+      }
+      if (method === "PUT") {
+        const idx = store.routines.findIndex((r) => r.id === id);
+        if (idx === -1) {
+          return route.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "Not found" }),
+          });
+        }
+        const body = request.postDataJSON();
+        const routine = store.routines[idx];
+        routine.name = body.name;
+        routine.entries = (body.entries ?? []).map(
+          (e: { item_id: string; item_title: string; item_type: string }, i: number) => ({
+            id: generateId(),
+            item_id: e.item_id,
+            item_title: e.item_title,
+            item_type: e.item_type,
+            position: i,
+          })
+        );
+        routine.updated_at = new Date().toISOString();
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(routine),
+        });
+      }
+      if (method === "DELETE") {
+        const idx = store.routines.findIndex((r) => r.id === id);
+        if (idx === -1) {
+          return route.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "Not found" }),
+          });
+        }
+        store.routines.splice(idx, 1);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "Routine deleted" }),
+        });
+      }
+    }
+
     // Unmatched routes
     return route.fulfill({
       status: 404,
@@ -252,6 +354,7 @@ export const test = base.extend<{ mockApi: MockStore }>({
         pieces: createSeedPieces(),
         exercises: createSeedExercises(),
         sessions: [],
+        routines: createSeedRoutines(),
       };
       await setupApiMock(page, store);
       await use(store);

--- a/e2e/fixtures/seed-data.ts
+++ b/e2e/fixtures/seed-data.ts
@@ -87,10 +87,59 @@ export const STUB_EXERCISE: Exercise = {
   updated_at: NOW,
 };
 
+export interface RoutineEntry {
+  id: string;
+  item_id: string;
+  item_title: string;
+  item_type: string;
+  position: number;
+}
+
+export interface Routine {
+  id: string;
+  name: string;
+  entries: RoutineEntry[];
+  created_at: string;
+  updated_at: string;
+}
+
+const STUB_ROUTINE_ID = "01JSTUB0000000000ROUTN00001";
+
+export const STUB_ROUTINE: Routine = {
+  id: STUB_ROUTINE_ID,
+  name: "Morning Warm-up",
+  entries: [
+    {
+      id: "01JSTUB0000000000RENTY00001",
+      item_id: STUB_EXERCISE_ID,
+      item_title: "Hanon No. 1",
+      item_type: "exercise",
+      position: 0,
+    },
+    {
+      id: "01JSTUB0000000000RENTY00002",
+      item_id: STUB_PIECE_ID,
+      item_title: "Clair de Lune",
+      item_type: "piece",
+      position: 1,
+    },
+  ],
+  created_at: NOW,
+  updated_at: NOW,
+};
+
 export function createSeedPieces(): Piece[] {
   return [structuredClone(STUB_PIECE)];
 }
 
 export function createSeedExercises(): Exercise[] {
   return [structuredClone(STUB_EXERCISE)];
+}
+
+export function createSeedRoutines(): Routine[] {
+  return [];
+}
+
+export function createSeedRoutinesWithStub(): Routine[] {
+  return [structuredClone(STUB_ROUTINE)];
 }

--- a/e2e/tests/analytics.spec.ts
+++ b/e2e/tests/analytics.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../fixtures/api-mock";
+import { PracticeSession, SetlistEntry } from "../fixtures/seed-data";
+
+function createCompletedSession(overrides?: Partial<PracticeSession>): PracticeSession {
+  const now = new Date();
+  const startedAt = new Date(now.getTime() - 30 * 60 * 1000); // 30 min ago
+  const entry: SetlistEntry = {
+    id: "01JTEST0000000000ENTRY00001",
+    item_id: "01JSTUB0000000000PIECE00001",
+    item_title: "Clair de Lune",
+    item_type: "piece",
+    position: 0,
+    duration_secs: 1800,
+    status: "Completed",
+    notes: null,
+  };
+  return {
+    id: "01JTEST0000000000SESN000001",
+    entries: [entry],
+    session_notes: null,
+    started_at: startedAt.toISOString(),
+    completed_at: now.toISOString(),
+    total_duration_secs: 1800,
+    completion_status: "Completed",
+    ...overrides,
+  };
+}
+
+test.describe("analytics page", () => {
+  test("shows empty state when no sessions exist", async ({ page }) => {
+    await page.goto("/analytics");
+
+    await expect(
+      page.getByRole("heading", { name: "Analytics" })
+    ).toBeVisible();
+
+    // Empty state
+    await expect(page.getByText("No practice data yet")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Start a Session" })
+    ).toBeVisible();
+  });
+
+  test("shows stat cards when sessions exist", async ({ page, mockApi }) => {
+    // Pre-seed a completed session from today
+    mockApi.sessions.push(createCompletedSession());
+
+    await page.goto("/analytics");
+
+    await expect(
+      page.getByRole("heading", { name: "Analytics" })
+    ).toBeVisible();
+
+    // Stat cards should be present (not the empty state)
+    await expect(
+      page.getByText("This Week", { exact: true })
+    ).toBeVisible();
+    await expect(page.getByText("Streak")).toBeVisible();
+
+    // Most Practised section should show the item
+    await expect(page.getByText("Most Practised")).toBeVisible();
+  });
+
+  test("shows most practised items with session data", async ({
+    page,
+    mockApi,
+  }) => {
+    mockApi.sessions.push(createCompletedSession());
+
+    await page.goto("/analytics");
+
+    // The most practised section should list "Clair de Lune"
+    await expect(page.getByText("Most Practised")).toBeVisible();
+    await expect(page.getByText("Clair de Lune")).toBeVisible();
+  });
+});

--- a/e2e/tests/edit-item.spec.ts
+++ b/e2e/tests/edit-item.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "../fixtures/api-mock";
+
+test.describe("edit library item", () => {
+  test("navigate to edit form and see pre-populated fields for a piece", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Navigate to Clair de Lune detail
+    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Clair de Lune", level: 2 })
+    ).toBeVisible();
+
+    // Click Edit link
+    await page.getByRole("link", { name: "Edit" }).click();
+
+    // Should be on the edit form
+    await expect(
+      page.getByRole("heading", { name: "Edit Library Item" })
+    ).toBeVisible();
+
+    // Fields should be pre-populated
+    await expect(page.locator("#edit-title")).toHaveValue("Clair de Lune");
+    await expect(page.locator("#edit-composer")).toHaveValue("Claude Debussy");
+    await expect(page.locator("#edit-key")).toHaveValue("Db Major");
+    await expect(page.locator("#edit-tempo-marking")).toHaveValue(
+      "Andante très expressif"
+    );
+    await expect(page.locator("#edit-bpm")).toHaveValue("66");
+    await expect(page.locator("#edit-notes")).toHaveValue(
+      "Third movement of Suite bergamasque"
+    );
+  });
+
+  test("edit piece title and save", async ({ page }) => {
+    await page.goto("/");
+
+    // Navigate to piece detail then edit
+    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    await page.getByRole("link", { name: "Edit" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Library Item" })
+    ).toBeVisible();
+
+    // Clear and change the title
+    await page.locator("#edit-title").fill("Clair de Lune (Revised)");
+
+    // Save
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Should redirect back to detail with updated title
+    await expect(
+      page.getByRole("heading", { name: "Clair de Lune (Revised)", level: 2 })
+    ).toBeVisible();
+  });
+
+  test("edit exercise category field", async ({ page }) => {
+    await page.goto("/");
+
+    // Navigate to Hanon No. 1 detail then edit
+    await page.getByRole("heading", { name: "Hanon No. 1" }).click();
+    await page.getByRole("link", { name: "Edit" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Library Item" })
+    ).toBeVisible();
+
+    // Category field should be visible and pre-populated for exercises
+    await expect(page.locator("#edit-category")).toHaveValue("Technique");
+
+    // Change it
+    await page.locator("#edit-category").fill("Finger Independence");
+
+    // Save
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Should redirect back to detail
+    await expect(
+      page.getByRole("heading", { name: "Hanon No. 1", level: 2 })
+    ).toBeVisible();
+  });
+
+  test("cancel edit returns to detail without changes", async ({ page }) => {
+    await page.goto("/");
+
+    // Navigate to piece detail then edit
+    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    await page.getByRole("link", { name: "Edit" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Library Item" })
+    ).toBeVisible();
+
+    // Change the title but cancel
+    await page.locator("#edit-title").fill("CHANGED TITLE");
+    await page.getByRole("link", { name: "Cancel" }).click();
+
+    // Should be back on the detail page with the ORIGINAL title
+    await expect(
+      page.getByRole("heading", { name: "Clair de Lune", level: 2 })
+    ).toBeVisible();
+  });
+});

--- a/e2e/tests/routines.spec.ts
+++ b/e2e/tests/routines.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "../fixtures/api-mock";
+import { createSeedRoutinesWithStub } from "../fixtures/seed-data";
+
+test.describe("routines page", () => {
+  test("shows empty state when no routines exist", async ({ page }) => {
+    await page.goto("/routines");
+
+    await expect(
+      page.getByRole("heading", { name: "Routines" })
+    ).toBeVisible();
+    await expect(page.getByText("No saved routines yet.")).toBeVisible();
+
+    // Should have a link to create a session
+    await expect(
+      page.getByRole("link", { name: "New Session" })
+    ).toBeVisible();
+  });
+
+  test("displays pre-seeded routine with entries", async ({
+    page,
+    mockApi,
+  }) => {
+    // Seed a routine before navigating
+    mockApi.routines = createSeedRoutinesWithStub();
+
+    await page.goto("/routines");
+
+    await expect(
+      page.getByRole("heading", { name: "Routines" })
+    ).toBeVisible();
+
+    // Should show the routine name
+    await expect(page.getByText("Morning Warm-up")).toBeVisible();
+
+    // Should show the item count badge
+    await expect(page.getByText("2 items")).toBeVisible();
+
+    // Should show Edit and Delete controls
+    await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Delete" })
+    ).toBeVisible();
+  });
+
+  test("delete routine with confirmation", async ({ page, mockApi }) => {
+    mockApi.routines = createSeedRoutinesWithStub();
+
+    await page.goto("/routines");
+    await expect(page.getByText("Morning Warm-up")).toBeVisible();
+
+    // Click Delete — should show confirmation
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(
+      page.getByText("Delete this routine? This cannot be undone.")
+    ).toBeVisible();
+
+    // Cancel — should dismiss
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(
+      page.getByText("Delete this routine? This cannot be undone.")
+    ).not.toBeVisible();
+
+    // Delete again and confirm
+    await page.getByRole("button", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Confirm Delete" }).click();
+
+    // Should show empty state
+    await expect(page.getByText("No saved routines yet.")).toBeVisible();
+  });
+
+  test("save routine from session builder", async ({ page }) => {
+    await page.goto("/sessions/new");
+
+    // Add an item to the setlist
+    await page.getByText("Clair de Lune").click();
+
+    // Expand the "Save as Routine" form
+    await page.getByRole("button", { name: "Save as Routine" }).click();
+
+    // Enter a routine name and save
+    const routineNameInput = page.getByPlaceholder("e.g. Morning Warm-up");
+    await routineNameInput.fill("My New Routine");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    // Verify the routine appears on the routines page
+    await page.goto("/routines");
+    await expect(page.getByText("My New Routine")).toBeVisible();
+  });
+
+  test("load routine into session builder", async ({ page, mockApi }) => {
+    mockApi.routines = createSeedRoutinesWithStub();
+
+    await page.goto("/sessions/new");
+
+    // Should see the saved routine in the "Saved Routines" section
+    await expect(page.getByText("Saved Routines")).toBeVisible();
+    await expect(page.getByText("Morning Warm-up")).toBeVisible();
+
+    // Load the routine
+    await page.getByRole("button", { name: "Load" }).click();
+
+    // Setlist should now have the routine's entries (items also appear in library list)
+    // Check that the Start Session button is enabled (proves items were loaded)
+    await expect(
+      page.getByRole("button", { name: "Start Session" })
+    ).toBeEnabled();
+  });
+});

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -57,4 +57,100 @@ test.describe("sessions page", () => {
     ).toBeVisible();
     await expect(page.getByText("1 session", { exact: true })).toBeVisible();
   });
+
+  test("multi-item session with skip", async ({ page }) => {
+    await page.goto("/sessions/new");
+
+    // Add both items to the setlist
+    await page.getByText("Clair de Lune").click();
+    await page.getByText("Hanon No. 1").click();
+
+    // Start the session
+    await page.getByRole("button", { name: "Start Session" }).click();
+
+    // Should show first item
+    await expect(page.getByText("Item 1 of 2")).toBeVisible();
+
+    // Skip the first item
+    await page.getByRole("button", { name: "Skip" }).click();
+
+    // Should advance to second item
+    await expect(page.getByText("Item 2 of 2")).toBeVisible();
+
+    // Finish the session (last item)
+    await page.getByRole("button", { name: "Finish Session" }).click();
+
+    // Summary should show both items
+    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Items Practiced")).toBeVisible();
+  });
+
+  test("cancel building returns to sessions list", async ({ page }) => {
+    await page.goto("/sessions/new");
+
+    // Should be on the builder
+    await expect(
+      page.getByRole("heading", { name: "New Practice Session" })
+    ).toBeVisible();
+
+    // Click Cancel
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Should redirect to sessions list
+    await expect(
+      page.getByRole("heading", { name: "Practice Sessions" })
+    ).toBeVisible();
+  });
+
+  test("multi-item session with Next Item navigation", async ({ page }) => {
+    await page.goto("/sessions/new");
+
+    // Add both items
+    await page.getByText("Clair de Lune").click();
+    await page.getByText("Hanon No. 1").click();
+
+    // Start session
+    await page.getByRole("button", { name: "Start Session" }).click();
+
+    // First item
+    await expect(page.getByText("Item 1 of 2")).toBeVisible();
+
+    // Next Item (not last, so button says "Next Item")
+    await page.getByRole("button", { name: "Next Item" }).click();
+
+    // Second item
+    await expect(page.getByText("Item 2 of 2")).toBeVisible();
+
+    // Now it's the last item, so button says "Finish Session"
+    await page.getByRole("button", { name: "Finish Session" }).click();
+
+    // Summary
+    await expect(page.getByText("Session Complete!")).toBeVisible();
+
+    // Save
+    await page.getByRole("button", { name: "Save Session" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Practice Sessions" })
+    ).toBeVisible();
+    await expect(page.getByText("1 session", { exact: true })).toBeVisible();
+  });
+
+  test("end session early", async ({ page }) => {
+    await page.goto("/sessions/new");
+
+    // Add both items
+    await page.getByText("Clair de Lune").click();
+    await page.getByText("Hanon No. 1").click();
+
+    // Start session
+    await page.getByRole("button", { name: "Start Session" }).click();
+    await expect(page.getByText("Item 1 of 2")).toBeVisible();
+
+    // End early
+    await page.getByRole("button", { name: "End Early" }).click();
+
+    // Should see summary with "Ended Early" indicator
+    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Ended Early")).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Adds 16 new E2E tests across 3 new spec files and extends the existing sessions spec, bringing the total from 14 to 30 tests
- Extends the API mock fixture with full routines CRUD handlers and adds routine seed data factories
- Covers previously untested features: routines management, analytics dashboard, edit library item form, and advanced session flows (skip, cancel, end early, multi-item navigation)

## Test plan
- [ ] All 30 E2E tests pass locally (`just e2e` or `cd e2e && npx playwright test`)
- [ ] CI passes on the branch
- [ ] No existing tests broken by the changes

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)