### PR TITLE
Standardise timestamp formatting across all views

### DIFF
--- a/crates/intrada-web/src/helpers.rs
+++ b/crates/intrada-web/src/helpers.rs
@@ -1,6 +1,21 @@
 use std::collections::HashSet;
 
+use chrono::DateTime;
 use intrada_core::{LibraryItemView, Tempo};
+
+/// Format an ISO 8601 / RFC 3339 date string to "d Mon YYYY" (e.g. "4 Mar 2026").
+pub fn format_date_short(iso: &str) -> String {
+    DateTime::parse_from_rfc3339(iso)
+        .map(|dt| dt.format("%-d %b %Y").to_string())
+        .unwrap_or_else(|_| iso.to_string())
+}
+
+/// Format an ISO 8601 / RFC 3339 datetime string to "d Mon YYYY, HH:MM" (e.g. "4 Mar 2026, 14:30").
+pub fn format_datetime_short(iso: &str) -> String {
+    DateTime::parse_from_rfc3339(iso)
+        .map(|dt| dt.format("%-d %b %Y, %H:%M").to_string())
+        .unwrap_or_else(|_| iso.to_string())
+}
 
 /// Parse comma-separated tags string into Vec<String>.
 /// Trims whitespace, filters empty entries.
@@ -392,5 +407,29 @@ mod tests {
         let exclude = vec!["CLASSICAL".to_string()];
         let result = filter_suggestions(&suggestions, "", &exclude, 8);
         assert_eq!(result, vec!["Jazz"]);
+    }
+
+    // format_date_short / format_datetime_short tests
+    #[test]
+    fn test_format_date_short_valid() {
+        assert_eq!(format_date_short("2026-03-04T14:30:00+00:00"), "4 Mar 2026");
+    }
+
+    #[test]
+    fn test_format_date_short_fallback() {
+        assert_eq!(format_date_short("not-a-date"), "not-a-date");
+    }
+
+    #[test]
+    fn test_format_datetime_short_valid() {
+        assert_eq!(
+            format_datetime_short("2026-03-04T14:30:00+00:00"),
+            "4 Mar 2026, 14:30"
+        );
+    }
+
+    #[test]
+    fn test_format_datetime_short_fallback() {
+        assert_eq!(format_datetime_short("nope"), "nope");
     }
 }

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -11,6 +11,7 @@ use crate::components::{
     SkeletonLine, TempoProgressChart, TypeBadge,
 };
 use intrada_web::core_bridge::process_effects;
+use intrada_web::helpers::{format_date_short, format_datetime_short};
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 #[component]
@@ -170,10 +171,10 @@ pub fn DetailView() -> impl IntoView {
 
                             <div class="mt-2 pt-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs text-faint">
                                 <div>
-                                    <span class="font-medium">"Created: "</span>{created_at}
+                                    <span class="font-medium">"Created: "</span>{format_datetime_short(&created_at)}
                                 </div>
                                 <div>
-                                    <span class="font-medium">"Updated: "</span>{updated_at}
+                                    <span class="font-medium">"Updated: "</span>{format_datetime_short(&updated_at)}
                                 </div>
                             </div>
                         </Card>
@@ -216,7 +217,7 @@ pub fn DetailView() -> impl IntoView {
                                                     <h4 class="field-label mb-2">"Score History"</h4>
                                                     <div class="space-y-1.5">
                                                         {history.into_iter().map(|entry| {
-                                                            let display_date = entry.session_date.split('T').next().unwrap_or(&entry.session_date).to_string();
+                                                            let display_date = format_date_short(&entry.session_date);
                                                             view! {
                                                                 <div class="flex items-center justify-between text-sm">
                                                                     <span class="text-muted">{display_date}</span>

--- a/crates/intrada-web/src/views/goals.rs
+++ b/crates/intrada-web/src/views/goals.rs
@@ -8,6 +8,7 @@ use crate::components::{
     Button, ButtonVariant, Card, Icon, IconName, PageHeading, SkeletonCardList,
 };
 use intrada_web::core_bridge::process_effects;
+use intrada_web::helpers::format_date_short;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// Goals page — lists active goals with progress bars, plus completed/archived history.
@@ -327,12 +328,4 @@ fn GoalProgressBar(progress: GoalProgress) -> impl IntoView {
             <p class="text-xs text-secondary">{progress.display_text}</p>
         </div>
     }
-}
-
-/// Format an ISO date string to a short display format (e.g. "24 Feb 2026").
-fn format_date_short(iso: &str) -> String {
-    // Parse the ISO date and format nicely, fallback to raw string
-    chrono::DateTime::parse_from_rfc3339(iso)
-        .map(|dt| dt.format("%d %b %Y").to_string())
-        .unwrap_or_else(|_| iso.to_string())
 }

--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -7,6 +7,7 @@ use crate::components::{
     Button, ButtonVariant, Card, Icon, IconName, PageHeading, SkeletonCardList,
 };
 use intrada_web::core_bridge::process_effects;
+use intrada_web::helpers::format_datetime_short;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// All-sessions list view showing every completed practice session.
@@ -142,7 +143,7 @@ fn SessionRow(
                                         } else {
                                             None
                                         }}
-                                        <span class="text-xs text-faint">{started_at}</span>
+                                        <span class="text-xs text-faint">{format_datetime_short(&started_at)}</span>
                                     </div>
                                     {session_intention.map(|intention| {
                                         view! {


### PR DESCRIPTION
## Summary
- Extract `format_date_short()` and `format_datetime_short()` into shared `helpers.rs`
- Apply consistent formatting: dates as "25 Feb 2026", datetimes as "25 Feb 2026, 14:30"
- Replace raw RFC3339 strings in item detail, session list, and score history
- Remove duplicate local helper from goals.rs

## Affected views
- `detail.rs` — created_at, updated_at, score history dates
- `sessions.rs` — started_at timestamp
- `goals.rs` — now uses shared helper

## Test plan
- [ ] View a library item detail page — timestamps should show "25 Feb 2026, 14:30" format
- [ ] View score history — dates should show "25 Feb 2026" format
- [ ] View session history — started_at should show "25 Feb 2026, 14:30" format
- [ ] View goals — deadline/completed dates unchanged ("25 Feb 2026" format)

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)