### PR TITLE
docs: teacher assignment capture (#267) and roadmap restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ specs/                # SpecKit design artifacts
 | [`CLAUDE.md`](CLAUDE.md) | Development guidelines, architecture, design system rules |
 | [`docs/development-workflow.md`](docs/development-workflow.md) | End-to-end feature workflow, SpecKit stages, AI subagents |
 | [`docs/roadmap.md`](docs/roadmap.md) | Product roadmap (Plan/Practice/Track pillars) — **single source of truth** |
-| [`VISION.md`](VISION.md) | Product vision and research foundation |
+| [`VISION.md`](VISION.md) | Product vision |
+| [`docs/research-foundation.md`](docs/research-foundation.md) | Research basis for design decisions |
 | [`SETUP.md`](SETUP.md) | Deployment & configuration (Cloudflare, Fly.io, Turso, CI/CD) |
 
 ## CI/CD

--- a/VISION.md
+++ b/VISION.md
@@ -2,779 +2,146 @@
 
 **Your Intentional Practice Companion**
 
-*Product Vision & Research Foundation — March 2026*
+*Product Vision — April 2026*
 
 ---
 
-## 1. Product Vision
+## The Problem
 
-### 1.1 The Problem
+Musicians practise but don't always progress. Hours pass at the instrument, yet the same passages stumble, the same keys feel unfamiliar, and the sense of forward motion stalls. This isn't a talent problem — it's a practice design problem with three layers.
 
-Musicians at every level share a common frustration: they practise, but they don't always progress. Hours pass at the instrument, yet weeks later the same passages stumble, the same keys feel unfamiliar, and the sense of forward motion stalls. The gap between effort and improvement is not a talent problem — it's a practice design problem.
+**Material gets lost.** A teacher introduces a new voicing pattern, assigns ii-V-I progressions across all keys, suggests a tune to transcribe. The musician scrawls it in a notebook. A week later, the notation is cryptic, the context is gone, and half the assignment is forgotten. Over a year, dozens of rich, multi-key exercises accumulate — and most of them disappear. Even self-directed musicians face this: ideas, exercises, and repertoire scatter across apps, sheets, and memory.
 
-Most practice is unstructured. Musicians repeat what feels comfortable, avoid what feels hard, and lack visibility into whether they're actually improving. Existing tools either track time (which measures attendance, not progress) or overwhelm with features that feel like work rather than music.
+**Deciding what to practise is paralysing.** The musician sits down with 30 minutes. They could work on voicings, scales over changes, a new tune, that passage from last week, or revisit something from a month ago. The material is effectively infinite — twelve keys, multiple voicing types, dozens of exercises — and without a plan, the decision cost is high enough to either stall the session entirely or push the musician into grabbing whatever's on the music stand. Research confirms the intuition: choice is only motivating when the learner has the competence and knowledge to choose meaningfully. When they don't, excessive choice becomes a burden rather than a freedom.
 
-But beneath the structural problem lies a deeper one: **music has one of the longest feedback loops of any skill.** A software developer writes code and sees whether it works in seconds. An athlete shoots a basket and the ball goes in or it doesn't. A musician practises a passage and… it sounds slightly better? Maybe? Improvement in music is often invisible for weeks or months — motor skills consolidate between sessions, not within them (Walker & Stickgold, 2004; Brashers-Krug, Shadmehr & Bizzi, 1996). You have to trust the process before you can see the results.
-
-There is a third layer to the problem: **the sheer volume of what *could* be practised is paralysing.** A pianist learning to improvise faces twelve keys, dozens of chord voicings per key, multiple scale types, ornaments, rhythmic patterns, harmonic substitutions — the material is effectively infinite. Without guidance, the obvious question is not "how do I practise?" but "what should I even be working on?" Even classically trained musicians crossing into improvisation often need a teacher not for technique instruction but simply to answer that question — to cut through the noise and identify what actually matters *right now*. Research on choice in learning contexts confirms the intuition: choice is only motivating when the learner has the competence and knowledge to choose meaningfully (Katz & Assor, 2007). When they don't — and by definition, learners at the boundary of their knowledge don't — excessive choice becomes a burden rather than a freedom (Schwartz, 2004; Iyengar & Lepper, 2000). The result is either paralysis (the musician sits down and doesn't know where to start) or scattershot practice (they try a bit of everything and master nothing).
-
-What musicians need is not more material — the internet has made that infinite — but a **critical path**: the minimum, well-sequenced set of things to practise that leads most efficiently to their specific goal. You don't need to practise scales in every key over two octaves to learn a specific piece. You need the keys, the passages, and the techniques that piece demands — and then to build outward from there. This is what good teachers do instinctively: they filter, sequence, and focus. It's also what self-taught musicians consistently lack (Duke, 2005; Hallam, 2001). In essence, the meta-skill that separates effective from ineffective practice is *learning how to learn* — and that meta-skill is precisely what teachers transmit and what self-directed musicians must somehow develop on their own.
-
-This delayed feedback is particularly devastating for musicians with ADHD, whose brains require frequent evidence of progress to sustain engagement (Barkley, 2015). But it affects every musician: the gap between effort and visible reward is where motivation dies. Research on why music students abandon their instruments points consistently to declining motivation and a lost sense of progress rather than a lack of talent or time (Hallam, 1998; Evans, 2015). Without external evidence that practice is working, "trust the process" becomes an empty mantra.
-
-> **Open question:** While the connection between delayed feedback and dropout is strongly supported by motivation research (SDT, self-efficacy theory), there is limited direct research measuring the *specific* feedback loop length in music learning versus other domains. The claim that music has "one of the longest" feedback loops is an informed inference from motor consolidation research and practitioner experience, not a directly measured comparison. This is a testable hypothesis that Intrada's own data could eventually contribute to answering.
-
-### 1.2 The Vision
-
-**Intrada is an intentional practice companion that helps musicians practise smarter, see their progress, and trust the process — by making invisible progress visible.**
-
-Its core job is twofold: **shrink the feedback loop** by surfacing evidence of improvement that the musician cannot yet feel, and **illuminate the critical path** by guiding each musician toward the specific material that matters most for their goals right now. Together, these make progress both *visible* and *efficient* — the musician can see that practice is working, and trust that they are working on the right things.
-
-It sits at the intersection of three evidence-based principles: the science of learning (spaced repetition, interleaved practice, deliberate practice), the psychology of motivation (self-determination theory, growth mindset), and the practical realities of musical skill acquisition (technique across all keys, repertoire management, goal-directed study).
-
-Intrada doesn't replace your teacher or your musicianship. It gives you the structure, visibility, and encouragement to make every practice session count.
-
-### 1.3 Core Value Proposition
-
-Where other apps track minutes or provide generic tools, Intrada offers something different:
-
-- **Shrink the feedback loop** — surface evidence of progress before the musician can feel it, turning weeks of invisible improvement into daily visible signals
-- **Illuminate the critical path** — guide musicians toward the specific material that matters for their goals, cutting through the noise of everything they *could* practise to focus on what they *should* practise right now
-- **Fine-grained metric-based progression** — track mastery at the level of individual keys, passages, and techniques, not just "time spent"
-- **Smart scheduling** — algorithmically surface what you need to practise based on spaced repetition and interleaved practice research
-- **Mindful and intentional practice** — encourage focus, reflection, and deliberate engagement rather than mindless repetition
-- **Visible progress** — visualise improvement over time so musicians can see that the process works
-- **Trust the process** — positive encouragement grounded in evidence that sustained, structured effort leads to real growth
-- **Accessible by design** — designed with neurodivergent musicians in mind, reducing friction and supporting diverse cognitive styles
-
-### 1.4 Target Users
-
-Intrada is designed for self-directed musicians who are past the beginner stage and serious about improvement. This includes jazz and classical pianists, instrumental students at intermediate to advanced level, adult returners to music, and anyone preparing for graded exams, auditions, or performance. The common thread is a desire to practise more effectively, not just more.
-
-An estimated 15–20% of the population is neurodivergent (a commonly cited range combining ADHD, autism, dyslexia, and other cognitive variations, though exact prevalence depends on diagnostic criteria and definition), and the intersection of ADHD with music is particularly significant — music provides the kind of stimulation and flow that ADHD brains thrive on, and ADHD behaviours are often notably *absent* during active music-making (Wilde & Welch, 2022). Designing for neurodivergent musicians isn't niche — it's likely a meaningful portion of Intrada's audience, and features that support executive function challenges benefit every user.
-
-### 1.5 Musician Tracks — Entry Points, Not Boxes
-
-Musicians come to Intrada with fundamentally different motivations, and a single onboarding path cannot serve them all. Intrada recognises six distinct tracks — not as rigid categories, but as starting points that shape the initial experience.
-
-> **Assumption:** These six tracks are a product design hypothesis based on practitioner observation and user interviews, not empirically validated categories. The underlying principle — that musicians have different motivations that should shape their experience — is well-supported by SDT research (different forms of motivation lead to different practice behaviours; Evans & Bonneville-Roussy, 2016). But the specific six categories, their boundaries, and whether they capture the most meaningful distinctions are untested. They should be validated against real user data and refined as the product matures.
-
-| Track | Motivation | What they need from Intrada |
-|-------|-----------|----------------------------|
-| **The Entertainer** | Learn one thing to impress friends | Focused, single-goal workflow; quick wins; minimal admin |
-| **The Jammer** | Jam with pals | Repertoire breadth; key fluency; feel over perfection |
-| **The Virtuoso (Classical)** | Mastery through the classical tradition | Technique, études, exam prep; fine-grained progression; tempo targets |
-| **The Virtuoso (Jazz)** | Mastery through the jazz tradition | Standards, improvisation, transcription; key-aware practice across all 12 |
-| **The Soul Player** | Play for themselves | Personal enjoyment; consistency over scores; low-pressure structure |
-| **The Late Starter** | Always wanted to but thinks it's too late | Encouragement; proof that progress is possible at any stage; gentle goals |
-
-#### How tracks shape the experience
-
-Tracks influence the onboarding journey, default library suggestions, session structure, analytics framing, and encouragement tone. A Virtuoso sees mastery scores and tempo progress front and centre; a Soul Player sees consistency and time spent; a Late Starter sees evidence of growth from zero with warmth and normalisation.
-
-| Touchpoint | How it varies |
-|------------|--------------|
-| **Onboarding** | Different welcome questions, starter library, initial goal templates |
-| **Session defaults** | Duration, scoring emphasis, focus mode (e.g. Soul Player might skip scoring) |
-| **Analytics framing** | Virtuoso → precision metrics; Soul Player → consistency; Late Starter → progress from baseline |
-| **Encouragement tone** | Virtuoso → data-driven; Late Starter → warmth and normalisation; Jammer → social readiness |
-| **Goal suggestions** | Track-appropriate templates (e.g. "Learn 3 standards this month" vs "Play for 10 minutes, 3 times this week") |
-
-#### A shared foundation that diverges
-
-All tracks share a common core: the act of showing up, playing, and reflecting. The fundamental loop — pick something to practise, play it with intention, notice what happened — is universal. What changes between tracks is the framing, the defaults, and the emphasis.
-
-This means the onboarding journey can begin with shared ground. Every musician, regardless of track, benefits from building a library, running a first session, and seeing their initial data. The divergence happens in how the app responds after that: what it suggests next, how it frames progress, what goals it offers, how much structure it applies.
-
-Think of it as a tree: the trunk is the core practice loop that every musician recognises. The branches are where tracks diverge — a Virtuoso's branch emphasises precision, tempo targets, and exam preparation; a Jammer's branch emphasises repertoire breadth and playing with others; a Late Starter's branch emphasises evidence that it is not too late and that small steps compound.
-
-This shared-then-divergent structure has practical benefits. It means the core product stays simple — one practice loop, one library, one session flow. The track system layers on top as a personalisation lens rather than requiring separate feature paths. A musician who changes track does not need to relearn the app; they see the same structure through different eyes.
-
-#### Fluidity is core
-
-Tracks are entry points, not permanent assignments. Musicians can change track at any time — no friction, no confirmation dialog. The app actively signals this: real musical journeys are not linear. Someone starts as a Late Starter, gains confidence, becomes a Jammer, then catches the mastery bug. Moving from Virtuoso to Soul Player is not giving up — it is choosing what matters now.
-
-Track changes trigger a gentle experience refresh: updated suggestions, reframed analytics, adjusted defaults — without losing any data or history. The musician's complete practice record travels with them regardless of which track they are on.
-
-This design is grounded in SDT: autonomy means the musician defines their own relationship with practice, and that definition can evolve. It also connects to growth mindset research — if the app frames a track change as regression, it undermines the very belief system that sustains long-term engagement.
-
-### 1.5 Musician Tracks — Entry Points, Not Boxes
-
-Musicians come to Intrada with fundamentally different motivations, and a single onboarding path cannot serve them all. Intrada recognises six distinct tracks — not as rigid categories, but as starting points that shape the initial experience.
-
-| Track | Motivation | What they need from Intrada |
-|-------|-----------|----------------------------|
-| **The Entertainer** | Learn one thing to impress friends | Focused, single-goal workflow; quick wins; minimal admin |
-| **The Jammer** | Jam with pals | Repertoire breadth; key fluency; feel over perfection |
-| **The Virtuoso (Classical)** | Mastery through the classical tradition | Technique, études, exam prep; fine-grained progression; tempo targets |
-| **The Virtuoso (Jazz)** | Mastery through the jazz tradition | Standards, improvisation, transcription; key-aware practice across all 12 |
-| **The Soul Player** | Play for themselves | Personal enjoyment; consistency over scores; low-pressure structure |
-| **The Late Starter** | Always wanted to but thinks it's too late | Encouragement; proof that progress is possible at any stage; gentle goals |
-
-#### How tracks shape the experience
-
-Tracks influence the onboarding journey, default library suggestions, session structure, analytics framing, and encouragement tone. A Virtuoso sees mastery scores and tempo progress front and centre; a Soul Player sees consistency and time spent; a Late Starter sees evidence of growth from zero with warmth and normalisation.
-
-| Touchpoint | How it varies |
-|------------|--------------|
-| **Onboarding** | Different welcome questions, starter library, initial goal templates |
-| **Session defaults** | Duration, scoring emphasis, focus mode (e.g. Soul Player might skip scoring) |
-| **Analytics framing** | Virtuoso → precision metrics; Soul Player → consistency; Late Starter → progress from baseline |
-| **Encouragement tone** | Virtuoso → data-driven; Late Starter → warmth and normalisation; Jammer → social readiness |
-| **Goal suggestions** | Track-appropriate templates (e.g. "Learn 3 standards this month" vs "Play for 10 minutes, 3 times this week") |
-
-#### A shared foundation that diverges
-
-All tracks share a common core: the act of showing up, playing, and reflecting. The fundamental loop — pick something to practise, play it with intention, notice what happened — is universal. What changes between tracks is the framing, the defaults, and the emphasis.
-
-This means the onboarding journey can begin with shared ground. Every musician, regardless of track, benefits from building a library, running a first session, and seeing their initial data. The divergence happens in how the app responds after that: what it suggests next, how it frames progress, what goals it offers, how much structure it applies.
-
-Think of it as a tree: the trunk is the core practice loop that every musician recognises. The branches are where tracks diverge — a Virtuoso's branch emphasises precision, tempo targets, and exam preparation; a Jammer's branch emphasises repertoire breadth and playing with others; a Late Starter's branch emphasises evidence that it is not too late and that small steps compound.
-
-This shared-then-divergent structure has practical benefits. It means the core product stays simple — one practice loop, one library, one session flow. The track system layers on top as a personalisation lens rather than requiring separate feature paths. A musician who changes track does not need to relearn the app; they see the same structure through different eyes.
-
-#### Fluidity is core
-
-Tracks are entry points, not permanent assignments. Musicians can change track at any time — no friction, no confirmation dialog. The app actively signals this: real musical journeys are not linear. Someone starts as a Late Starter, gains confidence, becomes a Jammer, then catches the mastery bug. Moving from Virtuoso to Soul Player is not giving up — it is choosing what matters now.
-
-Track changes trigger a gentle experience refresh: updated suggestions, reframed analytics, adjusted defaults — without losing any data or history. The musician's complete practice record travels with them regardless of which track they are on.
-
-This design is grounded in SDT: autonomy means the musician defines their own relationship with practice, and that definition can evolve. It also connects to growth mindset research — if the app frames a track change as regression, it undermines the very belief system that sustains long-term engagement.
+**Progress is invisible for too long.** Music has one of the longest feedback loops of any skill. A software developer writes code and sees whether it works in seconds. A musician practises a passage and it sounds… slightly better? Maybe? Improvement is often invisible for weeks — motor skills consolidate between sessions, not within them. Without external evidence that practice is working, anxiety fills the gap: "Am I doing the right thing? Is this the right voicing? Am I wasting my time?" The musician needs to trust the process before they can see the results, but trust without evidence is hard to sustain.
 
 ---
 
-## 2. Research Foundation
+## What Intrada Does
 
-Intrada's design is grounded in well-established findings from cognitive psychology, motor learning, and music education research. This section summarises the key principles that inform every feature decision, including honest acknowledgement of where the evidence is strong and where it is more nuanced.
+Intrada is where a musician's practice material lives and where their daily practice plan comes from. It captures what you need to work on, organises it so you can find it, schedules it so you revisit things at the right time, and tracks your progress so you can see that the work is paying off.
 
-### 2.1 Spaced Repetition
+### Five Layers
 
-The spacing effect is one of the most robust findings in learning science. Material reviewed at increasing intervals is retained far more effectively than material crammed in a single session. A meta-analysis by Donovan & Radosevich (1999) across 63 studies with 112 effect sizes found an overall mean weighted effect size of d=0.46, indicating that spaced practice conditions significantly outperform massed practice conditions. A more recent meta-analysis by Cepeda et al. (2006), reviewing 317 experiments across 184 articles, confirmed the spacing benefit and found that the optimal spacing interval increases as the desired retention interval increases.
+These build on each other. You can't schedule what you haven't captured, you can't space what you haven't scheduled, and you can't show progress on what you haven't tracked.
 
-**Important nuance for music:** Donovan & Radosevich also found that the spacing effect is moderated by task complexity — more complex tasks benefit less from distributed practice than simpler ones. Musical skill acquisition involves complex motor coordination, and Simmons (2012) found no spacing effect when teaching a 17-note piano sequence to novices, suggesting that the effect "may not always be demonstrable for complex motor skills." However, Moss (1995), reviewing 120 articles, found spacing improved learning of motor skills in over 80% of studies reviewed. The weight of evidence supports spacing for music, but Intrada's scheduling algorithm should be understood as leveraging a *general principle with strong support* rather than a precisely calibrated system proven specifically for instrument practice.
+**1. Capture and remember.** Every exercise, piece, voicing pattern, scale, lick, and technique lives in Intrada — structured, searchable, and connected to its context. When your teacher introduces ii-V-I progressions in a new voicing, you capture it once and the app knows it's an exercise that spans twelve keys. Your practice notes are searchable across your entire history. Nothing gets lost in a notebook.
 
-> **Citation note:** Moss (1995) is an unpublished review cited secondarily via Firth et al. (2023). The specific "120 articles" and "80%+" claims cannot be independently verified from the primary source. The broader claim — that spacing benefits motor skills — is well-supported by published meta-analyses, but this specific citation should be treated with caution.
+**2. Plan what to do today.** Given your available time and your library of material, Intrada generates a practice session. You sit down, tap start, and play. The app absorbs the decision-making burden — you always *can* choose what to work on, but you never *have to*. A 15-minute session gets a focused selection; a 60-minute session gets a broader one. The path from "I want to practise" to "I am practising" requires one decision: start.
 
-Intrada applies this by tracking when each item was last practised and scheduling reviews at increasing intervals based on the musician's self-rated mastery, while remaining tuneable as we learn more about how spacing interacts with musical skill retention.
+**3. Space it for retention.** Intrada schedules returns to material at intervals optimised for long-term retention, not just coverage. Items you're learning surface frequently; items you've consolidated appear less often but before you've forgotten them. The app manages the spacing so you don't have to — and so exercises from six weeks ago don't silently decay while you focus on this week's assignment. This is grounded in decades of research on spaced repetition and interleaved practice.
 
-### 2.2 Interleaved Practice
+**4. Show that it's working.** Progress in music is real but gradual. Intrada makes it visible. Mastery ratings per item, per key, and per tempo accumulate over weeks and months into evidence you can see: "Your Db mastery went from 2 to 4 over the last three weeks." This isn't gamification — it's the external confirmation that the process is working, delivered before you can feel it yourself. It turns weeks of invisible improvement into daily visible signals.
 
-Carter & Grahn (2016) compared blocked and interleaved practice schedules with advanced clarinetists (n=10) in an ecologically valid practice environment. Whenever there was a ratings difference between conditions, pieces practised in the interleaved schedule were rated higher by expert assessors, though results varied across raters. Participant questionnaires revealed that interleaved practice had positive effects on goal setting, focus, and mistake identification. Notably, while 6 of 10 participants found the interleaved schedule more useful, the majority still preferred the blocked schedule — consistent with a well-documented phenomenon where blocked practice feels more productive despite producing inferior retention.
-
-This "contextual interference effect" has broader support in motor skill learning research (Shea & Morgan, 1979; Magill & Hall, 1990), though results in music specifically are mixed. Stambaugh (2009) found interleaving benefits for beginner clarinetists, but Stambaugh & Demorest (2010) found no effect for technical accuracy in intermediate students. A more recent study by Mathias & Goldman (2025) with violinists explored increasing contextual interference within sessions, suggesting that a gradual shift from blocked to interleaved practice within a session may be optimal.
-
-**Design implication:** Because musicians tend to resist interleaving despite its benefits, Intrada provides a user-facing interleaving intensity preference — from "gentle mixing" (similar items grouped loosely) through to "full interleave" (maximum variety between consecutive items). This respects autonomy (SDT) while nudging toward evidence-based scheduling. The Mathias & Goldman finding also informs session structure: sessions can begin with more similar items and increase variety as the session progresses, easing the transition for musicians unfamiliar with interleaved practice.
-
-### 2.3 Deliberate Practice
-
-Ericsson, Krampe & Tesch-Römer (1993) introduced the deliberate practice framework, proposing that expert performance is the result of prolonged, focused, effortful practice designed to improve specific aspects of performance. Their original study with violinists at a Berlin music academy found that the best violinists had accumulated significantly more solitary practice hours than less accomplished peers by age 20. This work has been enormously influential across domains.
-
-However, the evidence base has been refined considerably since 1993. A meta-analysis by Macnamara, Hambrick & Oswald (2014) found that deliberate practice explained only about 21% of variance in music performance — substantial and practically meaningful, but far from the "sufficient account" Ericsson originally claimed. A direct replication by Macnamara & Maitra (2019), using improved double-blind methodology, found the effect was "substantial, but considerably smaller than the original study's effect size," explaining about 26% of performance variance. They also found that practice designed by the performers themselves was perceived as more relevant to improvement than teacher-designed practice.
-
-What remains well-supported is the *qualitative* aspect of deliberate practice: that focused attention on specific goals, working at the edge of one's ability, and incorporating feedback leads to better outcomes than mindless repetition. Ambrose et al. (2010) synthesise this broader evidence, emphasising that a feedback-correction cycle — practising, evaluating, adjusting — is central to effective skill development.
-
-Ericsson's original framework also emphasised that deliberate practice is effortful and requires recovery. This has implications for Intrada's design: the app should not only structure practice but also support appropriate rest, flagging when a musician's practice volume significantly exceeds their historical average or recommended thresholds.
-
-Intrada supports deliberate practice by prompting musicians to set specific goals for each practice item, rate their performance honestly, and reflect on what improved and what didn't. It does not claim that practice quantity alone determines outcomes, but that practice *quality* matters enormously.
-
-### 2.4 Self-Determination Theory (SDT)
-
-Ryan & Deci's SDT framework identifies three basic psychological needs that sustain motivation: autonomy (feeling in control of one's actions), competence (feeling effective and capable), and relatedness (feeling connected to others). Evans & Bonneville-Roussy (2016) found that university music students' autonomous motivation predicted both the frequency of practice and the proportion of practice sessions reported as highly productive.
-
-Crucially for Intrada's design, Valenzuela, Codina & Pestana (2018) investigated SDT in the context of conservatoire instrument practice (N=162) and found that perceived competence was the strongest predictor of flow variations during practice. Autonomous motivation had a direct positive effect on flow, while controlled motivation had an inverse effect. This has direct implications: visible progress and evidence of improvement feed the sense of competence that sustains motivation and flow states.
-
-More recent work by Bonneville-Roussy & Evans (2024), studying 213 university music students across the UK and Canada, found that teacher autonomy support predicted autonomous motivation, which in turn predicted both practice time and practice quality. This reinforces the importance of autonomy-supportive design — Intrada should suggest and support, not dictate.
-
-Intrada supports autonomy through user-driven goal setting and flexible practice design; competence through granular progress tracking and evidence of growth; and encouragement through positive, process-focused messaging.
-
-### 2.5 Growth Mindset & Process Trust
-
-Dweck's implicit theories framework (Dweck, 2006) distinguishes between a growth mindset (the belief that abilities can be developed through effort and learning) and a fixed mindset (the belief that abilities are innate and unchangeable). In educational contexts, Blackwell, Trzesniewski & Dweck (2007) found that students with a growth mindset outperformed fixed-mindset peers over time, even when controlling for initial achievement levels. Music is a domain where fixed-mindset beliefs about "talent" are particularly prevalent (O'Neill, 2002).
-
-The growth mindset literature has faced legitimate scrutiny. A meta-analysis by Sisk et al. (2018) found that mindset interventions had only weak effects on academic achievement overall, though effects were larger for academically at-risk students. Dweck & Yeager (2019) responded by clarifying that mindset interventions are most effective when they are sustained and embedded in supportive contexts, rather than delivered as one-off treatments.
-
-For Intrada, the relevant takeaway is not that a brief mindset intervention will transform practice, but that the *design of the tool itself* can reinforce growth-oriented beliefs. Progress visualisations provide objective evidence that effort leads to improvement. Process-focused encouragement tied to specific data points ("Your Db mastery went from 2 to 4 over three weeks") provides the kind of effort-linked feedback that Dweck's research associates with adaptive motivation.
-
-**Design implication for consistency tracking:** Growth mindset research also informs how Intrada handles practice gaps. Rather than streak-based tracking that creates anxiety around breaking a streak (and can trigger shame-driven avoidance, particularly in musicians with ADHD), Intrada uses "comeback" framing that emphasises the return rather than the gap. "You've practised 4 of the last 7 days — that's great spacing for retention" rather than "5 day streak — don't break it!"
-
-> **Assumption:** The claim that streak-based tracking causes anxiety and avoidance is a design hypothesis, not a research-proven finding. While there is general psychology research on shame-avoidance cycles and ADHD emotional dysregulation (Barkley, 2015), no published study directly compares streak-based versus comeback-based practice tracking in music apps. The design choice is informed by SDT principles (autonomy support) and anecdotal practitioner experience with apps like Duolingo (whose own research has shown streaks drive retention but at the cost of some anxiety). This is a reasonable design decision but should not be presented as research-proven.
-
-### 2.6 Retrieval Practice
-
-An emerging area of relevance is retrieval practice — the finding that actively recalling information produces better long-term retention than passive review. While extensively studied in verbal learning, Wellmann & Skillicorn (2024) recently proposed the first systematic application of retrieval practice to jazz performance education, noting that its benefits should extend to music learning given that the underlying memory mechanisms are domain-general. They recommend spaced retrieval schedules with intervals of at least 24 hours between practice sessions of the same material for optimal retention.
-
-This supports Intrada's scheduling approach: rather than letting musicians repeatedly drill the same material in a single session, the app encourages returning to material across sessions, leveraging both spacing and retrieval effects.
-
-> **Open question:** Wellmann & Skillicorn's proposal is theoretical — they argue retrieval practice *should* benefit music learning based on domain-general memory mechanisms, but this has not been empirically tested in a music practice context. The underlying principle is sound (retrieval practice benefits are among the most replicated findings in cognitive psychology), but the specific transfer to complex motor skills with a musical-expressive component remains an assumption.
-
-### 2.7 Neurodiversity & Music Practice
-
-Research at the intersection of ADHD and music reveals both specific challenges and important strengths that inform Intrada's design.
-
-**Executive function and task initiation.** ADHD involves deficits in task initiation, planning, organisation, and working memory (Barkley, 2015). Starting a practice session is often harder than sustaining one — the ADHD brain struggles with the transition from "thinking about practising" to "actually practising." Every decision point before playing begins is an opportunity for the ADHD brain to stall. This has direct implications for interaction design: the path from opening the app to playing should involve as few decisions as possible.
-
-**Time blindness.** ADHD involves a disrupted sense of time passing (Ptacek et al., 2019). Musicians with ADHD may vastly underestimate or overestimate how long they've been practising, lose track of time during hyperfocused work on one item (neglecting others), or struggle to pace a practice session. This is distinct from poor time management — it's a perceptual deficit that external time cues can help mitigate.
-
-**Hyperfocus paradox.** ADHD brains can enter hyperfocus states on engaging tasks, which for musicians might mean spending 45 minutes on one satisfying piece while neglecting the scale work that actually needs attention. The interleaved scheduling in Intrada is potentially therapeutic here — it externally structures what the ADHD brain struggles to self-regulate.
-
-**Emotional dysregulation.** Frustration tolerance is often lower in ADHD. A practice session that repeatedly surfaces difficult material without any sense of progress can trigger emotional shutdown. Encouragement and visible progress features are not motivational niceties — for ADHD musicians, they may be the difference between sustained engagement and abandonment.
-
-**Music-specific findings.** Research identifies timing deficits in ADHD, including difficulties with beat tracking and processing short time intervals (Puyjarinet et al., 2017; Serrallach et al., 2022). However, these deficits do not extend to improvisation and musical expression (Grob et al., 2022), and Wilde & Welch (2022) found that ADHD behaviours were often *absent* during active music-making. Raz (2025) found that musicians with ADHD showed enhanced cognitive abilities compared to non-musician ADHD peers, including better sustained attention and impulse control. This suggests that the practice session itself may be less affected than the surrounding executive function demands — deciding what to practise, starting, transitioning between items, and stopping.
-
-**Broader neurodiversity.** Beyond ADHD, sensory processing differences (common in autism), dyslexia (affecting 10–15% of the population), and other cognitive variations all influence how musicians interact with a practice tool. Design principles that support neurodivergent users — reduced visual clutter, predictable navigation, configurable feedback, accessible typography — benefit every user.
-
-### 2.8 The Feedback Loop Problem & Self-Taught Learning
-
-The feedback loop problem identified in Section 1.1 is not just a motivational challenge — it connects to a well-documented set of failure modes in self-directed practice and explains why teacher guidance is so effective.
-
-#### What teachers actually do
-
-Effective music teaching is not primarily about demonstrating technique. Duke (2005) describes the core teacher functions as: **diagnose** (identify what specifically is going wrong), **decompose** (break complex skills into manageable sub-skills), **sequence** (order learning steps appropriately), and **regulate** (monitor progress and adjust the plan). These functions are forms of metacognition that expert musicians have internalised but that developing musicians typically lack (Hallam, 2001).
-
-Bonneville-Roussy & Evans (2024) found that teacher autonomy support predicted autonomous motivation, which in turn predicted both practice time and quality. Critically, Macnamara & Maitra (2019) found that self-designed practice was perceived as more relevant than teacher-designed practice. These are not contradictory: the ideal is a teacher who helps the musician develop their own practice intelligence, not one who dictates every session.
-
-#### Self-taught failure modes
-
-Without the diagnostic and regulatory functions a teacher provides, self-directed musicians exhibit predictable failure patterns:
-
-- **Inability to self-diagnose** — Musicians cannot hear their own errors with the objectivity of an external listener. They often misidentify what is going wrong, leading to practice strategies that address the wrong problem (Hallam, 2001).
-- **Repetition without variation** — The instinct to "just play it again" without changing approach is one of the most common and least productive practice strategies. Duke, Simmons & Cash (2009) found that what distinguished the top performers in learning a new passage was not how much they practised, but how they practised — specifically, they varied tempo systematically, targeted error sections rather than restarting from the beginning, and practised the passage in overlapping segments.
-- **Avoidance of difficult material** — Self-directed musicians gravitate toward material they can already play, spending disproportionate time on comfortable repertoire and avoiding the uncomfortable edge where learning happens (Renwick & McPherson, 2002).
-- **Wrong difficulty level** — Without external calibration, musicians frequently attempt material that is either too easy (leading to boredom) or too hard (leading to frustration). Wilson et al.'s (2019) 85% Rule suggests that optimal learning occurs at roughly 85% accuracy — one error per six attempts — but self-taught musicians have no way to objectively assess where they sit on this continuum.
-- **Poor session structure** — Without external scaffolding, practice sessions tend to lack warm-up, spend too long on single items, and end without consolidation or reflection. This contrasts with the deliberate practice framework's emphasis on structured, goal-directed work (Ericsson et al., 1993).
-- **No stopping rules** — Musicians without guidance either stop too early (abandoning an item after the first successful attempt, before overlearning consolidates the skill) or stop too late (drilling past the point of diminishing returns, risking both injury and encoding of fatigue-related errors).
-
-#### Motor consolidation: why progress is invisible
-
-The biological basis for the delayed feedback loop is motor memory consolidation. Walker & Stickgold (2004) demonstrated that motor skill performance improves 20–26% following a night of sleep, with no additional practice. Brashers-Krug, Shadmehr & Bizzi (1996) showed that motor memories require several hours to consolidate and are vulnerable to interference during this window.
-
-This means a musician can practise a passage, feel like they made no progress, go to sleep, and return the next day measurably better — but they will attribute the improvement to the new session's practice rather than the previous day's. The subjective experience is: "I practised yesterday and it didn't help; today it suddenly clicked." Without data to show the trajectory, the musician's narrative becomes "I'm not improving" even when they objectively are.
-
-> **This is Intrada's core design opportunity.** By tracking mastery ratings, tempo progress, and practice patterns over time, the app can surface evidence of improvement that the musician cannot yet perceive. "Your average mastery score for this piece has gone from 2.3 to 3.1 over the past two weeks" is the kind of signal that turns invisible progress into visible evidence — shrinking the feedback loop from weeks to days.
-
-#### What this means for Intrada
-
-Intrada cannot replicate all teacher functions — it cannot listen to a musician play and diagnose tonal issues or suggest a different fingering. But it can address the *structural* functions that teachers provide:
-
-| Teacher function | How Intrada addresses it |
-|-----------------|-------------------------|
-| **Diagnose** | Data patterns surface what the musician cannot self-diagnose — persistent weak keys, plateau detection, effort/progress mismatches |
-| **Decompose** | Key-aware exercise management and section-level tracking break complex goals into measurable sub-skills |
-| **Sequence** | Smart scheduling orders practice material based on evidence (spacing, interleaving, goal alignment) rather than impulse |
-| **Regulate** | Progress visualisation and session analytics provide the external monitoring that self-taught musicians lack |
-
-> **Open question:** The extent to which a software tool can meaningfully replicate teacher regulatory functions is untested. The hypothesis is promising — data-driven feedback and intelligent scheduling address the *information* gap in self-taught practice — but whether this translates to improved outcomes compared to unstructured self-teaching is an empirical question that Intrada's data could help answer over time.
-
-> **Assumption:** The self-taught failure modes listed above are drawn from research on music students in educational contexts (typically school-age or conservatoire students). Whether adult self-directed learners — who form a significant portion of Intrada's target audience — exhibit the same patterns is assumed but not specifically validated. Adult learners may have better metacognitive abilities from other domains, or they may have different failure modes entirely.
-
-### 2.9 The Choice Overload Problem & Guided Learning
-
-Learning a musical instrument is one of the most daunting undertakings an adult can attempt. The amount of material is effectively infinite: twelve keys, multiple scale types, chord voicings, arpeggios, ornaments, rhythmic patterns, stylistic conventions, repertoire — and that's before considering that each musical tradition has its own vocabulary. The internet has made access to this material trivially easy, but access is not the same as curation. The self-taught musician faces what Schwartz (2004) calls the "paradox of choice" — more options don't lead to better decisions; they lead to worse ones, or no decision at all.
-
-#### Choice is only motivating when you know how to choose
-
-The relationship between choice and motivation is not linear. Patall, Cooper & Robinson (2008) found in a meta-analysis that providing choice generally enhances intrinsic motivation — but the effect diminishes or reverses when choices become too numerous or complex. Katz & Assor (2007) showed that choice is only motivating when learners have the competence and knowledge to make meaningful choices. When they don't, choice becomes a burden.
-
-This is directly relevant to music practice. A musician who has been playing for ten years knows instinctively that their Db major scale needs work, that they should practise their weak chord voicings before a gig, and that the bridge of their new piece needs isolated attention. A musician at the boundary of their knowledge — whether a beginner or an experienced player moving into a new style — has no basis for these decisions. They face a blank page and an infinite menu.
-
-#### The critical path problem
-
-In software engineering, the "critical path" is the minimum sequence of tasks that determines the total time to project completion. Music learning has an analogous structure: for any specific goal, there is a subset of material that matters most and a sequence in which it should be learned. You don't need to practise scales in every key over two octaves before you can learn a specific piece — you need the keys that piece uses, the techniques it demands, and the supporting exercises that build those specific skills.
-
-Good teachers identify this critical path instinctively. They look at where the student is, where they want to go, and draw the shortest line between the two — filtering out the 90% of possible material that, while valuable in the abstract, isn't relevant to the current goal. This is the *sequencing* function from Section 2.8, but viewed through the lens of what to *exclude* rather than what to include.
-
-Research on guided versus unguided learning strongly supports this filtering function. Kirschner, Sweller & Clark (2006) argued that minimal guidance during instruction does not work, particularly for novices, because unguided approaches impose excessive cognitive load — the learner spends cognitive resources on deciding what to do rather than actually doing it. Mayer (2004) reviewed decades of evidence and concluded that guided instruction consistently outperforms pure discovery learning. Alfieri et al. (2011) found in a meta-analysis that unassisted discovery rarely benefits learners, but *guided* discovery — with scaffolding, feedback, and structure — outperforms both unguided discovery and rote instruction.
-
-#### Learning how to learn
-
-The meta-skill that separates effective from ineffective practice is metacognition — the ability to monitor, evaluate, and direct one's own learning. Hallam (2001) studied how practice strategies develop with expertise and found that novices tend to play through entire pieces start-to-finish, while experts identify specific problem areas and deploy targeted strategies. The difference is not just skill — it's knowledge about *how to practise*.
-
-This metacognitive development is slow. McPherson & Renwick (2001) found in a longitudinal study that children's ability to self-regulate their practice — including choosing what to work on — develops gradually and is a major differentiator in outcomes. Williamon & Valentine (2000) showed that practice quality (including strategic decision-making about what to practise) is a stronger predictor of performance quality than practice quantity.
-
-The implication for Intrada is significant: the app should not just provide material and scheduling, but should actively teach musicians *how to learn*. Every intelligent scheduling decision the app makes is an implicit lesson in practice design. Over time, the musician should internalise these patterns — understanding why the app surfaces certain items, why it interleaves different material types, why it prioritises some keys over others — and develop their own metacognitive skills.
-
-> **Assumption:** The claim that Intrada can develop musicians' metacognitive skills through example (implicit modelling via scheduling decisions) is a design hypothesis, not an established finding. Explicit metacognitive instruction has strong research support (Hallam, 2001; McPherson & Zimmerman, 2002), but whether passive exposure to intelligent scheduling transfers metacognitive skills is untested. This is an area where user research could inform whether explicit "here's why I scheduled this" explanations accelerate learning.
-
-#### What this means for Intrada
-
-The choice overload problem reinforces three design principles:
-
-1. **Default to guidance.** The app should always have an answer to "what should I practise?" — not a menu of everything the musician *could* do, but a curated recommendation of what they *should* do right now, given their goals and current state. The one-tap session start (Section 4.2) is the primary expression of this principle.
-2. **Goal-driven filtering.** When a musician sets a goal ("learn this piece by March," "get comfortable improvising over ii-V-I progressions"), the library and scheduler should filter aggressively — surfacing only the material that serves that goal and deprioritising everything else. The musician can always explore beyond the recommendation, but the default path is focused.
-3. **Progressive disclosure.** The full breadth of what could be practised should be available but not presented up front. A musician starting a new exercise sees the keys they need now, not all twelve. As they master the immediate set, the app reveals the next layer. This mirrors the scaffolding approach (Wood, Bruner & Ross, 1976) — support is removed gradually as competence develops.
-
-### 2.10 Goal-Specific Pathways: From Aspiration to Curriculum
-
-The critical path principle (Section 2.9) identifies what musicians need — a focused, well-sequenced subset of material rather than the full universe of what could be practised. But the principle alone doesn't answer the most concrete and important question a musician can ask: **"I want to play *this* — how do I get there?"**
-
-"I want to play Claire de Lune — where do I even start?" "I want to improvise like Bill Evans — what do I actually need to learn?" These are not scheduling problems or motivation problems. They are curriculum design problems — and they are precisely what good teachers solve, often instinctively, in the first lesson after a student names their goal.
-
-#### Backward design: start with the destination
-
-Wiggins & McTighe (2005) formalised "backward design" in education: begin with the desired outcome, determine what evidence would demonstrate mastery, then design the learning experiences that lead there. This inverts the traditional approach of starting with available content and hoping it leads somewhere useful.
-
-Applied to music, backward design means: a pianist whose goal is to play Debussy's *Claire de Lune* doesn't need a generic piano curriculum. They need the specific skills that piece demands — reading fluency in Db major, control of soft dynamics, pedal technique for sustained resonance, independence of inner voices, rhythmic flexibility for rubato — and a sequence that builds those skills from wherever the musician currently stands. The pathway is goal-specific, not instrument-generic.
-
-#### Prerequisite hierarchies in music
-
-Musical skills form natural hierarchies where complex abilities depend on simpler foundations. Gagné (1985) described how instruction should ensure prerequisite skills are in place before higher-order skills are attempted. Gordon (2007) developed this into a detailed sequential framework specific to music — progressing through aural/oral skills, verbal association, partial synthesis, symbolic association, and composite synthesis — with each stage building on the last.
-
-Every target piece or skill can be decomposed into prerequisite chains. To improvise over jazz standards, a musician needs: functional harmony, voice leading, scale-chord relationships, rhythmic vocabulary, and the ear training to hear chord changes in real time — each of which has its own prerequisites. To play a Chopin nocturne, they need: reading fluency in the relevant keys, chord voicing technique, dynamic control at soft volumes, pedal management, and melodic projection above accompaniment texture. Each of these connects to specific, proven exercises and studies that generations of teachers have refined.
-
-Graded examination systems — ABRSM, the Royal Conservatory, Trinity College London — encode these hierarchies into structured syllabi. The Suzuki method (Suzuki, 1969) builds prerequisite chains directly into its carefully sequenced repertoire, with each piece introducing skills needed for the next. These systems have demonstrated the value of sequenced learning over more than a century of use. Their limitation is that they define a single generic path for all learners of an instrument, regardless of individual goals or starting points.
-
-#### Material within the zone of proximal development
-
-Vygotsky (1978) described the "zone of proximal development" (ZPD) — the gap between what a learner can do independently and what they can achieve with appropriate guidance. Material within this zone is optimally challenging: difficult enough to promote learning, approachable enough to avoid frustration. Lehmann, Sloboda & Woody (2007) apply this directly to music, arguing that effective skill acquisition requires material calibrated to the learner's current level.
-
-A well-designed pathway keeps every step within the musician's ZPD. Each exercise, study, or piece should build on mastered prerequisites and stretch toward the next milestone. This is what distinguishes a pathway from a reading list: it is sequenced for the individual learner, not ordered by publishing convention.
-
-#### Adaptive pathways through knowledge tracing
-
-Static curricula — even well-designed ones — cannot adapt to the individual. Two musicians with the same goal but different starting points, learning speeds, and strengths need different paths. Corbett & Anderson (1995) developed "knowledge tracing," a Bayesian model that estimates learner mastery of individual skills based on their response history. This approach underlies modern adaptive learning platforms and is directly applicable to music: by tracking mastery of individual skills (keys, techniques, reading fluency, chord progressions), the system can infer which prerequisites are met and which pathway steps need attention.
-
-The result is a pathway that adjusts as the musician progresses — skipping what they already know, spending more time where they struggle, and revealing new material only when the foundation is solid. This is progressive disclosure (Section 2.9) applied at the curriculum level.
-
-> **Assumption:** The claim that prerequisite relationships between musical skills can be reliably modelled and automatically sequenced is a design hypothesis. Music pedagogy involves significant tacit knowledge — experienced teachers make sequencing decisions based on intuitions about student readiness that may not reduce to measurable prerequisites. Initial pathways will likely need expert curation (informed by established pedagogical traditions), with adaptive personalisation layered on top as the system accumulates data. Teacher integration (Section 4.9) could provide invaluable input here.
-
-#### What this means for Intrada
-
-Guided pathways are the feature that turns Intrada from a practice *tracker* into a practice *companion*. They answer the question every self-directed musician asks: *"I want to do this — how do I get there?"*
-
-1. **Goal as entry point.** When a musician sets an aspiration — a target piece, a skill to develop, a style to explore — the app generates a pathway: a sequenced set of exercises, studies, and sub-skills that leads from where they are now to that goal.
-2. **Concrete, proven material.** Pathways recommend specific exercises and studies with established pedagogical value — the material a teacher would actually assign. Czerny studies for finger independence, Hanon for evenness, Aebersold patterns for jazz vocabulary, Bach chorales for voice leading. The app connects aspiration to actionable daily practice.
-3. **Visible progress through the pathway.** Each step has measurable criteria (mastery rating, tempo target, key coverage). The musician can see where they are in the journey — not just "am I practising?" but "am I getting closer to my goal?" This is the feedback loop principle (Section 1.1) applied at the curriculum level.
-4. **Adaptive pacing.** The pathway adjusts based on actual progress. A musician who masters a prerequisite quickly moves on; one who struggles stays until the foundation is solid. The app doesn't judge pace — it adapts to it.
+**5. Identify gaps and guide what's next.** Over time, Intrada gets smarter. It surfaces patterns you can't see yourself — "You consistently struggle with keys that have four or more flats" or "You spend most of your time on pieces and almost none on the keys you rated lowest." Initially this comes from your practice data alone. Later, it extends to suggesting specific exercises to address weaknesses and generating practice pathways toward goals — the kind of curriculum guidance that a teacher provides instinctively.
 
 ---
 
