### PR TITLE
Add DB sort indexes and request timing middleware

### DIFF
--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -17,7 +17,7 @@ intrada-core = { path = "../intrada-core" }
 
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
 libsql = { version = "0.9", default-features = false, features = ["remote", "core"] }
 libsql_migration = { version = "0.2", features = ["content"] }
 

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -198,6 +198,14 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0028_index_goals_user_id",
         "CREATE INDEX IF NOT EXISTS idx_goals_user_id ON goals(user_id);",
     ),
+    (
+        "0029_index_items_user_created",
+        "CREATE INDEX IF NOT EXISTS idx_items_user_created ON items(user_id, created_at DESC);",
+    ),
+    (
+        "0030_index_sessions_user_started",
+        "CREATE INDEX IF NOT EXISTS idx_sessions_user_started ON sessions(user_id, started_at DESC);",
+    ),
 ];
 
 /// Run migrations via libsql_migration (production path — tracks applied state).

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -7,6 +7,8 @@ mod sessions;
 use axum::http::{header, HeaderValue, Method};
 use axum::Router;
 use tower_http::cors::CorsLayer;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use tracing::Level;
 
 use crate::state::AppState;
 
@@ -21,9 +23,14 @@ pub fn api_router(state: AppState) -> Router {
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 
+    let trace = TraceLayer::new_for_http()
+        .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+        .on_response(DefaultOnResponse::new().level(Level::INFO));
+
     Router::new()
         .nest("/api", api_routes())
         .layer(cors)
+        .layer(trace)
         .with_state(state)
 }
 


### PR DESCRIPTION
## Summary
- **#146** — Add composite indexes `items(user_id, created_at DESC)` and `sessions(user_id, started_at DESC)` covering the WHERE + ORDER BY in list queries
- **#147** — Add `tower-http` TraceLayer for INFO-level request logging: method, URI, status, and latency on every request

## Changes
| File | Change |
|------|--------|
| `migrations.rs` | Migrations 0029 + 0030: two `CREATE INDEX` statements |
| `Cargo.toml` | Add `"trace"` feature to `tower-http` |
| `routes/mod.rs` | Add `TraceLayer` to the Axum router |

## Example log output
```
INFO request{method=POST uri=/api/sessions}: started processing request
INFO request{method=POST uri=/api/sessions}: finished processing request latency=47 ms status=201
```

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test -p intrada-api` — 69 tests pass (includes single-statement migration guard)
- [ ] Verify indexes created on deploy (`EXPLAIN QUERY PLAN SELECT ... FROM items WHERE user_id = ? ORDER BY created_at DESC`)

Closes #146
Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)