### PR TITLE
Set __clerk_publishable_key before loading Clerk SDK

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -16,7 +16,9 @@
         async init(publishableKey) {
           if (!publishableKey || this._ready) return;
           try {
-            // Dynamically load Clerk SDK to prevent auto-init
+            // Set the key globally BEFORE loading the SDK so its
+            // auto-init picks it up instead of throwing "Missing publishableKey".
+            window.__clerk_publishable_key = publishableKey;
             if (!window.Clerk) {
               await new Promise((resolve, reject) => {
                 const s = document.createElement('script');
@@ -27,10 +29,15 @@
                 document.head.appendChild(s);
               });
             }
-            const Clerk = window.Clerk;
-            if (!Clerk) { this._initFailed = true; return; }
-            this._clerk = new Clerk(publishableKey);
-            await this._clerk.load();
+            // After the SDK auto-inits, window.Clerk is the ready instance
+            const clerk = window.Clerk;
+            if (!clerk) { this._initFailed = true; return; }
+            // If Clerk auto-initialized, it may already be loaded;
+            // if not (constructor form), call load().
+            if (typeof clerk.load === 'function' && !clerk.loaded) {
+              await clerk.load();
+            }
+            this._clerk = clerk;
             this._ready = true;
           } catch (e) {
             console.error("Clerk init failed:", e);


### PR DESCRIPTION
## Summary
- Sets `window.__clerk_publishable_key` before dynamically loading `clerk.browser.js`, so the SDK's auto-init picks up the key instead of throwing "Missing publishableKey"
- Uses the auto-initialized `window.Clerk` instance instead of calling `new Clerk(key)` manually

## Context
The `clerk.browser.js` UMD bundle auto-initializes on load and throws "Missing publishableKey" if `window.__clerk_publishable_key` is not set at load time. Our previous approach of dynamically loading the script and then calling `new Clerk(key)` didn't work because the auto-init fires first and throws before our code runs.

## Test plan
- [ ] CI passes (E2E tests use the existing `__intrada_auth` mock, unaffected by this change)
- [ ] Production site at myintrada.com no longer shows "Missing publishableKey" console error
- [ ] Google OAuth sign-in flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)