-## 3. Product Pillars
+## Who It's For
 
-These six pillars organise Intrada's feature set. Each pillar maps directly to the research foundation and addresses a specific user need.
+Intrada is for self-directed musicians who are past the beginner stage and serious about improvement. The common thread is a desire to practise more effectively, not just more.
 
-| Pillar | What It Does | Research Basis |
-|--------|-------------|----------------|
-| **Library & Organisation** | Manage pieces, exercises, and techniques. Group items by key, genre, or goal. Auto-generate key variations for exercises. | Reduces cognitive load so musicians focus on playing, not admin |
-| **Smart Scheduling** | Algorithmically generate practice setlists using spaced repetition intervals and interleaved ordering. | Spacing effect (Donovan & Radosevich, 1999; Cepeda et al., 2006); Contextual interference (Carter & Grahn, 2016; Shea & Morgan, 1979) |
-| **Intentional Practice** | Prompt goal-setting per item, encourage reflection after each session, support deliberate engagement. | Deliberate practice (Ericsson et al., 1993; Macnamara et al., 2014); Feedback-correction cycle (Ambrose et al., 2010) |
-| **Metric-Based Progression** | Track mastery scores per key/passage/tempo. Log improvement over time with fine granularity. | Perceived competence predicts flow (Valenzuela et al., 2018); SDT competence need (Ryan & Deci, 2000) |
-| **Progress Visualisation** | Charts, heatmaps, and dashboards showing improvement trends, consistency, and coverage gaps. | Growth mindset (Dweck, 2006; Blackwell et al., 2007); SDT competence; Process trust |
-| **Encouragement & Goals** | Goal-setting framework. Positive, process-focused messaging. Celebration of consistency over perfection. | SDT autonomy and competence (Evans & Bonneville-Roussy, 2016; Bonneville-Roussy & Evans, 2024); Growth mindset |
+This includes musicians working with a teacher who need a structured place to capture assignments and manage the growing library of material between lessons. It includes self-taught musicians who lack the external structure a teacher provides. It includes adult returners who are rebuilding skills after a gap and need evidence that progress is real. It includes anyone preparing for graded exams, auditions, or performance.
+
+Intrada is instrument-agnostic but designed from a keyboard and jazz perspective first — where exercises multiply across twelve keys and the volume of material is especially overwhelming.
+
+### Musician Tracks — Entry Points, Not Boxes
+
+Musicians come to Intrada with different motivations: some want mastery through deliberate practice, some want to learn one piece to play at a party, some are returning to an instrument after years away. Intrada recognises these different starting points through *tracks* — not rigid categories, but lenses that shape onboarding, default suggestions, analytics framing, and encouragement tone.
+
+Tracks are fluid. A Late Starter who gains confidence becomes a Jammer. A Virtuoso who burns out becomes a Soul Player. The app never frames a change as failure — it adapts, and the musician's complete history travels with them.
+
+> **Note:** The specific tracks (Entertainer, Jammer, Virtuoso Classical/Jazz, Soul Player, Late Starter) are a design hypothesis, not validated categories. The underlying principle — that different motivations should shape the experience — is well-supported. The specific categories will be refined against real user data. See the [Research Foundation](docs/research-foundation.md) for the SDT basis.
 
 ---
 
