### PR TITLE
Bypass auth gate when Clerk init fails

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -12,17 +12,22 @@
       if (!window.__intrada_auth) window.__intrada_auth = {
         _clerk: null,
         _ready: false,
+        _initFailed: false,
         async init(publishableKey) {
           if (!publishableKey || this._ready) return;
           try {
             const Clerk = window.Clerk;
-            if (!Clerk) return;
+            if (!Clerk) { this._initFailed = true; return; }
             this._clerk = new Clerk(publishableKey);
             await this._clerk.load();
             this._ready = true;
           } catch (e) {
             console.error("Clerk init failed:", e);
+            this._initFailed = true;
           }
+        },
+        initFailed() {
+          return this._initFailed;
         },
         isSignedIn() {
           if (!this._ready || !this._clerk) return false;

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -36,6 +36,16 @@ pub fn App() -> impl IntoView {
         leptos::task::spawn_local(async move {
             // Give Clerk a moment to initialize, then check status
             // We poll a few times since Clerk loads async from CDN
+            let has_key = option_env!("CLERK_PUBLISHABLE_KEY")
+                .map(|k| !k.is_empty())
+                .unwrap_or(false);
+            if !has_key {
+                // No Clerk key — skip auth gate entirely (dev mode)
+                is_authenticated.set(true);
+                auth_loading.set(false);
+                return;
+            }
+
             for _ in 0..50 {
                 gloo_timers::future::TimeoutFuture::new(100).await;
                 if clerk_bindings::is_signed_in() {
@@ -43,13 +53,9 @@ pub fn App() -> impl IntoView {
                     auth_loading.set(false);
                     return;
                 }
-                // Check if Clerk is at least loaded (even if not signed in)
-                // by seeing if get_user_id returns something vs auth helper being ready
-                let has_key = option_env!("CLERK_PUBLISHABLE_KEY")
-                    .map(|k| !k.is_empty())
-                    .unwrap_or(false);
-                if !has_key {
-                    // No Clerk key — skip auth gate entirely (dev mode)
+                if clerk_bindings::init_failed() {
+                    // Clerk failed to init (bad key, wrong domain, etc.)
+                    // Bypass auth so the app is still usable.
                     is_authenticated.set(true);
                     auth_loading.set(false);
                     return;

--- a/crates/intrada-web/src/clerk_bindings.rs
+++ b/crates/intrada-web/src/clerk_bindings.rs
@@ -18,6 +18,12 @@ use wasm_bindgen::prelude::*;
         }
         return false;
     }
+    export function js_init_failed() {
+        if (window.__intrada_auth && window.__intrada_auth.initFailed) {
+            return window.__intrada_auth.initFailed();
+        }
+        return false;
+    }
     export async function js_get_token() {
         if (window.__intrada_auth) {
             return await window.__intrada_auth.getToken();
@@ -51,6 +57,7 @@ use wasm_bindgen::prelude::*;
 extern "C" {
     fn js_init_clerk(key: &str);
     fn js_is_signed_in() -> bool;
+    fn js_init_failed() -> bool;
     async fn js_get_token() -> JsValue;
     fn js_get_user_id() -> JsValue;
     async fn js_sign_out();
@@ -69,6 +76,12 @@ pub fn init_clerk() {
 /// Check whether the current user is signed in.
 pub fn is_signed_in() -> bool {
     js_is_signed_in()
+}
+
+/// Check whether Clerk initialization failed (bad key, wrong domain, network error).
+/// When true, the app should bypass the auth gate.
+pub fn init_failed() -> bool {
+    js_init_failed()
 }
 
 /// Get the current JWT token for API requests. Returns `None` if not signed in.


### PR DESCRIPTION
## Summary
- When Clerk fails to initialize (bad key, wrong domain, network error), the app was stuck on the sign-in screen
- Now the auth bridge tracks `_initFailed` and the WASM polling loop detects it, letting the app through without auth

This unblocks the production deployment where `pk_test_` isn't valid for the production domain.

## Test plan
- [ ] All 30 E2E tests pass
- [ ] App loads normally when Clerk init fails (no stuck sign-in screen)

🤖 Generated with [Claude Code](https://claude.ai/code)