### PR TITLE
Load Clerk SDK dynamically to prevent auto-init error

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -16,6 +16,17 @@
         async init(publishableKey) {
           if (!publishableKey || this._ready) return;
           try {
+            // Dynamically load Clerk SDK to prevent auto-init
+            if (!window.Clerk) {
+              await new Promise((resolve, reject) => {
+                const s = document.createElement('script');
+                s.src = 'https://cdn.jsdelivr.net/npm/@clerk/clerk-js@5/dist/clerk.browser.js';
+                s.crossOrigin = 'anonymous';
+                s.onload = resolve;
+                s.onerror = reject;
+                document.head.appendChild(s);
+              });
+            }
             const Clerk = window.Clerk;
             if (!Clerk) { this._initFailed = true; return; }
             this._clerk = new Clerk(publishableKey);
@@ -64,16 +75,6 @@
         },
       };
     </script>
-    <script
-      async
-      crossorigin="anonymous"
-      src="https://cdn.jsdelivr.net/npm/@clerk/clerk-js@5/dist/clerk.browser.js"
-      onload="
-        if (window.__intrada_clerk_key) {
-          window.__intrada_auth.init(window.__intrada_clerk_key);
-        }
-      "
-    ></script>
   </head>
   <body>
     <noscript>

--- a/crates/intrada-web/src/clerk_bindings.rs
+++ b/crates/intrada-web/src/clerk_bindings.rs
@@ -8,7 +8,6 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(inline_js = "
     export function js_init_clerk(key) {
         if (window.__intrada_auth) {
-            window.__intrada_clerk_key = key;
             window.__intrada_auth.init(key);
         }
     }


### PR DESCRIPTION
## Summary
The Clerk CDN `<script>` tag auto-initializes on load and throws "Missing publishableKey" even when the `data-clerk-publishable-key` attribute is removed. 

Fix: remove the static `<script>` tag entirely and load the Clerk SDK dynamically inside the `init()` function. This way Clerk only loads when we have a key to pass it, preventing the auto-init error.

Also removes the now-unused `window.__intrada_clerk_key` global.

## Test plan
- [ ] Visit `myintrada.com` — no more "Missing publishableKey" console error
- [ ] Sign-in with Google should work
- [ ] E2E tests pass (mock is unaffected since it defines `__intrada_auth` before page load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)