-## 4. Feature Detail
+## Core Principles
 
-### 4.1 Library & Organisation
+### Progress Is the Product
 
-The library is the foundation of Intrada. Musicians add pieces, exercises, scales, licks, etudes, and any other practice material. Each item has metadata including instrument, genre/style tags, difficulty level, effort level, and tempo targets.
+The primary value Intrada delivers is the feeling of making progress. Every feature should either enable progress or make it visible. If a feature doesn't serve one of those functions, it doesn't belong.
 
-#### Key-Aware Grouping
+### Simplicity Over Features
 
-A distinguishing feature of Intrada is key-aware exercise management. When a musician adds a jazz lick or chord progression exercise, they can specify that it should be practised in all 12 keys (or a subset). Intrada automatically generates 12 sub-items grouped under the parent exercise, each tracking mastery independently. This is essential for jazz musicians working on ii-V-I progressions, blues heads, or chord voicings, and for classical musicians working through technical exercises in all keys.
+Every interaction should feel lightweight. If logging a practice session takes more than 30 seconds, it's too slow. Musicians will abandon tools that feel like work. The app stays out of the way during practice and does its thinking before and after.
 
-The musician sees the parent exercise as a single library item, but can drill into per-key progress. The smart scheduler treats each key as a separate scheduling unit, so weaker keys surface more frequently.
+### One Tap to Start
 
-#### Item Types
+Every decision point between "I want to practise" and "I am practising" is a potential session-ending barrier — particularly for musicians with executive function challenges. The default path requires one decision: tap start. Everything else is optional.
 
-- **Pieces** — repertoire with sections/passages as sub-items
-- **Exercises** — technical studies, scales, arpeggios, patterns
-- **Licks/Vocabulary** — jazz vocabulary items, typically practised across keys
-- **Technique** — specific technical goals (e.g. left hand independence, pedalling)
+### Celebrate Comeback, Not Streak
 
-#### Warm-Up Routines & Templates
+Intrada never shows a broken streak counter or a zero. It celebrates returns: "Welcome back — your scheduling has adapted and we've got a session ready." Consistency matters, but the framing determines whether it motivates or shames.
 
-Many musicians have consistent warm-up routines (long tones, scales in a particular pattern, Hanon exercises, etc.). Intrada supports reusable "routines" — a saved sequence of items that can be inserted as a block into any practice session. This reduces daily decision-making, supports consistency, and is particularly valuable for musicians who struggle with session initiation.
+### No Journey Is Linear
 
-#### Searchable Practice Notes
+Musicians plateau, change direction, take breaks, restart, and redefine what they want from their instrument. Intrada normalises all of this. Taking a break is not quitting. Choosing enjoyment over mastery is not giving up. Coming back after six months is not starting over.
 
-All practice notes and reflections are full-text searchable across the entire history. A musician who can search "left hand" across all their practice notes and see every session where they noted left-hand difficulties gets a longitudinal view of a persistent challenge. This supports the self-awareness and metacognition that characterise effective practicers (Hallam, 2001).
+### Designed for Every Mind
 
-### 4.2 Smart Practice Scheduling
+Designing for neurodivergent musicians isn't a separate workstream — it's embedded in Intrada's core design. Reducing decisions to start, externalising time, celebrating comeback over streak, and supporting variable session lengths all stem from this principle. These features benefit every musician, but they're essential for musicians with ADHD, who are likely a meaningful portion of the audience.
 
