### PR TITLE
Fix detail/edit pages showing 'not found' on hard refresh

### DIFF
--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -7,8 +7,8 @@ use leptos_router::NavigateOptions;
 use intrada_core::{Event, ItemEvent, ViewModel};
 
 use crate::components::{
-    parse_target_bpm, BackLink, Button, ButtonVariant, Card, FieldLabel, TempoProgressChart,
-    TypeBadge,
+    parse_target_bpm, BackLink, Button, ButtonVariant, Card, FieldLabel, SkeletonBlock,
+    SkeletonLine, TempoProgressChart, TypeBadge,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -25,269 +25,282 @@ pub fn DetailView() -> impl IntoView {
 
     let show_delete_confirm = RwSignal::new(false);
 
-    // Find the item in the current ViewModel
-    let item = view_model
-        .get_untracked()
-        .items
-        .into_iter()
-        .find(|i| i.id == id);
-
-    let Some(item) = item else {
-        // Item not found — show message with link back to list
-        return view! {
-            <div class="text-center py-8">
-                <p class="text-secondary mb-4">"Item not found."</p>
-                <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
-                    "← Back to Library"
-                </A>
-            </div>
-        }
-        .into_any();
-    };
-
-    // Destructure item fields to avoid excessive cloning
-    let intrada_core::LibraryItemView {
-        id: item_id,
-        title,
-        subtitle,
-        item_type,
-        category,
-        key,
-        tempo,
-        notes,
-        tags,
-        created_at,
-        updated_at,
-        practice,
-        latest_achieved_tempo: _,
-    } = item;
-
-    let tempo_for_history = tempo.clone();
-    let edit_href = format!("/library/{}/edit", item_id);
-    let id_for_delete = item_id.clone();
-    let type_for_badge = item_type;
-
     view! {
         <div class="space-y-4">
-            // Back link
             <BackLink label="Back to Library" href="/".to_string() />
 
-            // Delete confirmation banner (FR-011)
             {move || {
-                if show_delete_confirm.get() {
-                    let id_del = id_for_delete.clone();
-                    let core_del = core.clone();
-                    let navigate_del = navigate.clone();
-                    Some(view! {
-                        <div class="rounded-lg bg-danger-surface border border-danger/20 p-4" role="alert">
-                            <p class="text-sm text-danger-text mb-3">
-                                "Are you sure you want to delete this item? This action cannot be undone."
-                            </p>
-                            <div class="flex gap-3">
-                                <Button
-                                    variant=ButtonVariant::Danger
-                                    loading=Signal::derive(move || is_submitting.get())
-                                    on_click=Callback::new(move |_| {
-                                        let event = Event::Item(ItemEvent::Delete { id: id_del.clone() });
-                                        let core_ref = core_del.borrow();
-                                        let effects = core_ref.process_event(event);
-                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                        navigate_del("/", NavigateOptions { replace: true, ..Default::default() });
-                                    })>
-                                    {move || if is_submitting.get() { "Deleting\u{2026}" } else { "Confirm Delete" }}
-                                </Button>
-                                <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| { show_delete_confirm.set(false); })>
-                                    "Cancel"
-                                </Button>
-                            </div>
-                        </div>
-                    })
-                } else {
-                    None
-                }
-            }}
+                // Reactively find item — re-runs when ViewModel updates after fetch
+                let item = view_model
+                    .get()
+                    .items
+                    .into_iter()
+                    .find(|i| i.id == id);
 
-            // Detail card
-            <Card>
-                // Header: title + type badge
-                <div class="flex items-start justify-between gap-3 mb-6">
-                    <div>
-                        <h2 class="text-2xl font-bold text-primary">{title}</h2>
-                        {if !subtitle.is_empty() {
-                            Some(view! {
-                                <p class="text-lg text-muted mt-1">{subtitle.clone()}</p>
-                            })
-                        } else {
-                            None
-                        }}
-                    </div>
-                    <TypeBadge item_type=type_for_badge.clone() />
-                </div>
+                if let Some(item) = item {
+                    let intrada_core::LibraryItemView {
+                        id: item_id,
+                        title,
+                        subtitle,
+                        item_type,
+                        category,
+                        key,
+                        tempo,
+                        notes,
+                        tags,
+                        created_at,
+                        updated_at,
+                        practice,
+                        latest_achieved_tempo: _,
+                    } = item;
 
-                // Fields grid (FR-007, FR-008: omit empty optional fields)
-                <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 mb-6">
-                    {category.map(|cat| {
-                        view! {
-                            <div>
-                                <FieldLabel text="Category" />
-                                <dd class="mt-1 text-sm text-secondary">{cat}</dd>
-                            </div>
-                        }
-                    })}
-                    {key.map(|k| {
-                        view! {
-                            <div>
-                                <FieldLabel text="Key" />
-                                <dd class="mt-1 text-sm text-secondary">{k}</dd>
-                            </div>
-                        }
-                    })}
-                    {tempo.map(|t| {
-                        view! {
-                            <div>
-                                <FieldLabel text="Tempo" />
-                                <dd class="mt-1 text-sm text-secondary">{t}</dd>
-                            </div>
-                        }
-                    })}
-                </dl>
+                    let tempo_for_history = tempo.clone();
+                    let edit_href = format!("/library/{}/edit", item_id);
+                    let id_for_delete = item_id.clone();
+                    let type_for_badge = item_type;
+                    let core_for_delete = core.clone();
+                    let navigate_for_delete = navigate.clone();
 
-                // Notes
-                {notes.map(|n| {
                     view! {
-                        <div class="mb-6">
-                            <FieldLabel text="Notes" />
-                            <dd class="text-sm text-secondary whitespace-pre-wrap">{n}</dd>
-                        </div>
-                    }
-                })}
+                        // Delete confirmation banner (FR-011)
+                        {move || {
+                            if show_delete_confirm.get() {
+                                let id_del = id_for_delete.clone();
+                                let core_del = core_for_delete.clone();
+                                let navigate_del = navigate_for_delete.clone();
+                                Some(view! {
+                                    <div class="rounded-lg bg-danger-surface border border-danger/20 p-4" role="alert">
+                                        <p class="text-sm text-danger-text mb-3">
+                                            "Are you sure you want to delete this item? This action cannot be undone."
+                                        </p>
+                                        <div class="flex gap-3">
+                                            <Button
+                                                variant=ButtonVariant::Danger
+                                                loading=Signal::derive(move || is_submitting.get())
+                                                on_click=Callback::new(move |_| {
+                                                    let event = Event::Item(ItemEvent::Delete { id: id_del.clone() });
+                                                    let core_ref = core_del.borrow();
+                                                    let effects = core_ref.process_event(event);
+                                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                                    navigate_del("/", NavigateOptions { replace: true, ..Default::default() });
+                                                })>
+                                                {move || if is_submitting.get() { "Deleting\u{2026}" } else { "Confirm Delete" }}
+                                            </Button>
+                                            <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| { show_delete_confirm.set(false); })>
+                                                "Cancel"
+                                            </Button>
+                                        </div>
+                                    </div>
+                                })
+                            } else {
+                                None
+                            }
+                        }}
 
-                // Tags
-                {if !tags.is_empty() {
-                    Some(view! {
-                        <div class="mb-6">
-                            <FieldLabel text="Tags" />
-                            <dd class="flex flex-wrap gap-1.5">
-                                {tags.into_iter().map(|tag| {
-                                    view! {
-                                        <span class="inline-flex items-center rounded-full border border-border-default px-2.5 py-0.5 text-xs text-muted">
-                                            {tag}
-                                        </span>
-                                    }
-                                }).collect::<Vec<_>>()}
-                            </dd>
-                        </div>
-                    })
-                } else {
-                    None
-                }}
-
-                // Timestamps
-                <div class="mt-2 pt-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs text-faint">
-                    <div>
-                        <span class="font-medium">"Created: "</span>{created_at}
-                    </div>
-                    <div>
-                        <span class="font-medium">"Updated: "</span>{updated_at}
-                    </div>
-                </div>
-            </Card>
-
-            // Practice summary (spacing between stacked cards)
-            {practice.map(|p| {
-                let has_scores = !p.score_history.is_empty();
-                let has_tempo_history = !p.tempo_history.is_empty();
-                let target_tempo = tempo_for_history.clone();
-                view! {
-                    <Card>
-                        <div class="space-y-4">
-                            // Practice stats
-                            <div>
-                                <h3 class="text-sm font-semibold text-primary mb-1">"Practice Summary"</h3>
-                                <p class="text-sm text-secondary">
-                                    {format!(
-                                        "{} session{}, {} min total",
-                                        p.session_count,
-                                        if p.session_count == 1 { "" } else { "s" },
-                                        p.total_minutes
-                                    )}
-                                </p>
+                        // Detail card
+                        <Card>
+                            <div class="flex items-start justify-between gap-3 mb-6">
+                                <div>
+                                    <h2 class="text-2xl font-bold text-primary">{title}</h2>
+                                    {if !subtitle.is_empty() {
+                                        Some(view! {
+                                            <p class="text-lg text-muted mt-1">{subtitle.clone()}</p>
+                                        })
+                                    } else {
+                                        None
+                                    }}
+                                </div>
+                                <TypeBadge item_type=type_for_badge.clone() />
                             </div>
 
-                            // Latest confidence score
-                            {p.latest_score.map(|score| {
+                            <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4 mb-6">
+                                {category.map(|cat| {
+                                    view! {
+                                        <div>
+                                            <FieldLabel text="Category" />
+                                            <dd class="mt-1 text-sm text-secondary">{cat}</dd>
+                                        </div>
+                                    }
+                                })}
+                                {key.map(|k| {
+                                    view! {
+                                        <div>
+                                            <FieldLabel text="Key" />
+                                            <dd class="mt-1 text-sm text-secondary">{k}</dd>
+                                        </div>
+                                    }
+                                })}
+                                {tempo.map(|t| {
+                                    view! {
+                                        <div>
+                                            <FieldLabel text="Tempo" />
+                                            <dd class="mt-1 text-sm text-secondary">{t}</dd>
+                                        </div>
+                                    }
+                                })}
+                            </dl>
+
+                            {notes.map(|n| {
                                 view! {
-                                    <div class="flex items-center gap-3">
-                                        <span class="text-sm text-muted">"Current confidence:"</span>
-                                        <span class="text-2xl font-bold text-accent-text">
-                                            {format!("{}/5", score)}
-                                        </span>
+                                    <div class="mb-6">
+                                        <FieldLabel text="Notes" />
+                                        <dd class="text-sm text-secondary whitespace-pre-wrap">{n}</dd>
                                     </div>
                                 }
                             })}
 
-                            // Score history
-                            {if has_scores {
-                                let history = p.score_history;
-                                view! {
-                                    <div>
-                                        <h4 class="field-label mb-2">"Score History"</h4>
-                                        <div class="space-y-1.5">
-                                            {history.into_iter().map(|entry| {
-                                                // Format date for display (extract date portion from RFC3339)
-                                                let display_date = entry.session_date.split('T').next().unwrap_or(&entry.session_date).to_string();
+                            {if !tags.is_empty() {
+                                Some(view! {
+                                    <div class="mb-6">
+                                        <FieldLabel text="Tags" />
+                                        <dd class="flex flex-wrap gap-1.5">
+                                            {tags.into_iter().map(|tag| {
                                                 view! {
-                                                    <div class="flex items-center justify-between text-sm">
-                                                        <span class="text-muted">{display_date}</span>
-                                                        <span class="inline-flex items-center rounded-md bg-badge-piece-bg px-1.5 py-0.5 text-xs font-medium text-accent-text ring-1 ring-accent-focus/20 ring-inset">
-                                                            {format!("{}/5", entry.score)}
-                                                        </span>
-                                                    </div>
+                                                    <span class="inline-flex items-center rounded-full border border-border-default px-2.5 py-0.5 text-xs text-muted">
+                                                        {tag}
+                                                    </span>
                                                 }
                                             }).collect::<Vec<_>>()}
+                                        </dd>
+                                    </div>
+                                })
+                            } else {
+                                None
+                            }}
+
+                            <div class="mt-2 pt-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs text-faint">
+                                <div>
+                                    <span class="font-medium">"Created: "</span>{created_at}
+                                </div>
+                                <div>
+                                    <span class="font-medium">"Updated: "</span>{updated_at}
+                                </div>
+                            </div>
+                        </Card>
+
+                        // Practice summary
+                        {practice.map(|p| {
+                            let has_scores = !p.score_history.is_empty();
+                            let has_tempo_history = !p.tempo_history.is_empty();
+                            let target_tempo = tempo_for_history.clone();
+                            view! {
+                                <Card>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <h3 class="text-sm font-semibold text-primary mb-1">"Practice Summary"</h3>
+                                            <p class="text-sm text-secondary">
+                                                {format!(
+                                                    "{} session{}, {} min total",
+                                                    p.session_count,
+                                                    if p.session_count == 1 { "" } else { "s" },
+                                                    p.total_minutes
+                                                )}
+                                            </p>
                                         </div>
-                                    </div>
-                                }.into_any()
-                            } else {
-                                view! {
-                                    <p class="text-xs text-faint">"No confidence scores recorded yet"</p>
-                                }.into_any()
-                            }}
 
-                            // Tempo progress chart (#66)
-                            {if has_tempo_history {
-                                let target = parse_target_bpm(&target_tempo);
-                                view! {
-                                    <div>
-                                        <h4 class="field-label mb-2">"Tempo Progress"</h4>
-                                        <TempoProgressChart
-                                            entries=p.tempo_history
-                                            target_bpm=target
-                                            latest_tempo=p.latest_tempo
-                                        />
+                                        {p.latest_score.map(|score| {
+                                            view! {
+                                                <div class="flex items-center gap-3">
+                                                    <span class="text-sm text-muted">"Current confidence:"</span>
+                                                    <span class="text-2xl font-bold text-accent-text">
+                                                        {format!("{}/5", score)}
+                                                    </span>
+                                                </div>
+                                            }
+                                        })}
+
+                                        {if has_scores {
+                                            let history = p.score_history;
+                                            view! {
+                                                <div>
+                                                    <h4 class="field-label mb-2">"Score History"</h4>
+                                                    <div class="space-y-1.5">
+                                                        {history.into_iter().map(|entry| {
+                                                            let display_date = entry.session_date.split('T').next().unwrap_or(&entry.session_date).to_string();
+                                                            view! {
+                                                                <div class="flex items-center justify-between text-sm">
+                                                                    <span class="text-muted">{display_date}</span>
+                                                                    <span class="inline-flex items-center rounded-md bg-badge-piece-bg px-1.5 py-0.5 text-xs font-medium text-accent-text ring-1 ring-accent-focus/20 ring-inset">
+                                                                        {format!("{}/5", entry.score)}
+                                                                    </span>
+                                                                </div>
+                                                            }
+                                                        }).collect::<Vec<_>>()}
+                                                    </div>
+                                                </div>
+                                            }.into_any()
+                                        } else {
+                                            view! {
+                                                <p class="text-xs text-faint">"No confidence scores recorded yet"</p>
+                                            }.into_any()
+                                        }}
+
+                                        {if has_tempo_history {
+                                            let target = parse_target_bpm(&target_tempo);
+                                            view! {
+                                                <div>
+                                                    <h4 class="field-label mb-2">"Tempo Progress"</h4>
+                                                    <TempoProgressChart
+                                                        entries=p.tempo_history
+                                                        target_bpm=target
+                                                        latest_tempo=p.latest_tempo
+                                                    />
+                                                </div>
+                                            }.into_any()
+                                        } else {
+                                            ().into_any()
+                                        }}
                                     </div>
-                                }.into_any()
-                            } else {
-                                ().into_any()
-                            }}
+                                </Card>
+                            }
+                        })}
+
+                        // Action buttons (FR-009, FR-011)
+                        <div class="flex flex-col sm:flex-row gap-3">
+                            <A href=edit_href attr:class="cta-link">
+                                "Edit"
+                            </A>
+                            <Button
+                                variant=ButtonVariant::DangerOutline
+                                disabled=Signal::derive(move || is_submitting.get())
+                                on_click=Callback::new(move |_| { show_delete_confirm.set(true); })
+                            >
+                                "Delete"
+                            </Button>
                         </div>
-                    </Card>
+                    }.into_any()
+                } else if is_loading.get() {
+                    // Data still loading — show skeleton placeholder
+                    view! {
+                        <Card>
+                            <div class="space-y-4 animate-pulse">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="flex-1 space-y-3">
+                                        <SkeletonLine width="w-2/3" height="h-7" />
+                                        <SkeletonLine width="w-1/2" height="h-5" />
+                                    </div>
+                                    <SkeletonLine width="w-16" height="h-6" />
+                                </div>
+                                <div class="grid grid-cols-2 gap-4">
+                                    <SkeletonLine width="w-3/4" />
+                                    <SkeletonLine width="w-1/2" />
+                                </div>
+                                <SkeletonBlock height="h-20" />
+                            </div>
+                        </Card>
+                    }.into_any()
+                } else {
+                    // Loading complete, item genuinely not found
+                    view! {
+                        <div class="text-center py-8">
+                            <p class="text-secondary mb-4">"Item not found."</p>
+                            <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
+                                "← Back to Library"
+                            </A>
+                        </div>
+                    }.into_any()
                 }
-            })}
-
-            // Action buttons (FR-009, FR-011)
-            <div class="flex flex-col sm:flex-row gap-3">
-                <A href=edit_href attr:class="cta-link">
-                    "Edit"
-                </A>
-                <Button
-                    variant=ButtonVariant::DangerOutline
-                    disabled=Signal::derive(move || is_submitting.get())
-                    on_click=Callback::new(move |_| { show_delete_confirm.set(true); })
-                >
-                    "Delete"
-                </Button>
-            </div>
+            }}
         </div>
-    }.into_any()
+    }
 }

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -9,8 +9,8 @@ use leptos_router::NavigateOptions;
 use intrada_core::{Event, ItemEvent, UpdateItem, ViewModel};
 
 use crate::components::{
-    AutocompleteTextField, BackLink, Button, ButtonVariant, Card, PageHeading, TagInput, TextArea,
-    TextField, TypeTabs,
+    AutocompleteTextField, BackLink, Button, ButtonVariant, Card, PageHeading, SkeletonBlock,
+    SkeletonLine, TagInput, TextArea, TextField, TypeTabs,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::helpers::{parse_tempo, parse_tempo_display, unique_composers, unique_tags};
@@ -27,25 +27,61 @@ pub fn EditLibraryItemForm() -> impl IntoView {
     let id = params.read().get("id").unwrap_or_default();
     let navigate = use_navigate();
 
-    // Find item to pre-populate
+    // Find item to pre-populate — use get_untracked() since we only need
+    // the initial value for form fields. If data hasn't loaded yet, we show
+    // a loading state and re-check reactively.
     let item = view_model
         .get_untracked()
         .items
         .into_iter()
         .find(|i| i.id == id);
 
-    let Some(item) = item else {
+    // If item not found and still loading, show skeleton then re-check
+    if item.is_none() {
+        let id = id.clone();
         return view! {
-            <div class="text-center py-8">
-                <p class="text-secondary mb-4">"Item not found."</p>
-                <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
-                    "← Back to Library"
-                </A>
+            <div class="sm:max-w-2xl sm:mx-auto">
+                <BackLink label="Cancel" href="/".to_string() />
+                <PageHeading text="Edit Library Item" />
+                {move || {
+                    if is_loading.get() {
+                        view! {
+                            <Card>
+                                <div class="space-y-4 animate-pulse">
+                                    <SkeletonLine width="w-1/3" height="h-6" />
+                                    <SkeletonLine width="w-full" height="h-10" />
+                                    <SkeletonLine width="w-full" height="h-10" />
+                                    <SkeletonLine width="w-2/3" height="h-10" />
+                                    <SkeletonBlock height="h-24" />
+                                </div>
+                            </Card>
+                        }.into_any()
+                    } else {
+                        // Check if item appeared after loading completed
+                        let item_found = view_model.get().items.iter().any(|i| i.id == id);
+                        if item_found {
+                            // Data loaded — redirect to self to re-render with item data
+                            let url = format!("/library/{}/edit", id);
+                            let navigate = use_navigate();
+                            navigate(&url, NavigateOptions { replace: true, ..Default::default() });
+                            ().into_any()
+                        } else {
+                            view! {
+                                <div class="text-center py-8">
+                                    <p class="text-secondary mb-4">"Item not found."</p>
+                                    <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
+                                        "← Back to Library"
+                                    </A>
+                                </div>
+                            }.into_any()
+                        }
+                    }
+                }}
             </div>
-        }
-        .into_any();
-    };
+        }.into_any();
+    }
 
+    let item = item.expect("item confirmed Some above");
     let item_id = item.id.clone();
     let back_href = format!("/library/{}", item_id);
 

--- a/crates/intrada-web/src/views/routine_edit.rs
+++ b/crates/intrada-web/src/views/routine_edit.rs
@@ -8,7 +8,8 @@ use intrada_core::validation::MAX_ROUTINE_NAME;
 use intrada_core::{Event, RoutineEntry, RoutineEntryView, RoutineEvent, ViewModel};
 
 use crate::components::{
-    BackLink, Button, ButtonVariant, Card, DragHandle, DropIndicator, PageHeading,
+    BackLink, Button, ButtonVariant, Card, DragHandle, DropIndicator, PageHeading, SkeletonBlock,
+    SkeletonLine,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::hooks::use_drag_reorder;
@@ -32,18 +33,49 @@ pub fn RoutineEditView() -> impl IntoView {
         .into_iter()
         .find(|r| r.id == id);
 
-    let Some(routine) = routine else {
+    // If routine not found and still loading, show skeleton then re-check
+    if routine.is_none() {
+        let id = id.clone();
         return view! {
-            <div class="text-center py-8">
-                <p class="text-secondary mb-4">"Routine not found."</p>
-                <A href="/routines" attr:class="text-accent-text hover:text-accent-hover font-medium">
-                    "\u{2190} Back to Routines"
-                </A>
+            <div class="sm:max-w-2xl sm:mx-auto">
+                <BackLink label="Back to Routines" href="/routines".to_string() />
+                <PageHeading text="Edit Routine" />
+                {move || {
+                    if is_loading.get() {
+                        view! {
+                            <Card>
+                                <div class="space-y-4 animate-pulse">
+                                    <SkeletonLine width="w-1/3" height="h-6" />
+                                    <SkeletonLine width="w-full" height="h-10" />
+                                    <SkeletonBlock height="h-32" />
+                                </div>
+                            </Card>
+                        }.into_any()
+                    } else {
+                        // Check if routine appeared after loading completed
+                        let found = view_model.get().routines.iter().any(|r| r.id == id);
+                        if found {
+                            let url = format!("/routines/{}/edit", id);
+                            let navigate = use_navigate();
+                            navigate(&url, NavigateOptions { replace: true, ..Default::default() });
+                            ().into_any()
+                        } else {
+                            view! {
+                                <div class="text-center py-8">
+                                    <p class="text-secondary mb-4">"Routine not found."</p>
+                                    <A href="/routines" attr:class="text-accent-text hover:text-accent-hover font-medium">
+                                        "\u{2190} Back to Routines"
+                                    </A>
+                                </div>
+                            }.into_any()
+                        }
+                    }
+                }}
             </div>
-        }
-        .into_any();
-    };
+        }.into_any();
+    }
 
+    let routine = routine.expect("routine confirmed Some above");
     let routine_id = routine.id.clone();
     let name = RwSignal::new(routine.name.clone());
     let entries: RwSignal<Vec<RoutineEntryView>> = RwSignal::new(routine.entries.clone());


### PR DESCRIPTION
## Summary
- Fix detail views (`/library/:id`, `/library/:id/edit`, `/routines/:id/edit`) showing "not found" on hard refresh
- Show skeleton loading placeholders while initial data loads
- Only show "not found" when loading completes and item genuinely doesn't exist

## Root cause
Views used `get_untracked()` and returned "not found" before `fetch_initial_data()` completed. List views had loading guards but detail/edit views didn't.

## Test plan
- [ ] Hard-refresh a library item detail page — should show skeleton then content
- [ ] Hard-refresh an edit page — should show skeleton then form
- [ ] Hard-refresh a routine edit page — should show skeleton then form
- [ ] Navigate to a non-existent item ID — should show "not found" after load completes

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)