### PR TITLE
Update CORS origin to myintrada.com

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,7 @@ primary_region = 'lhr'
   RUST_LOG = 'info'
   PORT = '8080'
   CLERK_ISSUER_URL = 'https://clerk.myintrada.com'
+  ALLOWED_ORIGIN = 'https://myintrada.com'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary
- Sets `ALLOWED_ORIGIN = 'https://myintrada.com'` in fly.toml so the API server's CORS policy allows requests from the new production domain

## Context
After migrating to `myintrada.com`, API requests from the frontend were blocked by CORS because the API still had `Access-Control-Allow-Origin: https://intrada.jonyardley.workers.dev`.

## Important
If `ALLOWED_ORIGIN` was previously set as a Fly secret, it will take precedence over the `fly.toml` env var. In that case, run:
```
flyctl secrets unset ALLOWED_ORIGIN -a intrada-api
```

## Test plan
- [ ] CI passes
- [ ] After deploy, API requests from myintrada.com no longer get CORS errors
- [ ] Library, sessions, and routines load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)