-The scheduler is Intrada's core intelligence. Given a musician's available practice time and their library, it generates an optimal practice setlist.
-
-#### Scheduling Algorithm
-
-The algorithm combines four factors. First, **spaced repetition urgency**: items whose review is overdue based on their mastery level and time since last practice are prioritised. The spacing intervals follow a modified SM-2 algorithm adapted for musical skill learning, with parameters that should be validated against user data over time (see Section 2.1 on the nuances of spacing for motor skills).
-
-> **Assumption:** SM-2 was designed for verbal flashcard learning (Wozniak, 1987) and its interval growth parameters are calibrated for declarative memory retention. Musical skill learning involves procedural/motor memory with different consolidation dynamics (Walker & Stickgold, 2004). No published research validates SM-2 parameters for motor skill scheduling. Intrada's initial parameters are informed guesses that must be refined empirically through user data. This is a known unknown, not a solved problem. Second, **interleaving**: the generated setlist alternates between different types of material (e.g. scale work, then a piece passage, then a lick in a new key) rather than grouping similar items together, with the degree of interleaving adjustable by the musician. Third, **goal alignment**: items tagged as relevant to the musician's current goals receive a priority boost. Fourth, **difficulty balancing**: the session balances effort across its duration, front-loading demanding work when focus is fresh and tapering toward lighter review material, avoiding sequences of multiple high-effort items back-to-back.
-
-The Donovan & Radosevich (1999) finding that task complexity moderates the spacing effect informs the algorithm: items tagged as "high effort" may receive different scheduling parameters (shorter intervals) than "maintenance" items.
-
-#### Session Structure
-
-A generated practice session includes warm-up items (drawn from saved routines or algorithmically selected), focused work items (the core of the session), and review/consolidation items. Each item has a suggested time allocation. The musician can accept the suggested session, swap items, or adjust time allocations — maintaining autonomy while benefiting from intelligent scheduling. This flexibility is a deliberate design choice informed by SDT: the musician stays in control (Bonneville-Roussy & Evans, 2024).
-
-#### One-Tap Session Start
-
-The default interaction when opening Intrada is a ready-to-go session with a prominent "Start" button. No configuration required. The app has already decided what to practise based on the scheduling algorithm — the musician just has to begin. This directly addresses task initiation difficulty (Barkley, 2015) and reduces cognitive overhead for all users. The musician can always choose to modify the session, but the default path is zero-decision start.
-
-This is also the primary expression of the critical path principle (Section 2.9). The generated session is not a random selection from the library — it is a curated, goal-aware recommendation that answers the question every musician silently asks when they sit down: "what should I work on?" By absorbing the decision-making burden, the app eliminates the blank-page problem that derails practice before it begins (see Katz & Assor, 2007 on choice as burden for learners without domain knowledge to choose meaningfully).
-
-#### Short Session Support
-
-Intrada prominently offers short session options: 10, 15, 20, and 30 minutes alongside longer options. A 15-minute practice session using spaced repetition and interleaving is genuinely valuable — the spacing research shows that shorter, more frequent sessions often outperform longer, less frequent ones. Framing short sessions as legitimate and effective, rather than as "not enough," is both evidence-based and inclusive.
-
-### 4.3 Intentional Practice Mode
-
-When a musician starts practising an item, Intrada prompts them to set a micro-goal: what specifically will they focus on? This could be accuracy, evenness, dynamics, tempo, or any user-defined focus area. After the practice block, they rate their performance and note what improved and what needs further work.
-
-This micro-cycle of goal → practice → reflect mirrors the deliberate practice feedback loop. It's lightweight enough to not feel burdensome, but structured enough to prevent mindless repetition. The qualitative value of focused, goal-directed practice is well-supported even where quantitative claims about practice hours have been moderated (Macnamara & Maitra, 2019).
-
-**Note:** This micro-cycle is introduced early to establish the intentional practice habit from day one. Research on habit formation suggests that early interaction patterns tend to persist — if musicians learn to use Intrada without intentional practice prompts, adding them later may feel like friction rather than enhancement.
-
-#### Focus Mode
-
-During active practice, the screen shows only what's immediately relevant: the current item, the timer, and a simple rating control. No menu bars, no other library items visible, no notification badges. This "focus mode" minimises visual distraction, benefiting all users and particularly those with ADHD or sensory processing differences. The full UI with navigation, library, and dashboards is available but not competing for attention during the practice session itself.
-
-#### Visible Timers with Progress Indication
-
-A visible, always-present timer during practice shows both elapsed time per item and elapsed time for the session. The timer is visual rather than purely numerical — a progress ring or bar that fills is easier to perceive peripherally than digits. Gentle alerts at transition points (a soft chime or haptic when the suggested time for an item is reached) help with pacing without feeling punitive.
-
-At the end of each session, a "time spent vs. planned" summary helps musicians calibrate their internal time sense over time — particularly valuable for musicians with ADHD-related time blindness (Ptacek et al., 2019).
-
-#### Transition Prompts
-
-Intrada provides explicit, gentle transition cues between practice items: a visual and/or haptic prompt when the suggested time has elapsed, a brief preview of what's coming next (reducing the cognitive load of "what do I do now?"), and an optional micro-break (even 30 seconds between items helps reset attention). Sessions begin with more similar items and increase variety as the session progresses, easing transitions (informed by Mathias & Goldman, 2025).
-
-#### Repetition Counter
-
-An optional tool available during practice on any item: a simple counter that tracks consecutive correct repetitions toward a target. The musician taps "got it" to increment or "missed" to decrement (never below zero). When the counter reaches the target, the item is marked as achieved for that session and the app prompts a transition to the next item.
-
-The target is configurable per item (default 5, adjustable from 3 to 10). The decrement-on-error mechanic is the key design choice: it prevents musicians from counting sloppy repetitions toward their goal and ensures the final sequence of attempts represents genuine consistency rather than accumulated luck.
-
-**Research basis:** The overlearning literature supports continuing correct repetitions beyond initial success to improve retention. Driskell, Willis & Copper (1992) reviewed 11 studies and found that overlearning (50–100% additional correct trials beyond the criterion of first success) has a positive influence on retention, with a moderate overall effect size (d = 0.753). Practically, this means if it takes a few attempts to get a passage right, doing 3–5 more correct repetitions is beneficial, with diminishing returns beyond that. Experienced music pedagogues converge on a similar range — enough to confirm consistency, not so many that habituation and careless errors set in.
-
-> **Note on the 85% Rule:** Wilson et al. (2019) derived the 85% optimal accuracy rate using mathematical modelling of gradient-descent learning in neural networks and binary classification tasks. The original paper is about *machine learning systems*, not human motor skill acquisition. The application to music practice repetitions below is a **creative inference** — the principle resonates intuitively (practice should be challenging but not overwhelming), and it aligns with Vygotsky's zone of proximal development concept, but it is not a direct application of the original research. The 85% figure should be treated as a useful heuristic, not a precise prescription for musical practice.
-
-The 85% Rule (Wilson et al., 2019) found that learning is optimised at roughly 85% accuracy — about 1 error per 6 attempts. This has two implications for the repetition counter. First, it validates the decrement mechanic: errors during the process are expected and healthy, not failures. Second, it suggests the target shouldn't be too high — requiring 10 consecutive perfect repetitions may indicate the material is already too easy for maximal learning, or may frustrate musicians working at the productive edge of their ability. A default of 5 balances overlearning benefit against the 85% principle: a musician working at appropriate difficulty will typically experience a few decrements on the way to 5, resulting in a total attempt count where the error rate falls naturally in a productive range.
-
-This feature is entirely optional — musicians can practise without it. But when used, it provides an objective "done" signal for an item, which is particularly valuable for musicians who either move on too quickly (a single success doesn't confirm learning) or stay too long (perfectionist drilling past the point of diminishing returns). For musicians with ADHD, the counter provides a concrete, visible goal that supports task focus and provides a clear endpoint for transitioning to the next item.
-
-### 4.4 Metric-Based Progression
-
-Intrada tracks multiple dimensions of mastery for each item:
-
-- **Mastery score** — a 1–5 self-rating after each practice session, decaying over time if not practised
-- **Tempo progression** — track comfortable tempo over time, working up to target
-- **Per-key mastery** — for key-aware items, independent tracking per key
-- **Consistency** — how regularly the item is practised
-- **Notes & reflections** — qualitative log of what's working and what isn't, full-text searchable
-
-### 4.5 Progress Visualisation
-
-Visualisations are Intrada's primary tool for **shrinking the feedback loop** (Section 1.1). They serve two purposes: they provide actionable insight (where are the gaps?) and they reinforce the sense of competence that sustains motivation. Since perceived competence is the strongest predictor of flow during instrument practice (Valenzuela et al., 2018), making progress visible is not a cosmetic feature — it is motivationally central. Every visualisation should answer the question the musician is silently asking: *"Is this working?"*
-
-Progress visualisation is also the app's most direct response to the self-taught failure modes documented in Section 2.8. Where a teacher would say "look how far you've come since September," Intrada shows the data. Where a teacher would say "you're avoiding your weak keys," Intrada surfaces the coverage gap. The visualisations are not just motivation — they are a partial substitute for the diagnostic and regulatory functions that self-directed musicians lack.
-
-Planned visualisations include:
-
-- **Key coverage heatmap** — a circle-of-fifths view showing mastery level per key for any exercise, immediately revealing weak keys
-- **Mastery timeline** — line charts showing how mastery scores have improved over weeks and months
-- **Practice consistency calendar** — using "comeback" framing that emphasises frequency over streaks (e.g. "4 of the last 7 days" rather than "5 day streak"), celebrating returns after gaps rather than penalising them
-- **Tempo progress chart** — showing tempo increase over time toward target BPM
-- **Goal progress dashboard** — percentage completion toward active goals
-
-**Basic encouragement messaging** (comparing current ratings to recent history) can be delivered before the full visualisation suite. Simple messages like "Your Db mastery went from 2 to 4 over the last three weeks" require only comparison of existing data, not charts or dashboards, and provide the competence feedback that sustains motivation early on.
-
-### 4.6 Goals & Encouragement
-
-Musicians set goals at multiple levels: session goals (what will I focus on today?), weekly goals (what do I want to accomplish this week?), and milestone goals (learn this piece by March, get all keys to mastery level 4). Intrada tracks progress toward each and provides process-focused encouragement.
-
-The encouragement philosophy avoids empty praise — Dweck's own clarifications emphasise that process praise only works when tied to learning outcomes (Dweck & Yeager, 2019). Instead, Intrada highlights objective evidence: "Your Db mastery went from 2 to 4 over the last three weeks — that's the spacing effect at work." This ties progress back to the process, reinforcing trust that the method works.
-
-**Customisable encouragement:** Encouragement messaging is configurable in frequency (every item, once per session, weekly summary only, off), tone (data-focused, warm, minimal), and delivery (inline during practice, end-of-session summary, notification). Some musicians find unsolicited encouragement patronising or distracting; others depend on it for motivation. This respects the reality that musicians — particularly neurodivergent musicians — are not a monolith.
-
-**Track-aware defaults:** The musician's active track (see Section 1.5) sets sensible defaults for encouragement style. A Virtuoso receives precision-focused, data-driven feedback; a Late Starter receives warmer messaging that normalises the learning curve and celebrates small wins; a Soul Player receives gentle consistency nudges without performance pressure. These defaults can always be overridden — the track provides a starting point, not a constraint.
-
-### 4.7 Rest & Recovery Awareness
-
-The deliberate practice literature emphasises that effortful practice requires recovery. Intrada tracks total practice time per day and week and gently flags when a musician is practising significantly more than their historical average or exceeding recommended thresholds. The messaging is encouraging: "You've been putting in serious work this week — your body and brain need recovery time to consolidate what you've learned." This protects against burnout and repetitive strain.
-
-### 4.8 Practice Session Recording & Playback (Future)
-
-A simple audio recording feature — record a run-through, play it back, then rate — supports the feedback-correction cycle central to deliberate practice. The recording doesn't need to be high-fidelity or stored long-term. Even a "record this attempt → listen back → delete or keep" flow is valuable.
-
-This also addresses a limitation of self-rated mastery: ratings are subjective and can drift over time. Occasional recordings create an objective anchor. A musician might *feel* like their Bb major scale hasn't improved, but comparing a recording from three weeks ago with today's tells a different story — directly reinforcing perceived competence.
-
-### 4.9 Teacher Integration (Future)
-
-Macnamara & Maitra (2019) found that self-designed practice was perceived as more relevant than teacher-designed practice, but Bonneville-Roussy & Evans (2024) found that teacher autonomy support predicted better outcomes. These aren't contradictory: the ideal is a teacher who helps the musician design their own practice, not one who dictates it.
-
-A teacher integration feature could allow a teacher to suggest items for the student's library, set target tempos or milestone goals, and view (with permission) progress dashboards. The musician retains full control over their daily practice — the teacher provides guidance at the goal and repertoire level. This positions Intrada as a bridge between lessons rather than a replacement for them.
-
-### 4.10 AI Practice Assistant (Future)
-
-A future AI layer could replicate the *structural* teacher functions identified in Section 2.8 — not the musical ear of a teacher, but the diagnostic, planning, and regulatory intelligence that self-directed musicians lack.
-
-**Goal decomposition:** When a musician says "I want to learn this piece by March," the AI can decompose that goal into specific sub-tasks (learn sections A–D independently, bring each to target tempo, chain sections, work on dynamics, prepare for performance conditions), schedule them appropriately, and track progress against each. This replicates the teacher function of *decomposition* and *sequencing* — two functions that self-taught musicians consistently lack (Duke, 2005; Hallam, 2001).
-
-**Pattern detection and diagnosis:** The AI analyses practice data to surface what the musician cannot self-diagnose — "You consistently struggle with keys that have four or more flats," "Your mastery ratings drop on items you haven't practised in more than 10 days," "You spend 40% of your time on pieces and only 10% on the keys you rated lowest." This is the *diagnostic* function.
-
-**Post-session synthesis:** After a session, the AI offers a brief review connecting today's work to the bigger picture — "You brought two more keys of this exercise above mastery level 3 this week. At this rate, you'll have all 12 above 3 within two weeks." This directly addresses the feedback loop problem by surfacing trajectory-level progress after every session.
-
-**Guided pathway generation:** This is the AI's most transformative function — the engine behind the guided pathways described in Section 2.10. When a musician sets a goal, the AI generates a complete, sequenced pathway from where they are now to where they want to be. This is not generic advice; it is a personalised curriculum built from the musician's mastery data, the specific demands of the goal, and the prerequisite relationships between skills (Gagné, 1985; Gordon, 2007).
-
-Consider two examples. A musician asks: *"I want to play Claire de Lune — how do I even start?"* The AI analyses the piece's demands (Db major fluency, wide chord voicings, pp/ppp dynamic control, pedal technique, inner-voice independence), compares these against the musician's current mastery data, identifies the gaps, and generates a pathway of specific exercises and studies — Czerny or Hanon exercises adapted to Db major, dynamic control drills, pedal exercises, and simplified arrangements of the opening bars — sequenced so each step builds on the last. The musician doesn't face a blank page; they face step one of a clear journey.
-
-A different musician asks: *"How do I learn to improvise like Bill Evans?"* The AI decomposes this into prerequisite skill chains — basic chord construction, rootless voicings, ii-V-I progressions in all keys, modal scale relationships, melodic phrasing patterns, transcription study of Evans recordings — and sequences them based on what the musician already knows. A pianist who can already voice major and minor seventh chords starts further along the path than one who is building chords for the first time.
-
-In both cases, the pathway uses backward design (Wiggins & McTighe, 2005): start with the destination, identify what mastery looks like, then work backward to the current starting point. Catrambone (1998) showed that explicitly labelling subgoals in complex tasks significantly improves learning transfer; the AI makes these subgoals visible and concrete, giving each step in the pathway a clear name and measurable criterion.
-
-The pathway adapts as the musician progresses. Knowledge tracing (Corbett & Anderson, 1995) estimates mastery of individual skills from practice data, allowing the system to skip prerequisites the musician has already met, linger on skills that need more work, and adjust pacing to keep material within the zone of proximal development (Vygotsky, 1978). Initial pathways will draw on expert-curated templates grounded in established pedagogical traditions; the AI personalises timing, sequencing, and emphasis based on individual data.
-
-**Adaptive scheduling:** The AI adapts interleaving intensity based on user response patterns, automatically adjusting mixing aggressiveness based on how the musician responds to different levels of contextual interference over time. It could also detect plateau patterns and suggest strategy changes — shifting from repetition-based to variation-based practice when progress stalls (informed by Duke, Simmons & Cash, 2009).
-
-> **Open question:** The extent to which AI-generated practice advice improves outcomes compared to algorithmically-generated schedules alone is unknown. There is growing evidence from adaptive learning platforms (Duolingo's Birdbrain model, Khan Academy's mastery-based pathways) that personalised sequencing improves retention, but these operate on declarative knowledge tasks, not complex motor-musical skills. Whether similar benefits transfer to music practice is a testable hypothesis but not an established finding.
-
-This feature builds on the existing library and data layer — the AI has access to the musician's practice history, mastery data, and goals, making its suggestions specific and actionable rather than generic.
+Specific commitments: sensory-considerate defaults (no auto-playing sounds, calm palette, configurable contrast), accessible typography (clean fonts, adequate spacing, dark grey on off-white), predictable navigation (same layout, same flows, stable across versions), and configurable feedback (frequency, tone, and delivery all adjustable).
 
 ---
 
-## 5. Competitive Landscape
+## How Practice Material Works
 
-Understanding existing solutions helps position Intrada's unique contribution.
+### Key-Aware Grouping
 
-| App | Strengths | Weaknesses | Intrada Differentiator |
-|-----|-----------|------------|----------------------|
-| **Modacity** | Deliberate practice guidance, recording, mastery rating, good UX | No spaced repetition scheduling, no per-key tracking, expensive subscription, basic statistics | Algorithmic scheduling, key-aware tracking, fine-grained metrics, research-backed process |
-| **Tonic** | Social/community features, gamification, practice streaks | Social-first rather than practice-quality-first, no deep progress metrics, no scheduling intelligence | Practice quality over social metrics, deep per-item analytics, privacy-first |
-| **Piano Practice Assistant** | True spaced repetition, section-level tracking, interleaved practice, research-grounded | Android-only, piano-only, minimal UX polish, no goal framework | Cross-platform, instrument-agnostic, polished UX, goal-setting, encouragement layer |
-| **Instrumentive** | Practice habit tracking, recording, metronome, similar to Modacity | Focuses on habit building over practice quality, limited analytics | Both habit and quality, research-backed scheduling, richer data model |
+When a musician adds an exercise to be practised across keys, Intrada generates sub-items for each key, tracking mastery independently. The smart scheduler treats each key as a separate unit — weaker keys surface more frequently. This is essential for jazz musicians working through voicings, progressions, and patterns, and for classical musicians working through technical exercises.
 
-**Intrada's unique position**: the only app that combines spaced repetition scheduling, interleaved practice generation, key-aware exercise management, fine-grained metric tracking, neurodiversity-informed design, and a research-backed encouragement framework — all in a clean, instrument-agnostic package.
+The app also recognises when a musician always practises keys as a sequential loop and can prompt independent key practice to ensure genuine fluency rather than motor pattern reinforcement.
 
----
+### Item Types
 
-## 6. Product Roadmap
+Pieces (repertoire with sections), exercises (scales, arpeggios, technical studies), licks and vocabulary (jazz patterns, typically across keys), and techniques (specific technical goals like left-hand independence or pedalling).
 
-The detailed roadmap lives in [`docs/roadmap.md`](docs/roadmap.md) and is the single
-source of truth for what's built, what's next, and what's planned.
+### Routines
 
-The roadmap is organised around three activity pillars — **Plan** (decide what to
-practise), **Practice** (play with intention), and **Track** (see the process working).
-Each pillar advances independently; a musician benefits from progress in any of them
-without waiting for the others. Within each pillar, features are placed on a rolling
-horizon: **Now** (next 4 weeks), **Next** (4–12 weeks), and **Later** (12+ weeks).
-
-See the roadmap for current status, feature list, and prioritisation model.
+Reusable sequences of items — a warm-up routine, a technical block, a cool-down set — that can be inserted into any session. This reduces daily decision-making, supports consistency, and is particularly valuable for musicians who struggle with session initiation.
 
 ---
 
-## 7. Inclusive Design Principles
+## The Scheduling Intelligence
 
-Designing for neurodivergent musicians isn't a separate workstream — it's embedded in Intrada's core design. These principles apply across all phases and benefit every user.
+The scheduler combines spaced repetition urgency (what's overdue for review), interleaved ordering (mixing material types for better retention), goal alignment (what serves the musician's current objectives), and time fitting (what fits in the available session length).
 
-### 7.1 Reduce Decisions to Start
-
-Every decision point between "I want to practise" and "I am practising" is an opportunity for any musician to stall — and for a musician with executive function challenges, it's a potential session-ending barrier. The default path through Intrada requires one decision: tap "Start." Everything else is optional.
-
-This principle extends beyond session initiation to the entire practice planning process. The choice overload research (Section 2.9) shows that having to decide *what* to practise — not just *when* — consumes cognitive resources that would be better spent on the practice itself (Katz & Assor, 2007; Kirschner, Sweller & Clark, 2006). The app absorbs this decision-making burden by maintaining a ready recommendation at all times, informed by the musician's goals, current state, and scheduling intelligence. The musician always *can* choose; they never *have to*.
-
-### 7.2 Externalise Time
-
-Time blindness affects ADHD musicians (Ptacek et al., 2019), but all musicians benefit from external time structure. Visual progress indicators, gentle transition prompts, and post-session time summaries make time concrete and manageable rather than abstract and anxiety-inducing.
-
-### 7.3 Celebrate Comeback, Not Streak
-
-Consistency matters, but the framing of consistency determines whether it motivates or shames. Intrada never shows a broken streak counter or a zero. It celebrates returns: "Welcome back — your scheduling has adapted and we've got a session ready for you." This aligns with growth mindset research (Dweck & Yeager, 2019) and protects against the emotional dysregulation that can turn a missed day into an abandoned practice habit.
-
-### 7.4 No Journey Is Linear
-
-Musical development is not a straight line. Musicians plateau, change direction, take breaks, restart, and redefine what they want from their instrument. Intrada normalises all of this.
-
-The tracks system (Section 1.5) embodies this principle: a musician can shift between tracks at any time, and the app never frames a change as failure. Taking a break is not quitting. Choosing enjoyment over mastery is not giving up. Coming back after six months is not starting over — the data is still there, the progress is still real, and the app adapts to where the musician is now.
-
-This is particularly important for the Late Starter track. Someone who picks up an instrument at 40, 50, or 60 carries a specific kind of vulnerability — the belief that it is "too late." Every interaction in Intrada should counter that belief with evidence: progress is measurable, improvement is real, and starting points do not determine destinations.
-
-### 7.5 Sensory Sensitivity
-
-Avoid auto-playing sounds, sudden animations, or bright flashing elements. Offer colour themes including high-contrast and low-contrast modes, with a calm, muted palette as the default. All haptic feedback and sound cues are optional and configurable. Music notation rendering (if added) avoids overly dense visual presentation, allowing the musician to control how much is visible at once.
-
-### 7.6 Accessible Typography
-
-Use a clean sans-serif font as the default. Ensure sufficient contrast between text and background — dark grey on off-white rather than pure black on pure white to reduce visual stress. Adequate line spacing and letter spacing support readability for the estimated 10–15% of the population with some degree of dyslexia, and benefit every user.
-
-### 7.7 Predictable Navigation
-
-Navigation elements are always in the same place. The flow through a practice session follows the same pattern every time. Core workflows remain stable across versions. Consistency is a form of accessibility — particularly for autistic users who benefit from predictable interface behaviour, but for all users who build muscle memory around their tools.
-
-### 7.8 Configurable Feedback
-
-Not all musicians want the same encouragement. Messaging is configurable in frequency (every item, once per session, weekly summary only, off), tone (data-focused, warm, minimal), and delivery (inline during practice, end-of-session summary, notification). What motivates one musician may irritate another — particularly across neurodivergent profiles.
+This isn't AI — it's an algorithm grounded in well-established learning science. The research basis is documented in the [Research Foundation](docs/research-foundation.md).
 
 ---
 
-## 8. General Design Principles
+## Future Vision
 
-These principles guide every feature and design decision in Intrada.
+The five layers describe what Intrada is building toward now. Beyond them lie capabilities that extend the product significantly:
 
-**1. Simplicity over features.** Every interaction should feel lightweight. If logging a practice session takes more than 30 seconds, it's too slow. Musicians will abandon tools that feel like work.
+**AI-assisted curriculum design.** When a musician says "I want to play Claire de Lune" or "I want to improvise like Bill Evans," the app decomposes the goal into prerequisite skills, maps them against the musician's current mastery data, and generates a sequenced pathway of exercises and studies. This is the "illuminate the critical path" promise at its most ambitious — and it depends on the data foundation that layers 1–4 build.
 
-**2. Progress is the product.** The primary value Intrada delivers is the feeling of making progress. Every feature should either enable progress or make it visible. This is grounded in the finding that perceived competence is the strongest predictor of flow during practice (Valenzuela et al., 2018).
+**Correctness validation.** Helping musicians answer "am I doing this right?" — whether a voicing choice is appropriate, whether a scale fits the harmony. This requires either AI musical knowledge or teacher integration, and is the hardest problem in the stack.
 
-**3. Trust the musician.** Intrada provides structure and intelligence, but the musician stays in control. Suggested sessions can always be modified. Self-ratings are trusted. Autonomy is preserved — consistent with SDT research showing that autonomy support predicts better practice outcomes (Bonneville-Roussy & Evans, 2024).
+**Teacher integration.** Teachers can suggest items, set target tempos, view progress (with permission), and share routines. This bridges the gap between lesson and practice room — the teacher's assignments flow directly into the student's practice plan.
 
-**4. Evidence over opinion.** Feature decisions are grounded in learning science research. Encouragement is grounded in observable data, not empty platitudes. Where the evidence is nuanced (see Section 2), we acknowledge the limitations honestly.
+**Audio recording and playback.** Record a run-through, play it back, compare to weeks ago. Objective evidence of improvement that goes beyond numerical ratings.
 
-**5. Music first, tech second.** The app should feel like a musical tool, not a productivity app. Terminology, aesthetics, and workflows should reflect how musicians think about practice.
+**Adaptive intelligence.** The scheduling algorithm learns from the musician's response patterns — adjusting interleaving intensity, detecting plateaus, and suggesting strategy changes when progress stalls.
 
-**6. Offline-first.** Musicians practise wherever their instrument is, not necessarily where there's internet. The app must work fully offline and sync when connected.
-
-**7. Designing for the edges improves the middle.** Features that support neurodivergent musicians — reduced friction, external time structure, configurable feedback, sensory consideration — make the experience better for everyone. Accessibility is not a separate feature; it's a design philosophy embedded from the foundation.
-
-**8. Meet musicians where they are.** A musician's relationship with practice is personal and evolving. Intrada adapts to where the musician is now — their motivation, their experience level, their current chapter — rather than prescribing a single path. Tracks (Section 1.5) shape the entry point; fluidity ensures the app grows with the musician. No journey is linear, and the app should never make a musician feel they are on the wrong one.
+These are real ambitions, not aspirational padding. But they depend on the foundation being solid first. See the [roadmap](docs/roadmap.md) for current priorities and timeline.
 
 ---
 
-## 9. Technical Considerations
+## Research Foundation
 
-### 9.1 Current Architecture
-
-The existing Intrada codebase uses a Crux pure-core pattern in Rust with a Leptos/WASM web frontend, an Axum API server, and Turso (libsql/SQLite) for persistence. This architecture is solid for a cross-platform approach, with the pure core being portable to iOS, Android, and desktop shells.
-
-### 9.2 Platform Decision: iOS-First vs Web-First
-
-Given the rewrite context, a key decision is whether to target iOS native (Swift/SwiftUI) or continue with the Rust/WASM/Crux approach. Considerations include:
-
-- **iOS-first (SwiftUI):** Best UX for the primary use case (practising at an instrument with a phone/tablet nearby). Native haptics, notifications, and offline-first with SwiftData/Core Data. Faster iteration for a solo developer.
-- **Crux/Rust (current):** True cross-platform potential, but higher complexity. Web shell already exists. The pure-core pattern is architecturally elegant but adds development overhead.
-
-Recommendation: for Phase 1–3, optimise for speed and UX quality. If iOS is the primary target, SwiftUI with a clean data layer will get to a usable product faster. The Crux core can be retained for the business logic if cross-platform is a near-term goal.
-
-### 9.3 Data Model
-
-The core data model needs to support the fine-grained tracking that differentiates Intrada. Key entities include: Library Items (with type, metadata, key-awareness flag, target tempo, effort level), Sub-Items (per-key instances, sections/passages), Practice Sessions (timestamp, duration, items practised), Practice Logs (per-item within a session: mastery rating, tempo achieved, notes, focus area, goal, reflection), Routines (saved sequences of items for warm-ups or recurring patterns), Goals (type, target, deadline, linked items), and Scheduling State (per sub-item: last practised, interval, ease factor).
-
-### 9.4 Scheduling Algorithm
-
-The spaced repetition engine should be adapted from SM-2 but with modifications for musical skill learning. As discussed in Section 2.1, musical skills involve complex motor coordination with different retention characteristics to verbal learning. The algorithm parameters should be tuneable and should be validated against user data over time. Initial parameters should err on the side of shorter intervals than typical flashcard systems, with the expectation that they will be refined as real usage data accumulates. Items with higher effort tags may receive different scheduling parameters (shorter intervals, less aggressive interval growth) than maintenance items.
+Intrada's design decisions are grounded in evidence from learning science, motivational psychology, and music education research. The detailed research basis — including spaced repetition, interleaved practice, deliberate practice, self-determination theory, growth mindset, choice overload, and goal-specific pathways — is documented separately in the [Research Foundation](docs/research-foundation.md).
 
 ---
 
-## 10. References
+## Competitive Position
 
-> **Reference validation note:** All references below have been verified as real published works to the best of current knowledge. Where a reference is secondary, unpublished, or has a date discrepancy between online-first and print publication, this is noted. Two references — Moss (1995) and the Mathias & Goldman year — carry specific caveats documented in the text where they are cited.
+Existing practice apps either track time (measuring attendance, not progress), overwhelm with features that feel like work, or optimise for social engagement over practice quality. Intrada's unique position is the combination of structured capture, evidence-based scheduling, key-aware tracking, fine-grained progress metrics, and neurodiversity-informed design — in a clean, instrument-agnostic package.
 
-Alfieri, L., Brooks, P. J., Aldrich, N. J., & Tenenbaum, H. R. (2011). Does discovery-based instruction enhance learning? *Journal of Educational Psychology*, 103(1), 1–18. https://doi.org/10.1037/a0021017
-
-Ambrose, S. A., Bridges, M. W., DiPietro, M., Lovett, M. C., & Norman, M. K. (2010). *How Learning Works: Seven Research-Based Principles for Smart Teaching*. San Francisco: Jossey-Bass. ISBN: 978-0-470-48410-4.
-
-Barkley, R. A. (2015). *Attention-Deficit Hyperactivity Disorder: A Handbook for Diagnosis and Treatment* (4th ed.). New York: Guilford Press.
-
-Blackwell, L. S., Trzesniewski, K. H., & Dweck, C. S. (2007). Implicit theories of intelligence predict achievement across an adolescent transition: A longitudinal study and an intervention. *Child Development*, 78(1), 246–263. https://doi.org/10.1111/j.1467-8624.2007.00995.x
-
-Bonneville-Roussy, A., & Evans, P. (2024). The support of autonomy, motivation, and music practice in university music students: A self-determination theory perspective. *Psychology of Music*. https://doi.org/10.1177/03057356241296109
-
-Brashers-Krug, T., Shadmehr, R., & Bizzi, E. (1996). Consolidation in human motor learning. *Nature*, 382, 252–255. https://doi.org/10.1038/382252a0
-
-Carter, C. E., & Grahn, J. A. (2016). Optimizing music learning: Exploring how blocked and interleaved practice schedules affect advanced performance. *Frontiers in Psychology*, 7, 1251. https://doi.org/10.3389/fpsyg.2016.01251
-
-Catrambone, R. (1998). The subgoal learning model: Creating better examples so that students can solve novel problems. *Journal of Experimental Psychology: General*, 127(4), 355–376. https://doi.org/10.1037/0096-3445.127.4.355
-
-Cepeda, N. J., Pashler, H., Vul, E., Wixted, J. T., & Rohrer, D. (2006). Distributed practice in verbal recall tasks: A review and quantitative synthesis. *Psychological Bulletin*, 132(3), 354–380. https://doi.org/10.1037/0033-2909.132.3.354
-
-Corbett, A. T., & Anderson, J. R. (1995). Knowledge tracing: Modeling the acquisition of procedural knowledge. *User Modeling and User-Adapted Interaction*, 4(4), 253–278. https://doi.org/10.1007/BF01099821
-
-Donovan, J. J., & Radosevich, D. J. (1999). A meta-analytic review of the distribution of practice effect: Now you see it, now you don't. *Journal of Applied Psychology*, 84(5), 795–805. https://doi.org/10.1037/0021-9010.84.5.795
-
-Driskell, J. E., Willis, R. P., & Copper, C. (1992). Effect of overlearning on retention. *Journal of Applied Psychology*, 77(5), 615–622. https://doi.org/10.1037/0021-9010.77.5.615
-
-Duke, R. A. (2005). *Intelligent Music Teaching: Essays on the Core Principles of Effective Instruction*. Austin, TX: Learning and Behavior Resources.
-
-Duke, R. A., Simmons, A. L., & Cash, C. D. (2009). It's not how much; it's how: Characteristics of practice behavior and retention of performance skills. *Journal of Research in Music Education*, 56(4), 310–321. https://doi.org/10.1177/0022429408328851
-
-Dweck, C. S. (2006). *Mindset: The New Psychology of Success*. New York: Random House.
-
-Dweck, C. S., & Yeager, D. S. (2019). Mindsets: A view from two eras. *Perspectives on Psychological Science*, 14(3), 481–496. https://doi.org/10.1177/1745691618804166
-
-Ericsson, K. A., Krampe, R. T., & Tesch-Römer, C. (1993). The role of deliberate practice in the acquisition of expert performance. *Psychological Review*, 100(3), 363–406. https://doi.org/10.1037/0033-295X.100.3.363
-
-Evans, P. (2015). Self-determination theory: An approach to motivation in music education. *Musicae Scientiae*, 19(1), 65–83. https://doi.org/10.1177/1029864914568044
-
-Evans, P., & Bonneville-Roussy, A. (2016). Self-determined motivation for practice in university music students. *Psychology of Music*, 44(5), 1095–1110. https://doi.org/10.1177/0305735615610926
-
-Gagné, R. M. (1985). *The Conditions of Learning and Theory of Instruction* (4th ed.). New York: Holt, Rinehart and Winston.
-
-Gordon, E. E. (2007). *Learning Sequences in Music: A Contemporary Music Learning Theory*. Chicago: GIA Publications.
-
-Grob, C. M., Biasutti, M., & Schacter, E. N. (2022). Musical improvisation and expression in individuals with ADHD. *Frontiers in Psychology*, 13, 895780.
-
-Hallam, S. (1998). The predictors of achievement and dropout in instrumental tuition. *Psychology of Music*, 26(2), 116–132. https://doi.org/10.1177/0305735698262002
-
-Hallam, S. (2001). The development of metacognition in musicians: Implications for education. *British Journal of Music Education*, 18(1), 27–39.
-
-Iyengar, S. S., & Lepper, M. R. (2000). When choice is demotivating: Can one desire too much of a good thing? *Journal of Personality and Social Psychology*, 79(6), 995–1006. https://doi.org/10.1037/0022-3514.79.6.995
-
-Katz, I., & Assor, A. (2007). When choice motivates and when it does not. *Educational Psychology Review*, 19(4), 429–442. https://doi.org/10.1007/s10648-006-9027-y
-
-Kirschner, P. A., Sweller, J., & Clark, R. E. (2006). Why minimal guidance during instruction does not work: An analysis of the failure of constructivist, discovery, problem-based, experiential, and inquiry-based teaching. *Educational Psychologist*, 41(2), 75–86. https://doi.org/10.1207/s15326985ep4102_1
-
-Lehmann, A. C., Sloboda, J. A., & Woody, R. H. (2007). *Psychology for Musicians: Understanding and Acquiring the Skills*. Oxford: Oxford University Press.
-
-Macnamara, B. N., Hambrick, D. Z., & Oswald, F. L. (2014). Deliberate practice and performance in music, games, sports, education, and professions: A meta-analysis. *Psychological Science*, 25(8), 1608–1618. https://doi.org/10.1177/0956797614535810
-
-Macnamara, B. N., & Maitra, M. (2019). The role of deliberate practice in expert performance: Revisiting Ericsson, Krampe & Tesch-Römer (1993). *Royal Society Open Science*, 6(8), 190327. https://doi.org/10.1098/rsos.190327
-
-Mathias, T., & Goldman, A. (2025). How does increasing contextual interference in a musical practice session affect acquisition and retention? *Journal of Research in Music Education*. https://doi.org/10.1177/00224294231222801
-
-Mayer, R. E. (2004). Should there be a three-strikes rule against pure discovery learning? The case for guided methods of instruction. *American Psychologist*, 59(1), 14–19. https://doi.org/10.1037/0003-066X.59.1.14
-
-McPherson, G. E., & Renwick, J. M. (2001). A longitudinal study of self-regulation in children's musical practice. *Music Education Research*, 3(2), 169–186. https://doi.org/10.1080/14613800120089232
-
-McPherson, G. E., & Zimmerman, B. J. (2002). Self-regulation of musical learning: A social cognitive perspective. In R. Colwell & C. Richardson (Eds.), *The New Handbook of Research on Music Teaching and Learning* (pp. 327–347). Oxford: Oxford University Press.
-
-Moss, S. L. (1995). The distribution of practice effect: A review of the literature. Unpublished review, cited in Firth et al. (2023).
-
-O'Neill, S. A. (2002). The self-identity of young musicians. In R. A. R. MacDonald, D. J. Hargreaves, & D. Miell (Eds.), *Musical Identities* (pp. 79–96). Oxford University Press.
-
-Patall, E. A., Cooper, H., & Robinson, J. C. (2008). The effects of choice on intrinsic motivation and related outcomes: A meta-analysis of research findings. *Psychological Bulletin*, 134(2), 270–300. https://doi.org/10.1037/0033-2909.134.2.270
-
-Ptacek, R., Weissenberger, S., Braaten, E., Klicperova-Baker, M., Goetz, M., Raboch, J., & Stefano, G. B. (2019). Clinical implications of the perception of time in attention deficit hyperactivity disorder (ADHD): A review. *Medical Science Monitor*, 25, 3918–3924.
-
-Puyjarinet, F., Bégel, V., Lopez, R., Dellacherie, D., & Dalla Bella, S. (2017). Children and adults with Attention-Deficit/Hyperactivity Disorder cannot move to the beat. *Scientific Reports*, 7, 11550.
-
-Raz, S. (2025). Enhancing cognitive abilities in young adults with ADHD through instrumental music training. *Psychological Research*, 89, 9. https://doi.org/10.1007/s00426-024-02048-2
-
-Renwick, J. M., & McPherson, G. E. (2002). Interest and choice: Student-selected repertoire and its effect on practising behaviour. *British Journal of Music Education*, 19(2), 173–188. https://doi.org/10.1017/S0265051702000256
-
-Ryan, R. M., & Deci, E. L. (2000). Self-determination theory and the facilitation of intrinsic motivation, social development, and well-being. *American Psychologist*, 55(1), 68–78. https://doi.org/10.1037/0003-066X.55.1.68
-
-Schwartz, B. (2004). *The Paradox of Choice: Why More Is Less*. New York: Ecco/HarperCollins.
-
-Serrallach, B., Groß, C., Christiner, M., Wildermuth, S., & Schneider, P. (2022). Musical performance in adolescents with ADHD, ADD and dyslexia — Behavioral and neurophysiological aspects. *Brain Sciences*, 12(2), 127.
-
-Shea, J. B., & Morgan, R. L. (1979). Contextual interference effects on the acquisition, retention, and transfer of a motor skill. *Journal of Experimental Psychology: Human Learning and Memory*, 5(2), 179–187. https://doi.org/10.1037/0278-7393.5.2.179
-
-Simmons, A. L. (2012). Distributed practice and procedural memory consolidation in musicians' skill learning. *Journal of Research in Music Education*, 59(4), 357–368. https://doi.org/10.1177/0022429411424798
-
-Sisk, V. F., Burgoyne, A. P., Sun, J., Butler, J. L., & Macnamara, B. N. (2018). To what extent and under what circumstances are growth mind-sets important to academic achievement? Two meta-analyses. *Psychological Science*, 29(4), 549–571. https://doi.org/10.1177/0956797617739704
-
-Stambaugh, L. A. (2009). Effects of practice schedule on wind instrument performance: A preliminary application of a motor learning principle. *Update: Applications of Research in Music Education*, 27(2), 20–28.
-
-Stambaugh, L. A., & Demorest, S. M. (2010). Effects of practice schedule on the acquisition and retention of wind instrument skills. *Journal of Research in Music Education*, 58(4), 357–367.
-
-Suzuki, S. (1969). *Nurtured by Love: A New Approach to Education*. New York: Exposition Press.
-
-Valenzuela, R., Codina, N., & Pestana, J. V. (2018). Self-determination theory applied to flow in conservatoire music practice: The roles of perceived autonomy and competence, and autonomous and controlled motivation. *Psychology of Music*, 46(1), 33–48. https://doi.org/10.1177/0305735617694502
-
-Vygotsky, L. S. (1978). *Mind in Society: The Development of Higher Psychological Processes*. Cambridge, MA: Harvard University Press.
-
-Walker, M. P., & Stickgold, R. (2004). Sleep-dependent learning and memory consolidation. *Neuron*, 44(1), 121–133. https://doi.org/10.1016/j.neuron.2004.08.031
-
-Wellmann, M., & Skillicorn, A. T. (2024). Research-to-resource: Introducing retrieval practice in jazz pedagogy. *Journal of Research in Music Education*. https://doi.org/10.1177/87551233221146282
-
-Wiggins, G., & McTighe, J. (2005). *Understanding by Design* (2nd ed.). Alexandria, VA: Association for Supervision and Curriculum Development (ASCD).
-
-Wilde, E. M., & Welch, G. F. (2022). Attention deficit hyperactivity disorder (ADHD) and musical behaviour: The significance of context. *Psychology of Music*, 50(6), 1903–1920.
-
-Williamon, A., & Valentine, E. (2000). Quantity and quality of musical practice as predictors of performance quality. *British Journal of Psychology*, 91(3), 353–376. https://doi.org/10.1348/000712600161871
-
-Wilson, R. C., Shenhav, A., Straccia, M., & Cohen, J. D. (2019). The Eighty Five Percent Rule for optimal learning. *Nature Communications*, 10, 4646. https://doi.org/10.1038/s41467-019-12552-4
-
-Wood, D., Bruner, J. S., & Ross, G. (1976). The role of tutoring in problem solving. *Journal of Child Psychology and Psychiatry*, 17(2), 89–100. https://doi.org/10.1111/j.1469-7610.1976.tb00381.x
+A detailed competitive analysis is maintained in the [Research Foundation](docs/research-foundation.md).
 
 ---
 
-*Intrada: Practise with intention. See the progress. Trust the process.*
+*The vision is a living document. It evolves as the product matures and as real user data validates or challenges its assumptions.*

--- a/docs/research-foundation.md
+++ b/docs/research-foundation.md
@@ -1,0 +1,326 @@
+# Intrada — Research Foundation
+
+*Evidence base for design decisions — extracted from product vision, April 2026*
+
+This document contains the academic and empirical grounding for Intrada's design decisions. It is referenced from the [Product Vision](../VISION.md) and informs the [Roadmap](roadmap.md). The research is organised by topic, with honest acknowledgement of where evidence is strong and where it is more nuanced.
+
+---
+
+## 1. Spaced Repetition
+
+The spacing effect is one of the most robust findings in learning science. Material reviewed at increasing intervals is retained far more effectively than material crammed in a single session. A meta-analysis by Donovan & Radosevich (1999) across 63 studies with 112 effect sizes found an overall mean weighted effect size of d=0.46, indicating that spaced practice conditions significantly outperform massed practice conditions. A more recent meta-analysis by Cepeda et al. (2006), reviewing 317 experiments across 184 articles, confirmed the spacing benefit and found that the optimal spacing interval increases as the desired retention interval increases.
+
+**Important nuance for music:** Donovan & Radosevich also found that the spacing effect is moderated by task complexity — more complex tasks benefit less from distributed practice than simpler ones. Musical skill acquisition involves complex motor coordination, and Simmons (2012) found no spacing effect when teaching a 17-note piano sequence to novices, suggesting that the effect "may not always be demonstrable for complex motor skills." However, Moss (1995), reviewing 120 articles, found spacing improved learning of motor skills in over 80% of studies reviewed. The weight of evidence supports spacing for music, but Intrada's scheduling algorithm should be understood as leveraging a *general principle with strong support* rather than a precisely calibrated system proven specifically for instrument practice.
+
+> **Citation note:** Moss (1995) is an unpublished review cited secondarily via Firth et al. (2023). The specific "120 articles" and "80%+" claims cannot be independently verified from the primary source. The broader claim — that spacing benefits motor skills — is well-supported by published meta-analyses, but this specific citation should be treated with caution.
+
+**Design implication:** Intrada tracks when each item was last practised and schedules reviews at increasing intervals based on the musician's self-rated mastery, while remaining tuneable as we learn more about how spacing interacts with musical skill retention.
+
+**Scheduling algorithm note:** SM-2 was designed for verbal flashcard learning (Wozniak, 1987) and its interval growth parameters are calibrated for declarative memory retention. Musical skill learning involves procedural/motor memory with different consolidation dynamics (Walker & Stickgold, 2004). No published research validates SM-2 parameters for motor skill scheduling. Intrada's initial parameters are informed guesses that must be refined empirically through user data. This is a known unknown, not a solved problem.
+
+---
+
+## 2. Interleaved Practice
+
+Carter & Grahn (2016) compared blocked and interleaved practice schedules with advanced clarinetists (n=10) in an ecologically valid practice environment. Whenever there was a ratings difference between conditions, pieces practised in the interleaved schedule were rated higher by expert assessors, though results varied across raters. Participant questionnaires revealed that interleaved practice had positive effects on goal setting, focus, and mistake identification. Notably, while 6 of 10 participants found the interleaved schedule more useful, the majority still preferred the blocked schedule — consistent with a well-documented phenomenon where blocked practice feels more productive despite producing inferior retention.
+
+This "contextual interference effect" has broader support in motor skill learning research (Shea & Morgan, 1979; Magill & Hall, 1990), though results in music specifically are mixed. Stambaugh (2009) found interleaving benefits for beginner clarinetists, but Stambaugh & Demorest (2010) found no effect for technical accuracy in intermediate students. A more recent study by Mathias & Goldman (2025) with violinists explored increasing contextual interference within sessions, suggesting that a gradual shift from blocked to interleaved practice within a session may be optimal.
+
+**Design implication:** Because musicians tend to resist interleaving despite its benefits, Intrada provides a user-facing interleaving intensity preference — from "gentle mixing" (similar items grouped loosely) through to "full interleave" (maximum variety between consecutive items). This respects autonomy (SDT) while nudging toward evidence-based scheduling. The Mathias & Goldman finding also informs session structure: sessions can begin with more similar items and increase variety as the session progresses, easing the transition for musicians unfamiliar with interleaved practice.
+
+---
+
+## 3. Deliberate Practice
+
+Ericsson, Krampe & Tesch-Römer (1993) introduced the deliberate practice framework, proposing that expert performance is the result of prolonged, focused, effortful practice designed to improve specific aspects of performance. Their original study with violinists at a Berlin music academy found that the best violinists had accumulated significantly more solitary practice hours than less accomplished peers by age 20. This work has been enormously influential across domains.
+
+However, the evidence base has been refined considerably since 1993. A meta-analysis by Macnamara, Hambrick & Oswald (2014) found that deliberate practice explained only about 21% of variance in music performance — substantial and practically meaningful, but far from the "sufficient account" Ericsson originally claimed. A direct replication by Macnamara & Maitra (2019), using improved double-blind methodology, found the effect was "substantial, but considerably smaller than the original study's effect size," explaining about 26% of performance variance. They also found that practice designed by the performers themselves was perceived as more relevant to improvement than teacher-designed practice.
+
+What remains well-supported is the *qualitative* aspect of deliberate practice: that focused attention on specific goals, working at the edge of one's ability, and incorporating feedback leads to better outcomes than mindless repetition. Ambrose et al. (2010) synthesise this broader evidence, emphasising that a feedback-correction cycle — practising, evaluating, adjusting — is central to effective skill development.
+
+Ericsson's original framework also emphasised that deliberate practice is effortful and requires recovery. This has implications for Intrada's design: the app should not only structure practice but also support appropriate rest, flagging when a musician's practice volume significantly exceeds their historical average or recommended thresholds.
+
+**Design implication:** Intrada supports deliberate practice by prompting musicians to set specific goals for each practice item, rate their performance honestly, and reflect on what improved and what didn't. It does not claim that practice quantity alone determines outcomes, but that practice *quality* matters enormously.
+
+---
+
+## 4. Self-Determination Theory (SDT)
+
+Ryan & Deci's SDT framework identifies three basic psychological needs that sustain motivation: autonomy (feeling in control of one's actions), competence (feeling effective and capable), and relatedness (feeling connected to others). Evans & Bonneville-Roussy (2016) found that university music students' autonomous motivation predicted both the frequency of practice and the proportion of practice sessions reported as highly productive.
+
+Crucially for Intrada's design, Valenzuela, Codina & Pestana (2018) investigated SDT in the context of conservatoire instrument practice (N=162) and found that perceived competence was the strongest predictor of flow variations during practice. Autonomous motivation had a direct positive effect on flow, while controlled motivation had an inverse effect. This has direct implications: visible progress and evidence of improvement feed the sense of competence that sustains motivation and flow states.
+
+More recent work by Bonneville-Roussy & Evans (2024), studying 213 university music students across the UK and Canada, found that teacher autonomy support predicted autonomous motivation, which in turn predicted both practice time and practice quality. This reinforces the importance of autonomy-supportive design — Intrada should suggest and support, not dictate.
+
+**Design implication:** Intrada supports autonomy through user-driven goal setting and flexible practice design; competence through granular progress tracking and evidence of growth; and encouragement through positive, process-focused messaging.
+
+---
+
+## 5. Growth Mindset & Process Trust
+
+Dweck's implicit theories framework (Dweck, 2006) distinguishes between a growth mindset (the belief that abilities can be developed through effort and learning) and a fixed mindset (the belief that abilities are innate and unchangeable). In educational contexts, Blackwell, Trzesniewski & Dweck (2007) found that students with a growth mindset outperformed fixed-mindset peers over time, even when controlling for initial achievement levels. Music is a domain where fixed-mindset beliefs about "talent" are particularly prevalent (O'Neill, 2002).
+
+The growth mindset literature has faced legitimate scrutiny. A meta-analysis by Sisk et al. (2018) found that mindset interventions had only weak effects on academic achievement overall, though effects were larger for academically at-risk students. Dweck & Yeager (2019) responded by clarifying that mindset interventions are most effective when they are sustained and embedded in supportive contexts, rather than delivered as one-off treatments.
+
+For Intrada, the relevant takeaway is not that a brief mindset intervention will transform practice, but that the *design of the tool itself* can reinforce growth-oriented beliefs. Progress visualisations provide objective evidence that effort leads to improvement. Process-focused encouragement tied to specific data points ("Your Db mastery went from 2 to 4 over three weeks") provides the kind of effort-linked feedback that Dweck's research associates with adaptive motivation.
+
+**Design implication for consistency tracking:** Growth mindset research informs how Intrada handles practice gaps. Rather than streak-based tracking that creates anxiety around breaking a streak (and can trigger shame-driven avoidance, particularly in musicians with ADHD), Intrada uses "comeback" framing that emphasises the return rather than the gap. "You've practised 4 of the last 7 days — that's great spacing for retention" rather than "5 day streak — don't break it!"
+
+> **Assumption:** The claim that streak-based tracking causes anxiety and avoidance is a design hypothesis, not a research-proven finding. While there is general psychology research on shame-avoidance cycles and ADHD emotional dysregulation (Barkley, 2015), no published study directly compares streak-based versus comeback-based practice tracking in music apps. The design choice is informed by SDT principles (autonomy support) and anecdotal practitioner experience. This is a reasonable design decision but should not be presented as research-proven.
+
+---
+
+## 6. Retrieval Practice
+
+An emerging area of relevance is retrieval practice — the finding that actively recalling information produces better long-term retention than passive review. While extensively studied in verbal learning, Wellmann & Skillicorn (2024) recently proposed the first systematic application of retrieval practice to jazz performance education, noting that its benefits should extend to music learning given that the underlying memory mechanisms are domain-general. They recommend spaced retrieval schedules with intervals of at least 24 hours between practice sessions of the same material for optimal retention.
+
+**Design implication:** Rather than letting musicians repeatedly drill the same material in a single session, the app encourages returning to material across sessions, leveraging both spacing and retrieval effects.
+
+> **Open question:** Wellmann & Skillicorn's proposal is theoretical — they argue retrieval practice *should* benefit music learning based on domain-general memory mechanisms, but this has not been empirically tested in a music practice context. The underlying principle is sound, but the specific transfer to complex motor skills with a musical-expressive component remains an assumption.
+
+---
+
+## 7. Neurodiversity & Music Practice
+
+Research at the intersection of ADHD and music reveals both specific challenges and important strengths that inform Intrada's design.
+
+**Executive function and task initiation.** ADHD involves deficits in task initiation, planning, organisation, and working memory (Barkley, 2015). Starting a practice session is often harder than sustaining one — the ADHD brain struggles with the transition from "thinking about practising" to "actually practising." Every decision point before playing begins is an opportunity for the ADHD brain to stall. This has direct implications for interaction design: the path from opening the app to playing should involve as few decisions as possible.
+
+**Time blindness.** ADHD involves a disrupted sense of time passing (Ptacek et al., 2019). Musicians with ADHD may vastly underestimate or overestimate how long they've been practising, lose track of time during hyperfocused work on one item (neglecting others), or struggle to pace a practice session. This is distinct from poor time management — it's a perceptual deficit that external time cues can help mitigate.
+
+**Hyperfocus paradox.** ADHD brains can enter hyperfocus states on engaging tasks, which for musicians might mean spending 45 minutes on one satisfying piece while neglecting the scale work that actually needs attention. The interleaved scheduling in Intrada is potentially therapeutic here — it externally structures what the ADHD brain struggles to self-regulate.
+
+**Emotional dysregulation.** Frustration tolerance is often lower in ADHD. A practice session that repeatedly surfaces difficult material without any sense of progress can trigger emotional shutdown. Encouragement and visible progress features are not motivational niceties — for ADHD musicians, they may be the difference between sustained engagement and abandonment.
+
+**Music-specific findings.** Research identifies timing deficits in ADHD, including difficulties with beat tracking and processing short time intervals (Puyjarinet et al., 2017; Serrallach et al., 2022). However, these deficits do not extend to improvisation and musical expression (Grob et al., 2022), and Wilde & Welch (2022) found that ADHD behaviours were often *absent* during active music-making. Raz (2025) found that musicians with ADHD showed enhanced cognitive abilities compared to non-musician ADHD peers, including better sustained attention and impulse control. This suggests that the practice session itself may be less affected than the surrounding executive function demands — deciding what to practise, starting, transitioning between items, and stopping.
+
+**Broader neurodiversity.** Beyond ADHD, sensory processing differences (common in autism), dyslexia (affecting 10–15% of the population), and other cognitive variations all influence how musicians interact with a practice tool. Design principles that support neurodivergent users — reduced visual clutter, predictable navigation, configurable feedback, accessible typography — benefit every user.
+
+---
+
+## 8. The Feedback Loop Problem & Self-Taught Learning
+
+### What teachers actually do
+
+Effective music teaching is not primarily about demonstrating technique. Duke (2005) describes the core teacher functions as: **diagnose** (identify what specifically is going wrong), **decompose** (break complex skills into manageable sub-skills), **sequence** (order learning steps appropriately), and **regulate** (monitor progress and adjust the plan). These functions are forms of metacognition that expert musicians have internalised but that developing musicians typically lack (Hallam, 2001).
+
+Bonneville-Roussy & Evans (2024) found that teacher autonomy support predicted autonomous motivation, which in turn predicted both practice time and quality. The implication: the most effective tools behave like good teachers — they provide structure without dictating, and they support the musician's own agency.
+
+### Self-taught failure modes
+
+Without a teacher's regulatory functions, self-taught musicians frequently exhibit:
+
+- **Comfort zone bias** — repeating familiar material rather than working on weaknesses. This produces practice that feels productive but doesn't target the skills most in need of development.
+- **Miscalibrated difficulty** — practising material that is either too easy (no learning) or too hard (frustration without progress). Wilson et al.'s (2019) 85% Rule suggests that optimal learning occurs at roughly 85% accuracy, but self-taught musicians have no way to objectively assess where they sit on this continuum.
+- **Poor session structure** — without external scaffolding, practice sessions tend to lack warm-up, spend too long on single items, and end without consolidation or reflection.
+- **No stopping rules** — musicians without guidance either stop too early (abandoning an item after the first successful attempt, before overlearning consolidates the skill) or stop too late (drilling past the point of diminishing returns).
+
+### Motor consolidation: why progress is invisible
+
+The biological basis for the delayed feedback loop is motor memory consolidation. Walker & Stickgold (2004) demonstrated that motor skill performance improves 20–26% following a night of sleep, with no additional practice. Brashers-Krug, Shadmehr & Bizzi (1996) showed that motor memories require several hours to consolidate and are vulnerable to interference during this window.
+
+This means a musician can practise a passage, feel like they made no progress, go to sleep, and return the next day measurably better — but they will attribute the improvement to the new session's practice rather than the previous day's. Without data to show the trajectory, the musician's narrative becomes "I'm not improving" even when they objectively are.
+
+> **This is Intrada's core design opportunity.** By tracking mastery ratings, tempo progress, and practice patterns over time, the app can surface evidence of improvement that the musician cannot yet perceive.
+
+### What Intrada can address
+
+| Teacher function | How Intrada addresses it |
+|-----------------|-------------------------|
+| **Diagnose** | Data patterns surface what the musician cannot self-diagnose — persistent weak keys, plateau detection, effort/progress mismatches |
+| **Decompose** | Key-aware exercise management and section-level tracking break complex goals into measurable sub-skills |
+| **Sequence** | Smart scheduling orders practice material based on evidence (spacing, interleaving, goal alignment) rather than impulse |
+| **Regulate** | Progress visualisation and session analytics provide the external monitoring that self-taught musicians lack |
+
+> **Open question:** The extent to which a software tool can meaningfully replicate teacher regulatory functions is untested. The hypothesis is promising — data-driven feedback and intelligent scheduling address the *information* gap in self-taught practice — but whether this translates to improved outcomes compared to unstructured self-teaching is an empirical question that Intrada's data could help answer over time.
+
+> **Assumption:** The self-taught failure modes listed above are drawn from research on music students in educational contexts (typically school-age or conservatoire students). Whether adult self-directed learners — who form a significant portion of Intrada's target audience — exhibit the same patterns is assumed but not specifically validated. Adult learners may have better metacognitive abilities from other domains, or they may have different failure modes entirely.
+
+---
+
+## 9. The Choice Overload Problem & Guided Learning
+
+The amount of material a musician *could* practise is effectively infinite. The internet has made access to material trivially easy, but access is not the same as curation. The self-taught musician faces what Schwartz (2004) calls the "paradox of choice" — more options don't lead to better decisions; they lead to worse ones, or no decision at all.
+
+### Choice is only motivating when you know how to choose
+
+The relationship between choice and motivation is not linear. Katz & Assor (2007) argue that choice enhances motivation only when three conditions are met: the choices align with the learner's interests and values, the learner has sufficient competence to evaluate the options, and the number of options is manageable. Patall, Cooper & Robinson (2008) found that choice has positive effects on intrinsic motivation and task performance, but that these effects diminish when the number of options increases.
+
+The guided learning literature reinforces this. Kirschner, Sweller & Clark (2006) argued that minimally guided instruction (including pure discovery learning) is less effective than guided instruction for novice and intermediate learners. Alfieri et al. (2011) confirmed in a meta-analysis that unassisted discovery learning does not benefit learners, but that enhanced discovery (with scaffolding, feedback, and worked examples) significantly outperforms direct instruction. Mayer (2004) called for a "three-strikes rule" against pure discovery, arguing that guided methods consistently produce better outcomes.
+
+### Design implications
+
+1. **Default to guidance.** The app should always have an answer to "what should I practise?" — not a menu of everything the musician *could* do, but a curated recommendation of what they *should* do right now, given their goals and current state.
+2. **Goal-driven filtering.** When a musician sets a goal, the library and scheduler should filter aggressively — surfacing only the material that serves that goal and deprioritising everything else.
+3. **Progressive disclosure.** The full breadth of what could be practised should be available but not presented up front. A musician starting a new exercise sees the keys they need now, not all twelve. As they master the immediate set, the app reveals the next layer.
+
+---
+
+## 10. Goal-Specific Pathways: From Aspiration to Curriculum
+
+The critical path principle (Section 9) identifies what musicians need — a focused, well-sequenced subset of material rather than the full universe of what could be practised. But the principle alone doesn't answer the most concrete question a musician can ask: **"I want to play *this* — how do I get there?"**
+
+### Backward design
+
+Wiggins & McTighe (2005) formalised "backward design" in education: begin with the desired outcome, determine what evidence would demonstrate mastery, then design the learning experiences that lead there. Applied to music, a pianist whose goal is to play Debussy's *Claire de Lune* doesn't need a generic piano curriculum. They need the specific skills that piece demands — and a sequence that builds those skills from wherever they currently stand.
+
+### Prerequisite hierarchies in music
+
+Musical skills form natural hierarchies where complex abilities depend on simpler foundations. Gagné (1985) described how instruction should ensure prerequisite skills are in place before higher-order skills are attempted. Gordon (2007) developed this into a detailed sequential framework specific to music. Graded examination systems — ABRSM, the Royal Conservatory, Trinity College London — encode these hierarchies into structured syllabi. The Suzuki method builds prerequisite chains directly into its carefully sequenced repertoire.
+
+These systems have demonstrated the value of sequenced learning over more than a century of use. Their limitation is that they define a single generic path for all learners of an instrument, regardless of individual goals or starting points.
+
+### Material within the zone of proximal development
+
+Vygotsky (1978) described the "zone of proximal development" (ZPD) — the gap between what a learner can do independently and what they can achieve with appropriate guidance. Lehmann, Sloboda & Woody (2007) apply this directly to music, arguing that effective skill acquisition requires material calibrated to the learner's current level. A well-designed pathway keeps every step within the musician's ZPD.
+
+### Adaptive pathways through knowledge tracing
+
+Corbett & Anderson (1995) developed "knowledge tracing," a Bayesian model that estimates learner mastery of individual skills based on their response history. This approach underlies modern adaptive learning platforms and is directly applicable to music: by tracking mastery of individual skills, the system can infer which prerequisites are met and which pathway steps need attention.
+
+> **Assumption:** The claim that prerequisite relationships between musical skills can be reliably modelled and automatically sequenced is a design hypothesis. Music pedagogy involves significant tacit knowledge — experienced teachers make sequencing decisions based on intuitions about student readiness that may not reduce to measurable prerequisites. Initial pathways will likely need expert curation, with adaptive personalisation layered on top as the system accumulates data.
+
+---
+
+## 11. Overlearning & the Repetition Counter
+
+The overlearning literature supports continuing correct repetitions beyond initial success to improve retention. Driskell, Willis & Copper (1992) reviewed 11 studies and found that overlearning (50–100% additional correct trials beyond the criterion of first success) has a positive influence on retention, with a moderate overall effect size (d = 0.753). Practically, this means if it takes a few attempts to get a passage right, doing 3–5 more correct repetitions is beneficial, with diminishing returns beyond that.
+
+> **Note on the 85% Rule:** Wilson et al. (2019) derived the 85% optimal accuracy rate using mathematical modelling of gradient-descent learning in neural networks and binary classification tasks. The original paper is about *machine learning systems*, not human motor skill acquisition. The application to music practice repetitions is a **creative inference** — the principle resonates intuitively and aligns with Vygotsky's zone of proximal development, but it is not a direct application of the original research. The 85% figure should be treated as a useful heuristic, not a precise prescription.
+
+---
+
+## 12. Competitive Landscape
+
+| App | Strengths | Weaknesses | Intrada Differentiator |
+|-----|-----------|------------|----------------------|
+| **Modacity** | Deliberate practice guidance, recording, mastery rating, good UX | No spaced repetition scheduling, no per-key tracking, expensive subscription, basic statistics | Algorithmic scheduling, key-aware tracking, fine-grained metrics, research-backed process |
+| **Tonic** | Social/community features, gamification, practice streaks | Social-first rather than practice-quality-first, no deep progress metrics, no scheduling intelligence | Practice quality over social metrics, deep per-item analytics, privacy-first |
+| **Piano Practice Assistant** | True spaced repetition, section-level tracking, interleaved practice, research-grounded | Android-only, piano-only, minimal UX polish, no goal framework | Cross-platform, instrument-agnostic, polished UX, goal-setting, encouragement layer |
+| **Instrumentive** | Practice habit tracking, recording, metronome, similar to Modacity | Focuses on habit building over practice quality, limited analytics | Both habit and quality, research-backed scheduling, richer data model |
+
+**Intrada's unique position**: the only app that combines spaced repetition scheduling, interleaved practice generation, key-aware exercise management, fine-grained metric tracking, neurodiversity-informed design, and a research-backed encouragement framework — all in a clean, instrument-agnostic package.
+
+---
+
+## References
+
+> **Reference validation note:** All references below have been verified as real published works to the best of current knowledge. Where a reference is secondary, unpublished, or has a date discrepancy between online-first and print publication, this is noted. Two references — Moss (1995) and the Mathias & Goldman year — carry specific caveats documented in the text where they are cited.
+
+Alfieri, L., Brooks, P. J., Aldrich, N. J., & Tenenbaum, H. R. (2011). Does discovery-based instruction enhance learning? *Journal of Educational Psychology*, 103(1), 1–18. https://doi.org/10.1037/a0021017
+
+Ambrose, S. A., Bridges, M. W., DiPietro, M., Lovett, M. C., & Norman, M. K. (2010). *How Learning Works: Seven Research-Based Principles for Smart Teaching*. San Francisco: Jossey-Bass. ISBN: 978-0-470-48410-4.
+
+Barkley, R. A. (2015). *Attention-Deficit Hyperactivity Disorder: A Handbook for Diagnosis and Treatment* (4th ed.). New York: Guilford Press.
+
+Blackwell, L. S., Trzesniewski, K. H., & Dweck, C. S. (2007). Implicit theories of intelligence predict achievement across an adolescent transition: A longitudinal study and an intervention. *Child Development*, 78(1), 246–263. https://doi.org/10.1111/j.1467-8624.2007.00995.x
+
+Bonneville-Roussy, A., & Evans, P. (2024). The support of autonomy, motivation, and music practice in university music students: A self-determination theory perspective. *Psychology of Music*. https://doi.org/10.1177/03057356241296109
+
+Brashers-Krug, T., Shadmehr, R., & Bizzi, E. (1996). Consolidation in human motor learning. *Nature*, 382, 252–255. https://doi.org/10.1038/382252a0
+
+Carter, C. E., & Grahn, J. A. (2016). Optimizing music learning: Exploring how blocked and interleaved practice schedules affect advanced performance. *Frontiers in Psychology*, 7, 1251. https://doi.org/10.3389/fpsyg.2016.01251
+
+Catrambone, R. (1998). The subgoal learning model: Creating better examples so that students can solve novel problems. *Journal of Experimental Psychology: General*, 127(4), 355–376. https://doi.org/10.1037/0096-3445.127.4.355
+
+Cepeda, N. J., Pashler, H., Vul, E., Wixted, J. T., & Rohrer, D. (2006). Distributed practice in verbal recall tasks: A review and quantitative synthesis. *Psychological Bulletin*, 132(3), 354–380. https://doi.org/10.1037/0033-2909.132.3.354
+
+Corbett, A. T., & Anderson, J. R. (1995). Knowledge tracing: Modeling the acquisition of procedural knowledge. *User Modeling and User-Adapted Interaction*, 4(4), 253–278. https://doi.org/10.1007/BF01099821
+
+Donovan, J. J., & Radosevich, D. J. (1999). A meta-analytic review of the distribution of practice effect: Now you see it, now you don't. *Journal of Applied Psychology*, 84(5), 795–805. https://doi.org/10.1037/0021-9010.84.5.795
+
+Driskell, J. E., Willis, R. P., & Copper, C. (1992). Effect of overlearning on retention. *Journal of Applied Psychology*, 77(5), 615–622. https://doi.org/10.1037/0021-9010.77.5.615
+
+Duke, R. A. (2005). *Intelligent Music Teaching: Essays on the Core Principles of Effective Instruction*. Austin, TX: Learning and Behavior Resources.
+
+Duke, R. A., Simmons, A. L., & Cash, C. D. (2009). It's not how much; it's how: Characteristics of practice behavior and retention of performance skills. *Journal of Research in Music Education*, 56(4), 310–321. https://doi.org/10.1177/0022429408328851
+
+Dweck, C. S. (2006). *Mindset: The New Psychology of Success*. New York: Random House.
+
+Dweck, C. S., & Yeager, D. S. (2019). Mindsets: A view from two eras. *Perspectives on Psychological Science*, 14(3), 481–496. https://doi.org/10.1177/1745691618804166
+
+Ericsson, K. A., Krampe, R. T., & Tesch-Römer, C. (1993). The role of deliberate practice in the acquisition of expert performance. *Psychological Review*, 100(3), 363–406. https://doi.org/10.1037/0033-295X.100.3.363
+
+Evans, P. (2015). Self-determination theory: An approach to motivation in music education. *Musicae Scientiae*, 19(1), 65–83. https://doi.org/10.1177/1029864914568044
+
+Evans, P., & Bonneville-Roussy, A. (2016). Self-determined motivation for practice in university music students. *Psychology of Music*, 44(5), 1095–1110. https://doi.org/10.1177/0305735615610926
+
+Gagné, R. M. (1985). *The Conditions of Learning and Theory of Instruction* (4th ed.). New York: Holt, Rinehart and Winston.
+
+Gordon, E. E. (2007). *Learning Sequences in Music: A Contemporary Music Learning Theory*. Chicago: GIA Publications.
+
+Grob, C. M., Biasutti, M., & Schacter, E. N. (2022). Musical improvisation and expression in individuals with ADHD. *Frontiers in Psychology*, 13, 895780.
+
+Hallam, S. (1998). The predictors of achievement and dropout in instrumental tuition. *Psychology of Music*, 26(2), 116–132. https://doi.org/10.1177/0305735698262002
+
+Hallam, S. (2001). The development of metacognition in musicians: Implications for education. *British Journal of Music Education*, 18(1), 27–39.
+
+Iyengar, S. S., & Lepper, M. R. (2000). When choice is demotivating: Can one desire too much of a good thing? *Journal of Personality and Social Psychology*, 79(6), 995–1006. https://doi.org/10.1037/0022-3514.79.6.995
+
+Katz, I., & Assor, A. (2007). When choice motivates and when it does not. *Educational Psychology Review*, 19(4), 429–442. https://doi.org/10.1007/s10648-006-9027-y
+
+Kirschner, P. A., Sweller, J., & Clark, R. E. (2006). Why minimal guidance during instruction does not work: An analysis of the failure of constructivist, discovery, problem-based, experiential, and inquiry-based teaching. *Educational Psychologist*, 41(2), 75–86. https://doi.org/10.1207/s15326985ep4102_1
+
+Lehmann, A. C., Sloboda, J. A., & Woody, R. H. (2007). *Psychology for Musicians: Understanding and Acquiring the Skills*. Oxford: Oxford University Press.
+
+Macnamara, B. N., Hambrick, D. Z., & Oswald, F. L. (2014). Deliberate practice and performance in music, games, sports, education, and professions: A meta-analysis. *Psychological Science*, 25(8), 1608–1618. https://doi.org/10.1177/0956797614535810
+
+Macnamara, B. N., & Maitra, M. (2019). The role of deliberate practice in expert performance: Revisiting Ericsson, Krampe & Tesch-Römer (1993). *Royal Society Open Science*, 6(8), 190327. https://doi.org/10.1098/rsos.190327
+
+Mathias, T., & Goldman, A. (2025). How does increasing contextual interference in a musical practice session affect acquisition and retention? *Journal of Research in Music Education*. https://doi.org/10.1177/00224294231222801
+
+Mayer, R. E. (2004). Should there be a three-strikes rule against pure discovery learning? The case for guided methods of instruction. *American Psychologist*, 59(1), 14–19. https://doi.org/10.1037/0003-066X.59.1.14
+
+McPherson, G. E., & Renwick, J. M. (2001). A longitudinal study of self-regulation in children's musical practice. *Music Education Research*, 3(2), 169–186. https://doi.org/10.1080/14613800120089232
+
+McPherson, G. E., & Zimmerman, B. J. (2002). Self-regulation of musical learning: A social cognitive perspective. In R. Colwell & C. Richardson (Eds.), *The New Handbook of Research on Music Teaching and Learning* (pp. 327–347). Oxford: Oxford University Press.
+
+Moss, S. L. (1995). The distribution of practice effect: A review of the literature. Unpublished review, cited in Firth et al. (2023).
+
+O'Neill, S. A. (2002). The self-identity of young musicians. In R. A. R. MacDonald, D. J. Hargreaves, & D. Miell (Eds.), *Musical Identities* (pp. 79–96). Oxford University Press.
+
+Patall, E. A., Cooper, H., & Robinson, J. C. (2008). The effects of choice on intrinsic motivation and related outcomes: A meta-analysis of research findings. *Psychological Bulletin*, 134(2), 270–300. https://doi.org/10.1037/0033-2909.134.2.270
+
+Ptacek, R., Weissenberger, S., Braaten, E., Klicperova-Baker, M., Goetz, M., Raboch, J., & Stefano, G. B. (2019). Clinical implications of the perception of time in attention deficit hyperactivity disorder (ADHD): A review. *Medical Science Monitor*, 25, 3918–3924.
+
+Puyjarinet, F., Bégel, V., Lopez, R., Dellacherie, D., & Dalla Bella, S. (2017). Children and adults with Attention-Deficit/Hyperactivity Disorder cannot move to the beat. *Scientific Reports*, 7, 11550.
+
+Raz, S. (2025). Enhancing cognitive abilities in young adults with ADHD through instrumental music training. *Psychological Research*, 89, 9. https://doi.org/10.1007/s00426-024-02048-2
+
+Renwick, J. M., & McPherson, G. E. (2002). Interest and choice: Student-selected repertoire and its effect on practising behaviour. *British Journal of Music Education*, 19(2), 173–188. https://doi.org/10.1017/S0265051702000256
+
+Ryan, R. M., & Deci, E. L. (2000). Self-determination theory and the facilitation of intrinsic motivation, social development, and well-being. *American Psychologist*, 55(1), 68–78. https://doi.org/10.1037/0003-066X.55.1.68
+
+Schwartz, B. (2004). *The Paradox of Choice: Why More Is Less*. New York: Ecco/HarperCollins.
+
+Serrallach, B., Groß, C., Christiner, M., Wildermuth, S., & Schneider, P. (2022). Musical performance in adolescents with ADHD, ADD and dyslexia — Behavioral and neurophysiological aspects. *Brain Sciences*, 12(2), 127.
+
+Shea, J. B., & Morgan, R. L. (1979). Contextual interference effects on the acquisition, retention, and transfer of a motor skill. *Journal of Experimental Psychology: Human Learning and Memory*, 5(2), 179–187. https://doi.org/10.1037/0278-7393.5.2.179
+
+Simmons, A. L. (2012). Distributed practice and procedural memory consolidation in musicians' skill learning. *Journal of Research in Music Education*, 59(4), 357–368. https://doi.org/10.1177/0022429411424798
+
+Sisk, V. F., Burgoyne, A. P., Sun, J., Butler, J. L., & Macnamara, B. N. (2018). To what extent and under what circumstances are growth mind-sets important to academic achievement? Two meta-analyses. *Psychological Science*, 29(4), 549–571. https://doi.org/10.1177/0956797617739704
+
+Stambaugh, L. A. (2009). Effects of practice schedule on wind instrument performance: A preliminary application of a motor learning principle. *Update: Applications of Research in Music Education*, 27(2), 20–28.
+
+Stambaugh, L. A., & Demorest, S. M. (2010). Effects of practice schedule on the acquisition and retention of wind instrument skills. *Journal of Research in Music Education*, 58(4), 357–367.
+
+Suzuki, S. (1969). *Nurtured by Love: A New Approach to Education*. New York: Exposition Press.
+
+Valenzuela, R., Codina, N., & Pestana, J. V. (2018). Self-determination theory applied to flow in conservatoire music practice: The roles of perceived autonomy and competence, and autonomous and controlled motivation. *Psychology of Music*, 46(1), 33–48. https://doi.org/10.1177/0305735617694502
+
+Vygotsky, L. S. (1978). *Mind in Society: The Development of Higher Psychological Processes*. Cambridge, MA: Harvard University Press.
+
+Walker, M. P., & Stickgold, R. (2004). Sleep-dependent learning and memory consolidation. *Neuron*, 44(1), 121–133. https://doi.org/10.1016/j.neuron.2004.08.031
+
+Wellmann, M., & Skillicorn, A. T. (2024). Research-to-resource: Introducing retrieval practice in jazz pedagogy. *Journal of Research in Music Education*. https://doi.org/10.1177/87551233221146282
+
+Wiggins, G., & McTighe, J. (2005). *Understanding by Design* (2nd ed.). Alexandria, VA: Association for Supervision and Curriculum Development (ASCD).
+
+Wilde, E. M., & Welch, G. F. (2022). Attention deficit hyperactivity disorder (ADHD) and musical behaviour: The significance of context. *Psychology of Music*, 50(6), 1903–1920.
+
+Williamon, A., & Valentine, E. (2000). Quantity and quality of musical practice as predictors of performance quality. *British Journal of Psychology*, 91(3), 353–376. https://doi.org/10.1348/000712600161871
+
+Wilson, R. C., Shenhav, A., Straccia, M., & Cohen, J. D. (2019). The Eighty Five Percent Rule for optimal learning. *Nature Communications*, 10, 4646. https://doi.org/10.1038/s41467-019-12552-4
+
+Wood, D., Bruner, J. S., & Ross, G. (1976). The role of tutoring in problem solving. *Journal of Child Psychology and Psychiatry*, 17(2), 89–100. https://doi.org/10.1111/j.1469-7610.1976.tb00381.x

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,11 +1,16 @@
 # intrada — Product Roadmap
 
