### PR TITLE
Fix E2E test for duplicate Add Item links

### DIFF
--- a/e2e/tests/add-item.spec.ts
+++ b/e2e/tests/add-item.spec.ts
@@ -4,8 +4,10 @@ test.describe("add library item", () => {
   test("add a piece with all fields", async ({ page }) => {
     await page.goto("/");
 
-    // Navigate to add form
-    await page.getByRole("link", { name: "Add Item" }).click();
+    // Navigate to add form — use .first() because the library page has an
+    // "Add Item" CTA in the header and a second one in the empty state;
+    // Playwright's strict mode rejects ambiguous matches.
+    await page.getByRole("link", { name: "Add Item" }).first().click();
 
     // Piece tab should be active by default
     await expect(page.getByRole("tab", { name: "Piece" })).toHaveAttribute(

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -45,7 +45,7 @@ test.describe("navigation", () => {
   test("add item page is reachable and has cancel link", async ({ page }) => {
     await page.goto("/");
 
-    await page.getByRole("link", { name: "Add Item" }).click();
+    await page.getByRole("link", { name: "Add Item" }).first().click();
     await expect(
       page.getByRole("heading", { name: "Add Library Item" })
     ).toBeVisible();


### PR DESCRIPTION
## Summary
- The design system PR (#133) restructured the library page with two "Add Item" CTA links — one in the header and one in the empty state
- Playwright's strict mode rejects `getByRole('link', { name: 'Add Item' })` when it resolves to 2 elements
- Fixed by using `.first()` in both `add-item.spec.ts` and `navigation.spec.ts` to target the header link

## Test plan
- [ ] CI E2E tests pass (all 30 tests)
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)