### PR TITLE
fix: iOS bugs — routine start, analytics layout, empty states

### DIFF
--- a/ios/Intrada/Components/EmptyStateView.swift
+++ b/ios/Intrada/Components/EmptyStateView.swift
@@ -32,7 +32,7 @@ struct EmptyStateView: View {
             }
         }
         .padding(Spacing.cardComfortable)
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 

--- a/ios/Intrada/Navigation/MainTabView.swift
+++ b/ios/Intrada/Navigation/MainTabView.swift
@@ -70,6 +70,12 @@ struct MainTabView: View {
                 }
             .tag(Tab.analytics)
         }
+        .onChange(of: core.viewModel.sessionStatus) { _, newStatus in
+            // Auto-switch to Practice tab when a routine is loaded or session starts
+            if newStatus == .building || newStatus == .active {
+                selectedTab = .practice
+            }
+        }
         .tint(Color.accent)
         .confirmationDialog(
             "Sign Out",

--- a/ios/Intrada/Views/Analytics/AnalyticsDashboardView.swift
+++ b/ios/Intrada/Views/Analytics/AnalyticsDashboardView.swift
@@ -62,10 +62,13 @@ struct AnalyticsDashboardView: View {
     private func iPadDashboard(_ analytics: AnalyticsView) -> some View {
         VStack(spacing: Spacing.card) {
             // Top row: consistency + weekly summary side by side
-            HStack(spacing: Spacing.card) {
+            HStack(alignment: .top, spacing: Spacing.card) {
                 consistencyCard(analytics.streak)
+                    .frame(maxHeight: .infinity, alignment: .top)
                 weeklySummaryCard(analytics.weeklySummary)
+                    .frame(maxHeight: .infinity, alignment: .top)
             }
+            .fixedSize(horizontal: false, vertical: true)
 
             // Insights + chart side by side
             HStack(alignment: .top, spacing: Spacing.card) {
@@ -73,14 +76,20 @@ struct AnalyticsDashboardView: View {
                     neglected: analytics.neglectedItems,
                     scoreChanges: analytics.scoreChanges
                 )
+                .frame(maxHeight: .infinity, alignment: .top)
                 practiceChartCard(analytics.dailyTotals)
+                    .frame(maxHeight: .infinity, alignment: .top)
             }
+            .fixedSize(horizontal: false, vertical: true)
 
             // Bottom row: top items + score trends side by side
             HStack(alignment: .top, spacing: Spacing.card) {
                 topItemsCard(analytics.topItems)
+                    .frame(maxHeight: .infinity, alignment: .top)
                 scoreTrendsCard(analytics.scoreTrends)
+                    .frame(maxHeight: .infinity, alignment: .top)
             }
+            .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, Spacing.cardComfortable)
         .padding(.bottom, Spacing.cardComfortable)

--- a/ios/Intrada/Views/Practice/SessionBuilderView.swift
+++ b/ios/Intrada/Views/Practice/SessionBuilderView.swift
@@ -11,6 +11,7 @@ struct SessionBuilderView: View {
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var searchText = ""
     @State private var isSheetPresented = false
+    @State private var showRoutinePicker = false
 
     /// Library items filtered by search text (shell-local concern).
     private var filteredItems: [LibraryItemView] {
@@ -137,6 +138,15 @@ struct SessionBuilderView: View {
                     .font(.system(size: 28, weight: .bold))
                     .foregroundStyle(Color.textPrimary)
                 Spacer()
+                if !core.viewModel.routines.isEmpty {
+                    Button {
+                        showRoutinePicker = true
+                    } label: {
+                        Label("Routine", systemImage: "list.bullet.rectangle")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(Color.accentText)
+                    }
+                }
             }
             .padding(.horizontal, Spacing.card)
             .padding(.bottom, 4)
@@ -171,6 +181,9 @@ struct SessionBuilderView: View {
             .presentationDragIndicator(.visible)
             .presentationBackground(Color.backgroundApp)
         }
+        .sheet(isPresented: $showRoutinePicker) {
+            routinePickerSheet
+        }
     }
 
     // MARK: - iPad Layout
@@ -187,6 +200,15 @@ struct SessionBuilderView: View {
                         .font(.system(size: 28, weight: .bold))
                         .foregroundStyle(Color.textPrimary)
                     Spacer()
+                    if !core.viewModel.routines.isEmpty {
+                        Button {
+                            showRoutinePicker = true
+                        } label: {
+                            Label("Load Routine", systemImage: "list.bullet.rectangle")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(Color.accentText)
+                        }
+                    }
                 }
                 .padding(.horizontal, Spacing.card)
 
@@ -238,6 +260,44 @@ struct SessionBuilderView: View {
     private func startSession() {
         let now = ISO8601DateFormatter().string(from: Date())
         core.update(.session(.startSession(now: now)))
+    }
+
+    // MARK: - Routine Picker
+
+    private var routinePickerSheet: some View {
+        NavigationStack {
+            List {
+                ForEach(core.viewModel.routines, id: \.id) { (routine: RoutineView) in
+                    Button {
+                        core.update(.routine(.loadRoutineIntoSetlist(routineId: routine.id)))
+                        showRoutinePicker = false
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(routine.name)
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(Color.textPrimary)
+                            Text("\(routine.entryCount) items")
+                                .font(.system(size: 12))
+                                .foregroundStyle(Color.textMuted)
+                        }
+                    }
+                    .listRowBackground(Color.surfaceSecondary)
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.backgroundApp)
+            .navigationTitle("Load Routine")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cancel") {
+                        showRoutinePicker = false
+                    }
+                    .foregroundStyle(Color.accentText)
+                }
+            }
+        }
     }
 }
 

--- a/ios/Intrada/Views/Routines/RoutineDetailView.swift
+++ b/ios/Intrada/Views/Routines/RoutineDetailView.swift
@@ -30,6 +30,12 @@ struct RoutineDetailView: View {
                         .padding(.horizontal, Spacing.card)
                         .padding(.top, Spacing.card)
 
+                        // Start practice button
+                        ButtonView("Start Practice", variant: .primary) {
+                            core.update(.routine(.loadRoutineIntoSetlist(routineId: routine.id)))
+                        }
+                        .padding(.horizontal, Spacing.card)
+
                         // Entry list card
                         CardView(padding: 0) {
                             LazyVStack(spacing: 0) {


### PR DESCRIPTION
## Summary

Fixes three user-reported iOS bugs.

## Bug 1: No way to start a routine (iPhone/iPad)

**Problem:** Routine detail view showed entries and an Edit button, but no way to actually use the routine to start practising.

**Fix:** 
- Added "Start Practice" button to `RoutineDetailView` that dispatches `loadRoutineIntoSetlist`
- Added `onChange(of: sessionStatus)` in `MainTabView` to auto-switch to the Practice tab when session status transitions to Building or Active

## Bug 2: Analytics card sizing (iPhone/iPad)

**Problem:** Cards in iPad side-by-side layout had unequal heights, looking inconsistent.

**Fix:** Added `.frame(maxHeight: .infinity, alignment: .top)` on each card within HStack pairs, plus `.fixedSize(horizontal: false, vertical: true)` on each row so cards match their sibling's height.

## Bug 3: Empty states not full screen

**Problem:** Empty states on Routines, Practice, and Analytics had black borders at top and bottom — the `EmptyStateView` only expanded horizontally, not vertically.

**Fix:** Changed `EmptyStateView` from `.frame(maxWidth: .infinity)` to `.frame(maxWidth: .infinity, maxHeight: .infinity)`.

## Test plan

- [ ] iPhone: tap routine → see "Start Practice" button → tap → lands on Practice tab builder with routine loaded
- [ ] iPad: same flow works
- [ ] Analytics iPad: cards in each row have equal heights
- [ ] Empty states on Routines/Practice/Analytics fill the screen (no black borders)
- [ ] `just ios-swift-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)