-*Updated 2026-04-03*
+*Updated 2026-04-10*
 
-Everything in intrada serves one of three activities a musician does around their
-instrument. This roadmap is organised around those three pillars, not delivery
-phases. Each pillar advances independently — a musician benefits from progress in
-any of them without waiting for the others.
+Everything in intrada serves the five layers described in the [Product Vision](../VISION.md):
+**Capture → Plan → Space → Show → Guide**. These layers build on each other — you
+can't schedule what you haven't captured, you can't space what you haven't scheduled,
+and you can't show progress on what you haven't tracked.
+
+The roadmap is also organised around three activity pillars — **Plan** (decide what to
+practise), **Practice** (play with intention), and **Track** (see the process working) —
+which cut across the layers. Features are placed on a rolling horizon: **Now** (next
+4 weeks), **Next** (4–12 weeks), and **Later** (12+ weeks).
 
 ---
 
@@ -49,24 +54,14 @@ any of them without waiting for the others.
 
 ---
 
-## Current Focus: iOS Feature Parity
+## Prioritisation Model
 
-Building out the iOS app as the primary user channel. SwiftUI shell using
-the shared Crux core via UniFFI/BCS bridge. Shell, CI, and design system are
-complete — now building out feature views to reach parity with the web app.
+Features are prioritised by **vision layer first, then pillar**. Layer 1 (Capture)
+features take precedence over Layer 2 (Plan), which take precedence over Layer 3
+(Space), and so on. Within a layer, the three pillars advance independently.
 
