### PR TITLE
Configure production domain myintrada.com

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ primary_region = 'lhr'
 [env]
   RUST_LOG = 'info'
   PORT = '8080'
+  CLERK_ISSUER_URL = 'https://clerk.myintrada.com'
 
 [http_service]
   internal_port = 8080

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,10 @@ name = "intrada"
 main = "./worker.js"
 compatibility_date = "2026-02-15"
 
+routes = [
+  { pattern = "myintrada.com", custom_domain = true },
+]
+
 [assets]
 directory = "crates/intrada-web/dist"
 not_found_handling = "single-page-application"


### PR DESCRIPTION
## Summary
- Add `CLERK_ISSUER_URL = 'https://clerk.myintrada.com'` to `fly.toml` so the API server validates JWTs against the production Clerk instance
- Add `myintrada.com` custom domain route to `wrangler.toml` so Cloudflare Workers serves the app on the new domain

## Prerequisites (manual, already done)
- [x] Registered `myintrada.com` via Cloudflare Registrar
- [x] Added zone to Cloudflare
- [x] Added 5 Clerk DNS CNAME records, all verified
- [x] Added `myintrada.com` as Custom Domain on Cloudflare Worker
- [x] Updated `CLERK_PUBLISHABLE_KEY` GitHub secret with `pk_live_` key
- [x] Configured Google OAuth in Clerk production instance

## What happens on merge
- **Frontend**: Redeploys to Cloudflare Workers, now serving on `myintrada.com` with production Clerk key
- **API**: Redeploys to Fly.io with `CLERK_ISSUER_URL` set, enabling JWT validation

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)