### PR TITLE
Guard JWT decode against panics causing 502 errors

### DIFF
--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -55,8 +55,21 @@ impl FromRequestParts<AppState> for AuthUser {
         validation.validate_aud = false;
 
         for key in auth_config.decoding_keys.iter() {
-            if let Ok(data) = decode::<Claims>(token, key, &validation) {
-                return Ok(AuthUser(data.claims.sub));
+            // Wrap decode in catch_unwind to guard against panics in
+            // the underlying crypto library when processing malformed tokens.
+            let token_owned = token.to_owned();
+            let key_clone = key.clone();
+            let validation_clone = validation.clone();
+            let result = std::panic::catch_unwind(move || {
+                decode::<Claims>(&token_owned, &key_clone, &validation_clone)
+            });
+            match result {
+                Ok(Ok(data)) => return Ok(AuthUser(data.claims.sub)),
+                Ok(Err(_)) => continue,
+                Err(_) => {
+                    tracing::warn!("JWT decode panicked — treating as invalid token");
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Wraps `jsonwebtoken::decode()` in `catch_unwind` to prevent server crashes from malformed JWT tokens
- Invalid tokens now return 401 Unauthorized instead of crashing the server (502 Bad Gateway)

## Root cause
When the browser sends a valid Clerk JWT to the API, the `jsonwebtoken` crate's `decode()` function panics during RSA signature verification on certain token payloads. This crashes the request handler, and Fly.io returns 502 Bad Gateway (with no CORS headers, making it look like a CORS error in the browser).

Reproduction:
```bash
# Simple string → 401 (OK)
curl -H "Authorization: Bearer test" https://intrada-api.fly.dev/api/items

# Structured JWT → 502 (crash!)
curl -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.fake" https://intrada-api.fly.dev/api/items
```

## Test plan
- [ ] CI passes
- [ ] Structured but invalid JWTs return 401 instead of 502
- [ ] Valid Clerk JWTs from signed-in users are accepted and API data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)