-Build order follows the user journey: library first (need items to practise),
-then sessions (the core loop), then routines and analytics. After iOS parity,
-cross-platform features (Crux core + API) benefit both shells simultaneously.
-
-| # | Feature | Size | Depends on |
-|---|---------|------|------------|
-| ~~195~~ | ~~**Library** — browse, search & manage repertoire~~ | ~~M~~ | Done |
-| ~~196~~ | ~~**Session builder** — construct practice setlists~~ | ~~M~~ | Done |
-| ~~197~~ | ~~**Active session** — focus mode, timer & scoring~~ | ~~L~~ | Done |
-| ~~198~~ | ~~**Session summary & history**~~ | ~~M~~ | Done |
-| ~~199~~ | ~~**Routines** — create, edit & manage practice routines~~ | ~~M~~ | Done |
-| ~~201~~ | ~~**Analytics dashboard** — practice insights & visualisation~~ | ~~M~~ | Done |
+The question to ask is: "What's the most important thing I haven't captured yet?"
+before "What's the smartest way to schedule it?"
 
 ---
 
@@ -74,33 +69,40 @@ cross-platform features (Crux core + API) benefit both shells simultaneously.
 
 ### Plan — "Decide what to practise"
 
-Before the instrument comes out. Building sessions, organising the library, setting
-goals, and eventually letting the app decide for you.
+Before the instrument comes out. Building sessions, organising the library, and
+eventually letting the app decide for you.
+
+#### Now (next 4 weeks)
+
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 46 | **Multi-key practice** — assign multiple keys to items, track mastery per key independently. | XL | 1: Capture |
+| 267 | **Teacher assignment capture** — quick-capture flow optimised for post-lesson entry. Structured fields for exercise type, keys, voicing details, teacher notes. Designed to replace the notebook. | M | 1: Capture |
+| 212 | **Short session presets** — 10/15/20/30 minute options. | S | 2: Plan |
 
 #### Next (4-12 weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 50 | **Section/passage management** — break pieces into practisable sections with independent mastery scores and tempo targets. | L |
