### PR TITLE
Force WASM rebuild to pick up Clerk key changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.18/tailwindcss-linux-x64
           chmod +x tailwindcss-linux-x64
           mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+      - name: Force rebuild when env vars change
+        run: touch crates/intrada-web/src/clerk_bindings.rs
       - name: Build WASM (release)
         working-directory: crates/intrada-web
         env:


### PR DESCRIPTION
## Summary
`option_env!("CLERK_PUBLISHABLE_KEY")` bakes the value at compile time, but Cargo and `rust-cache` don't track environment variable changes for cache invalidation. When the GitHub secret was updated from `pk_test_` to `pk_live_`, the cached WASM binary was reused without recompilation — so the old (empty/test) key was still embedded.

Fix: touch `clerk_bindings.rs` before the WASM build to force Cargo to recompile `intrada-web`, ensuring the current `CLERK_PUBLISHABLE_KEY` value is always baked in.

## Root cause
The "Missing publishableKey" error on production was caused by the Rust build cache serving a stale WASM binary that had the old key compiled in.

## Test plan
- [ ] After merge, verify `myintrada.com` no longer shows "Missing publishableKey"
- [ ] Verify Clerk initializes successfully with the `pk_live_` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)