### PR TITLE
Filter out already-added items in session/routine builders (#165)

### DIFF
--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -436,15 +436,27 @@ pub fn SetlistBuilder() -> impl IntoView {
                 <h3 class="section-title">"Library Items"</h3>
                 {move || {
                     let vm = view_model.get();
-                    if vm.items.is_empty() {
+                    // Collect item IDs already in the setlist so we can hide them
+                    let added_ids: std::collections::HashSet<&str> = vm
+                        .building_setlist
+                        .as_ref()
+                        .map(|s| s.entries.iter().map(|e| e.item_id.as_str()).collect())
+                        .unwrap_or_default();
+                    let available: Vec<_> = vm.items.iter().filter(|i| !added_ids.contains(i.id.as_str())).collect();
+                    if available.is_empty() {
+                        let msg = if vm.items.is_empty() {
+                            "No library items available."
+                        } else {
+                            "All library items have been added."
+                        };
                         view! {
-                            <p class="text-sm text-muted">"No library items available."</p>
+                            <p class="text-sm text-muted">{msg}</p>
                         }.into_any()
                     } else {
                         let core_add = core_library.clone();
                         view! {
                             <div class="space-y-2">
-                                {vm.items.iter().map(|item| {
+                                {available.into_iter().map(|item| {
                                     let item_id = item.id.clone();
                                     let title = item.title.clone();
                                     let item_type = item.item_type.clone();

--- a/crates/intrada-web/src/views/routine_edit.rs
+++ b/crates/intrada-web/src/views/routine_edit.rs
@@ -302,9 +302,16 @@ pub fn RoutineEditView() -> impl IntoView {
                                 <p class="text-sm text-muted">"No library items available."</p>
                             }.into_any()
                         } else {
+                            // Collect item IDs already in the routine to dim them
+                            let added_ids: std::collections::HashSet<String> = entries
+                                .get()
+                                .iter()
+                                .map(|e| e.item_id.clone())
+                                .collect();
                             view! {
                                 <div class="space-y-2">
                                     {vm.items.iter().map(|item| {
+                                        let already_added = added_ids.contains(&item.id);
                                         let title = item.title.clone();
                                         let item_type = item.item_type.clone();
                                         let id_for_entry = item.id.clone();
@@ -312,7 +319,11 @@ pub fn RoutineEditView() -> impl IntoView {
                                         let type_for_entry = item.item_type.clone();
                                         view! {
                                             <div
-                                                class="flex items-center justify-between rounded-lg bg-surface-secondary px-3 py-2 hover:bg-surface-hover cursor-pointer"
+                                                class={if already_added {
+                                                    "flex items-center justify-between rounded-lg bg-surface-secondary px-3 py-2 opacity-50"
+                                                } else {
+                                                    "flex items-center justify-between rounded-lg bg-surface-secondary px-3 py-2 hover:bg-surface-hover cursor-pointer"
+                                                }}
                                                 on:click=move |_| {
                                                     let new_entry = RoutineEntryView {
                                                         id: ulid::Ulid::new().to_string(),
@@ -328,8 +339,12 @@ pub fn RoutineEditView() -> impl IntoView {
                                                     <span class="text-sm text-primary">{title}</span>
                                                     <span class="text-xs text-faint">{item_type}</span>
                                                 </div>
-                                                <span class="text-xs font-medium text-accent-text">
-                                                    "+ Add"
+                                                <span class={if already_added {
+                                                    "text-xs font-medium text-muted"
+                                                } else {
+                                                    "text-xs font-medium text-accent-text"
+                                                }}>
+                                                    {if already_added { "Added" } else { "+ Add" }}
                                                 </span>
                                             </div>
                                         }


### PR DESCRIPTION
## Summary
- **Session builder**: Items already in the setlist are hidden from the library list. Shows "All library items have been added" when all items are in the setlist.
- **Routine editor**: Already-added items are visually dimmed (50% opacity, muted label text, "Added" instead of "+ Add") but remain clickable since routines may intentionally include the same item multiple times.

## Test plan
- [ ] Start a new session, add an item — verify it disappears from the library list
- [ ] Add all items — verify "All library items have been added" message shows
- [ ] Remove an item from the setlist — verify it reappears in the library list
- [ ] Edit a routine, add an item — verify it appears dimmed with "Added" label
- [ ] Verify dimmed routine items are still clickable (allows intentional duplicates)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)