-| 46 | **Multi-key practice** — assign multiple keys to items, track mastery per key independently. | XL |
-| 45 | **Archive/retire workflow** — handle completed/mastered items so the active library stays focused. | M |
-| 53 | **Full-text search** — search across all practice notes to find recurring themes. | M |
-| 142 | **Session time budgeting** — declare available time, allocate across items automatically or manually. | M |
-| 57 | **One-tap session start** — open the app, tap Start, play. Initial version uses recent routine + items not practised recently. | L |
-| 59 | **Session planning** — input available time, get a structured plan with warm-up, focused work, and review segments. | L |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 50 | **Section/passage management** — break pieces into practisable sections with independent mastery scores and tempo targets. | L | 1: Capture |
+| 53 | **Full-text search** — search across all practice notes to find recurring themes. | M | 1: Capture |
+| 45 | **Archive/retire workflow** — handle completed/mastered items so the active library stays focused. | M | 1: Capture |
+| 57 | **One-tap session start** — open the app, tap Start, play. Initial version uses recent routine + items not practised recently + decayed mastery scores. Upgraded when spacing engine ships. | L | 2: Plan |
+| 142 | **Session time budgeting** — declare available time, allocate across items automatically or manually. | M | 2: Plan |
+| 59 | **Session planning** — input available time, get a structured plan with warm-up, focused work, and review segments. | L | 2: Plan |
+| 58 | **Mastery decay model** — scores decrease over time without review, creating natural scheduling urgency. Gives one-tap start smarter item selection without the full spacing engine. | M | 3: Space |
 
 #### Later (12+ weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 55 | **Spaced repetition engine** — modified SM-2 algorithm for optimal review intervals based on mastery scores and time since last practice. | XL |
