### PR TITLE
Clean up Crux implementation (closes #99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,11 +83,28 @@ cargo test -p intrada-api  # API tests only (includes auth tests)
 ## Architecture Patterns
 
 - **Crux core/shell split**: `intrada-core` contains zero I/O. All side effects are represented as enum variants and executed by the web shell. The core must compile on any Rust target without WASM dependencies.
-- **Effect enum**: Currently named `StorageEffect` (historical misnomer — it carries all side effects, not just storage)
+- **Effect enum**: `AppEffect` carries all side-effect requests (HTTP API calls, localStorage). The shell processes each variant in `core_bridge.rs`.
 - **API client**: `api_client.rs` has generic helpers (`get_json`, `post_json`, `put_json`, `delete`) with built-in 401 retry
 - **Validation**: `intrada-core/src/validation.rs` is the single source of truth for all validation constants and rules
 - **Database**: Positional column indexing (`row.get(0)`, etc.) with a `SELECT_COLUMNS` const to keep column order in one place
 - **Migrations**: Sequential numbered migrations in `intrada-api/src/migrations.rs`, each must be a single SQL statement
+- **Refresh-after-mutate**: Every write operation (create/update/delete) is followed by a full re-fetch from the API via `spawn_mutate()`. This keeps the Crux model as the single source of truth without client-side merge logic.
+
+### State boundary
+
+State is split between two systems. This is intentional — Crux owns *what the user has*,
+Leptos owns *what the user is doing right now*.
+
+| State kind | Where it lives | Examples |
+|------------|---------------|----------|
+| Domain data | Crux `Model` → `ViewModel` | Items, sessions, routines, active session progress, analytics |
+| UI interaction | Leptos signals | Form field values, loading/submitting flags, timer ticks, drag state, tab selection |
+| Crash recovery | localStorage | `intrada:session-in-progress` (single key, FR-008) |
+
+**Rules:**
+- Domain state must flow through `Event` → `Model` → `ViewModel`. Never store domain data in Leptos signals.
+- UI state that has no meaning outside the current view stays in Leptos signals. Don't inflate the Crux model with ephemeral UI concerns.
+- The `ViewModel` is the read-only projection that views consume. Views never mutate it directly.
 
 ## Code Style
 
@@ -203,7 +220,6 @@ These documents should stay in sync. When any one changes, check the others:
 
 ## Known Tech Debt
 
-- `StorageEffect` should be renamed to `AppEffect` or `SideEffect`
 - Sessions and routines SQL is inline in route handlers (items has a dedicated `db/items.rs` module)
 - Legacy `pieces` and `exercises` tables from early migrations still exist in the schema
 - `dependabot.yml` needs `package-ecosystem` set to `"cargo"`

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -36,12 +36,12 @@ pub enum Event {
 /// Side effects the core requests from shells.
 pub enum Effect {
     Render(Request<RenderOperation>),
-    Storage(Box<Request<StorageEffect>>),
+    App(Box<Request<AppEffect>>),
 }
 
-/// Storage operations handled by the shell.
+/// Side-effect operations handled by the shell (HTTP API calls, localStorage).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum StorageEffect {
+pub enum AppEffect {
     LoadAll,
     SaveItem(Item),
     UpdateItem(Item),
@@ -56,7 +56,7 @@ pub enum StorageEffect {
     DeleteRoutine { id: String },
 }
 
-impl Operation for StorageEffect {
+impl Operation for AppEffect {
     type Output = ();
 }
 
@@ -68,9 +68,9 @@ impl From<Request<RenderOperation>> for Effect {
     }
 }
 
-impl From<Request<StorageEffect>> for Effect {
-    fn from(request: Request<StorageEffect>) -> Self {
-        Effect::Storage(Box::new(request))
+impl From<Request<AppEffect>> for Effect {
+    fn from(request: Request<AppEffect>) -> Self {
+        Effect::App(Box::new(request))
     }
 }
 

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use super::types::{CreateItem, Tempo, UpdateItem};
-use crate::app::{Effect, Event, StorageEffect};
+use crate::app::{AppEffect, Effect, Event};
 use crate::error::LibraryError;
 use crate::model::Model;
 use crate::validation;
@@ -77,7 +77,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::SaveItem(item)).into(),
+                Command::notify_shell(AppEffect::SaveItem(item)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -118,7 +118,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
 
             let item = item.clone();
             Command::all([
-                Command::notify_shell(StorageEffect::UpdateItem(item)).into(),
+                Command::notify_shell(AppEffect::UpdateItem(item)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -132,7 +132,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::DeleteItem { id }).into(),
+                Command::notify_shell(AppEffect::DeleteItem { id }).into(),
                 crux_core::render::render(),
             ])
         }
@@ -158,7 +158,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
 
             let item = item.clone();
             Command::all([
-                Command::notify_shell(StorageEffect::UpdateItem(item)).into(),
+                Command::notify_shell(AppEffect::UpdateItem(item)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -176,7 +176,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
 
             let item = item.clone();
             Command::all([
-                Command::notify_shell(StorageEffect::UpdateItem(item)).into(),
+                Command::notify_shell(AppEffect::UpdateItem(item)).into(),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/domain/routine.rs
+++ b/crates/intrada-core/src/domain/routine.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use crux_core::Command;
 use serde::{Deserialize, Serialize};
 
-use crate::app::{Effect, Event, StorageEffect};
+use crate::app::{AppEffect, Effect, Event};
 use crate::domain::session::{EntryStatus, SessionStatus, SetlistEntry};
 use crate::model::Model;
 use crate::validation;
@@ -103,7 +103,7 @@ pub fn handle_routine_event(event: RoutineEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::SaveRoutine(routine)).into(),
+                Command::notify_shell(AppEffect::SaveRoutine(routine)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -155,7 +155,7 @@ pub fn handle_routine_event(event: RoutineEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::SaveRoutine(routine)).into(),
+                Command::notify_shell(AppEffect::SaveRoutine(routine)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -209,7 +209,7 @@ pub fn handle_routine_event(event: RoutineEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::DeleteRoutine { id }).into(),
+                Command::notify_shell(AppEffect::DeleteRoutine { id }).into(),
                 crux_core::render::render(),
             ])
         }
@@ -249,7 +249,7 @@ pub fn handle_routine_event(event: RoutineEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::UpdateRoutine(updated)).into(),
+                Command::notify_shell(AppEffect::UpdateRoutine(updated)).into(),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use crux_core::Command;
 use serde::{Deserialize, Serialize};
 
-use crate::app::{Effect, Event, StorageEffect};
+use crate::app::{AppEffect, Effect, Event};
 use crate::domain::item::{Item, ItemKind};
 use crate::error::LibraryError;
 use crate::model::Model;
@@ -340,7 +340,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::SaveItem(item)).into(),
+                Command::notify_shell(AppEffect::SaveItem(item)).into(),
                 crux_core::render::render(),
             ])
         }
@@ -412,7 +412,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 session_started_at: now,
             };
 
-            let save_effect = StorageEffect::SaveSessionInProgress(active.clone());
+            let save_effect = AppEffect::SaveSessionInProgress(active.clone());
             model.session_status = SessionStatus::Active(active);
             model.last_error = None;
 
@@ -458,7 +458,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             active.current_item_started_at = now;
             model.last_error = None;
 
-            let save_effect = StorageEffect::SaveSessionInProgress(active.clone());
+            let save_effect = AppEffect::SaveSessionInProgress(active.clone());
             Command::all([
                 Command::notify_shell(save_effect).into(),
                 crux_core::render::render(),
@@ -495,7 +495,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             active.current_item_started_at = now;
             model.last_error = None;
 
-            let save_effect = StorageEffect::SaveSessionInProgress(active.clone());
+            let save_effect = AppEffect::SaveSessionInProgress(active.clone());
             Command::all([
                 Command::notify_shell(save_effect).into(),
                 crux_core::render::render(),
@@ -522,7 +522,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             active.entries.push(entry);
             model.last_error = None;
 
-            let save_effect = StorageEffect::SaveSessionInProgress(active.clone());
+            let save_effect = AppEffect::SaveSessionInProgress(active.clone());
             Command::all([
                 Command::notify_shell(save_effect).into(),
                 crux_core::render::render(),
@@ -561,9 +561,9 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             active.entries.push(entry);
             model.last_error = None;
 
-            let save_effect_session = StorageEffect::SaveSessionInProgress(active.clone());
+            let save_effect_session = AppEffect::SaveSessionInProgress(active.clone());
             Command::all([
-                Command::notify_shell(StorageEffect::SaveItem(item)).into(),
+                Command::notify_shell(AppEffect::SaveItem(item)).into(),
                 Command::notify_shell(save_effect_session).into(),
                 crux_core::render::render(),
             ])
@@ -683,8 +683,8 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::SavePracticeSession(practice_session)).into(),
-                Command::notify_shell(StorageEffect::ClearSessionInProgress).into(),
+                Command::notify_shell(AppEffect::SavePracticeSession(practice_session)).into(),
+                Command::notify_shell(AppEffect::ClearSessionInProgress).into(),
                 crux_core::render::render(),
             ])
         }
@@ -699,7 +699,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::ClearSessionInProgress).into(),
+                Command::notify_shell(AppEffect::ClearSessionInProgress).into(),
                 crux_core::render::render(),
             ])
         }
@@ -730,7 +730,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                Command::notify_shell(StorageEffect::DeletePracticeSession { id }).into(),
+                Command::notify_shell(AppEffect::DeletePracticeSession { id }).into(),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -5,7 +5,7 @@ pub mod error;
 pub mod model;
 pub mod validation;
 
-pub use app::{Effect, Event, Intrada, StorageEffect};
+pub use app::{AppEffect, Effect, Event, Intrada};
 pub use domain::item::{Item, ItemEvent, ItemKind};
 pub use domain::routine::{Routine, RoutineEntry, RoutineEvent};
 pub use domain::session::{

--- a/crates/intrada-web/src/core_bridge.rs
+++ b/crates/intrada-web/src/core_bridge.rs
@@ -1,8 +1,9 @@
 use crux_core::Core;
 use leptos::prelude::{RwSignal, Set};
+use std::future::Future;
 use wasm_bindgen_futures::spawn_local;
 
-use intrada_core::{Effect, Event, Intrada, Routine, StorageEffect, ViewModel};
+use intrada_core::{AppEffect, Effect, Event, Intrada, Routine, ViewModel};
 
 use crate::api_client;
 use crate::types::{IsLoading, IsSubmitting, SharedCore};
@@ -135,9 +136,9 @@ pub fn process_effects(
     for effect in effects {
         match effect {
             Effect::Render(_) => {}
-            Effect::Storage(boxed_request) => match &boxed_request.operation {
+            Effect::App(boxed_request) => match &boxed_request.operation {
                 // ---- Load operations: spawn async HTTP fetch ----
-                StorageEffect::LoadAll => {
+                AppEffect::LoadAll => {
                     let core = leptos::prelude::expect_context::<SharedCore>();
                     let vm = *view_model;
                     let loading = *is_loading;
@@ -161,7 +162,7 @@ pub fn process_effects(
                     });
                 }
 
-                StorageEffect::LoadSessions => {
+                AppEffect::LoadSessions => {
                     let core = leptos::prelude::expect_context::<SharedCore>();
                     let vm = *view_model;
                     let loading = *is_loading;
@@ -187,11 +188,7 @@ pub fn process_effects(
                 }
 
                 // ---- Library write operations ----
-                StorageEffect::SaveItem(item) => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::SaveItem(item) => {
                     let create = intrada_core::CreateItem {
                         title: item.title.clone(),
                         kind: item.kind.clone(),
@@ -202,23 +199,16 @@ pub fn process_effects(
                         notes: item.notes.clone(),
                         tags: item.tags.clone(),
                     };
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::create_item(&create).await {
-                            Ok(_) => refresh_library(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_library(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::create_item(&create).await },
+                        RefreshKind::Library,
+                    );
                 }
 
-                StorageEffect::UpdateItem(item) => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::UpdateItem(item) => {
                     let item_id = item.id.clone();
                     let update = intrada_core::UpdateItem {
                         title: Some(item.title.clone()),
@@ -229,142 +219,136 @@ pub fn process_effects(
                         notes: Some(item.notes.clone()),
                         tags: Some(item.tags.clone()),
                     };
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::update_item(&item_id, &update).await {
-                            Ok(_) => refresh_library(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_library(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::update_item(&item_id, &update).await },
+                        RefreshKind::Library,
+                    );
                 }
 
-                StorageEffect::DeleteItem { id } => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::DeleteItem { id } => {
                     let item_id = id.clone();
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::delete_item(&item_id).await {
-                            Ok(_) => refresh_library(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_library(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::delete_item(&item_id).await },
+                        RefreshKind::Library,
+                    );
                 }
 
                 // ---- Session write operations ----
-                StorageEffect::SavePracticeSession(session) => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::SavePracticeSession(session) => {
                     let session_data = session.clone();
                     // Clear in-progress from localStorage immediately (FR-008)
                     clear_session_in_progress();
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::create_session(&session_data).await {
-                            Ok(_) => refresh_sessions(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_sessions(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::create_session(&session_data).await },
+                        RefreshKind::Sessions,
+                    );
                 }
 
-                StorageEffect::DeletePracticeSession { id } => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::DeletePracticeSession { id } => {
                     let session_id = id.clone();
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::delete_session(&session_id).await {
-                            Ok(_) => refresh_sessions(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_sessions(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::delete_session(&session_id).await },
+                        RefreshKind::Sessions,
+                    );
                 }
 
                 // ---- Session-in-progress: localStorage only (FR-008) ----
-                StorageEffect::SaveSessionInProgress(session) => {
+                AppEffect::SaveSessionInProgress(session) => {
                     save_session_in_progress(session);
                 }
-                StorageEffect::ClearSessionInProgress => {
+                AppEffect::ClearSessionInProgress => {
                     clear_session_in_progress();
                 }
 
                 // ---- Routine operations ----
-                StorageEffect::SaveRoutine(routine) => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::SaveRoutine(routine) => {
                     let create = build_create_routine_request(routine);
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::create_routine(&create).await {
-                            Ok(_) => refresh_routines(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_routines(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::create_routine(&create).await },
+                        RefreshKind::Routines,
+                    );
                 }
 
-                StorageEffect::UpdateRoutine(routine) => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::UpdateRoutine(routine) => {
                     let routine_id = routine.id.clone();
                     let update = build_update_routine_request(routine);
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::update_routine(&routine_id, &update).await {
-                            Ok(_) => refresh_routines(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_routines(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::update_routine(&routine_id, &update).await },
+                        RefreshKind::Routines,
+                    );
                 }
 
-                StorageEffect::DeleteRoutine { id } => {
-                    let core = leptos::prelude::expect_context::<SharedCore>();
-                    let vm = *view_model;
-                    let loading = *is_loading;
-                    let submitting = *is_submitting;
+                AppEffect::DeleteRoutine { id } => {
                     let routine_id = id.clone();
-                    submitting.set(true);
-                    spawn_local(async move {
-                        match api_client::delete_routine(&routine_id).await {
-                            Ok(_) => refresh_routines(core, vm, loading, submitting).await,
-                            Err(e) => {
-                                report_error(&core, &vm, &loading, &submitting, e);
-                                refresh_routines(core, vm, loading, submitting).await;
-                            }
-                        }
-                    });
+                    spawn_mutate(
+                        view_model,
+                        is_loading,
+                        is_submitting,
+                        async move { api_client::delete_routine(&routine_id).await },
+                        RefreshKind::Routines,
+                    );
                 }
             },
         }
     }
     view_model.set(core.view());
+}
+
+/// Which data to re-fetch from the API after a write operation.
+#[derive(Clone, Copy)]
+enum RefreshKind {
+    Library,
+    Sessions,
+    Routines,
+}
+
+/// Spawn a mutating API call followed by a data refresh.
+///
+/// Encapsulates the "refresh-after-mutate" pattern used by all write operations:
+/// set submitting → run API call → report error (if any) → re-fetch from API.
+fn spawn_mutate<T, Fut>(
+    view_model: &RwSignal<ViewModel>,
+    is_loading: &IsLoading,
+    is_submitting: &IsSubmitting,
+    api_call: Fut,
+    kind: RefreshKind,
+) where
+    T: 'static,
+    Fut: Future<Output = Result<T, api_client::ApiError>> + 'static,
+{
+    let core = leptos::prelude::expect_context::<SharedCore>();
+    let vm = *view_model;
+    let loading = *is_loading;
+    let submitting = *is_submitting;
+    submitting.set(true);
+    spawn_local(async move {
+        if let Err(e) = api_call.await {
+            report_error(&core, &vm, &loading, &submitting, e);
+        }
+        match kind {
+            RefreshKind::Library => refresh_library(core, vm, loading, submitting).await,
+            RefreshKind::Sessions => refresh_sessions(core, vm, loading, submitting).await,
+            RefreshKind::Routines => refresh_routines(core, vm, loading, submitting).await,
+        }
+    });
 }
 
 /// Refresh library data from API after a mutation (refresh-after-mutate pattern).
@@ -479,16 +463,14 @@ fn report_error(
 #[cfg(test)]
 mod tests {
     use crux_core::Core;
-    use intrada_core::{
-        CreateItem, Effect, Event, Intrada, Item, ItemEvent, ItemKind, StorageEffect,
-    };
+    use intrada_core::{AppEffect, CreateItem, Effect, Event, Intrada, Item, ItemEvent, ItemKind};
 
     /// Extract storage effects from a Vec<Effect>, skipping Render effects.
-    fn storage_effects(effects: Vec<Effect>) -> Vec<StorageEffect> {
+    fn storage_effects(effects: Vec<Effect>) -> Vec<AppEffect> {
         effects
             .into_iter()
             .filter_map(|e| match e {
-                Effect::Storage(boxed_req) => Some(boxed_req.operation.clone()),
+                Effect::App(boxed_req) => Some(boxed_req.operation.clone()),
                 Effect::Render(_) => None,
             })
             .collect()
@@ -537,7 +519,7 @@ mod tests {
         assert!(
             storage
                 .iter()
-                .any(|e| matches!(e, StorageEffect::SaveItem(i) if i.title == "Moonlight Sonata")),
+                .any(|e| matches!(e, AppEffect::SaveItem(i) if i.title == "Moonlight Sonata")),
             "Expected SaveItem effect, got: {storage:?}"
         );
     }
@@ -563,7 +545,7 @@ mod tests {
         assert!(
             storage
                 .iter()
-                .any(|e| matches!(e, StorageEffect::SaveItem(i) if i.title == "C Major Scale")),
+                .any(|e| matches!(e, AppEffect::SaveItem(i) if i.title == "C Major Scale")),
             "Expected SaveItem effect, got: {storage:?}"
         );
     }
@@ -580,7 +562,7 @@ mod tests {
         assert!(
             storage
                 .iter()
-                .any(|e| matches!(e, StorageEffect::DeleteItem { id } if id == &item_id)),
+                .any(|e| matches!(e, AppEffect::DeleteItem { id } if id == &item_id)),
             "Expected DeleteItem effect, got: {storage:?}"
         );
     }
@@ -611,7 +593,7 @@ mod tests {
         assert!(
             storage
                 .iter()
-                .any(|e| matches!(e, StorageEffect::SaveSessionInProgress(_))),
+                .any(|e| matches!(e, AppEffect::SaveSessionInProgress(_))),
             "Expected SaveSessionInProgress effect, got: {storage:?}"
         );
     }
@@ -634,7 +616,7 @@ mod tests {
             core.process_event(Event::Session(SessionEvent::SaveSession { now: save_now }));
         let storage = storage_effects(effects);
         let session_id = storage.iter().find_map(|e| match e {
-            StorageEffect::SavePracticeSession(s) => Some(s.id.clone()),
+            AppEffect::SavePracticeSession(s) => Some(s.id.clone()),
             _ => None,
         });
         assert!(session_id.is_some(), "Expected SavePracticeSession effect");
@@ -646,7 +628,7 @@ mod tests {
         assert!(
             storage
                 .iter()
-                .any(|e| matches!(e, StorageEffect::DeletePracticeSession { .. })),
+                .any(|e| matches!(e, AppEffect::DeletePracticeSession { .. })),
             "Expected DeletePracticeSession effect, got: {storage:?}"
         );
     }


### PR DESCRIPTION
## Summary

Resolves the Crux review (#99) with a "keep and clean up" decision. Renames the misnamed effect enum, extracts repeated boilerplate, and documents the state boundary.

## Roadmap alignment
- Links to roadmap item in [`docs/roadmap.md`](../docs/roadmap.md) — issue #99
- Pillar: Cross-cutting (architecture)
- Horizon: Now

## Changes

**Rename `StorageEffect` → `AppEffect`** (6 files)
The old name was from when effects were localStorage-only. Now accurately reflects its scope: HTTP API calls + localStorage.

**Extract `spawn_mutate()` helper** (`core_bridge.rs`)
The "refresh-after-mutate" pattern was copy-pasted 8 times. Consolidated into a single generic function with a `RefreshKind` enum. Net reduction: 15 lines, but more importantly removes 8 near-identical code blocks.

**Document the state boundary** (`CLAUDE.md`)
Explicitly captures where state lives and the rules:
- Domain data → Crux `Model` → `ViewModel`
- UI interaction → Leptos signals
- Crash recovery → localStorage

Also updates Architecture Patterns and removes the completed tech debt item.

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes (249 tests)
- [x] CLAUDE.md updated
- [x] #99 closed with architectural decision recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)