### PR TITLE
Fix Clerk missing publishableKey error

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -67,7 +67,6 @@
     <script
       async
       crossorigin="anonymous"
-      data-clerk-publishable-key=""
       src="https://cdn.jsdelivr.net/npm/@clerk/clerk-js@5/dist/clerk.browser.js"
       onload="
         if (window.__intrada_clerk_key) {


### PR DESCRIPTION
## Summary
Remove the empty `data-clerk-publishable-key=""` attribute from the Clerk CDN script tag. Clerk's JS SDK auto-reads this attribute on load and throws "Missing publishableKey" when it's empty — even though we initialize Clerk manually via our auth bridge.

## Test plan
- [ ] Visit `myintrada.com` — no more "Missing publishableKey" console error
- [ ] Sign-in screen should show without the error message (or with a working Google button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)