### PR TITLE
Improve CI caching for faster pipeline runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "native"
       - run: cargo test
 
   clippy:
@@ -31,6 +33,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "native"
+          save-if: "false"
       - run: cargo clippy -- -D warnings
 
   wasm-build:
@@ -45,6 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "wasm"
+          cache-on-failure: true
       - uses: jetli/trunk-action@v0.5.1
       - name: Install Tailwind CSS v4 standalone CLI
         run: |
@@ -92,6 +98,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
       - name: Download web-dist artifact
         uses: actions/download-artifact@v7
         with:
@@ -100,7 +108,14 @@ jobs:
       - name: Install dependencies
         working-directory: e2e
         run: npm ci
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('e2e/package-lock.json') }}
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: e2e
         run: npx playwright install chromium
       - name: Run E2E tests


### PR DESCRIPTION
## Summary

- Share Rust compile cache between `test` and `clippy` jobs via `shared-key: "native"` — they compile the same native targets but previously maintained separate caches
- Clippy only restores the shared cache (`save-if: false`) since `test` builds the fuller artifact set
- Enable `cache-on-failure: true` on the WASM build job — at ~223s, losing a partial cache on failure is expensive
- Cache Playwright browser binaries (Chromium) — skips the ~12s download on cache hit, invalidates when `package-lock.json` changes
- Enable npm cache via `setup-node` built-in `cache: 'npm'` — avoids re-downloading packages during `npm ci`

## Impact

| Change | Expected saving |
|--------|----------------|
| Shared native cache (test + clippy) | Reduced total cache storage; better hit rate on cold starts |
| WASM cache-on-failure | Avoids full 223s rebuild after transient failures |
| Playwright browser cache | ~12s per E2E run on cache hit |
| npm cache | ~1-2s per E2E run |

No functional changes — `fmt` job intentionally has no cache since `cargo fmt --check` doesn't compile.

## Test plan

- [ ] CI pipeline passes on this PR (proves the workflow YAML is valid)
- [ ] Verify cache entries are created in Actions cache after first run
- [ ] Second run on same branch shows cache hits in rust-cache and Playwright steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)