### PR TITLE
fix: iOS concurrency cleanup — async/await and redundant MainActor

### DIFF
--- a/ios/Intrada/Components/AutocompleteField.swift
+++ b/ios/Intrada/Components/AutocompleteField.swift
@@ -36,7 +36,8 @@ struct AutocompleteField: View {
                     .onChange(of: isFocused) { _, focused in
                         if !focused {
                             // Delay hiding to allow tap on suggestion
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            Task {
+                                try? await Task.sleep(for: .milliseconds(200))
                                 showSuggestions = false
                             }
                         } else {

--- a/ios/Intrada/Components/TagInputView.swift
+++ b/ios/Intrada/Components/TagInputView.swift
@@ -38,7 +38,8 @@ struct TagInputView: View {
                             }
                             .onChange(of: isFocused) { _, focused in
                                 if !focused {
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                    Task {
+                                        try? await Task.sleep(for: .milliseconds(200))
                                         showSuggestions = false
                                     }
                                 }

--- a/ios/Intrada/Views/Practice/SessionSummaryView.swift
+++ b/ios/Intrada/Views/Practice/SessionSummaryView.swift
@@ -207,7 +207,7 @@ struct SessionSummaryView: View {
                     sessionNotesCommitTask = Task {
                         try? await Task.sleep(for: .seconds(1))
                         guard !Task.isCancelled else { return }
-                        await MainActor.run { commitSessionNotes() }
+                        commitSessionNotes()
                     }
                 }
         }


### PR DESCRIPTION
## Summary

Swift concurrency cleanup across iOS components. Closes #259.

## Changes

- **AutocompleteField.swift** — Replace `DispatchQueue.main.asyncAfter` with `Task { try? await Task.sleep(for: .milliseconds(200)) }` for suggestion dismissal delay
- **TagInputView.swift** — Same DispatchQueue → Task.sleep replacement
- **SessionSummaryView.swift** — Remove redundant `await MainActor.run { }` wrapper in debounced notes commit (the closure is already on the main actor)

## What was reviewed and left as-is

- **ActiveSessionView Timer** — The `Timer.publish().autoconnect()` as a `let` property was reviewed. SwiftUI's `.onReceive` automatically unsubscribes when the view is removed from the hierarchy, so explicit lifecycle management is unnecessary and would add complexity without benefit.

## Test plan

- [ ] `just ios-swift-check` — verify compile
- [ ] Test autocomplete suggestion dismissal still works (tap away, suggestions hide after 200ms)
- [ ] Test tag input suggestion dismissal
- [ ] Test session notes auto-save after 1s debounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)