-| 56 | **Interleaved setlist generator** — mixed-type sessions with configurable interleaving intensity. | L |
-| 58 | **Mastery decay model** — scores decrease over time without review, creating natural scheduling urgency. | M |
-| 42 | **Links to IMSLP** — link pieces to free sheet music on IMSLP. | S |
-| 43 | **Open-source exercise library** — built-in scales, arpeggios, Hanon, Czerny etc. | L |
-| 71 | **AI setlist generation** — goal-driven practice plans ("I have a gig in 3 weeks — build me a plan"). | L |
-| 76 | **AI goal coaching** — realistic goal setting and actionable daily practice plans. (blocked on goals redesign) | L |
-| 100 | **Personalisation** — user preferences and customisation. | — |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 55 | **Spaced repetition engine** — modified SM-2 algorithm for optimal review intervals based on mastery scores and time since last practice. First feature built when Later begins. | XL | 3: Space |
+| 56 | **Interleaved setlist generator** — mixed-type sessions with configurable interleaving intensity. | L | 3: Space |
+| 42 | **Links to IMSLP** — link pieces to free sheet music on IMSLP. | S | 1: Capture |
+| 43 | **Open-source exercise library** — built-in scales, arpeggios, Hanon, Czerny etc. | L | 1: Capture |
+| 71 | **AI setlist generation** — goal-driven practice plans ("I have a gig in 3 weeks — build me a plan"). | L | 5: Guide |
+| 76 | **AI goal coaching** — realistic goal setting and actionable daily practice plans. (blocked on goals redesign) | L | 5: Guide |
+| 100 | **Personalisation** — user preferences and customisation. | — | — |
 
 ---
 
@@ -111,20 +113,19 @@ focus, not admin.
 
 #### Next (4-12 weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 61 | **Encouragement messaging** — data-tied, process-focused messages comparing current ratings to recent history. | S |
-| 54 | **Dyslexia-friendly typography** — clean fonts, adequate spacing, sensory-considerate defaults, configurable contrast modes. | S |
-| 62 | **Rest & recovery awareness** — flag when practice volume significantly exceeds historical average. | S |
-| 166 | **Session tempo targets** — suggest incremental tempo targets based on recent progress toward the item's target BPM. | M |
-| 212 | **Short session presets** — 10/15/20/30 minute options | S |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 61 | **Encouragement messaging** — data-tied, process-focused messages comparing current ratings to recent history. | S | 4: Show |
+| 54 | **Dyslexia-friendly typography** — clean fonts, adequate spacing, sensory-considerate defaults, configurable contrast modes. | S | Cross-cutting |
+| 62 | **Rest & recovery awareness** — flag when practice volume significantly exceeds historical average. | S | 4: Show |
+| 166 | **Session tempo targets** — suggest incremental tempo targets based on recent progress toward the item's target BPM. | M | 2: Plan |
 
 #### Later (12+ weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 69 | **Audio recording & playback** — record a run-through, play it back, compare to weeks ago. | L |
-| 70 | **Customisable encouragement preferences** — frequency, tone, delivery controls. Respects neurodiversity. | M |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 69 | **Audio recording & playback** — record a run-through, play it back, compare to weeks ago. | L | 4: Show |
+| 70 | **Customisable encouragement preferences** — frequency, tone, delivery controls. Respects neurodiversity. | M | 4: Show |
 
 ---
 
@@ -135,20 +136,20 @@ is actually working.
 
 #### Next (4-12 weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 63 | **Mastery timeline charts** — per-item and aggregate line charts showing mastery improvement over weeks and months. | L |
-| 79 | **Calendar view** — calendar-based view of practice sessions. | M |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 63 | **Mastery timeline charts** — per-item and aggregate line charts showing mastery improvement over weeks and months. | L | 4: Show |
+| 79 | **Calendar view** — calendar-based view of practice sessions. | M | 4: Show |
 
 #### Later (12+ weeks)
 
-| # | Feature | Size |
-|---|---------|------|
-| 64 | **Circle of fifths widget** — interactive key coverage visualisation showing mastery per key. | L |
-| 72 | **AI pattern recognition** — identify systematic weaknesses from accumulated data. | L |
-| 73 | **AI session review** — post-session analysis with rebalancing suggestions. | M |
-| 74 | **Adaptive interleaving** — AI adjusts mixing intensity based on user patterns. | L |
-| 75 | **Teacher integration** — suggested items, progress visibility (with permission). | L |
+| # | Feature | Size | Vision Layer |
+|---|---------|------|-------------|
+| 64 | **Circle of fifths widget** — interactive key coverage visualisation showing mastery per key. Depends on multi-key (#46). | L | 4: Show |
+| 72 | **AI pattern recognition** — identify systematic weaknesses from accumulated data. | L | 5: Guide |
+| 73 | **AI session review** — post-session analysis with rebalancing suggestions. | M | 5: Guide |
+| 74 | **Adaptive interleaving** — AI adjusts mixing intensity based on user patterns. | L | 5: Guide |
+| 75 | **Teacher integration** — suggested items, progress visibility (with permission). | L | 5: Guide |
 
 ---
 
@@ -172,6 +173,11 @@ These don't belong to a single pillar — they support all three.
 | `pillar:plan` | Decide what to practise |
 | `pillar:practice` | Play with intention |
 | `pillar:track` | See the process working |
+| `layer:capture` | Vision Layer 1 — capture and remember |
+| `layer:plan` | Vision Layer 2 — plan what to do today |
+| `layer:space` | Vision Layer 3 — space it for retention |
+| `layer:show` | Vision Layer 4 — show that it's working |
+| `layer:guide` | Vision Layer 5 — identify gaps and guide |
 | `horizon:now` | Next 4 weeks |
 | `horizon:next` | 4-12 weeks |
 | `horizon:later` | 12+ weeks / future |
@@ -183,14 +189,15 @@ These don't belong to a single pillar — they support all three.
 
 Backlog > Ready > In Progress > In Review > Done
 
-The board columns are workflow states, not categories. Use the pillar and horizon
-labels to filter and slice the board.
+The board columns are workflow states, not categories. Use the pillar, layer, and
+horizon labels to filter and slice the board.
 
 ### Prioritisation
 
-Each pillar advances independently. "What's the most important Plan feature?"
-is a better question than "What phase are we in?" Within each pillar, the
-Priority field (P0/P1/P2) ranks items.
+**Vision layer first, then pillar.** Layer 1 features take precedence over Layer 2,
+and so on. Within a layer, "What's the most important Plan feature?" is a better
+question than "What phase are we in?" Within each pillar, the Priority field
+(P0/P1/P2) ranks items.
 
 ---
 
@@ -204,15 +211,18 @@ Priority field (P0/P1/P2) ranks items.
    Gets harder to retrofit the longer we wait.
 
 3. ~~**iOS native vs web-first.**~~ **Decided: iOS is the primary channel.**
-   The native shell is built and feature views are in progress (#195–#201).
-   Cross-platform features (Crux core, API) benefit both shells.
+   The native shell is built and feature views are complete.
+   Cross-platform features (Crux core + API) benefit both shells.
 
 4. **Scoring + tempo coupling.** Should every mastery rating require a tempo?
    Or is tempo optional (only for items with tempo targets)?
 
 5. **Teacher integration timing.** Currently horizon:later. Basic sharing
-   (routines, item suggestions) could come earlier without AI.
+   (routines, item suggestions) could come earlier without AI. The new
+   "teacher assignment capture" feature (#267) addresses the immediate
+   capture problem without requiring teacher-facing features.
 
 6. **Goals redesign.** The goals feature has been removed for a ground-up rethink.
-   What value should goals add to the practice experience? How do they connect
-   to the critical path and guided pathways vision?
+   The five vision layers don't depend on goals in the short term — Capture, Plan,
+   Space, and Show all work without them. Goals become important when reaching
+   Layer 5 (gap analysis, pathways). Deferring is intentional, not an oversight.


### PR DESCRIPTION
## Summary

- Add teacher assignment capture (#267) to Plan > Now table in roadmap
- Restructure roadmap around five vision layers (Capture → Plan → Space → Show → Guide)
- Split VISION.md research content into `docs/research-foundation.md`
- Update README documentation table

## Test plan

- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.ai/code)