### PR TITLE
Add to-be user journey diagram from vision

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,356 @@
+# intrada — Revised Product Roadmap
+
+*Draft for review — 2026-02-21*
+
+This roadmap replaces the four-phase structure in VISION.md with six smaller, more
+realistic phases. Each phase delivers a complete, valuable product — not a stepping
+stone. The changes are driven by a critical review of the user journey from product,
+teacher, and student perspectives.
+
+**Key changes from the original roadmap:**
+
+1. The original Phase 2 ("Intelligence") was overloaded — it contained the SRS engine,
+   interleaved scheduling, one-tap start, mastery decay, difficulty balancing, goals,
+   encouragement, and rest awareness. That's been split across Phases 3 and 4.
+2. Practice quality improvements (focus mode, rep counter, visual timer) move earlier —
+   they enhance the *existing* session system without needing the scheduling engine.
+3. Tempo-building is promoted to a first-class practice flow, not just a data field.
+4. A first-time user onboarding flow is added (it was completely absent).
+5. "Free practice" and "deep dive" modes are added to prevent the app feeling like it
+   *only* supports structured interleaved practice.
+6. The streak counter is reworked to comeback framing immediately, not deferred to Phase 3.
+7. Scoring captures tempo alongside mastery rating.
+
+---
+
+## What's Built Today
+
+| Area | Status |
+|------|--------|
+| Auth (Clerk/Google, JWT, JWKS refresh, 401 retry) | ✅ Complete |
+| Library CRUD (piece + exercise, tags, key, tempo, notes) | ✅ Complete |
+| Sessions (build → active → summary, timer, crash recovery) | ✅ Complete |
+| Routines (full CRUD, load into builder, save from summary) | ✅ Complete |
+| Analytics (weekly stats, streak, 28-day chart, top items, score trends) | ✅ Complete |
+| Scoring (1-5 per item) and per-item/session notes | ✅ Complete |
+| Search/filter infrastructure in core (ListQuery) | ✅ Backend only (no UI) |
+
+---
+
+## Phase 1: Practice Quality (4 weeks)
+
+**Theme: "Make every session count"**
+
+Enhance the existing session experience. No new scheduling intelligence — just make
+the act of practising meaningfully better with what we already have.
+
+### Features
+
+- **Focus mode** — strip the UI to essentials during active practice. Current item +
+  timer only. Navigation and library hidden but accessible via swipe/tap.
+- **Visual progress timer** — replace the numeric countdown with a progress ring/bar.
+  Show both per-item and total session elapsed. Gentle chime at suggested transition.
+- **Repetition counter** — optional per-item tool. Tap ✓ to increment, ✗ to decrement
+  (never below 0). Configurable target (3–10, default 5). When reached, auto-prompt
+  transition to next item.
+- **Lightweight micro-cycle** — before each item, a quick-tap focus selector (accuracy /
+  evenness / dynamics / tempo / custom). After each item, a 1–5 rating tap + optional
+  short note. **Not** a mandatory reflection essay — one tap is the minimum interaction.
+- **Light path for maintenance items** — items at mastery ≥ 4 get a streamlined flow:
+  focus mode → timer → quick rating → auto-transition. No goal prompt or extended
+  reflection. Configurable threshold.
+- **Search/filter UI** — expose the existing ListQuery infrastructure as a search bar +
+  filter chips on the library list. The backend is already built.
+- **Rework streak → comeback framing** — replace the current streak counter in analytics
+  with "X of the last 7 days" language. Celebrate returns, never shame gaps. This
+  aligns the existing analytics with the vision's inclusive design principles.
+- **Scoring captures tempo** — when rating an item, optionally record the tempo achieved
+  alongside the 1–5 mastery score. This is essential for tracking progress on items
+  where mastery is tempo-dependent.
+
+### Delivers
+
+A meaningfully better practice experience using the existing library and session system.
+Musicians feel the difference immediately — the app respects their time and attention
+during practice, not just before and after.
+
+### Dependencies
+
+None — all features enhance the existing system.
+
+---
+
+## Phase 2: Library Depth (4 weeks)
+
+**Theme: "A library that understands music"**
+
+Make the library genuinely useful for structured music study. This phase is prerequisite
+for the scheduling engine — the scheduler needs richer data to make intelligent decisions.
+
+### Features
+
+- **Key-aware exercise generation** — mark an exercise as "all 12 keys" and auto-generate
+  12 sub-items. Each tracks mastery independently. Parent exercise shows aggregate view.
+  Musician sees one library item but can drill into per-key progress.
+- **Section/passage management** — break pieces into practisable sections. Each section
+  has its own mastery score and tempo target. The scheduler (Phase 3) can surface
+  specific sections rather than whole pieces.
+- **Expanded item types** — add Licks/Vocabulary and Technique as first-class types
+  alongside Piece and Exercise. Each type can have type-specific metadata.
+- **Effort/difficulty tags** — per-item difficulty level and effort rating. These feed
+  the session difficulty balancer in Phase 3.
+- **Lesson capture flow** — "What did your teacher assign this week?" A quick-add
+  interface optimised for translating lesson notes into library items. Available from
+  onboarding and as a recurring entry point.
+- **First-time user onboarding** — guided flow for empty libraries: "How do you
+  practise?" → lesson capture or quick-add wizard → first session prompt. Addresses
+  the Day 1 cold-start problem.
+- **Free practice mode** — a timer-only mode that logs time without requiring items,
+  scores, or structure. Legitimises unstructured practice time. Logged in analytics
+  as "free practice" so it counts toward consistency.
+
+### Delivers
+
+The library becomes genuinely useful for structured music study. Jazz students can track
+all 12 keys. Classical students can break sonatas into sections. The cold-start problem
+is solved.
+
+### Dependencies
+
+Phase 1 (scoring captures tempo — needed for section-level tempo targets).
+
+---
+
+## Phase 3: Scheduling Intelligence (6 weeks)
+
+**Theme: "Practise what matters most"**
+
+The signature feature. This is the largest phase because the SRS engine, interleaved
+generator, and session planning all need to ship together to deliver the one-tap start
+experience.
+
+### Features
+
+- **Mastery decay model** — scores decrease over time if items aren't reviewed. Rate of
+  decay is configurable. Creates natural urgency in the scheduling algorithm.
+- **Spaced repetition engine** — modified SM-2 algorithm. Intervals based on mastery
+  scores + time since last practice. High-effort items get shorter intervals (informed
+  by Donovan & Radosevich's finding that task complexity moderates the spacing effect).
+  Parameters should be tuneable and validated against real user data over time.
+- **Interleaved setlist generator** — create mixed-type practice sessions. Session begins
+  with more similar items and increases variety as the session progresses (Mathias &
+  Goldman, 2025). Configurable interleaving intensity: gentle mixing → full interleave.
+- **Tempo-building practice flow** — a first-class sub-loop within any practice item.
+  Set current tempo + target tempo. Play → judge (solid?) → bump or hold → repeat.
+  Iterative tempo-building is how musicians actually work — it's a session within a
+  session. Metronome integration (built-in or external — **open question**).
+- **One-tap session start** — the landing screen shows today's algorithmically generated
+  session with a prominent Start button. Musician picks a duration, taps Start, and plays.
+  Zero other decisions.
+- **Short session options** — 10, 15, 20, 30, 45, 60 minutes prominently offered.
+  Framing: short sessions are legitimate and effective.
+- **Difficulty balancing** — front-load demanding work when focus is fresh. No back-to-back
+  high-effort items. Taper toward lighter review material.
+- **Deep dive mode** — pick ONE item, open-ended time, intensive work. The interleaved
+  approach is the default, but sometimes a musician needs to shed. This respects that
+  interleaving isn't always the right answer.
+- **Transition prompts** — gentle cues between items. Preview of what's coming next.
+  Optional 30-second micro-break. Reduces "what do I do now?" cognitive load.
+
+### Delivers
+
+Open app → tap Start → get a personalised, science-backed practice session. The tempo
+loop makes practice feel like real musicianship, not admin. Deep dive mode prevents the
+app from feeling prescriptive.
+
+### Dependencies
+
+Phase 2 (key-aware exercises, sections, effort tags — the scheduler needs this richer
+data to make good decisions).
+
+---
+
+## Phase 4: Goals & Encouragement (4 weeks)
+
+**Theme: "See the process working"**
+
+Add the motivational layer. Goals give direction; encouragement provides evidence that
+the direction is working.
+
+### Features
+
+- **Goal framework** — three tiers:
+  - Session goals: "Focus on left hand today" (set at session start)
+  - Weekly goals: "Practice 5 days this week" (set from goals screen)
+  - Milestone goals: "All keys to mastery 4 by March" (linked to specific items)
+- **Goal-aligned scheduling** — items tagged for active goals get a priority boost in
+  the scheduling algorithm. Active goals influence session composition.
+- **Encouragement messages** — data-tied, process-focused. "Your Db mastery went from
+  2 to 4 over three weeks — that's the spacing effect at work." Not empty praise.
+  Tied to observable improvements in the data.
+- **Rest & recovery awareness** — flag when practice volume significantly exceeds
+  historical average. "Your body and brain need recovery time to consolidate what
+  you've learned."
+- **Time vs planned comparison** — post-session summary shows planned duration vs actual.
+  Helps musicians calibrate their internal time sense. Particularly valuable for
+  musicians with ADHD-related time blindness.
+- **Quick close option** — save scores captured during practice, skip the detailed
+  summary. Respects that after 45 minutes of practice, some musicians just want to stop.
+
+### Delivers
+
+Musicians can set goals and see evidence that their practice is working. The
+encouragement is specific, data-grounded, and tied to the scheduling methodology —
+reinforcing trust in the process.
+
+### Dependencies
+
+Phase 3 (scheduling engine — goal-aligned scheduling needs the SRS engine).
+
+---
+
+## Phase 5: Visualisation & Insights (6 weeks)
+
+**Theme: "Trust the evidence"**
+
+The full visualisation suite. These features transform raw practice data into actionable
+insight and motivational fuel.
+
+### Features
+
+- **Mastery timeline charts** — per-item and aggregate line charts showing mastery
+  improvement over weeks and months.
+- **Key coverage heatmap** — circle-of-fifths view showing mastery level per key for any
+  exercise. Immediately reveals weak keys.
+- **Consistency calendar** — comeback framing: "4 of the last 7 days — great spacing for
+  retention." Not streak-focused. Celebrate returns after gaps.
+- **Tempo progress charts** — showing tempo increase over time toward target BPM per item.
+- **Goal progress dashboard** — percentage completion for active goals.
+- **Weekly summary with insights** — comparison to prior week. Shown on next app open
+  or via notification.
+- **Encouragement configuration** — frequency (every item / session / weekly / off),
+  tone (data-focused / warm / minimal), delivery (inline / summary / notification).
+  Respects that not all musicians want the same encouragement.
+- **Audio recording & playback** — record a run-through, play it back, rate it. Compare
+  to a recording from weeks ago. Provides an objective anchor for subjective mastery
+  ratings. (**Open question:** browser audio API viability on mobile.)
+
+### Delivers
+
+A musician can look at their dashboard and see concrete evidence of progress. Weak spots
+are visible. The sense of competence (SDT) is actively reinforced. The app becomes a
+motivational engine, not just a tracking tool.
+
+### Dependencies
+
+Phase 4 (goals — the goal dashboard needs the goal framework).
+
+---
+
+## Phase 6: Collaboration & Intelligence (6+ weeks)
+
+**Theme: "A practice partner who knows you"**
+
+AI-powered features and teacher collaboration. These leverage all the data accumulated
+in earlier phases.
+
+### Features
+
+- **Teacher integration (basic)** — teacher shares routines, suggests items for student's
+  library, sets target tempos or milestone goals, views progress dashboards (with
+  permission). Musician retains full control. This is a *collaboration* feature, not an
+  AI feature.
+- **Import/export** — share routines with other musicians. Import items from external
+  sources.
+- **AI setlist generation** — "I have a gig playing 8 standards in 3 weeks — build me a
+  practice plan."
+- **Pattern recognition** — identify systematic weaknesses (e.g. flat keys, left hand
+  passages) from accumulated practice data.
+- **Adaptive difficulty** — auto-adjust scheduling aggressiveness based on progress
+  patterns over time.
+- **Adaptive interleaving** — AI adjusts mixing intensity based on how the musician
+  responds to different levels of contextual interference.
+- **AI session review** — post-session analysis with rebalancing suggestions.
+- **Goal coaching** — help set realistic goals and break them into actionable daily
+  practice plans.
+
+### Delivers
+
+Intrada becomes a knowledgeable practice partner — one that understands the musician's
+history, patterns, and goals.
+
+### Dependencies
+
+Phase 5 (visualisations — the AI needs the data patterns that the visualisations reveal).
+
+---
+
+## Timeline Summary
+
+| Phase | Theme | Duration | Cumulative |
+|-------|-------|----------|------------|
+| 1. Practice Quality | Make every session count | 4 weeks | 4 weeks |
+| 2. Library Depth | A library that understands music | 4 weeks | 8 weeks |
+| 3. Scheduling Intelligence | Practise what matters most | 6 weeks | 14 weeks |
+| 4. Goals & Encouragement | See the process working | 4 weeks | 18 weeks |
+| 5. Visualisation & Insights | Trust the evidence | 6 weeks | 24 weeks |
+| 6. Collaboration & Intelligence | A practice partner who knows you | 6+ weeks | 30+ weeks |
+
+Total: ~30 weeks vs the original 24. More realistic given the additions (onboarding,
+tempo-building flow, free practice mode, deep dive mode, lesson capture).
+
+---
+
+## Open Questions
+
+These need decisions before or during implementation:
+
+1. **Metronome: built-in or external?** The tempo-building loop (Phase 3) needs a
+   metronome. Building one is non-trivial (accurate timing in WASM). Alternative:
+   design the flow to work alongside an external metronome app.
+
+2. **Offline-first architecture.** Vision Principle 6 says "offline-first." The current
+   architecture is API-dependent. What syncs? What doesn't? When does sync happen? This
+   is an architectural decision that gets harder to retrofit the longer we wait.
+
+3. **iOS native vs web-first.** The vision doc raises this question. For Phases 1–3,
+   the web shell is fine. For the tempo loop and audio recording (Phases 3 and 5),
+   native APIs would be significantly better. Decision point: before Phase 3.
+
+4. **Audio recording viability.** Browser MediaRecorder API works on desktop but is
+   inconsistent on mobile Safari. If audio recording is important, this pushes toward
+   native.
+
+5. **Teacher integration timing.** Currently Phase 6. Basic sharing (routines, item
+   suggestions) could come earlier without AI. Consider splitting: basic teacher
+   features in Phase 4, AI-powered teacher features in Phase 6.
+
+6. **Scoring + tempo coupling.** Should every mastery rating require a tempo? Or is
+   tempo optional (only relevant for items with tempo targets)? The student critique
+   suggests mastery is tempo-dependent, but not all items have tempo targets.
+
+---
+
+## Critique Integration Log
+
+Changes made based on the product/teacher/student review:
+
+| # | Critique | Resolution |
+|---|----------|------------|
+| 1 | Feature inventory, not journey | Added onboarding lane, emotional annotations, open questions |
+| 2 | First-time user invisible | Added Day 1 onboarding flow with empty-library handling |
+| 3 | No lesson → practice bridge | Added lesson capture as onboarding and recurring flow |
+| 4 | Phase 2 overloaded | Split into Phases 3 + 4; moved practice quality to Phase 1 |
+| 5 | Goals incoherent across diagram | Gave goals their own lane with set → link → track → achieve |
+| 6 | Tempo work absent | Tempo-building loop is first-class in Phase 3 practice flow |
+| 7 | No deep dive mode | Added alongside interleaved as a session type |
+| 8 | Micro-cycle too rigid | Added light path for maintenance items |
+| 9 | Sections need more depth | Sections get own mastery + tempo; schedulable independently |
+| 10 | Teacher integration too late | Noted as open question; basic sharing could move to Phase 4 |
+| 11 | Reflection is homework | Quick close option; rating is 1 tap, notes are optional |
+| 12 | Scoring too coarse (no tempo) | Scoring now captures tempo alongside mastery |
+| 13 | No free practice mode | Added: timer only, no structure, counts toward consistency |
+| 14 | Streak counter contradicts comeback | Rework streak → comeback in Phase 1, not deferred |
+| 15 | Offline absent | Flagged as cross-cutting principle + open question |
+| 16 | Too linear / not messy enough | Added cross-flow connections, lesson capture as re-entry |
+| 17 | No import/share | Added to Phase 6 (teacher integration) |

--- a/docs/user-journey-to-be.drawio
+++ b/docs/user-journey-to-be.drawio
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mxfile host="app.diagrams.net" modified="2026-02-20T00:00:00.000Z" agent="Claude" version="24.0.0" type="device">
+<mxfile host="app.diagrams.net" modified="2026-02-21T00:00:00.000Z" agent="Claude" version="24.0.0" type="device">
   <diagram name="To-Be User Journey" id="to-be-journey">
-    <mxGraphModel dx="2800" dy="2200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="2800" pageHeight="2200" math="0" shadow="0">
+    <mxGraphModel dx="3200" dy="3200" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="3200" pageHeight="3200" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -9,497 +9,606 @@
         <!-- ============================================================ -->
         <!-- TITLE & LEGEND                                               -->
         <!-- ============================================================ -->
-        <mxCell id="title" value="intrada — To-Be User Journey (Full Vision)" style="text;html=1;fontSize=28;fontStyle=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="1">
-          <mxGeometry x="700" y="20" width="700" height="40" as="geometry" />
+        <mxCell id="title" value="intrada — To-Be User Journey" style="text;html=1;fontSize=28;fontStyle=1;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="1">
+          <mxGeometry x="900" y="15" width="500" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="subtitle" value="Mapped from VISION.md — colour-coded by implementation phase" style="text;html=1;fontSize=13;fontStyle=2;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="1">
-          <mxGeometry x="750" y="55" width="600" height="25" as="geometry" />
+        <mxCell id="subtitle" value="Revised 2026-02-21 — incorporates product, teacher &amp; student critique" style="text;html=1;fontSize=12;fontStyle=2;align=center;verticalAlign=middle;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="1">
+          <mxGeometry x="850" y="50" width="600" height="20" as="geometry" />
         </mxCell>
 
-        <!-- Legend -->
+        <!-- Legend box -->
         <mxCell id="legend-box" value="" style="rounded=1;fillColor=#f9fafb;strokeColor=#d1d5db;arcSize=8;" vertex="1" parent="1">
-          <mxGeometry x="40" y="20" width="520" height="65" as="geometry" />
+          <mxGeometry x="40" y="15" width="700" height="60" as="geometry" />
         </mxCell>
-        <mxCell id="leg-title" value="LEGEND" style="text;fontSize=11;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="55" y="24" width="60" height="18" as="geometry" />
+        <mxCell id="leg-title" value="PHASE" style="text;fontSize=10;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="50" y="19" width="45" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-green" value="" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
-          <mxGeometry x="55" y="48" width="16" height="16" as="geometry" />
+        <mxCell id="lg1" value="" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="50" y="42" width="14" height="14" as="geometry" />
         </mxCell>
-        <mxCell id="leg-green-t" value="Built ✅" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="75" y="46" width="50" height="18" as="geometry" />
+        <mxCell id="lg1t" value="Built" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="68" y="41" width="35" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-blue" value="" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
-          <mxGeometry x="135" y="48" width="16" height="16" as="geometry" />
+        <mxCell id="lg2" value="" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="110" y="42" width="14" height="14" as="geometry" />
         </mxCell>
-        <mxCell id="leg-blue-t" value="Phase 1: Foundation" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="155" y="46" width="110" height="18" as="geometry" />
+        <mxCell id="lg2t" value="P1: Practice Quality" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="128" y="41" width="105" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-orange" value="" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
-          <mxGeometry x="270" y="48" width="16" height="16" as="geometry" />
+        <mxCell id="lg3" value="" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="240" y="42" width="14" height="14" as="geometry" />
         </mxCell>
-        <mxCell id="leg-orange-t" value="Phase 2: Intelligence" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="290" y="46" width="110" height="18" as="geometry" />
+        <mxCell id="lg3t" value="P2: Library Depth" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="258" y="41" width="95" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-purple" value="" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
-          <mxGeometry x="405" y="48" width="16" height="16" as="geometry" />
+        <mxCell id="lg4" value="" style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="360" y="42" width="14" height="14" as="geometry" />
         </mxCell>
-        <mxCell id="leg-purple-t" value="Phase 3: Visibility" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="425" y="46" width="110" height="18" as="geometry" />
+        <mxCell id="lg4t" value="P3: Scheduling" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="378" y="41" width="85" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-pink" value="" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
-          <mxGeometry x="55" y="24" width="16" height="16" as="geometry" />
+        <mxCell id="lg5" value="" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="470" y="42" width="14" height="14" as="geometry" />
         </mxCell>
-        <!-- Pink legend item positioned at top right of legend box -->
-        <mxCell id="leg-pink2" value="" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
-          <mxGeometry x="135" y="24" width="16" height="16" as="geometry" />
+        <mxCell id="lg5t" value="P4: Goals" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="488" y="41" width="55" height="16" as="geometry" />
         </mxCell>
-        <mxCell id="leg-pink-t" value="Phase 4: AI" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
-          <mxGeometry x="155" y="22" width="70" height="18" as="geometry" />
+        <mxCell id="lg6" value="" style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;" vertex="1" parent="1">
+          <mxGeometry x="550" y="42" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="lg6t" value="P5: Visibility" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="568" y="41" width="65" height="16" as="geometry" />
+        </mxCell>
+        <mxCell id="lg7" value="" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="640" y="42" width="14" height="14" as="geometry" />
+        </mxCell>
+        <mxCell id="lg7t" value="P6: AI" style="text;fontSize=9;fillColor=none;strokeColor=none;fontColor=#374151;" vertex="1" parent="1">
+          <mxGeometry x="658" y="41" width="35" height="16" as="geometry" />
+        </mxCell>
+
+        <!-- Emotion key -->
+        <mxCell id="leg-emo" value="💡= insight moment  ⚡= friction risk  💪= motivation boost  😌= relief" style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="1">
+          <mxGeometry x="110" y="19" width="420" height="16" as="geometry" />
         </mxCell>
 
         <!-- ============================================================ -->
-        <!-- ROW 1: ENTRY & ONE-TAP START                                 -->
+        <!-- ROW 1: FIRST VISIT & ONBOARDING                             -->
         <!-- ============================================================ -->
-        <mxCell id="entry-lane" value="1. Open &amp; Start" style="swimlane;startSize=28;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="110" width="2720" height="200" as="geometry" />
+        <mxCell id="onboard-lane" value="1. First Visit (Day 1 — empty library)" style="swimlane;startSize=26;fillColor=#fef3c7;strokeColor=#d97706;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="90" width="2400" height="200" as="geometry" />
         </mxCell>
 
-        <mxCell id="open-app" value="Open&#xa;myintrada.com" style="ellipse;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=11;" vertex="1" parent="entry-lane">
-          <mxGeometry x="20" y="50" width="110" height="55" as="geometry" />
+        <mxCell id="first-visit" value="First visit&#xa;myintrada.com" style="ellipse;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=10;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="20" y="45" width="100" height="50" as="geometry" />
         </mxCell>
 
-        <mxCell id="auth-gate" value="Auth Gate&#xa;(Clerk / Google)" style="rhombus;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;fontStyle=1;" vertex="1" parent="entry-lane">
-          <mxGeometry x="170" y="40" width="120" height="70" as="geometry" />
+        <mxCell id="auth" value="Sign in&#xa;(Google / Clerk)" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="155" y="45" width="120" height="45" as="geometry" />
         </mxCell>
 
-        <mxCell id="landing" value="Landing / Home&#xa;&#xa;One-tap &quot;Start&quot; button&#xa;shows today's session" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;fontStyle=0;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
-          <mxGeometry x="340" y="35" width="180" height="80" as="geometry" />
+        <mxCell id="empty-lib" value="⚡ Empty Library&#xa;&#xa;No items, no sessions,&#xa;no data for scheduling.&#xa;This is the critical moment." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="310" y="35" width="190" height="95" as="geometry" />
         </mxCell>
 
-        <mxCell id="quick-start" value="🎯 One-Tap Start&#xa;&#xa;Algorithm generates&#xa;optimal session from&#xa;SRS + interleaving.&#xa;Zero decisions needed." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;fontStyle=1;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
-          <mxGeometry x="570" y="20" width="180" height="110" as="geometry" />
+        <mxCell id="onboard-choice" value="How do you&#xa;practise?" style="rhombus;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;fontStyle=1;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="540" y="40" width="120" height="70" as="geometry" />
         </mxCell>
 
-        <mxCell id="short-opts" value="Short Session Options&#xa;&#xa;10 / 15 / 20 / 30 min&#xa;prominently offered&#xa;(short = legitimate)" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
-          <mxGeometry x="790" y="20" width="170" height="100" as="geometry" />
+        <mxCell id="lesson-capture" value="📝 Lesson Capture&#xa;&#xa;&quot;What did your teacher&#xa;assign this week?&quot;&#xa;Quick-add items from&#xa;lesson notes." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="700" y="35" width="180" height="110" as="geometry" />
         </mxCell>
 
-        <mxCell id="or-build" value="OR" style="text;fontSize=11;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#9ca3af;" vertex="1" parent="entry-lane">
-          <mxGeometry x="515" y="140" width="30" height="20" as="geometry" />
+        <mxCell id="quick-add" value="Quick Add Wizard&#xa;&#xa;&quot;Add 3-5 things you're&#xa;working on right now.&quot;&#xa;Minimal fields, fast." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="700" y="150" width="180" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="manual-build" value="Build Custom Session&#xa;(existing flow)" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;" vertex="1" parent="entry-lane">
-          <mxGeometry x="570" y="140" width="160" height="40" as="geometry" />
+        <mxCell id="first-session" value="💡 First Session Prompt&#xa;&#xa;&quot;You've added 4 items.&#xa;Ready for your first session?&quot;&#xa;→ straight to builder" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="920" y="35" width="190" height="100" as="geometry" />
         </mxCell>
 
-        <mxCell id="or-routine" value="OR" style="text;fontSize=11;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#9ca3af;" vertex="1" parent="entry-lane">
-          <mxGeometry x="760" y="140" width="30" height="20" as="geometry" />
+        <mxCell id="emo-first" value="😌 &quot;That was easy.&#xa;I can see this working.&quot;" style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#059669;" vertex="1" parent="onboard-lane">
+          <mxGeometry x="1130" y="50" width="160" height="30" as="geometry" />
         </mxCell>
 
-        <mxCell id="load-routine" value="Load Routine&#xa;(existing flow)" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;" vertex="1" parent="entry-lane">
-          <mxGeometry x="810" y="140" width="140" height="40" as="geometry" />
-        </mxCell>
-
-        <mxCell id="interleave-pref" value="⚙ Interleaving Intensity&#xa;&#xa;Gentle mixing → Full interleave&#xa;User controls schedule mixing" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
-          <mxGeometry x="1000" y="20" width="200" height="80" as="geometry" />
-        </mxCell>
-
-        <!-- Edges -->
-        <mxCell id="ee1" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="open-app" target="auth-gate" parent="entry-lane">
+        <!-- Onboarding edges -->
+        <mxCell id="ob1" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="first-visit" target="auth" parent="onboard-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="ee2" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="auth-gate" target="landing" parent="entry-lane">
+        <mxCell id="ob2" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="auth" target="empty-lib" parent="onboard-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="ee3" value="Start" style="edgeStyle=orthogonalEdgeStyle;fontStyle=1;fontColor=#d6b656;fontSize=9;" edge="1" source="landing" target="quick-start" parent="entry-lane">
+        <mxCell id="ob3" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="empty-lib" target="onboard-choice" parent="onboard-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="ee4" value="Custom" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;dashed=1;" edge="1" source="landing" target="manual-build" parent="entry-lane">
+        <mxCell id="ob4" value="Has teacher" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;" edge="1" source="onboard-choice" target="lesson-capture" parent="onboard-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ob5" value="Self-directed" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" source="onboard-choice" target="quick-add" parent="onboard-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="ob6" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="lesson-capture" target="first-session" parent="onboard-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- ============================================================ -->
-        <!-- ROW 2: LIBRARY & ORGANISATION                                -->
+        <!-- ROW 2: DAILY ENTRY (returning user)                          -->
         <!-- ============================================================ -->
-        <mxCell id="lib-lane" value="2. Library &amp; Organisation" style="swimlane;startSize=28;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="330" width="2720" height="220" as="geometry" />
+        <mxCell id="entry-lane" value="2. Daily Entry (returning user)" style="swimlane;startSize=26;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="310" width="2400" height="200" as="geometry" />
         </mxCell>
 
-        <mxCell id="lib-crud" value="Library CRUD&#xa;&#xa;• Pieces, Exercises&#xa;• Title, Composer, Key&#xa;• Tempo, BPM, Notes, Tags&#xa;• Filter by type/key/tags" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="20" y="40" width="180" height="110" as="geometry" />
+        <mxCell id="open-app" value="Open App" style="ellipse;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=10;" vertex="1" parent="entry-lane">
+          <mxGeometry x="20" y="55" width="90" height="45" as="geometry" />
         </mxCell>
 
-        <mxCell id="item-types" value="Expanded Item Types&#xa;&#xa;• Pieces (with sections)&#xa;• Exercises&#xa;• Licks / Vocabulary&#xa;• Technique goals" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="230" y="40" width="170" height="110" as="geometry" />
+        <mxCell id="landing" value="Home Screen&#xa;&#xa;💪 Welcome back message.&#xa;Today's suggested session&#xa;ready to go." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
+          <mxGeometry x="150" y="35" width="180" height="95" as="geometry" />
         </mxCell>
 
-        <mxCell id="key-aware" value="🎹 Key-Aware Exercises&#xa;&#xa;Mark exercise as &quot;all 12 keys&quot;&#xa;→ auto-generates 12 sub-items&#xa;→ each tracks mastery independently&#xa;→ weak keys surface more often" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="lib-lane">
-          <mxGeometry x="430" y="40" width="210" height="110" as="geometry" />
+        <mxCell id="one-tap" value="🎯 ONE-TAP START&#xa;&#xa;Algorithm picks items from&#xa;SRS + interleaving. You choose&#xa;duration. Zero other decisions.&#xa;THE default path." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="entry-lane">
+          <mxGeometry x="380" y="30" width="200" height="110" as="geometry" />
         </mxCell>
 
-        <mxCell id="sections" value="Section / Passage&#xa;Management&#xa;&#xa;Break pieces into&#xa;practisable sections" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="670" y="40" width="160" height="100" as="geometry" />
+        <mxCell id="short-opts" value="⏱ Duration picker&#xa;10 / 15 / 20 / 30 / 45 / 60 min&#xa;&quot;Short sessions = real progress&quot;" style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
+          <mxGeometry x="380" y="145" width="200" height="45" as="geometry" />
         </mxCell>
 
-        <mxCell id="search-ui" value="🔍 Full-Text Search&#xa;&#xa;Search across all&#xa;items + practice notes&#xa;+ reflections" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="860" y="40" width="160" height="100" as="geometry" />
+        <mxCell id="custom-build" value="Build Custom&#xa;Session" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;" vertex="1" parent="entry-lane">
+          <mxGeometry x="630" y="40" width="120" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="warmup-routines" value="Warm-Up Routines&#xa;&#xa;Saved sequences of items&#xa;as reusable templates.&#xa;Reduces daily decisions." style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="1050" y="40" width="170" height="100" as="geometry" />
+        <mxCell id="load-routine" value="Load Routine" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;" vertex="1" parent="entry-lane">
+          <mxGeometry x="630" y="90" width="120" height="35" as="geometry" />
         </mxCell>
 
-        <mxCell id="effort-tags" value="Effort / Difficulty Tags&#xa;&#xa;Per-item difficulty level&#xa;and effort rating for&#xa;session balancing" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
-          <mxGeometry x="1250" y="40" width="160" height="100" as="geometry" />
+        <mxCell id="free-practice" value="🎵 Free Practice&#xa;&#xa;Timer only. No structure.&#xa;Just play. Time is logged&#xa;but no items/scores required.&#xa;Legitimises unstructured time." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
+          <mxGeometry x="630" y="130" width="190" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ============================================================ -->
-        <!-- ROW 3: SMART SCHEDULING (Phase 2)                            -->
-        <!-- ============================================================ -->
-        <mxCell id="sched-lane" value="3. Smart Scheduling (Phase 2)" style="swimlane;startSize=28;fillColor=#fffbeb;strokeColor=#d6b656;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="570" width="2720" height="200" as="geometry" />
+        <mxCell id="deep-dive" value="🔬 Deep Dive&#xa;&#xa;Pick ONE item. Extended time.&#xa;Intensive work. For shedding,&#xa;not interleaving." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="entry-lane">
+          <mxGeometry x="860" y="40" width="170" height="90" as="geometry" />
         </mxCell>
 
-        <mxCell id="srs-engine" value="🧠 Spaced Repetition Engine&#xa;&#xa;Modified SM-2 algorithm.&#xa;Intervals based on mastery&#xa;scores + time since last practice.&#xa;High-effort items get shorter&#xa;intervals (Donovan &amp; Radosevich)." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="20" y="40" width="230" height="130" as="geometry" />
+        <mxCell id="lesson-entry" value="📝 Lesson Capture&#xa;(returning flow too)" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;whiteSpace=wrap;" vertex="1" parent="entry-lane">
+          <mxGeometry x="860" y="145" width="150" height="35" as="geometry" />
         </mxCell>
 
-        <mxCell id="interleave-gen" value="Interleaved Setlist Generator&#xa;&#xa;Mixed-type sessions: scale →&#xa;piece passage → lick in new key.&#xa;Begins similar, increases variety&#xa;(Mathias &amp; Goldman, 2025)." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="280" y="40" width="220" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="session-plan" value="Session Planning&#xa;&#xa;Input available time →&#xa;get structured plan:&#xa;warm-up → focus → review.&#xa;Adjustable by musician." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="530" y="40" width="190" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="mastery-decay" value="Mastery Decay Model&#xa;&#xa;Scores decrease over time&#xa;if items aren't reviewed.&#xa;Creates natural urgency&#xa;in scheduling." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="750" y="40" width="180" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="difficulty-balance" value="Difficulty Balancing&#xa;&#xa;Front-load demanding work&#xa;when focus is fresh.&#xa;No back-to-back high-effort.&#xa;Taper toward light review." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="960" y="40" width="190" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="goal-alignment" value="Goal-Aligned Scheduling&#xa;&#xa;Items tagged for current&#xa;goals get priority boost.&#xa;Active goals influence&#xa;session composition." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="1180" y="40" width="190" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="rest-recovery" value="Rest &amp; Recovery Awareness&#xa;&#xa;Flag unusually high practice&#xa;volumes. &quot;Your body and brain&#xa;need recovery time to&#xa;consolidate what you've learned.&quot;" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="sched-lane">
-          <mxGeometry x="1400" y="40" width="210" height="120" as="geometry" />
-        </mxCell>
-
-        <!-- ============================================================ -->
-        <!-- ROW 4: INTENTIONAL PRACTICE (During Session)                 -->
-        <!-- ============================================================ -->
-        <mxCell id="practice-lane" value="4. Intentional Practice (During Session)" style="swimlane;startSize=28;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="790" width="2720" height="280" as="geometry" />
-        </mxCell>
-
-        <!-- The micro-cycle -->
-        <mxCell id="micro-label" value="Intentional Practice Micro-Cycle (per item)" style="text;fontSize=11;fontStyle=3;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="practice-lane">
-          <mxGeometry x="20" y="35" width="300" height="20" as="geometry" />
-        </mxCell>
-
-        <mxCell id="goal-prompt" value="🎯 Set Micro-Goal&#xa;&#xa;&quot;What will you focus on?&quot;&#xa;Accuracy / Evenness /&#xa;Dynamics / Tempo / Custom" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
-          <mxGeometry x="20" y="65" width="180" height="100" as="geometry" />
-        </mxCell>
-
-        <mxCell id="focus-mode" value="🔇 Focus Mode&#xa;&#xa;Current item + timer ONLY.&#xa;No menus, no nav, no badges.&#xa;Minimal visual distraction.&#xa;Full UI accessible but hidden." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="practice-lane">
-          <mxGeometry x="240" y="65" width="190" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="timer-visual" value="⏱ Visual Timer&#xa;&#xa;Progress ring/bar (not digits).&#xa;Elapsed per item + session.&#xa;Gentle chime at transition.&#xa;Time blindness support." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
-          <mxGeometry x="470" y="65" width="180" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="rep-counter" value="🔢 Repetition Counter&#xa;(optional per item)&#xa;&#xa;Tap ✓ to increment&#xa;Tap ✗ to decrement (≥0)&#xa;Target: configurable (3-10)&#xa;Default: 5 (85% Rule)" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
-          <mxGeometry x="690" y="65" width="180" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="transition" value="Transition Prompt&#xa;&#xa;Preview of next item.&#xa;Optional 30s micro-break.&#xa;Session begins similar,&#xa;increases variety over time." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
-          <mxGeometry x="910" y="65" width="180" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="reflect-prompt" value="💭 Reflect&#xa;&#xa;&quot;What improved?&#xa;What needs more work?&quot;&#xa;Quick note per item.&#xa;Mastery self-rating (1-5)." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
-          <mxGeometry x="1130" y="65" width="180" height="110" as="geometry" />
-        </mxCell>
-
-        <!-- Micro-cycle flow arrows -->
-        <mxCell id="mc1" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="goal-prompt" target="focus-mode" parent="practice-lane">
+        <!-- Entry edges -->
+        <mxCell id="en1" style="edgeStyle=orthogonalEdgeStyle;" edge="1" source="open-app" target="landing" parent="entry-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="mc2" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="focus-mode" target="timer-visual" parent="practice-lane">
+        <mxCell id="en2" value="Start" style="edgeStyle=orthogonalEdgeStyle;fontStyle=1;fontColor=#d79b00;fontSize=9;" edge="1" source="landing" target="one-tap" parent="entry-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="mc3" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="timer-visual" target="rep-counter" parent="practice-lane">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="mc4" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d6b656;strokeWidth=2;" edge="1" source="rep-counter" target="transition" parent="practice-lane">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-        <mxCell id="mc5" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="transition" target="reflect-prompt" parent="practice-lane">
+        <mxCell id="en3" value="OR" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;dashed=1;fontColor=#9ca3af;" edge="1" source="landing" target="custom-build" parent="entry-lane">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Loop back arrow -->
-        <mxCell id="mc-loop" value="Next item →&#xa;repeat cycle" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;strokeWidth=2;dashed=1;fontSize=9;fontStyle=1;fontColor=#82b366;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="reflect-prompt" target="goal-prompt" parent="practice-lane">
+        <!-- ============================================================ -->
+        <!-- ROW 3: LIBRARY & ORGANISATION                                -->
+        <!-- ============================================================ -->
+        <mxCell id="lib-lane" value="3. Library &amp; Organisation" style="swimlane;startSize=26;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="530" width="2400" height="200" as="geometry" />
+        </mxCell>
+
+        <mxCell id="lib-crud" value="Library CRUD&#xa;&#xa;• Pieces, Exercises&#xa;• Title, Composer, Key&#xa;• Tempo, BPM, Notes, Tags&#xa;• Type/key/tag filtering" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="20" y="35" width="170" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="item-types" value="Expanded Types&#xa;&#xa;• Pieces (with sections)&#xa;• Exercises&#xa;• Licks / Vocabulary&#xa;• Technique goals" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="210" y="35" width="155" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="key-aware" value="🎹 Key-Aware Exercises&#xa;&#xa;Mark as &quot;all 12 keys&quot; →&#xa;auto-generates sub-items.&#xa;Each key tracks mastery&#xa;independently." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="385" y="35" width="180" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="sections" value="Sections / Passages&#xa;&#xa;Break pieces into&#xa;practisable chunks.&#xa;Each section can have&#xa;own tempo target + mastery." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="585" y="35" width="175" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="search-ui" value="🔍 Search / Filter UI&#xa;&#xa;Search items + practice&#xa;notes. Filter by type,&#xa;key, tags, category." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="780" y="35" width="160" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="effort-tags" value="Effort / Difficulty&#xa;&#xa;Per-item difficulty level&#xa;+ effort rating. Feeds&#xa;session balancing." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="960" y="35" width="155" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="routines" value="Warm-Up Routines&#xa;&#xa;Saved sequences.&#xa;Load, save, edit.&#xa;Reduces daily decisions." style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="1135" y="35" width="155" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="import-share" value="Import / Share&#xa;&#xa;Teacher shares routine.&#xa;Import items from&#xa;external source." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="lib-lane">
+          <mxGeometry x="1310" y="35" width="150" height="100" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- ROW 4: THE PRACTICE SESSION                                  -->
+        <!-- This is the core — showing multiple paths through practice   -->
+        <!-- ============================================================ -->
+        <mxCell id="practice-lane" value="4. During Practice" style="swimlane;startSize=26;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="750" width="2400" height="380" as="geometry" />
+        </mxCell>
+
+        <!-- Full micro-cycle label -->
+        <mxCell id="full-label" value="FULL MICRO-CYCLE — for items being actively learned" style="text;fontSize=10;fontStyle=3;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="practice-lane">
+          <mxGeometry x="20" y="32" width="350" height="18" as="geometry" />
+        </mxCell>
+
+        <mxCell id="goal-prompt" value="🎯 Set Focus&#xa;&#xa;Quick tap from presets:&#xa;Accuracy / Evenness /&#xa;Dynamics / Tempo / Custom&#xa;(1 tap, not a form)" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="20" y="55" width="170" height="105" as="geometry" />
+        </mxCell>
+
+        <mxCell id="focus-mode" value="🔇 Focus Mode&#xa;&#xa;Item name + timer ONLY.&#xa;No nav, no badges.&#xa;Full UI accessible via&#xa;swipe/tap but hidden." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="220" y="55" width="170" height="105" as="geometry" />
+        </mxCell>
+
+        <mxCell id="timer-visual" value="⏱ Visual Timer&#xa;&#xa;Progress ring (not digits).&#xa;Per-item + session elapsed.&#xa;Gentle chime at transition." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="420" y="55" width="165" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="tempo-loop" value="🎹 Tempo Work&#xa;&#xa;Current: ♩=80  Target: ♩=120&#xa;Play → judge → bump/hold.&#xa;Iterative tempo-building is&#xa;a session within a session.&#xa;Metronome integrated." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;fontStyle=0;" vertex="1" parent="practice-lane">
+          <mxGeometry x="615" y="55" width="190" height="120" as="geometry" />
+        </mxCell>
+
+        <mxCell id="rep-counter" value="🔢 Rep Counter&#xa;(optional)&#xa;&#xa;✓ = increment&#xa;✗ = decrement (≥0)&#xa;Target: 3-10 (default 5)&#xa;Done → auto-transition" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="835" y="55" width="165" height="120" as="geometry" />
+        </mxCell>
+
+        <mxCell id="transition" value="Transition Prompt&#xa;&#xa;Preview next item.&#xa;Optional 30s micro-break.&#xa;Variety increases through&#xa;the session." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1030" y="55" width="170" height="105" as="geometry" />
+        </mxCell>
+
+        <mxCell id="rate-item" value="Rate &amp; Note&#xa;&#xa;1-5 tap + tempo achieved.&#xa;Optional quick note.&#xa;(NOT mandatory essay)" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1230" y="55" width="165" height="100" as="geometry" />
+        </mxCell>
+
+        <!-- Full cycle arrows -->
+        <mxCell id="fc1" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="goal-prompt" target="focus-mode" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="fc2" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="focus-mode" target="timer-visual" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="fc3" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;strokeWidth=2;" edge="1" source="timer-visual" target="tempo-loop" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="fc4" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="tempo-loop" target="rep-counter" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="fc5" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;strokeWidth=2;" edge="1" source="rep-counter" target="transition" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="fc6" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;strokeWidth=2;" edge="1" source="transition" target="rate-item" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Loop back -->
+        <mxCell id="fc-loop" value="Next item → repeat" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#82b366;strokeWidth=2;dashed=1;fontSize=9;fontStyle=1;fontColor=#82b366;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="rate-item" target="goal-prompt" parent="practice-lane">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="1220" y="210" />
-              <mxPoint x="110" y="210" />
+              <mxPoint x="1313" y="185" />
+              <mxPoint x="105" y="185" />
             </Array>
           </mxGeometry>
         </mxCell>
 
-        <!-- Existing session features note -->
-        <mxCell id="existing-note" value="Current active session (timer, next/skip, end early, crash recovery) is retained and enhanced with these features" style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#6b7280;align=left;" vertex="1" parent="practice-lane">
-          <mxGeometry x="20" y="240" width="600" height="18" as="geometry" />
+        <!-- LIGHT path -->
+        <mxCell id="light-label" value="LIGHT PATH — for review/maintenance items (mastery ≥ 4)" style="text;fontSize=10;fontStyle=3;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="practice-lane">
+          <mxGeometry x="20" y="205" width="380" height="18" as="geometry" />
         </mxCell>
 
-        <!-- ============================================================ -->
-        <!-- ROW 5: POST-SESSION REFLECTION                               -->
-        <!-- ============================================================ -->
-        <mxCell id="post-lane" value="5. Post-Session" style="swimlane;startSize=28;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="1090" width="2720" height="200" as="geometry" />
+        <mxCell id="light-play" value="Focus Mode&#xa;+ Timer" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="20" y="230" width="110" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="summary-exist" value="Session Summary&#xa;(existing)&#xa;&#xa;• Per-entry scoring (1-5)&#xa;• Per-entry notes&#xa;• Session notes&#xa;• Save as routine" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="20" y="40" width="180" height="130" as="geometry" />
+        <mxCell id="light-rate" value="Quick 1-5 tap&#xa;(no note required)" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="170" y="230" width="130" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="time-compare" value="⏱ Time vs Planned&#xa;&#xa;Planned: 30 min → Actual: 38 min&#xa;Calibrates internal time sense.&#xa;Helps with ADHD time blindness." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="230" y="40" width="200" height="110" as="geometry" />
+        <mxCell id="light-next" value="Auto-transition&#xa;to next item" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="340" y="230" width="120" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="encouragement" value="💬 Encouragement Message&#xa;&#xa;&quot;Your Db mastery went from&#xa;2 to 4 over three weeks —&#xa;that's the spacing effect.&quot;&#xa;Process-focused, data-tied." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="460" y="40" width="200" height="120" as="geometry" />
+        <mxCell id="lt1" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;" edge="1" source="light-play" target="light-rate" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="lt2" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#6c8ebf;" edge="1" source="light-rate" target="light-next" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <mxCell id="weekly-goals" value="Goal Check-In&#xa;&#xa;Session goal: achieved?&#xa;Weekly goal: progress update.&#xa;Milestone: % complete." style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="690" y="40" width="180" height="110" as="geometry" />
+        <mxCell id="light-note" value="⚡ Key insight: maintenance items shouldn't carry full ceremony.&#xa;Musician controls which path via a &quot;quick review&quot; toggle or auto-detect from mastery level." style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#6b7280;align=left;" vertex="1" parent="practice-lane">
+          <mxGeometry x="20" y="280" width="550" height="28" as="geometry" />
         </mxCell>
 
-        <mxCell id="save-recording" value="🎙 Record &amp; Compare&#xa;&#xa;Record a run-through,&#xa;play it back, rate it.&#xa;Compare to 3 weeks ago.&#xa;Objective anchor for mastery." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="900" y="40" width="190" height="120" as="geometry" />
+        <!-- DEEP DIVE path -->
+        <mxCell id="dd-label" value="DEEP DIVE — single item, extended time" style="text;fontSize=10;fontStyle=3;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="practice-lane">
+          <mxGeometry x="620" y="205" width="280" height="18" as="geometry" />
         </mxCell>
 
-        <mxCell id="ai-review" value="🤖 AI Session Review&#xa;&#xa;&quot;You spent 40% on pieces,&#xa;10% on your weakest keys.&#xa;Want me to rebalance&#xa;tomorrow's session?&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
-          <mxGeometry x="1120" y="40" width="200" height="120" as="geometry" />
+        <mxCell id="dd-focus" value="Focus Mode on&#xa;ONE item. Open-ended&#xa;time. Tempo loop.&#xa;Rep counter available." style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="practice-lane">
+          <mxGeometry x="620" y="230" width="180" height="70" as="geometry" />
         </mxCell>
 
-        <!-- ============================================================ -->
-        <!-- ROW 6: PROGRESS VISUALISATION & GOALS                        -->
-        <!-- ============================================================ -->
-        <mxCell id="viz-lane" value="6. Progress &amp; Goals" style="swimlane;startSize=28;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="1310" width="2720" height="260" as="geometry" />
+        <mxCell id="dd-note" value="💡 For shedding a difficult passage. Respects that sometimes&#xa;interleaving is wrong — deep work on one thing is what's needed." style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#6b7280;align=left;" vertex="1" parent="practice-lane">
+          <mxGeometry x="620" y="310" width="420" height="28" as="geometry" />
         </mxCell>
 
-        <!-- Existing analytics -->
-        <mxCell id="existing-analytics" value="Existing Analytics&#xa;&#xa;• Weekly time + sessions&#xa;• Practice streak&#xa;• 28-day line chart&#xa;• Top 10 items&#xa;• Score trends (dot history)" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="20" y="40" width="180" height="130" as="geometry" />
+        <!-- TEMPO LOOP detail -->
+        <mxCell id="tempo-detail" value="The Tempo Loop (inside any practice item)" style="text;fontSize=10;fontStyle=3;fillColor=none;strokeColor=none;fontColor=#6b7280;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1100" y="205" width="300" height="18" as="geometry" />
         </mxCell>
 
-        <!-- Phase 3 visualisations -->
-        <mxCell id="mastery-timeline" value="📈 Mastery Timeline&#xa;&#xa;Line charts per item&#xa;and aggregate showing&#xa;mastery improvement&#xa;over weeks and months." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="230" y="40" width="180" height="120" as="geometry" />
+        <mxCell id="tempo-set" value="Set current +&#xa;target tempo" style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1100" y="230" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="tempo-play" value="Play at&#xa;current" style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1220" y="230" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="tempo-judge" value="Solid?" style="rhombus;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;fontStyle=1;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1320" y="225" width="70" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="tempo-bump" value="Bump&#xa;+5 BPM" style="rounded=1;fillColor=#ffe6cc;strokeColor=#d79b00;fontSize=9;whiteSpace=wrap;" vertex="1" parent="practice-lane">
+          <mxGeometry x="1410" y="230" width="70" height="40" as="geometry" />
         </mxCell>
 
-        <mxCell id="key-heatmap" value="🎵 Key Coverage Heatmap&#xa;&#xa;Circle-of-fifths view.&#xa;Mastery level per key&#xa;for any exercise.&#xa;Immediately reveals weak keys." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="440" y="40" width="190" height="120" as="geometry" />
+        <mxCell id="tt1" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;" edge="1" source="tempo-set" target="tempo-play" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
-
-        <mxCell id="consistency-cal" value="📅 Consistency Calendar&#xa;&#xa;Comeback framing:&#xa;&quot;4 of the last 7 days —&#xa;great spacing for retention&quot;&#xa;NOT &quot;5 day streak — don't break it&quot;" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="660" y="40" width="210" height="120" as="geometry" />
+        <mxCell id="tt2" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;" edge="1" source="tempo-play" target="tempo-judge" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
-
-        <mxCell id="tempo-chart" value="🎹 Tempo Progress&#xa;&#xa;Chart showing tempo&#xa;increase over time&#xa;toward target BPM." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="900" y="40" width="170" height="100" as="geometry" />
+        <mxCell id="tt3" value="Yes" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;fontSize=8;fontColor=#059669;" edge="1" source="tempo-judge" target="tempo-bump" parent="practice-lane">
+          <mxGeometry relative="1" as="geometry" />
         </mxCell>
-
-        <mxCell id="goal-dash" value="🎯 Goal Dashboard&#xa;&#xa;Session / Weekly / Milestone.&#xa;% completion tracking.&#xa;Process-focused messaging." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="1100" y="40" width="180" height="100" as="geometry" />
-        </mxCell>
-
-        <mxCell id="encourage-config" value="⚙ Encouragement Config&#xa;&#xa;Frequency: every item / session / weekly / off&#xa;Tone: data-focused / warm / minimal&#xa;Delivery: inline / summary / notification" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="1310" y="40" width="230" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="weekly-summary" value="📊 Weekly Summary&#xa;&#xa;Insights report with&#xa;comparison to prior week.&#xa;Sent via notification or&#xa;shown on next open." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
-          <mxGeometry x="1570" y="40" width="180" height="120" as="geometry" />
-        </mxCell>
-
-        <!-- Goal types row -->
-        <mxCell id="goals-label" value="Goal Types:" style="text;fontSize=10;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="viz-lane">
-          <mxGeometry x="230" y="180" width="80" height="18" as="geometry" />
-        </mxCell>
-        <mxCell id="goal-session" value="Session goals&#xa;(&quot;focus on LH today&quot;)" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;whiteSpace=wrap;" vertex="1" parent="viz-lane">
-          <mxGeometry x="320" y="175" width="140" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="goal-weekly" value="Weekly goals&#xa;(&quot;practice 5 days&quot;)" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;whiteSpace=wrap;" vertex="1" parent="viz-lane">
-          <mxGeometry x="480" y="175" width="140" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="goal-milestone" value="Milestone goals&#xa;(&quot;all keys to mastery 4 by March&quot;)" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=9;whiteSpace=wrap;" vertex="1" parent="viz-lane">
-          <mxGeometry x="640" y="175" width="190" height="40" as="geometry" />
-        </mxCell>
-
-        <!-- ============================================================ -->
-        <!-- ROW 7: FUTURE INTELLIGENCE (Phase 4)                         -->
-        <!-- ============================================================ -->
-        <mxCell id="ai-lane" value="7. AI &amp; Future Intelligence (Phase 4)" style="swimlane;startSize=28;fillColor=#fef2f2;strokeColor=#b85450;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="1590" width="2720" height="200" as="geometry" />
-        </mxCell>
-
-        <mxCell id="ai-setlist" value="🤖 AI Setlist Generation&#xa;&#xa;&quot;I have a gig playing 8&#xa;standards in 3 weeks —&#xa;build me a practice plan.&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="20" y="40" width="190" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="ai-patterns" value="Pattern Recognition&#xa;&#xa;&quot;You consistently struggle&#xa;with keys that have 4+&#xa;flats — here's a plan.&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="240" y="40" width="190" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="ai-difficulty" value="Adaptive Difficulty&#xa;&#xa;Auto-adjust scheduling&#xa;aggressiveness based on&#xa;progress patterns over time." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="460" y="40" width="190" height="110" as="geometry" />
-        </mxCell>
-
-        <mxCell id="ai-interleave" value="Adaptive Interleaving&#xa;&#xa;AI adjusts mixing intensity&#xa;based on how musician&#xa;responds to contextual&#xa;interference over time." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="680" y="40" width="190" height="120" as="geometry" />
-        </mxCell>
-
-        <mxCell id="teacher" value="👩‍🏫 Teacher Integration&#xa;&#xa;Teacher suggests items,&#xa;sets target tempos/goals,&#xa;views progress dashboards&#xa;(with permission).&#xa;Musician retains full control." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="900" y="40" width="200" height="130" as="geometry" />
-        </mxCell>
-
-        <mxCell id="ai-coaching" value="Goal Coaching&#xa;&#xa;Help set realistic goals.&#xa;Break into actionable plans.&#xa;Technique/theory guidance&#xa;in context." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
-          <mxGeometry x="1130" y="40" width="180" height="120" as="geometry" />
-        </mxCell>
-
-        <!-- ============================================================ -->
-        <!-- ROW 8: INCLUSIVE DESIGN (Cross-Cutting)                       -->
-        <!-- ============================================================ -->
-        <mxCell id="inclusive-lane" value="Cross-Cutting: Inclusive Design Principles" style="swimlane;startSize=28;fillColor=#f0fdf4;strokeColor=#82b366;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
-          <mxGeometry x="40" y="1810" width="2720" height="130" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-decisions" value="Reduce Decisions to Start&#xa;Default = one tap to play" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="20" y="40" width="170" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-time" value="Externalise Time&#xa;Visual timers, prompts" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="210" y="40" width="160" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-comeback" value="Celebrate Comeback&#xa;Not streak. Never shame." style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="390" y="40" width="170" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-sensory" value="Sensory Sensitivity&#xa;No auto-sounds, calm palette" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="580" y="40" width="180" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-typo" value="Accessible Typography&#xa;Sans-serif, spacing, contrast" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="780" y="40" width="180" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-nav" value="Predictable Navigation&#xa;Same flow every time" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="980" y="40" width="170" height="50" as="geometry" />
-        </mxCell>
-
-        <mxCell id="inc-feedback" value="Configurable Feedback&#xa;Frequency, tone, delivery" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;fontStyle=0;align=center;" vertex="1" parent="inclusive-lane">
-          <mxGeometry x="1170" y="40" width="170" height="50" as="geometry" />
-        </mxCell>
-
-        <!-- ============================================================ -->
-        <!-- CROSS-FLOW CONNECTIONS                                       -->
-        <!-- ============================================================ -->
-
-        <!-- Quick start feeds into practice micro-cycle -->
-        <mxCell id="xf1" value="Generated session&#xa;→ practice flow" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;dashed=1;strokeColor=#d6b656;fontColor=#d6b656;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" source="quick-start" target="goal-prompt" parent="1">
+        <mxCell id="tt4" value="No → stay" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;fontSize=8;dashed=1;fontColor=#b85450;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="tempo-judge" target="tempo-play" parent="practice-lane">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="700" y="770" />
-              <mxPoint x="150" y="770" />
+              <mxPoint x="1355" y="295" />
+              <mxPoint x="1260" y="295" />
             </Array>
           </mxGeometry>
         </mxCell>
-
-        <!-- SRS engine feeds quick start -->
-        <mxCell id="xf2" value="Powers" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;dashed=1;strokeColor=#d6b656;fontColor=#d6b656;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="srs-engine" target="quick-start" parent="1">
+        <mxCell id="tt5" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#d79b00;dashed=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" source="tempo-bump" target="tempo-play" parent="practice-lane">
           <mxGeometry relative="1" as="geometry">
             <Array as="points">
-              <mxPoint x="175" y="560" />
-              <mxPoint x="700" y="560" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- Practice → Post session -->
-        <mxCell id="xf3" value="Session complete →&#xa;Summary" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;fontStyle=1;strokeColor=#82b366;fontColor=#82b366;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="reflect-prompt" target="summary-exist" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="1370" y="910" />
-              <mxPoint x="1370" y="1060" />
-              <mxPoint x="40" y="1060" />
-              <mxPoint x="40" y="1195" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- Post session → Progress -->
-        <mxCell id="xf4" value="Data feeds&#xa;visualisations" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;dashed=1;strokeColor=#9673a6;fontColor=#9673a6;" edge="1" source="summary-exist" target="existing-analytics" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="150" y="1290" />
-              <mxPoint x="150" y="1350" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-
-        <!-- Key-aware exercises feed into key heatmap -->
-        <mxCell id="xf5" value="Per-key data →" style="edgeStyle=orthogonalEdgeStyle;fontSize=8;dashed=1;strokeColor=#9673a6;fontColor=#9673a6;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="key-aware" target="key-heatmap" parent="1">
-          <mxGeometry relative="1" as="geometry">
-            <Array as="points">
-              <mxPoint x="575" y="545" />
-              <mxPoint x="575" y="1300" />
+              <mxPoint x="1445" y="310" />
+              <mxPoint x="1260" y="310" />
             </Array>
           </mxGeometry>
         </mxCell>
 
         <!-- ============================================================ -->
-        <!-- NAVIGATION BAR                                               -->
+        <!-- ROW 5: POST-SESSION                                          -->
         <!-- ============================================================ -->
-        <mxCell id="nav-bar" value="Navigation:  Home  |  Library  |  Sessions  |  Routines  |  Analytics  |  Goals  |  Settings" style="text;fontSize=12;fontStyle=1;align=center;fillColor=#f5f5f5;strokeColor=#666666;rounded=1;spacingLeft=10;spacingRight=10;fontColor=#333333;" vertex="1" parent="1">
-          <mxGeometry x="540" y="1960" width="800" height="30" as="geometry" />
+        <mxCell id="post-lane" value="5. Post-Session" style="swimlane;startSize=26;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1150" width="2400" height="200" as="geometry" />
+        </mxCell>
+
+        <mxCell id="summary" value="Session Summary&#xa;&#xa;• Per-item scores (1-5)&#xa;• Per-item notes&#xa;• Session notes&#xa;• Save as routine" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="20" y="35" width="170" height="115" as="geometry" />
+        </mxCell>
+
+        <mxCell id="quick-close" value="⚡ Quick Close option&#xa;&#xa;Save scores from practice.&#xa;Skip detailed reflection.&#xa;&quot;I just want to stop.&quot;" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="215" y="35" width="170" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="time-compare" value="⏱ Time vs Planned&#xa;&#xa;Planned 30 min → Actual 38 min&#xa;💡 Calibrates time sense.&#xa;ADHD time blindness support." style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="410" y="35" width="190" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="encourage" value="💬 Encouragement&#xa;&#xa;Data-tied, process-focused.&#xa;&quot;Your Db mastery: 2 → 4&#xa;over three weeks.&quot;&#xa;NOT empty praise." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="625" y="35" width="180" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="goal-checkin" value="Goal Check-In&#xa;&#xa;Session goal: achieved?&#xa;Weekly goal: progress.&#xa;Milestone: % complete." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="830" y="35" width="165" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="recording" value="🎙 Record &amp; Compare&#xa;&#xa;Record → playback → rate.&#xa;Compare to last month.&#xa;Objective mastery anchor." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="1020" y="35" width="170" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ai-review" value="🤖 AI Review&#xa;&#xa;&quot;You spent 40% on pieces,&#xa;10% on weakest keys.&#xa;Rebalance tomorrow?&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="post-lane">
+          <mxGeometry x="1215" y="35" width="175" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="emo-post" value="💪 &quot;I can see I'm improving.&#xa;The data proves it.&quot;" style="text;fontSize=9;fontStyle=2;fillColor=none;strokeColor=none;fontColor=#059669;" vertex="1" parent="post-lane">
+          <mxGeometry x="625" y="155" width="200" height="25" as="geometry" />
         </mxCell>
 
         <!-- ============================================================ -->
-        <!-- PHASE SUMMARY BOX                                            -->
+        <!-- ROW 6: GOALS (own lane — coherent journey)                   -->
         <!-- ============================================================ -->
-        <mxCell id="phase-box" value="" style="rounded=1;fillColor=#f9fafb;strokeColor=#d1d5db;arcSize=6;" vertex="1" parent="1">
-          <mxGeometry x="40" y="2010" width="1500" height="150" as="geometry" />
-        </mxCell>
-        <mxCell id="phase-title" value="ROADMAP PHASES" style="text;fontSize=13;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#1e1b4b;" vertex="1" parent="1">
-          <mxGeometry x="60" y="2015" width="200" height="22" as="geometry" />
+        <mxCell id="goals-lane" value="6. Goals (set → track → achieve)" style="swimlane;startSize=26;fillColor=#f5f3ff;strokeColor=#9673a6;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1370" width="2400" height="170" as="geometry" />
         </mxCell>
 
-        <mxCell id="p-built" value="✅ BUILT&#xa;&#xa;Auth, Library CRUD (piece/exercise),&#xa;Sessions (build → active → summary),&#xa;Routines, Basic Analytics, Scoring,&#xa;Notes, Crash Recovery" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="1">
-          <mxGeometry x="60" y="2042" width="240" height="110" as="geometry" />
+        <mxCell id="goal-set" value="SET a goal&#xa;&#xa;Session: &quot;Focus on LH&quot;&#xa;Weekly: &quot;Practice 5 days&quot;&#xa;Milestone: &quot;All keys to 4&#xa;by March&quot;" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="20" y="35" width="170" height="110" as="geometry" />
         </mxCell>
 
-        <mxCell id="p-phase1" value="PHASE 1: Foundation (Wks 1-6)&#xa;&#xa;Key-aware exercises, item types,&#xa;section management, search UI,&#xa;effort tags, intentional practice&#xa;micro-cycle, focus mode, rep counter,&#xa;visual timer, time comparison" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="1">
-          <mxGeometry x="320" y="2042" width="240" height="110" as="geometry" />
+        <mxCell id="goal-link" value="LINK to items&#xa;&#xa;Tag items as relevant&#xa;to active goals.&#xa;Scheduling boosts&#xa;these items." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="215" y="35" width="155" height="110" as="geometry" />
         </mxCell>
 
-        <mxCell id="p-phase2" value="PHASE 2: Intelligence (Wks 7-12)&#xa;&#xa;SRS engine, interleaved generator,&#xa;one-tap start, short sessions,&#xa;mastery decay, transition prompts,&#xa;difficulty balancing, goal framework,&#xa;encouragement, rest awareness" style="rounded=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="1">
-          <mxGeometry x="580" y="2042" width="250" height="110" as="geometry" />
+        <mxCell id="goal-track" value="TRACK progress&#xa;&#xa;Dashboard: % complete.&#xa;Post-session check-in.&#xa;Weekly summary." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="395" y="35" width="155" height="100" as="geometry" />
         </mxCell>
 
-        <mxCell id="p-phase3" value="PHASE 3: Visibility (Wks 13-18)&#xa;&#xa;Mastery timeline, key heatmap,&#xa;consistency calendar (comeback),&#xa;tempo charts, goal dashboard,&#xa;encouragement config, weekly&#xa;summaries, audio recording" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="1">
-          <mxGeometry x="850" y="2042" width="240" height="110" as="geometry" />
+        <mxCell id="goal-achieve" value="💪 ACHIEVE&#xa;&#xa;Celebration moment.&#xa;Evidence of growth.&#xa;Set next goal." style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="575" y="35" width="145" height="100" as="geometry" />
         </mxCell>
 
-        <mxCell id="p-phase4" value="PHASE 4: AI (Wks 19-24+)&#xa;&#xa;AI setlist generation, pattern&#xa;recognition, adaptive difficulty,&#xa;adaptive interleaving, teacher&#xa;integration, goal coaching,&#xa;AI session review" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="1">
-          <mxGeometry x="1110" y="2042" width="240" height="110" as="geometry" />
+        <mxCell id="rest-aware" value="Rest Awareness&#xa;&#xa;&quot;Big week — your body&#xa;needs recovery to&#xa;consolidate learning.&quot;" style="rounded=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="745" y="35" width="165" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ai-coaching" value="🤖 AI Goal Coaching&#xa;&#xa;Realistic goal setting.&#xa;Break into daily plans.&#xa;Technique guidance." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="goals-lane">
+          <mxGeometry x="935" y="35" width="160" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="gg1" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;strokeWidth=2;" edge="1" source="goal-set" target="goal-link" parent="goals-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="gg2" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;strokeWidth=2;" edge="1" source="goal-link" target="goal-track" parent="goals-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="gg3" value="" style="edgeStyle=orthogonalEdgeStyle;strokeColor=#9673a6;strokeWidth=2;" edge="1" source="goal-track" target="goal-achieve" parent="goals-lane">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- ROW 7: PROGRESS VISUALISATION                                -->
+        <!-- ============================================================ -->
+        <mxCell id="viz-lane" value="7. Progress &amp; Visualisation" style="swimlane;startSize=26;fillColor=#f3f4f6;strokeColor=#9ca3af;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1560" width="2400" height="190" as="geometry" />
+        </mxCell>
+
+        <mxCell id="analytics-exist" value="Current Analytics&#xa;&#xa;• Weekly time + sessions&#xa;• 28-day line chart&#xa;• Top items by time&#xa;• Score trends" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="20" y="35" width="160" height="110" as="geometry" />
+        </mxCell>
+
+        <mxCell id="comeback-cal" value="📅 Consistency Calendar&#xa;&#xa;Comeback framing:&#xa;&quot;4 of the last 7 days&quot;&#xa;NOT a streak counter.&#xa;⚡ Rework existing streak!" style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="205" y="35" width="185" height="120" as="geometry" />
+        </mxCell>
+
+        <mxCell id="mastery-tl" value="📈 Mastery Timeline&#xa;&#xa;Per-item + aggregate.&#xa;Weeks and months." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="415" y="35" width="155" height="80" as="geometry" />
+        </mxCell>
+
+        <mxCell id="key-heat" value="🎵 Key Heatmap&#xa;&#xa;Circle of fifths.&#xa;Per-key mastery.&#xa;Reveals weak keys." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="595" y="35" width="150" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="tempo-chart" value="🎹 Tempo Progress&#xa;&#xa;Tempo vs time toward&#xa;target BPM per item." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="770" y="35" width="150" height="80" as="geometry" />
+        </mxCell>
+
+        <mxCell id="goal-dash" value="🎯 Goal Dashboard&#xa;&#xa;% progress per goal.&#xa;Process messaging." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="945" y="35" width="150" height="80" as="geometry" />
+        </mxCell>
+
+        <mxCell id="weekly-report" value="📊 Weekly Summary&#xa;&#xa;Insights + comparison&#xa;to prior week.&#xa;Shown on next open." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="1120" y="35" width="160" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="enc-config" value="⚙ Encouragement Config&#xa;&#xa;Frequency / Tone / Delivery&#xa;all user-controlled." style="rounded=1;fillColor=#d5e8d4;strokeColor=#67ab9f;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="viz-lane">
+          <mxGeometry x="1305" y="35" width="175" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- ROW 8: COLLABORATION & AI                                    -->
+        <!-- ============================================================ -->
+        <mxCell id="ai-lane" value="8. Collaboration &amp; AI" style="swimlane;startSize=26;fillColor=#fef2f2;strokeColor=#b85450;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1770" width="2400" height="180" as="geometry" />
+        </mxCell>
+
+        <mxCell id="teacher-basic" value="👩‍🏫 Teacher (basic)&#xa;&#xa;Share routines.&#xa;Suggest items.&#xa;Set target tempos.&#xa;View progress (with permission)." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
+          <mxGeometry x="20" y="35" width="185" height="115" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ai-setlist" value="🤖 AI Setlists&#xa;&#xa;&quot;8 standards, gig in 3 weeks&#xa;— build me a practice plan.&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
+          <mxGeometry x="230" y="35" width="185" height="90" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ai-patterns" value="Pattern Recognition&#xa;&#xa;&quot;You struggle with keys&#xa;that have 4+ flats.&quot;" style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
+          <mxGeometry x="440" y="35" width="170" height="90" as="geometry" />
+        </mxCell>
+
+        <mxCell id="ai-adaptive" value="Adaptive Intelligence&#xa;&#xa;Auto-adjust scheduling,&#xa;interleaving intensity,&#xa;difficulty over time." style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=10;whiteSpace=wrap;align=left;spacingLeft=8;" vertex="1" parent="ai-lane">
+          <mxGeometry x="635" y="35" width="175" height="100" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- CROSS-CUTTING: INCLUSIVE DESIGN + OFFLINE                    -->
+        <!-- ============================================================ -->
+        <mxCell id="xcut-lane" value="Cross-Cutting Principles" style="swimlane;startSize=26;fillColor=#f0fdf4;strokeColor=#82b366;fontStyle=1;fontSize=13;rounded=1;arcSize=6;swimlaneLine=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="1970" width="2400" height="100" as="geometry" />
+        </mxCell>
+
+        <mxCell id="xc1" value="Reduce Decisions&#xa;to Start" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="20" y="35" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc2" value="Externalise&#xa;Time" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="155" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc3" value="Comeback &gt;&#xa;Streak" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="270" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc4" value="Sensory&#xa;Sensitivity" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="385" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc5" value="Accessible&#xa;Typography" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="500" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc6" value="Predictable&#xa;Navigation" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="615" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc7" value="Configurable&#xa;Feedback" style="rounded=1;fillColor=#d5e8d4;strokeColor=#82b366;fontSize=9;whiteSpace=wrap;align=center;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="730" y="35" width="100" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="xc8" value="⚡ Offline-First&#xa;(Vision Principle 6)" style="rounded=1;fillColor=#fef3c7;strokeColor=#d97706;fontSize=9;whiteSpace=wrap;align=center;fontStyle=1;" vertex="1" parent="xcut-lane">
+          <mxGeometry x="855" y="35" width="140" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- CROSS-FLOW CONNECTIONS (between lanes)                       -->
+        <!-- ============================================================ -->
+
+        <!-- SRS powers one-tap start -->
+        <mxCell id="xf-srs" value="" style="edgeStyle=orthogonalEdgeStyle;dashed=1;strokeColor=#d79b00;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="530" y="750" as="sourcePoint" />
+            <mxPoint x="530" y="430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Practice lane → Post session -->
+        <mxCell id="xf-post" value="Session ends →" style="edgeStyle=orthogonalEdgeStyle;fontSize=9;fontStyle=1;strokeColor=#82b366;fontColor=#82b366;strokeWidth=2;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1395" y="955" as="sourcePoint" />
+            <mxPoint x="1395" y="1150" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1500" y="955" />
+              <mxPoint x="1500" y="1130" />
+              <mxPoint x="110" y="1130" />
+              <mxPoint x="110" y="1150" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Post session data → Visualisation -->
+        <mxCell id="xf-viz" value="Data →" style="edgeStyle=orthogonalEdgeStyle;fontSize=8;dashed=1;strokeColor=#67ab9f;fontColor=#67ab9f;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="110" y="1350" as="sourcePoint" />
+            <mxPoint x="110" y="1560" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+
+        <!-- Goals feed scheduling -->
+        <mxCell id="xf-goals" value="Goal-aligned&#xa;scheduling" style="edgeStyle=orthogonalEdgeStyle;fontSize=8;dashed=1;strokeColor=#9673a6;fontColor=#9673a6;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="300" y="1370" as="sourcePoint" />
+            <mxPoint x="300" y="750" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="300" y="1370" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- OPEN QUESTIONS BOX                                           -->
+        <!-- ============================================================ -->
+        <mxCell id="questions-box" value="" style="rounded=1;fillColor=#fef3c7;strokeColor=#d97706;arcSize=6;" vertex="1" parent="1">
+          <mxGeometry x="40" y="2090" width="1100" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="q-title" value="⚡ OPEN QUESTIONS" style="text;fontSize=12;fontStyle=1;fillColor=none;strokeColor=none;fontColor=#92400e;" vertex="1" parent="1">
+          <mxGeometry x="55" y="2095" width="200" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="q-items" value="1. Metronome: built-in or integrate with external?  2. Offline-first: what syncs and what doesn't?  3. iOS native vs web-first for Phase 3+?&#xa;4. Audio recording: browser API viable on mobile?  5. Teacher integration: basic sharing in Phase 4 or Phase 6?  6. Scoring: should mastery always capture tempo alongside rating?" style="text;fontSize=10;fillColor=none;strokeColor=none;fontColor=#92400e;align=left;whiteSpace=wrap;" vertex="1" parent="1">
+          <mxGeometry x="55" y="2118" width="1060" height="60" as="geometry" />
         </mxCell>
 
       </root>


### PR DESCRIPTION
## Summary
- Adds a comprehensive **to-be user journey** diagram (`docs/user-journey-to-be.drawio`) mapped directly from `VISION.md`
- Colour-coded by roadmap phase so the diagram doubles as an implementation roadmap
- Complements the existing `docs/user-journey.drawio` (as-is state)

## Structure
Seven horizontal swim lanes covering the complete musician journey:

1. **Open & Start** — Auth gate → one-tap start (Phase 2) vs manual build (built)
2. **Library & Organisation** — Current CRUD + key-aware exercises, sections, search, effort tags (Phase 1)
3. **Smart Scheduling** — SRS engine, interleaved generator, mastery decay, difficulty balancing (Phase 2)
4. **Intentional Practice** — Goal → Focus Mode → Timer → Rep Counter → Transition → Reflect micro-cycle (Phase 1)
5. **Post-Session** — Existing summary + time comparison, encouragement, recording, AI review (Phases 1-4)
6. **Progress & Goals** — Existing analytics + mastery timeline, key heatmap, consistency calendar, goal dashboard (Phase 3)
7. **AI & Future** — AI setlists, pattern recognition, adaptive scheduling, teacher integration (Phase 4)

Plus a cross-cutting **Inclusive Design Principles** row (7 principles from the vision).

## Colour Legend
- 🟢 Green = Currently built
- 🔵 Blue = Phase 1: Foundation (Weeks 1-6)
- 🟡 Orange = Phase 2: Intelligence (Weeks 7-12)
- 🟣 Purple = Phase 3: Visibility (Weeks 13-18)
- 🔴 Pink = Phase 4: AI (Weeks 19-24+)

## Test plan
- [ ] Open `docs/user-journey-to-be.drawio` in draw.io or VS Code draw.io extension
- [ ] Verify all features from VISION.md are represented
- [ ] Check phase colour-coding matches roadmap sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)