### PR TITLE
feat: lesson capture — date, notes, photos (#267)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ build reusable routines, and view analytics. Organised around three pillars:
 **Plan** (library, routines), **Practice** (focus mode, timers, scoring),
 **Track** (analytics, insights).
 
+**Platform priority**: iOS is the primary channel. Web stays functional but
+doesn't get active investment until iOS is in good shape. The Crux architecture
+means core improvements benefit both shells, so prioritise iOS shell work and
+defer web-only enhancements.
+
 ## Project Structure
 
 ```text
@@ -172,8 +177,9 @@ visual parity is required — users should not be able to tell which platform th
 ## Pencil Design Workflow
 
 All design in `design/intrada.pen` (single file). Required for new views and
-significant UI changes. Desktop (1440px) + Mobile (375px) frames. Reuse design
-system components. Colours must reference Pencil variables, not raw hex.
+significant UI changes. Mobile (375px) frames are primary; Desktop (1440px) frames
+are optional until web gets active investment. Reuse design system components.
+Colours must reference Pencil variables, not raw hex.
 
 ## Known Tech Debt
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
+dependencies = [
+ "http 1.4.0",
+ "log",
+ "rustls 0.23.37",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "attribute-derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +363,32 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-creds"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "axum"
@@ -396,6 +437,7 @@ dependencies = [
  "matchit 0.8.4",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -849,6 +891,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const-str"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1036,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crux_cli"
@@ -1220,6 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1296,6 +1365,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2033,6 +2111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2313,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
@@ -2238,7 +2336,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2570,6 +2668,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rsa",
+ "rust-s3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3225,6 +3324,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3351,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicov"
@@ -3261,6 +3387,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -3401,6 +3544,16 @@ name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "p256"
@@ -3835,6 +3988,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4112,6 +4275,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4120,6 +4284,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4201,6 +4366,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,6 +4470,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
@@ -4286,15 +4510,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4314,6 +4559,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -4392,6 +4647,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5093,6 +5358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,6 +5427,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -5523,6 +5807,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 intrada-core = { path = "../intrada-core" }
 
-axum = "0.8"
+axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 libsql = { version = "0.9", default-features = false, features = ["remote", "core"] }
@@ -28,7 +28,8 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
+rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls"] }
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/intrada-api/src/db/lessons.rs
+++ b/crates/intrada-api/src/db/lessons.rs
@@ -1,0 +1,302 @@
+use chrono::{DateTime, Utc};
+use libsql::Connection;
+
+use intrada_core::domain::lesson::{Lesson, LessonPhoto};
+use intrada_core::domain::types::{CreateLesson, UpdateLesson};
+
+use super::col;
+use crate::error::ApiError;
+use crate::storage::R2Client;
+
+const SELECT_COLUMNS: &str = "id, user_id, date, notes, created_at, updated_at";
+
+const PHOTO_SELECT_COLUMNS: &str = "id, lesson_id, user_id, storage_key, created_at";
+
+fn row_to_lesson(row: &libsql::Row, photos: Vec<LessonPhoto>) -> Result<Lesson, ApiError> {
+    let id: String = col!(row, 0)?;
+    let _user_id: String = col!(row, 1)?;
+    let date: String = col!(row, 2)?;
+    let notes: Option<String> = col!(row, 3)?;
+    let created_at_str: String = col!(row, 4)?;
+    let updated_at_str: String = col!(row, 5)?;
+
+    let created_at: DateTime<Utc> = created_at_str
+        .parse()
+        .map_err(|e| ApiError::Internal(format!("Invalid created_at: {e}")))?;
+    let updated_at: DateTime<Utc> = updated_at_str
+        .parse()
+        .map_err(|e| ApiError::Internal(format!("Invalid updated_at: {e}")))?;
+
+    Ok(Lesson {
+        id,
+        date,
+        notes,
+        photos,
+        created_at,
+        updated_at,
+    })
+}
+
+fn row_to_photo(row: &libsql::Row, r2: &R2Client) -> Result<LessonPhoto, ApiError> {
+    let id: String = col!(row, 0)?;
+    let _lesson_id: String = col!(row, 1)?;
+    let _user_id: String = col!(row, 2)?;
+    let storage_key: String = col!(row, 3)?;
+    let created_at_str: String = col!(row, 4)?;
+
+    let created_at: DateTime<Utc> = created_at_str
+        .parse()
+        .map_err(|e| ApiError::Internal(format!("Invalid created_at: {e}")))?;
+
+    let url = r2.public_url(&storage_key);
+
+    Ok(LessonPhoto {
+        id,
+        url,
+        created_at,
+    })
+}
+
+async fn list_photos_for_lesson(
+    conn: &Connection,
+    lesson_id: &str,
+    r2: &R2Client,
+) -> Result<Vec<LessonPhoto>, ApiError> {
+    let mut rows = conn
+        .query(
+            &format!(
+                "SELECT {PHOTO_SELECT_COLUMNS} FROM lesson_photos WHERE lesson_id = ?1 ORDER BY created_at ASC"
+            ),
+            libsql::params![lesson_id],
+        )
+        .await?;
+
+    let mut photos = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        photos.push(row_to_photo(&row, r2)?);
+    }
+    Ok(photos)
+}
+
+pub async fn list_lessons(
+    conn: &Connection,
+    user_id: &str,
+    r2: &R2Client,
+) -> Result<Vec<Lesson>, ApiError> {
+    let mut rows = conn
+        .query(
+            &format!("SELECT {SELECT_COLUMNS} FROM lessons WHERE user_id = ?1 ORDER BY date DESC"),
+            libsql::params![user_id],
+        )
+        .await?;
+
+    let mut lessons = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        let id: String = col!(row, 0)?;
+        let photos = list_photos_for_lesson(conn, &id, r2).await?;
+        lessons.push(row_to_lesson(&row, photos)?);
+    }
+    Ok(lessons)
+}
+
+pub async fn get_lesson(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+    r2: &R2Client,
+) -> Result<Option<Lesson>, ApiError> {
+    let mut rows = conn
+        .query(
+            &format!("SELECT {SELECT_COLUMNS} FROM lessons WHERE id = ?1 AND user_id = ?2"),
+            libsql::params![id, user_id],
+        )
+        .await?;
+
+    match rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        Some(row) => {
+            let photos = list_photos_for_lesson(conn, id, r2).await?;
+            Ok(Some(row_to_lesson(&row, photos)?))
+        }
+        None => Ok(None),
+    }
+}
+
+pub async fn insert_lesson(
+    conn: &Connection,
+    user_id: &str,
+    input: &CreateLesson,
+    r2: &R2Client,
+) -> Result<Lesson, ApiError> {
+    let id = ulid::Ulid::new().to_string();
+    let now = Utc::now();
+    let now_str = now.to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO lessons (id, user_id, date, notes, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params![
+            id.as_str(),
+            user_id,
+            input.date.as_str(),
+            input.notes.as_deref(),
+            now_str.as_str(),
+            now_str.as_str()
+        ],
+    )
+    .await?;
+
+    get_lesson(conn, &id, user_id, r2)
+        .await?
+        .ok_or_else(|| ApiError::Internal("Failed to read back inserted lesson".into()))
+}
+
+pub async fn update_lesson(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+    input: &UpdateLesson,
+    r2: &R2Client,
+) -> Result<Option<Lesson>, ApiError> {
+    let current = match get_lesson(conn, id, user_id, r2).await? {
+        Some(l) => l,
+        None => return Ok(None),
+    };
+
+    let date = input.date.as_deref().unwrap_or(&current.date);
+
+    let notes: Option<&str> = match &input.notes {
+        None => current.notes.as_deref(),
+        Some(opt) => opt.as_deref(),
+    };
+
+    let now = Utc::now();
+    let now_str = now.to_rfc3339();
+
+    conn.execute(
+        "UPDATE lessons SET date = ?1, notes = ?2, updated_at = ?3 WHERE id = ?4 AND user_id = ?5",
+        libsql::params![date, notes, now_str.as_str(), id, user_id],
+    )
+    .await?;
+
+    get_lesson(conn, id, user_id, r2).await
+}
+
+pub async fn delete_lesson(conn: &Connection, id: &str, user_id: &str) -> Result<bool, ApiError> {
+    let rows_affected = conn
+        .execute(
+            "DELETE FROM lessons WHERE id = ?1 AND user_id = ?2",
+            libsql::params![id, user_id],
+        )
+        .await?;
+
+    Ok(rows_affected > 0)
+}
+
+// ── Photo DB operations ────────────────────────────────────────────────
+
+pub async fn insert_lesson_photo(
+    conn: &Connection,
+    lesson_id: &str,
+    user_id: &str,
+    storage_key: &str,
+    r2: &R2Client,
+) -> Result<LessonPhoto, ApiError> {
+    let id = ulid::Ulid::new().to_string();
+    let now = Utc::now();
+    let now_str = now.to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO lesson_photos (id, lesson_id, user_id, storage_key, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            id.as_str(),
+            lesson_id,
+            user_id,
+            storage_key,
+            now_str.as_str()
+        ],
+    )
+    .await?;
+
+    Ok(LessonPhoto {
+        id,
+        url: r2.public_url(storage_key),
+        created_at: now,
+    })
+}
+
+pub async fn get_lesson_photo_storage_key(
+    conn: &Connection,
+    photo_id: &str,
+    lesson_id: &str,
+    user_id: &str,
+) -> Result<Option<String>, ApiError> {
+    let mut rows = conn
+        .query(
+            "SELECT storage_key FROM lesson_photos WHERE id = ?1 AND lesson_id = ?2 AND user_id = ?3",
+            libsql::params![photo_id, lesson_id, user_id],
+        )
+        .await?;
+
+    match rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        Some(row) => {
+            let key: String = col!(row, 0)?;
+            Ok(Some(key))
+        }
+        None => Ok(None),
+    }
+}
+
+pub async fn delete_lesson_photo(
+    conn: &Connection,
+    photo_id: &str,
+    lesson_id: &str,
+    user_id: &str,
+) -> Result<bool, ApiError> {
+    let rows_affected = conn
+        .execute(
+            "DELETE FROM lesson_photos WHERE id = ?1 AND lesson_id = ?2 AND user_id = ?3",
+            libsql::params![photo_id, lesson_id, user_id],
+        )
+        .await?;
+
+    Ok(rows_affected > 0)
+}
+
+pub async fn list_photo_storage_keys(
+    conn: &Connection,
+    lesson_id: &str,
+    user_id: &str,
+) -> Result<Vec<String>, ApiError> {
+    let mut rows = conn
+        .query(
+            "SELECT storage_key FROM lesson_photos WHERE lesson_id = ?1 AND user_id = ?2",
+            libsql::params![lesson_id, user_id],
+        )
+        .await?;
+
+    let mut keys = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        let key: String = col!(row, 0)?;
+        keys.push(key);
+    }
+    Ok(keys)
+}

--- a/crates/intrada-api/src/db/mod.rs
+++ b/crates/intrada-api/src/db/mod.rs
@@ -1,4 +1,5 @@
 pub mod items;
+pub mod lessons;
 pub mod routines;
 pub mod sessions;
 

--- a/crates/intrada-api/src/lib.rs
+++ b/crates/intrada-api/src/lib.rs
@@ -4,3 +4,4 @@ pub mod error;
 pub mod migrations;
 pub mod routes;
 pub mod state;
+pub mod storage;

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -2,6 +2,7 @@ use intrada_api::auth;
 use intrada_api::migrations;
 use intrada_api::routes;
 use intrada_api::state::AppState;
+use intrada_api::storage::R2Client;
 
 #[tokio::main]
 async fn main() {
@@ -64,7 +65,18 @@ async fn main() {
         });
     }
 
-    let state = AppState::new(db, allowed_origin, auth_config);
+    let r2 = match R2Client::from_env() {
+        Ok(client) => {
+            tracing::info!("R2 photo storage configured");
+            Some(client)
+        }
+        Err(msg) => {
+            tracing::warn!("R2 not configured — photo upload disabled ({msg})");
+            None
+        }
+    };
+
+    let state = AppState::new(db, allowed_origin, auth_config, r2);
     let router = routes::api_router(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -224,6 +224,36 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0034_drop_category_from_items",
         "ALTER TABLE items DROP COLUMN category;",
     ),
+    (
+        "0035_create_lessons",
+        "CREATE TABLE IF NOT EXISTS lessons (
+            id TEXT PRIMARY KEY NOT NULL,
+            user_id TEXT NOT NULL DEFAULT '',
+            date TEXT NOT NULL,
+            notes TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );",
+    ),
+    (
+        "0036_index_lessons_user_date",
+        "CREATE INDEX IF NOT EXISTS idx_lessons_user_date ON lessons(user_id, date DESC);",
+    ),
+    (
+        "0037_create_lesson_photos",
+        "CREATE TABLE IF NOT EXISTS lesson_photos (
+            id TEXT PRIMARY KEY NOT NULL,
+            lesson_id TEXT NOT NULL,
+            user_id TEXT NOT NULL DEFAULT '',
+            storage_key TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE
+        );",
+    ),
+    (
+        "0038_index_lesson_photos_lesson_id",
+        "CREATE INDEX IF NOT EXISTS idx_lesson_photos_lesson_id ON lesson_photos(lesson_id);",
+    ),
 ];
 
 /// Run migrations via libsql_migration (production path — tracks applied state).

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -1,0 +1,187 @@
+use axum::extract::{Multipart, Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+
+use intrada_core::domain::lesson::Lesson;
+use intrada_core::domain::types::{CreateLesson, UpdateLesson};
+use intrada_core::validation;
+
+use crate::auth::AuthUser;
+use crate::db;
+use crate::error::ApiError;
+use crate::state::AppState;
+use crate::storage::R2Client;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_lessons).post(create_lesson))
+        .route(
+            "/{id}",
+            get(get_lesson).put(update_lesson).delete(delete_lesson),
+        )
+        .route("/{id}/photos", post(upload_photo))
+        .route("/{id}/photos/{photo_id}", delete(delete_photo))
+}
+
+async fn list_lessons(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> Result<Json<Vec<Lesson>>, ApiError> {
+    let conn = state.connect().await?;
+    let r2 = state.r2()?;
+    let lessons = db::lessons::list_lessons(&conn, &user_id, r2).await?;
+    Ok(Json(lessons))
+}
+
+async fn get_lesson(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<String>,
+) -> Result<Json<Lesson>, ApiError> {
+    let conn = state.connect().await?;
+    let r2 = state.r2()?;
+    let lesson = db::lessons::get_lesson(&conn, &id, &user_id, r2)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
+    Ok(Json(lesson))
+}
+
+async fn create_lesson(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(input): Json<CreateLesson>,
+) -> Result<(StatusCode, Json<Lesson>), ApiError> {
+    validation::validate_create_lesson(&input)?;
+    let conn = state.connect().await?;
+    let r2 = state.r2()?;
+    let lesson = db::lessons::insert_lesson(&conn, &user_id, &input, r2).await?;
+    Ok((StatusCode::CREATED, Json(lesson)))
+}
+
+async fn update_lesson(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<String>,
+    Json(input): Json<UpdateLesson>,
+) -> Result<Json<Lesson>, ApiError> {
+    validation::validate_update_lesson(&input)?;
+    let conn = state.connect().await?;
+    let r2 = state.r2()?;
+    let lesson = db::lessons::update_lesson(&conn, &id, &user_id, &input, r2)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
+    Ok(Json(lesson))
+}
+
+async fn delete_lesson(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let conn = state.connect().await?;
+
+    // Delete photos from R2 if storage is configured
+    if let Ok(r2) = state.r2() {
+        let keys = db::lessons::list_photo_storage_keys(&conn, &id, &user_id).await?;
+        for key in keys {
+            let _ = r2.delete(&key).await;
+        }
+    }
+
+    let deleted = db::lessons::delete_lesson(&conn, &id, &user_id).await?;
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError::NotFound(format!("Lesson not found: {id}")))
+    }
+}
+
+// ── Photo endpoints ────────────────────────────────────────────────────
+
+/// Max photo upload size: 5 MB
+const MAX_PHOTO_SIZE: usize = 5 * 1024 * 1024;
+
+async fn upload_photo(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    let r2 = state.r2()?;
+    let conn = state.connect().await?;
+
+    // Verify lesson exists and belongs to user
+    db::lessons::get_lesson(&conn, &id, &user_id, r2)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
+
+    // Extract the photo field from multipart
+    let field = multipart
+        .next_field()
+        .await
+        .map_err(|e| ApiError::Validation(format!("Invalid multipart data: {e}")))?
+        .ok_or_else(|| ApiError::Validation("No photo field in request".into()))?;
+
+    let content_type = field
+        .content_type()
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    // Validate content type
+    if !matches!(content_type.as_str(), "image/jpeg" | "image/png") {
+        return Err(ApiError::Validation("Photo must be JPEG or PNG".into()));
+    }
+
+    let data = field
+        .bytes()
+        .await
+        .map_err(|e| ApiError::Validation(format!("Failed to read photo data: {e}")))?;
+
+    if data.len() > MAX_PHOTO_SIZE {
+        return Err(ApiError::Validation(format!(
+            "Photo exceeds maximum size of {} MB",
+            MAX_PHOTO_SIZE / (1024 * 1024)
+        )));
+    }
+
+    // Upload to R2
+    let photo_id = ulid::Ulid::new().to_string();
+    let storage_key = R2Client::photo_key(&user_id, &id, &photo_id);
+    r2.upload(&storage_key, &data, &content_type).await?;
+
+    // Record in DB
+    let photo = db::lessons::insert_lesson_photo(&conn, &id, &user_id, &storage_key, r2).await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(serde_json::json!({
+            "id": photo.id,
+            "url": photo.url,
+            "created_at": photo.created_at.to_rfc3339(),
+        })),
+    ))
+}
+
+async fn delete_photo(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path((id, photo_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let conn = state.connect().await?;
+
+    // Get storage key before deleting from DB
+    let storage_key = db::lessons::get_lesson_photo_storage_key(&conn, &photo_id, &id, &user_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Photo not found: {photo_id}")))?;
+
+    // Delete from R2
+    if let Ok(r2) = state.r2() {
+        let _ = r2.delete(&storage_key).await;
+    }
+
+    // Delete from DB
+    db::lessons::delete_lesson_photo(&conn, &photo_id, &id, &user_id).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -1,7 +1,8 @@
-use axum::extract::{Multipart, Path, State};
+use axum::extract::{DefaultBodyLimit, Multipart, Path, State};
 use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use tower_http::limit::RequestBodyLimitLayer;
 
 use intrada_core::domain::lesson::Lesson;
 use intrada_core::domain::types::{CreateLesson, UpdateLesson};
@@ -13,15 +14,28 @@ use crate::error::ApiError;
 use crate::state::AppState;
 use crate::storage::R2Client;
 
+/// Max photo upload size: 5 MB
+const MAX_PHOTO_SIZE: usize = 5 * 1024 * 1024;
+
+/// HTTP body limit for photo uploads: 5 MB photo + multipart overhead.
+const PHOTO_BODY_LIMIT: usize = 6 * 1024 * 1024;
+
 pub fn router() -> Router<AppState> {
+    // Photo upload gets its own sub-router so the 6 MB body limit is
+    // scoped to just that route — JSON endpoints keep axum's default.
+    let photo_upload = Router::new()
+        .route("/{id}/photos", post(upload_photo))
+        .layer(DefaultBodyLimit::disable())
+        .layer(RequestBodyLimitLayer::new(PHOTO_BODY_LIMIT));
+
     Router::new()
         .route("/", get(list_lessons).post(create_lesson))
         .route(
             "/{id}",
             get(get_lesson).put(update_lesson).delete(delete_lesson),
         )
-        .route("/{id}/photos", post(upload_photo))
         .route("/{id}/photos/{photo_id}", delete(delete_photo))
+        .merge(photo_upload)
 }
 
 async fn list_lessons(
@@ -81,11 +95,15 @@ async fn delete_lesson(
 ) -> Result<StatusCode, ApiError> {
     let conn = state.connect().await?;
 
-    // Delete photos from R2 if storage is configured
+    // Delete photos from R2 if storage is configured. Log but don't fail
+    // the request on R2 errors — DB is the source of truth and the lesson
+    // delete below cascades the photo rows.
     if let Ok(r2) = state.r2() {
         let keys = db::lessons::list_photo_storage_keys(&conn, &id, &user_id).await?;
         for key in keys {
-            let _ = r2.delete(&key).await;
+            if let Err(e) = r2.delete(&key).await {
+                tracing::warn!(lesson_id = %id, storage_key = %key, error = ?e, "R2 photo delete failed; orphaning object");
+            }
         }
     }
 
@@ -99,8 +117,19 @@ async fn delete_lesson(
 
 // ── Photo endpoints ────────────────────────────────────────────────────
 
-/// Max photo upload size: 5 MB
-const MAX_PHOTO_SIZE: usize = 5 * 1024 * 1024;
+/// Inspect the leading bytes and return the canonical image content-type,
+/// or `None` if the bytes don't match a supported format. This is the only
+/// source of truth for a photo's content-type — the client-supplied
+/// multipart header is never trusted.
+fn sniff_image_content_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else {
+        None
+    }
+}
 
 async fn upload_photo(
     State(state): State<AppState>,
@@ -123,16 +152,6 @@ async fn upload_photo(
         .map_err(|e| ApiError::Validation(format!("Invalid multipart data: {e}")))?
         .ok_or_else(|| ApiError::Validation("No photo field in request".into()))?;
 
-    let content_type = field
-        .content_type()
-        .unwrap_or("application/octet-stream")
-        .to_string();
-
-    // Validate content type
-    if !matches!(content_type.as_str(), "image/jpeg" | "image/png") {
-        return Err(ApiError::Validation("Photo must be JPEG or PNG".into()));
-    }
-
     let data = field
         .bytes()
         .await
@@ -145,10 +164,16 @@ async fn upload_photo(
         )));
     }
 
+    // Determine content-type from the bytes themselves — never trust the
+    // client's multipart header. Prevents XSS via spoofed Content-Type on
+    // the public R2 URL.
+    let content_type = sniff_image_content_type(&data)
+        .ok_or_else(|| ApiError::Validation("Photo must be JPEG or PNG".into()))?;
+
     // Upload to R2
     let photo_id = ulid::Ulid::new().to_string();
     let storage_key = R2Client::photo_key(&user_id, &id, &photo_id);
-    r2.upload(&storage_key, &data, &content_type).await?;
+    r2.upload(&storage_key, &data, content_type).await?;
 
     // Record in DB
     let photo = db::lessons::insert_lesson_photo(&conn, &id, &user_id, &storage_key, r2).await?;
@@ -175,9 +200,13 @@ async fn delete_photo(
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Photo not found: {photo_id}")))?;
 
-    // Delete from R2
+    // Delete from R2. Log but don't fail the request on R2 errors — the
+    // DB row below is the authoritative pointer; orphaned R2 objects are
+    // recoverable via prefix sweep but a stuck DB row is not.
     if let Ok(r2) = state.r2() {
-        let _ = r2.delete(&storage_key).await;
+        if let Err(e) = r2.delete(&storage_key).await {
+            tracing::warn!(photo_id = %photo_id, storage_key = %storage_key, error = ?e, "R2 photo delete failed; orphaning object");
+        }
     }
 
     // Delete from DB

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -1,5 +1,6 @@
 mod health;
 mod items;
+mod lessons;
 mod routines;
 mod sessions;
 
@@ -30,7 +31,7 @@ pub fn api_router(state: AppState) -> Router {
     Router::new()
         .nest("/api", api_routes())
         .layer(cors)
-        .layer(RequestBodyLimitLayer::new(1_048_576)) // 1 MB
+        .layer(RequestBodyLimitLayer::new(6_291_456)) // 6 MB (5 MB photo + overhead)
         .layer(trace)
         .with_state(state)
 }
@@ -41,4 +42,5 @@ fn api_routes() -> Router<AppState> {
         .nest("/items", items::router())
         .nest("/sessions", sessions::router())
         .nest("/routines", routines::router())
+        .nest("/lessons", lessons::router())
 }

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -7,7 +7,6 @@ mod sessions;
 use axum::http::{header, HeaderValue, Method};
 use axum::Router;
 use tower_http::cors::CorsLayer;
-use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 
@@ -31,7 +30,6 @@ pub fn api_router(state: AppState) -> Router {
     Router::new()
         .nest("/api", api_routes())
         .layer(cors)
-        .layer(RequestBodyLimitLayer::new(6_291_456)) // 6 MB (5 MB photo + overhead)
         .layer(trace)
         .with_state(state)
 }

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -4,21 +4,36 @@ use libsql::{Connection, Database};
 
 use crate::auth::AuthConfig;
 use crate::error::ApiError;
+use crate::storage::R2Client;
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<Database>,
     pub allowed_origin: String,
     pub auth_config: Option<AuthConfig>,
+    pub r2: Option<R2Client>,
 }
 
 impl AppState {
-    pub fn new(db: Database, allowed_origin: String, auth_config: Option<AuthConfig>) -> Self {
+    pub fn new(
+        db: Database,
+        allowed_origin: String,
+        auth_config: Option<AuthConfig>,
+        r2: Option<R2Client>,
+    ) -> Self {
         Self {
             db: Arc::new(db),
             allowed_origin,
             auth_config,
+            r2,
         }
+    }
+
+    /// Get the R2 client, or return an error if not configured.
+    pub fn r2(&self) -> Result<&R2Client, ApiError> {
+        self.r2
+            .as_ref()
+            .ok_or_else(|| ApiError::Internal("Photo storage (R2) is not configured".into()))
     }
 
     /// Create a new database connection with PRAGMA foreign_keys = ON.

--- a/crates/intrada-api/src/storage.rs
+++ b/crates/intrada-api/src/storage.rs
@@ -1,0 +1,108 @@
+//! Cloudflare R2 storage client for lesson photo upload/delete.
+//!
+//! R2 is S3-compatible; we use the `rust-s3` crate for operations.
+//! Photos are stored as `{user_id}/{lesson_id}/{photo_id}.jpg`.
+
+use s3::bucket::Bucket;
+use s3::creds::Credentials;
+use s3::Region;
+
+use crate::error::ApiError;
+
+#[derive(Clone)]
+pub struct R2Client {
+    bucket: Box<Bucket>,
+    public_url_base: String,
+}
+
+impl R2Client {
+    /// Create a new R2 client from environment variables.
+    ///
+    /// Required env vars:
+    /// - `R2_ACCOUNT_ID` — Cloudflare account ID
+    /// - `R2_ACCESS_KEY_ID` — R2 API token access key
+    /// - `R2_SECRET_ACCESS_KEY` — R2 API token secret key
+    /// - `R2_BUCKET_NAME` — Name of the R2 bucket
+    /// - `R2_PUBLIC_URL` — Public URL base for the bucket (e.g., `https://photos.example.com`)
+    pub fn from_env() -> Result<Self, String> {
+        let account_id =
+            std::env::var("R2_ACCOUNT_ID").map_err(|_| "R2_ACCOUNT_ID must be set".to_string())?;
+        let access_key = std::env::var("R2_ACCESS_KEY_ID")
+            .map_err(|_| "R2_ACCESS_KEY_ID must be set".to_string())?;
+        let secret_key = std::env::var("R2_SECRET_ACCESS_KEY")
+            .map_err(|_| "R2_SECRET_ACCESS_KEY must be set".to_string())?;
+        let bucket_name = std::env::var("R2_BUCKET_NAME")
+            .map_err(|_| "R2_BUCKET_NAME must be set".to_string())?;
+        let public_url =
+            std::env::var("R2_PUBLIC_URL").map_err(|_| "R2_PUBLIC_URL must be set".to_string())?;
+
+        let region = Region::Custom {
+            region: "auto".to_string(),
+            endpoint: format!("https://{account_id}.r2.cloudflarestorage.com"),
+        };
+
+        let credentials = Credentials::new(Some(&access_key), Some(&secret_key), None, None, None)
+            .map_err(|e| format!("Failed to create R2 credentials: {e}"))?;
+
+        let bucket = Bucket::new(&bucket_name, region, credentials)
+            .map_err(|e| format!("Failed to create R2 bucket: {e}"))?
+            .with_path_style();
+
+        Ok(Self {
+            bucket,
+            public_url_base: public_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Generate the storage key for a lesson photo.
+    pub fn photo_key(user_id: &str, lesson_id: &str, photo_id: &str) -> String {
+        format!("{user_id}/{lesson_id}/{photo_id}.jpg")
+    }
+
+    /// Get the public URL for a storage key.
+    pub fn public_url(&self, key: &str) -> String {
+        format!("{}/{key}", self.public_url_base)
+    }
+
+    /// Upload photo bytes to R2.
+    pub async fn upload(&self, key: &str, data: &[u8], content_type: &str) -> Result<(), ApiError> {
+        self.bucket
+            .put_object_with_content_type(key, data, content_type)
+            .await
+            .map_err(|e| ApiError::Internal(format!("R2 upload failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Delete a photo from R2.
+    pub async fn delete(&self, key: &str) -> Result<(), ApiError> {
+        self.bucket
+            .delete_object(key)
+            .await
+            .map_err(|e| ApiError::Internal(format!("R2 delete failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Delete all photos for a lesson (by prefix).
+    pub async fn delete_lesson_photos(
+        &self,
+        user_id: &str,
+        lesson_id: &str,
+    ) -> Result<(), ApiError> {
+        let prefix = format!("{user_id}/{lesson_id}/");
+        let list = self
+            .bucket
+            .list(prefix, None)
+            .await
+            .map_err(|e| ApiError::Internal(format!("R2 list failed: {e}")))?;
+
+        for result in list {
+            for obj in result.contents {
+                self.bucket
+                    .delete_object(&obj.key)
+                    .await
+                    .map_err(|e| ApiError::Internal(format!("R2 delete failed: {e}")))?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -40,7 +40,7 @@ async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
         .await
         .expect("Failed to run migrations");
 
-    let state = AppState::new(db, "http://localhost:3000".to_string(), auth_config);
+    let state = AppState::new(db, "http://localhost:3000".to_string(), auth_config, None);
     routes::api_router(state)
 }
 

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -13,6 +13,7 @@ use crate::analytics::compute_analytics;
 #[cfg(test)]
 use crate::domain::item::ItemKind;
 use crate::domain::item::{handle_item_event, Item, ItemEvent};
+use crate::domain::lesson::{handle_lesson_event, Lesson, LessonEvent};
 use crate::domain::routine::{handle_routine_event, Routine, RoutineEvent};
 use crate::domain::session::{
     handle_session_event, ActiveSession, PracticeSession, SessionEvent, SessionStatus,
@@ -22,7 +23,7 @@ use crate::domain::session::{CompletionStatus, EntryStatus, SetlistEntry};
 use crate::domain::types::ListQuery;
 use crate::http;
 use crate::model::{
-    build_active_session_view, build_summary_view, entry_to_view, session_to_view,
+    build_active_session_view, build_summary_view, entry_to_view, lesson_to_view, session_to_view,
     BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model, SessionStatusView, ViewModel,
 };
 
@@ -47,11 +48,13 @@ pub enum Event {
     RefetchItems,
     RefetchSessions,
     RefetchRoutines,
+    RefetchLessons,
 
     // ── Domain ──────────────────────────────────────────────────────
     Item(ItemEvent),
     Session(SessionEvent),
     Routine(RoutineEvent),
+    Lesson(LessonEvent),
 
     // ── Data loaded callbacks ───────────────────────────────────────
     DataLoaded {
@@ -62,6 +65,12 @@ pub enum Event {
     },
     RoutinesLoaded {
         routines: Vec<Routine>,
+    },
+    LessonsLoaded {
+        lessons: Vec<Lesson>,
+    },
+    LessonLoaded {
+        lesson: Lesson,
     },
 
     // ── Write-confirmation callbacks ────────────────────────────────
@@ -157,11 +166,13 @@ impl App for Intrada {
             Event::RefetchItems => http::fetch_items(&model.api_base_url),
             Event::RefetchSessions => http::fetch_sessions(&model.api_base_url),
             Event::RefetchRoutines => http::fetch_routines(&model.api_base_url),
+            Event::RefetchLessons => http::fetch_lessons(&model.api_base_url),
 
             // ── Domain handlers ──────────────────────────────────────
             Event::Item(item_event) => handle_item_event(item_event, model),
             Event::Session(session_event) => handle_session_event(session_event, model),
             Event::Routine(routine_event) => handle_routine_event(routine_event, model),
+            Event::Lesson(lesson_event) => handle_lesson_event(lesson_event, model),
 
             // ── Data loaded callbacks ────────────────────────────────
             Event::DataLoaded { items } => {
@@ -176,6 +187,16 @@ impl App for Intrada {
             }
             Event::RoutinesLoaded { routines } => {
                 model.routines = routines;
+                crux_core::render::render()
+            }
+            Event::LessonsLoaded { lessons } => {
+                model.lessons = lessons;
+                model.last_error = None;
+                crux_core::render::render()
+            }
+            Event::LessonLoaded { lesson } => {
+                model.current_lesson = Some(lesson);
+                model.last_error = None;
                 crux_core::render::render()
             }
 
@@ -319,6 +340,12 @@ impl App for Intrada {
             })
             .collect();
 
+        // Build lesson views sorted by date descending
+        let mut lessons: Vec<_> = model.lessons.iter().map(lesson_to_view).collect();
+        lessons.sort_by(|a, b| b.date.cmp(&a.date));
+
+        let current_lesson = model.current_lesson.as_ref().map(lesson_to_view);
+
         ViewModel {
             items,
             sessions,
@@ -329,6 +356,8 @@ impl App for Intrada {
             error: model.last_error.clone(),
             analytics,
             routines,
+            lessons,
+            current_lesson,
         }
     }
 }

--- a/crates/intrada-core/src/domain/lesson.rs
+++ b/crates/intrada-core/src/domain/lesson.rs
@@ -1,0 +1,111 @@
+use chrono::{DateTime, Utc};
+use crux_core::Command;
+use serde::{Deserialize, Serialize};
+
+use super::types::{CreateLesson, UpdateLesson};
+use crate::app::{Effect, Event};
+use crate::model::Model;
+use crate::validation;
+
+/// A record of a single teaching session.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct Lesson {
+    pub id: String,
+    pub date: String,
+    pub notes: Option<String>,
+    pub photos: Vec<LessonPhoto>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Photo metadata for a lesson. Binary data lives in R2; core only sees metadata.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct LessonPhoto {
+    pub id: String,
+    pub url: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum LessonEvent {
+    FetchLessons,
+    FetchLesson { id: String },
+    Add(CreateLesson),
+    Update { id: String, input: UpdateLesson },
+    Delete { id: String },
+}
+
+pub fn handle_lesson_event(event: LessonEvent, model: &mut Model) -> Command<Effect, Event> {
+    match event {
+        LessonEvent::FetchLessons => crate::http::fetch_lessons(&model.api_base_url),
+        LessonEvent::FetchLesson { id } => crate::http::fetch_lesson(&model.api_base_url, &id),
+        LessonEvent::Add(input) => {
+            if let Err(e) = validation::validate_create_lesson(&input) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+
+            let now = chrono::Utc::now();
+            let lesson = Lesson {
+                id: ulid::Ulid::new().to_string(),
+                date: input.date.clone(),
+                notes: input.notes.clone(),
+                photos: Vec::new(),
+                created_at: now,
+                updated_at: now,
+            };
+
+            model.lessons.push(lesson);
+            model.last_error = None;
+
+            Command::all([
+                crate::http::create_lesson(&model.api_base_url, &input),
+                crux_core::render::render(),
+            ])
+        }
+        LessonEvent::Update { id, input } => {
+            if let Err(e) = validation::validate_update_lesson(&input) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+
+            let Some(lesson) = model.lessons.iter_mut().find(|l| l.id == id) else {
+                model.last_error = Some(format!("Lesson not found: {id}"));
+                return crux_core::render::render();
+            };
+
+            if let Some(date) = &input.date {
+                lesson.date = date.clone();
+            }
+            if let Some(notes) = &input.notes {
+                lesson.notes = notes.clone();
+            }
+            lesson.updated_at = chrono::Utc::now();
+            model.last_error = None;
+
+            let lesson_id = id.clone();
+            Command::all([
+                crate::http::update_lesson(&model.api_base_url, &lesson_id, &input),
+                crux_core::render::render(),
+            ])
+        }
+        LessonEvent::Delete { id } => {
+            let len_before = model.lessons.len();
+            model.lessons.retain(|l| l.id != id);
+            if model.lessons.len() == len_before {
+                model.last_error = Some(format!("Lesson not found: {id}"));
+                return crux_core::render::render();
+            }
+            model.last_error = None;
+
+            Command::all([
+                crate::http::delete_lesson(&model.api_base_url, &id),
+                crux_core::render::render(),
+            ])
+        }
+    }
+}

--- a/crates/intrada-core/src/domain/mod.rs
+++ b/crates/intrada-core/src/domain/mod.rs
@@ -1,15 +1,17 @@
 pub mod item;
+pub mod lesson;
 pub mod routine;
 pub mod session;
 pub mod types;
 
 pub use item::{Item, ItemEvent, ItemKind};
+pub use lesson::{Lesson, LessonEvent, LessonPhoto};
 pub use routine::{Routine, RoutineEntry};
 pub use session::{
     ActiveSession, CompletionStatus, EntryStatus, PracticeSession, SessionEvent, SessionStatus,
     SetlistEntry,
 };
 pub use types::{
-    CreateItem, CreateRoutineEntryRequest, CreateRoutineRequest, LibraryData, ListQuery,
-    SessionsData, Tempo, UpdateItem, UpdateRoutineRequest,
+    CreateItem, CreateLesson, CreateRoutineEntryRequest, CreateRoutineRequest, LibraryData,
+    ListQuery, SessionsData, Tempo, UpdateItem, UpdateLesson, UpdateRoutineRequest,
 };

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -143,6 +143,24 @@ impl UpdateRoutineRequest {
     }
 }
 
+// ── Lesson DTOs ────────────────────────────────────────────────────
+
+/// Request body for creating a lesson via the REST API.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct CreateLesson {
+    pub date: String,
+    pub notes: Option<String>,
+}
+
+/// Request body for updating a lesson via the REST API.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct UpdateLesson {
+    pub date: Option<String>,
+    pub notes: Option<Option<String>>,
+}
+
 /// Filters for listing/searching library items.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -8,8 +8,11 @@ use crux_core::Command;
 
 use crate::app::{Effect, Event};
 use crate::domain::item::Item;
+use crate::domain::lesson::Lesson;
 use crate::domain::session::PracticeSession;
-use crate::domain::types::{CreateItem, CreateRoutineRequest, UpdateItem, UpdateRoutineRequest};
+use crate::domain::types::{
+    CreateItem, CreateLesson, CreateRoutineRequest, UpdateItem, UpdateLesson, UpdateRoutineRequest,
+};
 
 type Http = crux_http::command::Http<Effect, Event>;
 
@@ -181,5 +184,68 @@ pub fn delete_routine(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         .then_send(|result| match result {
             Ok(_) => Event::DeleteConfirmed,
             Err(e) => Event::LoadFailed(format!("Failed to delete routine: {e}")),
+        })
+}
+
+// ── Lesson operations ──────────────────────────────────────────────────
+
+pub fn fetch_lessons(api_base_url: &str) -> Command<Effect, Event> {
+    Http::get(format!("{api_base_url}/api/lessons"))
+        .expect_json::<Vec<Lesson>>()
+        .build()
+        .then_send(|result| match result {
+            Ok(response) => match response.body().cloned() {
+                Some(lessons) => Event::LessonsLoaded { lessons },
+                None => Event::LoadFailed("Failed to parse lessons response".into()),
+            },
+            Err(e) => Event::LoadFailed(format!("Failed to load lessons: {e}")),
+        })
+}
+
+pub fn fetch_lesson(api_base_url: &str, id: &str) -> Command<Effect, Event> {
+    Http::get(format!("{api_base_url}/api/lessons/{id}"))
+        .expect_json::<Lesson>()
+        .build()
+        .then_send(|result| match result {
+            Ok(response) => match response.body().cloned() {
+                Some(lesson) => Event::LessonLoaded { lesson },
+                None => Event::LoadFailed("Failed to parse lesson response".into()),
+            },
+            Err(e) => Event::LoadFailed(format!("Failed to load lesson: {e}")),
+        })
+}
+
+pub fn create_lesson(api_base_url: &str, input: &CreateLesson) -> Command<Effect, Event> {
+    Http::post(format!("{api_base_url}/api/lessons"))
+        .body_json(input)
+        .expect("serialize CreateLesson")
+        .build()
+        .then_send(|result| match result {
+            Ok(_) => Event::RefetchLessons,
+            Err(e) => Event::LoadFailed(format!("Failed to save lesson: {e}")),
+        })
+}
+
+pub fn update_lesson(api_base_url: &str, id: &str, input: &UpdateLesson) -> Command<Effect, Event> {
+    Http::put(format!("{api_base_url}/api/lessons/{id}"))
+        .body_json(input)
+        .expect("serialize UpdateLesson")
+        .expect_json::<Lesson>()
+        .build()
+        .then_send(|result| match result {
+            Ok(response) => match response.body().cloned() {
+                Some(lesson) => Event::LessonLoaded { lesson },
+                None => Event::LoadFailed("update_lesson: server returned no body".into()),
+            },
+            Err(e) => Event::LoadFailed(format!("Failed to update lesson: {e}")),
+        })
+}
+
+pub fn delete_lesson(api_base_url: &str, id: &str) -> Command<Effect, Event> {
+    Http::delete(format!("{api_base_url}/api/lessons/{id}"))
+        .build()
+        .then_send(|result| match result {
+            Ok(_) => Event::DeleteConfirmed,
+            Err(e) => Event::LoadFailed(format!("Failed to delete lesson: {e}")),
         })
 }

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -8,12 +8,15 @@ pub mod validation;
 
 pub use app::{AppEffect, Effect, Event, Intrada};
 pub use domain::item::{Item, ItemEvent, ItemKind};
+pub use domain::lesson::{Lesson, LessonEvent, LessonPhoto};
 pub use domain::routine::{Routine, RoutineEntry, RoutineEvent};
 pub use domain::session::{
     ActiveSession, CompletionStatus, EntryStatus, PracticeSession, SessionEvent, SessionStatus,
     SetlistEntry,
 };
-pub use domain::types::{CreateItem, LibraryData, ListQuery, SessionsData, Tempo, UpdateItem};
+pub use domain::types::{
+    CreateItem, CreateLesson, LibraryData, ListQuery, SessionsData, Tempo, UpdateItem, UpdateLesson,
+};
 pub use error::LibraryError;
 
 // Re-export crux_http protocol types so shells can handle HTTP effects
@@ -21,11 +24,11 @@ pub use error::LibraryError;
 pub use crux_http::protocol::{HttpHeader, HttpResponse, HttpResult};
 pub use crux_http::{HttpError, HttpRequest};
 pub use model::{
-    ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model,
-    PracticeSessionView, RoutineEntryView, RoutineView, ScoreHistoryEntry, SessionStatusView,
-    SetlistEntryView, SummaryView, TempoHistoryEntry, ViewModel,
+    ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LessonPhotoView, LessonView,
+    LibraryItemView, Model, PracticeSessionView, RoutineEntryView, RoutineView, ScoreHistoryEntry,
+    SessionStatusView, SetlistEntryView, SummaryView, TempoHistoryEntry, ViewModel,
 };
 pub use validation::{
-    MAX_ACHIEVED_TEMPO, MAX_BPM, MAX_COMPOSER, MAX_NOTES, MAX_ROUTINE_NAME, MAX_TAG,
-    MAX_TEMPO_MARKING, MAX_TITLE, MIN_ACHIEVED_TEMPO, MIN_BPM,
+    MAX_ACHIEVED_TEMPO, MAX_BPM, MAX_COMPOSER, MAX_LESSON_NOTES, MAX_NOTES, MAX_ROUTINE_NAME,
+    MAX_TAG, MAX_TEMPO_MARKING, MAX_TITLE, MIN_ACHIEVED_TEMPO, MIN_BPM,
 };

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::analytics::AnalyticsView;
 use crate::domain::item::{Item, ItemKind};
+use crate::domain::lesson::Lesson;
 use crate::domain::routine::Routine;
 use crate::domain::session::{
     ActiveSession, CompletionStatus, EntryStatus, PracticeSession, RepAction, SessionStatus,
@@ -22,6 +23,8 @@ pub struct Model {
     pub active_query: Option<ListQuery>,
     pub last_error: Option<String>,
     pub routines: Vec<Routine>,
+    pub lessons: Vec<Lesson>,
+    pub current_lesson: Option<Lesson>,
     pub practice_summaries: HashMap<String, ItemPracticeSummary>,
 }
 
@@ -68,6 +71,57 @@ pub struct ViewModel {
     pub error: Option<String>,
     pub analytics: Option<AnalyticsView>,
     pub routines: Vec<RoutineView>,
+    pub lessons: Vec<LessonView>,
+    pub current_lesson: Option<LessonView>,
+}
+
+/// Represents a lesson for display in the UI.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct LessonView {
+    pub id: String,
+    pub date: String,
+    pub notes: Option<String>,
+    pub notes_preview: String,
+    pub photos: Vec<LessonPhotoView>,
+    pub has_photos: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Photo metadata for display in the UI.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct LessonPhotoView {
+    pub id: String,
+    pub url: String,
+}
+
+pub fn lesson_to_view(lesson: &Lesson) -> LessonView {
+    let notes_preview = lesson
+        .notes
+        .as_deref()
+        .unwrap_or("")
+        .chars()
+        .take(100)
+        .collect::<String>();
+    LessonView {
+        id: lesson.id.clone(),
+        date: lesson.date.clone(),
+        notes: lesson.notes.clone(),
+        notes_preview,
+        photos: lesson
+            .photos
+            .iter()
+            .map(|p| LessonPhotoView {
+                id: p.id.clone(),
+                url: p.url.clone(),
+            })
+            .collect(),
+        has_photos: !lesson.photos.is_empty(),
+        created_at: lesson.created_at.to_rfc3339(),
+        updated_at: lesson.updated_at.to_rfc3339(),
+    }
 }
 
 /// Represents a routine for display in the UI.

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -1,5 +1,5 @@
 use crate::domain::item::ItemKind;
-use crate::domain::types::{CreateItem, Tempo, UpdateItem};
+use crate::domain::types::{CreateItem, CreateLesson, Tempo, UpdateItem, UpdateLesson};
 use crate::error::LibraryError;
 
 /// Validation limits shared across shells (web, CLI).
@@ -25,6 +25,7 @@ pub const MIN_SESSION_TARGET_MINS: u32 = 5;
 pub const MAX_SESSION_TARGET_MINS: u32 = 120;
 pub const MIN_ACHIEVED_TEMPO: u16 = 1;
 pub const MAX_ACHIEVED_TEMPO: u16 = 500;
+pub const MAX_LESSON_NOTES: usize = 10_000;
 
 pub fn validate_title(title: &str) -> Result<(), LibraryError> {
     if title.is_empty() || title.len() > MAX_TITLE {
@@ -310,6 +311,54 @@ pub fn validate_routine_entry_fields(item_id: &str, item_title: &str) -> Result<
             field: "item_title".to_string(),
             message: "Entry item_title must not be empty".to_string(),
         });
+    }
+    Ok(())
+}
+
+// ── Lesson validation ──────────────────────────────────────────────
+
+fn validate_lesson_date(date: &str) -> Result<(), LibraryError> {
+    let parsed = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| {
+        LibraryError::Validation {
+            field: "date".to_string(),
+            message: "Date must be in YYYY-MM-DD format".to_string(),
+        }
+    })?;
+
+    let today = chrono::Utc::now().date_naive();
+    if parsed > today {
+        return Err(LibraryError::Validation {
+            field: "date".to_string(),
+            message: "Date cannot be in the future".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_lesson_notes(notes: Option<&str>) -> Result<(), LibraryError> {
+    if let Some(n) = notes {
+        if n.len() > MAX_LESSON_NOTES {
+            return Err(LibraryError::Validation {
+                field: "notes".to_string(),
+                message: format!("Notes must not exceed {MAX_LESSON_NOTES} characters"),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_create_lesson(input: &CreateLesson) -> Result<(), LibraryError> {
+    validate_lesson_date(&input.date)?;
+    validate_lesson_notes(input.notes.as_deref())?;
+    Ok(())
+}
+
+pub fn validate_update_lesson(input: &UpdateLesson) -> Result<(), LibraryError> {
+    if let Some(ref date) = input.date {
+        validate_lesson_date(date)?;
+    }
+    if let Some(ref notes) = input.notes {
+        validate_lesson_notes(notes.as_deref())?;
     }
     Ok(())
 }

--- a/ios/Intrada/Core/IntradaCore.swift
+++ b/ios/Intrada/Core/IntradaCore.swift
@@ -80,7 +80,9 @@ final class IntradaCore {
                 sessionStatus: .idle,
                 error: message,
                 analytics: nil,
-                routines: []
+                routines: [],
+                lessons: [],
+                currentLesson: nil
             )
         }
     }
@@ -260,6 +262,14 @@ final class IntradaCore {
         } catch {
             return .err(.io(error.localizedDescription))
         }
+    }
+
+    /// Get an auth token for direct API calls (e.g., photo upload outside Crux).
+    ///
+    /// Returns the raw JWT token string, or nil if no session is available.
+    func getAuthToken() async throws -> String? {
+        guard let clerkSession = clerk?.session else { return nil }
+        return try await clerkSession.getToken()
     }
 
     /// Get a Bearer token from Clerk for API authorization.

--- a/ios/Intrada/Generated/SharedTypes/SharedTypes.swift
+++ b/ios/Intrada/Generated/SharedTypes/SharedTypes.swift
@@ -546,6 +546,50 @@ public struct CreateItem: Hashable {
     }
 }
 
+public struct CreateLesson: Hashable {
+    @Indirect public var date: String
+    @Indirect public var notes: String?
+
+    public init(date: String, notes: String?) {
+        self.date = date
+        self.notes = notes
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializer.serialize_str(value: self.date)
+        try serializeOption(value: self.notes, serializer: serializer) { value, serializer in
+            try serializer.serialize_str(value: value)
+        }
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> CreateLesson {
+        try deserializer.increase_container_depth()
+        let date = try deserializer.deserialize_str()
+        let notes = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializer.deserialize_str()
+        }
+        try deserializer.decrease_container_depth()
+        return CreateLesson(date: date, notes: notes)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> CreateLesson {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
 public struct DailyPracticeTotal: Hashable {
     @Indirect public var date: String
     @Indirect public var minutes: UInt32
@@ -751,12 +795,16 @@ indirect public enum Event: Hashable {
     case refetchItems
     case refetchSessions
     case refetchRoutines
+    case refetchLessons
     case item(ItemEvent)
     case session(SessionEvent)
     case routine(RoutineEvent)
+    case lesson(LessonEvent)
     case dataLoaded(items: [Item])
     case sessionsLoaded(sessions: [PracticeSession])
     case routinesLoaded(routines: [Routine])
+    case lessonsLoaded(lessons: [Lesson])
+    case lessonLoaded(lesson: Lesson)
     case itemUpdated(item: Item)
     case routineUpdated(routine: Routine)
     case deleteConfirmed
@@ -779,47 +827,60 @@ indirect public enum Event: Hashable {
             try serializer.serialize_variant_index(value: 3)
         case .refetchRoutines:
             try serializer.serialize_variant_index(value: 4)
-        case .item(let x):
+        case .refetchLessons:
             try serializer.serialize_variant_index(value: 5)
-            try x.serialize(serializer: serializer)
-        case .session(let x):
+        case .item(let x):
             try serializer.serialize_variant_index(value: 6)
             try x.serialize(serializer: serializer)
-        case .routine(let x):
+        case .session(let x):
             try serializer.serialize_variant_index(value: 7)
             try x.serialize(serializer: serializer)
-        case .dataLoaded(let items):
+        case .routine(let x):
             try serializer.serialize_variant_index(value: 8)
+            try x.serialize(serializer: serializer)
+        case .lesson(let x):
+            try serializer.serialize_variant_index(value: 9)
+            try x.serialize(serializer: serializer)
+        case .dataLoaded(let items):
+            try serializer.serialize_variant_index(value: 10)
             try serializeArray(value: items, serializer: serializer) { item, serializer in
                 try item.serialize(serializer: serializer)
             }
         case .sessionsLoaded(let sessions):
-            try serializer.serialize_variant_index(value: 9)
+            try serializer.serialize_variant_index(value: 11)
             try serializeArray(value: sessions, serializer: serializer) { item, serializer in
                 try item.serialize(serializer: serializer)
             }
         case .routinesLoaded(let routines):
-            try serializer.serialize_variant_index(value: 10)
+            try serializer.serialize_variant_index(value: 12)
             try serializeArray(value: routines, serializer: serializer) { item, serializer in
                 try item.serialize(serializer: serializer)
             }
+        case .lessonsLoaded(let lessons):
+            try serializer.serialize_variant_index(value: 13)
+            try serializeArray(value: lessons, serializer: serializer) { item, serializer in
+                try item.serialize(serializer: serializer)
+            }
+        case .lessonLoaded(let lesson):
+            try serializer.serialize_variant_index(value: 14)
+            try lesson.serialize(serializer: serializer)
         case .itemUpdated(let item):
-            try serializer.serialize_variant_index(value: 11)
+            try serializer.serialize_variant_index(value: 15)
             try item.serialize(serializer: serializer)
         case .routineUpdated(let routine):
-            try serializer.serialize_variant_index(value: 12)
+            try serializer.serialize_variant_index(value: 16)
             try routine.serialize(serializer: serializer)
         case .deleteConfirmed:
-            try serializer.serialize_variant_index(value: 13)
+            try serializer.serialize_variant_index(value: 17)
         case .sessionSaved:
-            try serializer.serialize_variant_index(value: 14)
+            try serializer.serialize_variant_index(value: 18)
         case .loadFailed(let x):
-            try serializer.serialize_variant_index(value: 15)
+            try serializer.serialize_variant_index(value: 19)
             try serializer.serialize_str(value: x)
         case .clearError:
-            try serializer.serialize_variant_index(value: 16)
+            try serializer.serialize_variant_index(value: 20)
         case .setQuery(let x):
-            try serializer.serialize_variant_index(value: 17)
+            try serializer.serialize_variant_index(value: 21)
             try serializeOption(value: x, serializer: serializer) { value, serializer in
                 try value.serialize(serializer: serializer)
             }
@@ -854,57 +915,74 @@ indirect public enum Event: Hashable {
             try deserializer.decrease_container_depth()
             return .refetchRoutines
         case 5:
+            try deserializer.decrease_container_depth()
+            return .refetchLessons
+        case 6:
             let x = try ItemEvent.deserialize(deserializer: deserializer)
             try deserializer.decrease_container_depth()
             return .item(x)
-        case 6:
+        case 7:
             let x = try SessionEvent.deserialize(deserializer: deserializer)
             try deserializer.decrease_container_depth()
             return .session(x)
-        case 7:
+        case 8:
             let x = try RoutineEvent.deserialize(deserializer: deserializer)
             try deserializer.decrease_container_depth()
             return .routine(x)
-        case 8:
+        case 9:
+            let x = try LessonEvent.deserialize(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return .lesson(x)
+        case 10:
             let items = try deserializeArray(deserializer: deserializer) { deserializer in
                 try Item.deserialize(deserializer: deserializer)
             }
             try deserializer.decrease_container_depth()
             return .dataLoaded(items: items)
-        case 9:
+        case 11:
             let sessions = try deserializeArray(deserializer: deserializer) { deserializer in
                 try PracticeSession.deserialize(deserializer: deserializer)
             }
             try deserializer.decrease_container_depth()
             return .sessionsLoaded(sessions: sessions)
-        case 10:
+        case 12:
             let routines = try deserializeArray(deserializer: deserializer) { deserializer in
                 try Routine.deserialize(deserializer: deserializer)
             }
             try deserializer.decrease_container_depth()
             return .routinesLoaded(routines: routines)
-        case 11:
+        case 13:
+            let lessons = try deserializeArray(deserializer: deserializer) { deserializer in
+                try Lesson.deserialize(deserializer: deserializer)
+            }
+            try deserializer.decrease_container_depth()
+            return .lessonsLoaded(lessons: lessons)
+        case 14:
+            let lesson = try Lesson.deserialize(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return .lessonLoaded(lesson: lesson)
+        case 15:
             let item = try Item.deserialize(deserializer: deserializer)
             try deserializer.decrease_container_depth()
             return .itemUpdated(item: item)
-        case 12:
+        case 16:
             let routine = try Routine.deserialize(deserializer: deserializer)
             try deserializer.decrease_container_depth()
             return .routineUpdated(routine: routine)
-        case 13:
+        case 17:
             try deserializer.decrease_container_depth()
             return .deleteConfirmed
-        case 14:
+        case 18:
             try deserializer.decrease_container_depth()
             return .sessionSaved
-        case 15:
+        case 19:
             let x = try deserializer.deserialize_str()
             try deserializer.decrease_container_depth()
             return .loadFailed(x)
-        case 16:
+        case 20:
             try deserializer.decrease_container_depth()
             return .clearError
-        case 17:
+        case 21:
             let x = try deserializeOption(deserializer: deserializer) { deserializer in
                 try ListQuery.deserialize(deserializer: deserializer)
             }
@@ -1559,6 +1637,299 @@ public struct ItemScoreTrend: Hashable {
     }
 
     public static func bincodeDeserialize(input: [UInt8]) throws -> ItemScoreTrend {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
+public struct Lesson: Hashable {
+    @Indirect public var id: String
+    @Indirect public var date: String
+    @Indirect public var notes: String?
+    @Indirect public var photos: [LessonPhoto]
+    @Indirect public var createdAt: String
+    @Indirect public var updatedAt: String
+
+    public init(id: String, date: String, notes: String?, photos: [LessonPhoto], createdAt: String, updatedAt: String) {
+        self.id = id
+        self.date = date
+        self.notes = notes
+        self.photos = photos
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializer.serialize_str(value: self.id)
+        try serializer.serialize_str(value: self.date)
+        try serializeOption(value: self.notes, serializer: serializer) { value, serializer in
+            try serializer.serialize_str(value: value)
+        }
+        try serializeArray(value: self.photos, serializer: serializer) { item, serializer in
+            try item.serialize(serializer: serializer)
+        }
+        try serializer.serialize_str(value: self.createdAt)
+        try serializer.serialize_str(value: self.updatedAt)
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> Lesson {
+        try deserializer.increase_container_depth()
+        let id = try deserializer.deserialize_str()
+        let date = try deserializer.deserialize_str()
+        let notes = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializer.deserialize_str()
+        }
+        let photos = try deserializeArray(deserializer: deserializer) { deserializer in
+            try LessonPhoto.deserialize(deserializer: deserializer)
+        }
+        let createdAt = try deserializer.deserialize_str()
+        let updatedAt = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return Lesson(id: id, date: date, notes: notes, photos: photos, createdAt: createdAt, updatedAt: updatedAt)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> Lesson {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
+indirect public enum LessonEvent: Hashable {
+    case fetchLessons
+    case fetchLesson(id: String)
+    case add(CreateLesson)
+    case update(id: String, input: UpdateLesson)
+    case delete(id: String)
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        switch self {
+        case .fetchLessons:
+            try serializer.serialize_variant_index(value: 0)
+        case .fetchLesson(let id):
+            try serializer.serialize_variant_index(value: 1)
+            try serializer.serialize_str(value: id)
+        case .add(let x):
+            try serializer.serialize_variant_index(value: 2)
+            try x.serialize(serializer: serializer)
+        case .update(let id, let input):
+            try serializer.serialize_variant_index(value: 3)
+            try serializer.serialize_str(value: id)
+            try input.serialize(serializer: serializer)
+        case .delete(let id):
+            try serializer.serialize_variant_index(value: 4)
+            try serializer.serialize_str(value: id)
+        }
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> LessonEvent {
+        let index = try deserializer.deserialize_variant_index()
+        try deserializer.increase_container_depth()
+        switch index {
+        case 0:
+            try deserializer.decrease_container_depth()
+            return .fetchLessons
+        case 1:
+            let id = try deserializer.deserialize_str()
+            try deserializer.decrease_container_depth()
+            return .fetchLesson(id: id)
+        case 2:
+            let x = try CreateLesson.deserialize(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return .add(x)
+        case 3:
+            let id = try deserializer.deserialize_str()
+            let input = try UpdateLesson.deserialize(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return .update(id: id, input: input)
+        case 4:
+            let id = try deserializer.deserialize_str()
+            try deserializer.decrease_container_depth()
+            return .delete(id: id)
+        default: throw DeserializationError.invalidInput(issue: "Unknown variant index for LessonEvent: \(index)")
+        }
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> LessonEvent {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
+public struct LessonPhoto: Hashable {
+    @Indirect public var id: String
+    @Indirect public var url: String
+    @Indirect public var createdAt: String
+
+    public init(id: String, url: String, createdAt: String) {
+        self.id = id
+        self.url = url
+        self.createdAt = createdAt
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializer.serialize_str(value: self.id)
+        try serializer.serialize_str(value: self.url)
+        try serializer.serialize_str(value: self.createdAt)
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> LessonPhoto {
+        try deserializer.increase_container_depth()
+        let id = try deserializer.deserialize_str()
+        let url = try deserializer.deserialize_str()
+        let createdAt = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return LessonPhoto(id: id, url: url, createdAt: createdAt)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> LessonPhoto {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
+public struct LessonPhotoView: Hashable {
+    @Indirect public var id: String
+    @Indirect public var url: String
+
+    public init(id: String, url: String) {
+        self.id = id
+        self.url = url
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializer.serialize_str(value: self.id)
+        try serializer.serialize_str(value: self.url)
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> LessonPhotoView {
+        try deserializer.increase_container_depth()
+        let id = try deserializer.deserialize_str()
+        let url = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return LessonPhotoView(id: id, url: url)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> LessonPhotoView {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
+public struct LessonView: Hashable {
+    @Indirect public var id: String
+    @Indirect public var date: String
+    @Indirect public var notes: String?
+    @Indirect public var notesPreview: String
+    @Indirect public var photos: [LessonPhotoView]
+    @Indirect public var hasPhotos: Bool
+    @Indirect public var createdAt: String
+    @Indirect public var updatedAt: String
+
+    public init(id: String, date: String, notes: String?, notesPreview: String, photos: [LessonPhotoView], hasPhotos: Bool, createdAt: String, updatedAt: String) {
+        self.id = id
+        self.date = date
+        self.notes = notes
+        self.notesPreview = notesPreview
+        self.photos = photos
+        self.hasPhotos = hasPhotos
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializer.serialize_str(value: self.id)
+        try serializer.serialize_str(value: self.date)
+        try serializeOption(value: self.notes, serializer: serializer) { value, serializer in
+            try serializer.serialize_str(value: value)
+        }
+        try serializer.serialize_str(value: self.notesPreview)
+        try serializeArray(value: self.photos, serializer: serializer) { item, serializer in
+            try item.serialize(serializer: serializer)
+        }
+        try serializer.serialize_bool(value: self.hasPhotos)
+        try serializer.serialize_str(value: self.createdAt)
+        try serializer.serialize_str(value: self.updatedAt)
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> LessonView {
+        try deserializer.increase_container_depth()
+        let id = try deserializer.deserialize_str()
+        let date = try deserializer.deserialize_str()
+        let notes = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializer.deserialize_str()
+        }
+        let notesPreview = try deserializer.deserialize_str()
+        let photos = try deserializeArray(deserializer: deserializer) { deserializer in
+            try LessonPhotoView.deserialize(deserializer: deserializer)
+        }
+        let hasPhotos = try deserializer.deserialize_bool()
+        let createdAt = try deserializer.deserialize_str()
+        let updatedAt = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return LessonView(id: id, date: date, notes: notes, notesPreview: notesPreview, photos: photos, hasPhotos: hasPhotos, createdAt: createdAt, updatedAt: updatedAt)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> LessonView {
         let deserializer = BincodeDeserializer.init(input: input);
         let obj = try deserialize(deserializer: deserializer)
         if deserializer.get_buffer_offset() < input.count {
@@ -3428,6 +3799,58 @@ public struct UpdateItem: Hashable {
     }
 }
 
+public struct UpdateLesson: Hashable {
+    @Indirect public var date: String?
+    @Indirect public var notes: String??
+
+    public init(date: String?, notes: String??) {
+        self.date = date
+        self.notes = notes
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializeOption(value: self.date, serializer: serializer) { value, serializer in
+            try serializer.serialize_str(value: value)
+        }
+        try serializeOption(value: self.notes, serializer: serializer) { value, serializer in
+            try serializeOption(value: value, serializer: serializer) { value, serializer in
+                try serializer.serialize_str(value: value)
+            }
+        }
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> UpdateLesson {
+        try deserializer.increase_container_depth()
+        let date = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializer.deserialize_str()
+        }
+        let notes = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializeOption(deserializer: deserializer) { deserializer in
+                try deserializer.deserialize_str()
+            }
+        }
+        try deserializer.decrease_container_depth()
+        return UpdateLesson(date: date, notes: notes)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> UpdateLesson {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
+
 public struct ViewModel: Hashable {
     @Indirect public var items: [LibraryItemView]
     @Indirect public var sessions: [PracticeSessionView]
@@ -3438,8 +3861,10 @@ public struct ViewModel: Hashable {
     @Indirect public var error: String?
     @Indirect public var analytics: AnalyticsView?
     @Indirect public var routines: [RoutineView]
+    @Indirect public var lessons: [LessonView]
+    @Indirect public var currentLesson: LessonView?
 
-    public init(items: [LibraryItemView], sessions: [PracticeSessionView], activeSession: ActiveSessionView?, buildingSetlist: BuildingSetlistView?, summary: SummaryView?, sessionStatus: SessionStatusView, error: String?, analytics: AnalyticsView?, routines: [RoutineView]) {
+    public init(items: [LibraryItemView], sessions: [PracticeSessionView], activeSession: ActiveSessionView?, buildingSetlist: BuildingSetlistView?, summary: SummaryView?, sessionStatus: SessionStatusView, error: String?, analytics: AnalyticsView?, routines: [RoutineView], lessons: [LessonView], currentLesson: LessonView?) {
         self.items = items
         self.sessions = sessions
         self.activeSession = activeSession
@@ -3449,6 +3874,8 @@ public struct ViewModel: Hashable {
         self.error = error
         self.analytics = analytics
         self.routines = routines
+        self.lessons = lessons
+        self.currentLesson = currentLesson
     }
 
     public func serialize<S: Serializer>(serializer: S) throws {
@@ -3477,6 +3904,12 @@ public struct ViewModel: Hashable {
         }
         try serializeArray(value: self.routines, serializer: serializer) { item, serializer in
             try item.serialize(serializer: serializer)
+        }
+        try serializeArray(value: self.lessons, serializer: serializer) { item, serializer in
+            try item.serialize(serializer: serializer)
+        }
+        try serializeOption(value: self.currentLesson, serializer: serializer) { value, serializer in
+            try value.serialize(serializer: serializer)
         }
         try serializer.decrease_container_depth()
     }
@@ -3514,8 +3947,14 @@ public struct ViewModel: Hashable {
         let routines = try deserializeArray(deserializer: deserializer) { deserializer in
             try RoutineView.deserialize(deserializer: deserializer)
         }
+        let lessons = try deserializeArray(deserializer: deserializer) { deserializer in
+            try LessonView.deserialize(deserializer: deserializer)
+        }
+        let currentLesson = try deserializeOption(deserializer: deserializer) { deserializer in
+            try LessonView.deserialize(deserializer: deserializer)
+        }
         try deserializer.decrease_container_depth()
-        return ViewModel(items: items, sessions: sessions, activeSession: activeSession, buildingSetlist: buildingSetlist, summary: summary, sessionStatus: sessionStatus, error: error, analytics: analytics, routines: routines)
+        return ViewModel(items: items, sessions: sessions, activeSession: activeSession, buildingSetlist: buildingSetlist, summary: summary, sessionStatus: sessionStatus, error: error, analytics: analytics, routines: routines, lessons: lessons, currentLesson: currentLesson)
     }
 
     public static func bincodeDeserialize(input: [UInt8]) throws -> ViewModel {

--- a/ios/Intrada/Views/Lessons/LessonCaptureView.swift
+++ b/ios/Intrada/Views/Lessons/LessonCaptureView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Streamlined form for capturing a lesson — date, notes, photos.
+/// Optimised for speed: notes is the hero field, everything else optional.
+/// Presented as a sheet from the Library view.
+struct LessonCaptureView: View {
+    @Environment(IntradaCore.self) private var core
+    @Environment(ToastManager.self) private var toast
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var date: Date = .now
+    @State private var notes: String = ""
+    @State private var isSubmitting = false
+    @State private var savedLessonId: String?
+
+    /// Track lesson count to detect when core processes the create.
+    @State private var lessonCountBeforeSubmit: Int?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Spacing.card) {
+                // Date picker
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Date")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Color.textLabel)
+
+                    DatePicker(
+                        "",
+                        selection: $date,
+                        in: ...Date.now,
+                        displayedComponents: .date
+                    )
+                    .datePickerStyle(.compact)
+                    .labelsHidden()
+                }
+
+                // Notes — the hero field
+                TextAreaView(
+                    label: "Notes",
+                    text: $notes,
+                    placeholder: "What happened in your lesson? What did your teacher say?",
+                    error: nil
+                )
+
+                // Photo upload — only available after save (needs lesson ID)
+                if let lessonId = savedLessonId {
+                    PhotoCaptureView(lessonId: lessonId) {
+                        // Refresh lesson data after photo upload
+                        core.update(.lesson(.fetchLesson(id: lessonId)))
+                    }
+                } else {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Photos")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(Color.textLabel)
+
+                        Text("Save the lesson first, then attach photos")
+                            .font(.caption)
+                            .foregroundStyle(Color.textMuted)
+                    }
+                }
+
+                // Save button
+                ButtonView(
+                    "Save Lesson",
+                    variant: .primary,
+                    disabled: isSubmitting || notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    loading: isSubmitting
+                ) {
+                    submitForm()
+                }
+            }
+            .padding(Spacing.card)
+        }
+        .navigationTitle("Log Lesson")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+        }
+        .onChange(of: core.viewModel.lessons.count) { _, newCount in
+            guard isSubmitting, let before = lessonCountBeforeSubmit, newCount > before else { return }
+            toast.show("Lesson saved", variant: .success)
+            isSubmitting = false
+            dismiss()
+        }
+        .onChange(of: core.viewModel.error) { _, newError in
+            guard isSubmitting, newError != nil else { return }
+            isSubmitting = false
+        }
+    }
+
+    private func submitForm() {
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedNotes.isEmpty else { return }
+
+        isSubmitting = true
+        lessonCountBeforeSubmit = core.viewModel.lessons.count
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dateString = formatter.string(from: date)
+
+        let createLesson = CreateLesson(
+            date: dateString,
+            notes: trimmedNotes.isEmpty ? nil : trimmedNotes
+        )
+
+        core.update(.lesson(.add(createLesson)))
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LessonCaptureView()
+    }
+    .environment(IntradaCore())
+    .environment(ToastManager())
+    .preferredColorScheme(.dark)
+}

--- a/ios/Intrada/Views/Lessons/LessonDetailView.swift
+++ b/ios/Intrada/Views/Lessons/LessonDetailView.swift
@@ -1,0 +1,260 @@
+import SwiftUI
+
+/// Full detail view of a captured lesson — date, notes, photos.
+/// Supports edit mode and delete with confirmation.
+struct LessonDetailView: View {
+    let lessonId: String
+    @Binding var selectedLessonId: String?
+
+    @Environment(IntradaCore.self) private var core
+    @Environment(ToastManager.self) private var toast
+
+    @State private var isEditing = false
+    @State private var editDate: Date = .now
+    @State private var editNotes: String = ""
+    @State private var showDeleteConfirmation = false
+    @State private var isSubmitting = false
+
+    private var lesson: LessonView? {
+        core.viewModel.lessons.first { $0.id == lessonId }
+    }
+
+    var body: some View {
+        Group {
+            if let lesson {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Spacing.card) {
+                        if isEditing {
+                            editContent(lesson)
+                        } else {
+                            readContent(lesson)
+                        }
+                    }
+                    .padding(Spacing.card)
+                }
+                .navigationTitle(formatDate(lesson.date))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        if isEditing {
+                            Button("Save") { saveEdits() }
+                                .disabled(isSubmitting)
+                        } else {
+                            Menu {
+                                Button { startEditing(lesson) } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                Button(role: .destructive) {
+                                    showDeleteConfirmation = true
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis.circle")
+                            }
+                        }
+                    }
+                    if isEditing {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Cancel") { isEditing = false }
+                        }
+                    }
+                }
+            } else {
+                EmptyStateView(
+                    icon: "doc.text",
+                    title: "Lesson Not Found",
+                    message: "This lesson may have been deleted"
+                )
+            }
+        }
+        .onAppear {
+            core.update(.lesson(.fetchLesson(id: lessonId)))
+        }
+        .confirmationDialog(
+            "Delete Lesson",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) { deleteLesson() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete this lesson? This cannot be undone.")
+        }
+        .onChange(of: core.viewModel.lessons.count) { oldCount, newCount in
+            // Detect deletion
+            guard newCount < oldCount else { return }
+            if !core.viewModel.lessons.contains(where: { $0.id == lessonId }) {
+                toast.show("Lesson deleted", variant: .success)
+                selectedLessonId = nil
+            }
+        }
+    }
+
+    // MARK: - Read Mode
+
+    @ViewBuilder
+    private func readContent(_ lesson: LessonView) -> some View {
+        CardView {
+            VStack(alignment: .leading, spacing: Spacing.cardCompact) {
+                // Notes
+                if let notes = lesson.notes, !notes.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("NOTES")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundStyle(Color.textFaint)
+                            .tracking(0.8)
+
+                        Text(notes)
+                            .font(.subheadline)
+                            .foregroundStyle(Color.textSecondary)
+                    }
+                }
+
+                // Photos
+                if !lesson.photos.isEmpty {
+                    Divider()
+                        .overlay(Color.borderDefault)
+
+                    photoGallery(lesson.photos)
+                }
+            }
+        }
+    }
+
+    // MARK: - Edit Mode
+
+    @ViewBuilder
+    private func editContent(_ lesson: LessonView) -> some View {
+        CardView {
+            VStack(alignment: .leading, spacing: Spacing.card) {
+                // Date picker
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Date")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(Color.textLabel)
+
+                    DatePicker(
+                        "",
+                        selection: $editDate,
+                        in: ...Date.now,
+                        displayedComponents: .date
+                    )
+                    .datePickerStyle(.compact)
+                    .labelsHidden()
+                }
+
+                // Notes
+                TextAreaView(
+                    label: "Notes",
+                    text: $editNotes,
+                    placeholder: "What happened in your lesson?",
+                    error: nil
+                )
+
+                // Photo management
+                PhotoCaptureView(lessonId: lessonId) {
+                    core.update(.lesson(.fetchLesson(id: lessonId)))
+                }
+
+                // Existing photos
+                if !lesson.photos.isEmpty {
+                    photoGallery(lesson.photos)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    @ViewBuilder
+    private func photoGallery(_ photos: [LessonPhotoView]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("PHOTOS")
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(Color.textFaint)
+                .tracking(0.8)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(photos, id: \.id) { photo in
+                        AsyncImage(url: URL(string: photo.url)) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 80, height: 80)
+                                    .clipShape(RoundedRectangle(cornerRadius: DesignRadius.badge))
+                            case .failure:
+                                photoPlaceholder
+                            case .empty:
+                                ProgressView()
+                                    .frame(width: 80, height: 80)
+                            @unknown default:
+                                photoPlaceholder
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var photoPlaceholder: some View {
+        RoundedRectangle(cornerRadius: DesignRadius.badge)
+            .fill(Color.surfaceSecondary)
+            .frame(width: 80, height: 80)
+            .overlay(
+                Image(systemName: "photo")
+                    .foregroundStyle(Color.textFaint)
+            )
+    }
+
+    // MARK: - Actions
+
+    private func startEditing(_ lesson: LessonView) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        editDate = formatter.date(from: lesson.date) ?? .now
+        editNotes = lesson.notes ?? ""
+        isEditing = true
+    }
+
+    private func saveEdits() {
+        isSubmitting = true
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dateString = formatter.string(from: editDate)
+
+        let trimmedNotes = editNotes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let update = UpdateLesson(
+            date: dateString,
+            notes: trimmedNotes.isEmpty ? nil : trimmedNotes
+        )
+
+        core.update(.lesson(.update(id: lessonId, input: update)))
+        isEditing = false
+        isSubmitting = false
+        toast.show("Lesson updated", variant: .success)
+    }
+
+    private func deleteLesson() {
+        core.update(.lesson(.delete(id: lessonId)))
+    }
+
+    private func formatDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        guard let date = inputFormatter.date(from: dateString) else { return dateString }
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateStyle = .long
+        return outputFormatter.string(from: date)
+    }
+}

--- a/ios/Intrada/Views/Lessons/LessonListView.swift
+++ b/ios/Intrada/Views/Lessons/LessonListView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Reverse chronological list of lessons with NavigationSplitView on iPad.
+struct LessonListView: View {
+    @Environment(IntradaCore.self) private var core
+    @State private var selectedLessonId: String?
+
+    var body: some View {
+        NavigationSplitView {
+            Group {
+                if core.viewModel.lessons.isEmpty {
+                    EmptyStateView(
+                        icon: "pencil.and.list.clipboard",
+                        title: "No Lessons Yet",
+                        message: "Log your first lesson from the Library tab"
+                    )
+                } else {
+                    List(core.viewModel.lessons, id: \.id, selection: $selectedLessonId) { lesson in
+                        LessonRow(lesson: lesson)
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle("Lessons")
+            .onAppear {
+                core.update(.lesson(.fetchLessons))
+            }
+        } detail: {
+            if let lessonId = selectedLessonId {
+                LessonDetailView(
+                    lessonId: lessonId,
+                    selectedLessonId: $selectedLessonId
+                )
+            } else {
+                EmptyStateView(
+                    icon: "doc.text",
+                    title: "Select a Lesson",
+                    message: "Choose a lesson to view its details"
+                )
+            }
+        }
+    }
+}
+
+/// A single row in the lesson list.
+private struct LessonRow: View {
+    let lesson: LessonView
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(formatDate(lesson.date))
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.textPrimary)
+
+                Spacer()
+
+                if lesson.hasPhotos {
+                    Image(systemName: "photo")
+                        .font(.caption)
+                        .foregroundStyle(Color.textMuted)
+                }
+            }
+
+            if !lesson.notesPreview.isEmpty {
+                Text(lesson.notesPreview)
+                    .font(.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 4)
+        .listRowBackground(Color.clear)
+    }
+
+    private func formatDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        guard let date = inputFormatter.date(from: dateString) else { return dateString }
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateStyle = .medium
+        return outputFormatter.string(from: date)
+    }
+}
+
+#Preview {
+    LessonListView()
+        .environment(IntradaCore())
+        .preferredColorScheme(.dark)
+}

--- a/ios/Intrada/Views/Lessons/PhotoCaptureView.swift
+++ b/ios/Intrada/Views/Lessons/PhotoCaptureView.swift
@@ -1,0 +1,219 @@
+import PhotosUI
+import SwiftUI
+
+/// Camera + photo library picker with client-side compression and upload to API.
+///
+/// Used within LessonCaptureView and LessonDetailView (edit mode).
+/// Photos are compressed to 2048px longest edge, JPEG 80% before upload.
+/// Upload goes directly to POST /api/lessons/:id/photos (outside Crux).
+struct PhotoCaptureView: View {
+    let lessonId: String
+    let onPhotoUploaded: () -> Void
+
+    @Environment(IntradaCore.self) private var core
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var isUploading = false
+    @State private var uploadError: String?
+    @State private var showCamera = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.cardCompact) {
+            Text("Photos")
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundStyle(Color.textLabel)
+
+            HStack(spacing: Spacing.cardCompact) {
+                // Camera button (iOS only, not available on simulator sometimes)
+                if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                    Button {
+                        showCamera = true
+                    } label: {
+                        Label("Camera", systemImage: "camera")
+                            .font(.subheadline)
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                }
+
+                // Photo library picker
+                PhotosPicker(
+                    selection: $selectedItems,
+                    maxSelectionCount: 5,
+                    matching: .images
+                ) {
+                    Label("Photo Library", systemImage: "photo.on.rectangle")
+                        .font(.subheadline)
+                }
+                .buttonStyle(SecondaryButtonStyle())
+
+                if isUploading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let error = uploadError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(Color.dangerText)
+            }
+        }
+        .onChange(of: selectedItems) { _, newItems in
+            Task {
+                for item in newItems {
+                    await uploadPhotoItem(item)
+                }
+                selectedItems = []
+            }
+        }
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraView { image in
+                Task {
+                    await uploadImage(image)
+                }
+            }
+        }
+    }
+
+    private func uploadPhotoItem(_ item: PhotosPickerItem) async {
+        guard let data = try? await item.loadTransferable(type: Data.self) else {
+            uploadError = "Failed to load photo"
+            return
+        }
+        guard let uiImage = UIImage(data: data) else {
+            uploadError = "Invalid image data"
+            return
+        }
+        await uploadImage(uiImage)
+    }
+
+    private func uploadImage(_ image: UIImage) async {
+        isUploading = true
+        uploadError = nil
+        defer { isUploading = false }
+
+        // Compress to 2048px max edge
+        let compressed = compressImage(image, maxEdge: 2048, quality: 0.8)
+        guard let jpegData = compressed else {
+            uploadError = "Failed to compress photo"
+            return
+        }
+
+        // Upload directly to API (outside Crux)
+        do {
+            try await uploadToAPI(jpegData: jpegData)
+            onPhotoUploaded()
+        } catch {
+            uploadError = "Upload failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func compressImage(_ image: UIImage, maxEdge: CGFloat, quality: CGFloat) -> Data? {
+        let size = image.size
+        let longestEdge = max(size.width, size.height)
+
+        if longestEdge <= maxEdge {
+            return image.jpegData(compressionQuality: quality)
+        }
+
+        let scale = maxEdge / longestEdge
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+
+        UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
+        image.draw(in: CGRect(origin: .zero, size: newSize))
+        let resized = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return resized?.jpegData(compressionQuality: quality)
+    }
+
+    private func uploadToAPI(jpegData: Data) async throws {
+        let token = try await core.getAuthToken()
+        let url = URL(string: "\(Config.apiBaseURL)/api/lessons/\(lessonId)/photos")!
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        let boundary = UUID().uuidString
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        if let token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"photo\"; filename=\"photo.jpg\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+        body.append(jpegData)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+}
+
+// MARK: - Camera UIKit Bridge
+
+struct CameraView: UIViewControllerRepresentable {
+    let onCapture: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture, dismiss: dismiss)
+    }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage) -> Void
+        let dismiss: DismissAction
+
+        init(onCapture: @escaping (UIImage) -> Void, dismiss: DismissAction) {
+            self.onCapture = onCapture
+            self.dismiss = dismiss
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let image = info[.originalImage] as? UIImage {
+                onCapture(image)
+            }
+            dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            dismiss()
+        }
+    }
+}
+
+// MARK: - Secondary Button Style
+
+private struct SecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, Spacing.cardCompact)
+            .padding(.vertical, 8)
+            .background(Color.surfaceInput)
+            .cornerRadius(DesignRadius.input)
+            .overlay(
+                RoundedRectangle(cornerRadius: DesignRadius.input)
+                    .stroke(Color.borderInput, lineWidth: 1)
+            )
+            .foregroundStyle(Color.textSecondary)
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+    }
+}

--- a/ios/Intrada/Views/Library/LibraryView.swift
+++ b/ios/Intrada/Views/Library/LibraryView.swift
@@ -7,6 +7,7 @@ struct LibraryView: View {
     @Environment(IntradaCore.self) private var core
     @State private var selectedItemId: String?
     @State private var showAddSheet: Bool = false
+    @State private var showLessonSheet: Bool = false
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
@@ -19,13 +20,23 @@ struct LibraryView: View {
             .navigationSplitViewColumnWidth(min: 300, ideal: 320, max: 400)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        showAddSheet = true
-                    } label: {
-                        Image(systemName: "plus")
+                    HStack(spacing: 12) {
+                        Button {
+                            showLessonSheet = true
+                        } label: {
+                            Image(systemName: "pencil.and.list.clipboard")
+                        }
+                        .tint(.accent)
+                        .accessibilityLabel("Log lesson")
+
+                        Button {
+                            showAddSheet = true
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                        .tint(.accent)
+                        .accessibilityLabel("Add item")
                     }
-                    .tint(.accent)
-                    .accessibilityLabel("Add item")
                 }
             }
         } detail: {
@@ -45,6 +56,11 @@ struct LibraryView: View {
         .sheet(isPresented: $showAddSheet) {
             NavigationStack {
                 AddItemView()
+            }
+        }
+        .sheet(isPresented: $showLessonSheet) {
+            NavigationStack {
+                LessonCaptureView()
             }
         }
         .onAppear { autoSelectFirstItem() }

--- a/specs/269-teacher-capture/checklists/requirements.md
+++ b/specs/269-teacher-capture/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Teacher Assignment Capture
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Simplified from lesson-with-items to pure lesson capture (Layer 1).
+- Single notes field replaces separate summary + teacher notes.
+- Item linking and inline quick-add deferred to follow-up features.
+- Size back to M with the reduced scope.

--- a/specs/269-teacher-capture/contracts/api.md
+++ b/specs/269-teacher-capture/contracts/api.md
@@ -1,0 +1,165 @@
+# API Contracts: Teacher Assignment Capture
+
+Base URL: `/api`  
+Auth: JWT Bearer token (Clerk, RS256 against JWKS)  
+All endpoints scoped by `user_id` from JWT `sub` claim.
+
+---
+
+## Lessons
+
+### POST /api/lessons
+
+Create a new lesson.
+
+**Request**:
+```json
+{
+  "date": "2026-04-11",
+  "notes": "Worked on thirds, keep wrist relaxed..."
+}
+```
+
+**Validation**:
+- `date`: Required. Valid date string (YYYY-MM-DD). Cannot be in the future.
+- `notes`: Optional. Max 10,000 characters.
+
+**Response** (201 Created):
+```json
+{
+  "id": "01JRZX...",
+  "date": "2026-04-11",
+  "notes": "Worked on thirds, keep wrist relaxed...",
+  "photos": [],
+  "created_at": "2026-04-11T14:30:00Z",
+  "updated_at": "2026-04-11T14:30:00Z"
+}
+```
+
+**Errors**:
+- 400: Validation failure
+- 401: Unauthorized
+
+---
+
+### GET /api/lessons
+
+List all lessons for the authenticated user, reverse chronological.
+
+**Response** (200 OK):
+```json
+[
+  {
+    "id": "01JRZX...",
+    "date": "2026-04-11",
+    "notes": "Worked on thirds, keep wrist relaxed...",
+    "photos": [
+      {
+        "id": "01JRZ1...",
+        "url": "https://r2.example.com/user123/lesson456/photo789.jpg",
+        "created_at": "2026-04-11T14:31:00Z"
+      }
+    ],
+    "created_at": "2026-04-11T14:30:00Z",
+    "updated_at": "2026-04-11T14:30:00Z"
+  }
+]
+```
+
+**Errors**:
+- 401: Unauthorized
+
+---
+
+### GET /api/lessons/:id
+
+Get a single lesson by ID.
+
+**Response** (200 OK): Same shape as single item in list response.
+
+**Errors**:
+- 401: Unauthorized
+- 404: Not found (or belongs to another user)
+
+---
+
+### PUT /api/lessons/:id
+
+Update an existing lesson.
+
+**Request**:
+```json
+{
+  "date": "2026-04-10",
+  "notes": "Updated notes..."
+}
+```
+
+**Validation**: Same as create. All fields optional — only provided fields are updated.
+
+**Response** (200 OK): Updated lesson object (same shape as GET).
+
+**Errors**:
+- 400: Validation failure
+- 401: Unauthorized
+- 404: Not found
+
+---
+
+### DELETE /api/lessons/:id
+
+Delete a lesson and all associated photos.
+
+**Response** (204 No Content)
+
+**Side effects**: All photos in R2 for this lesson are also deleted.
+
+**Errors**:
+- 401: Unauthorized
+- 404: Not found
+
+---
+
+## Lesson Photos
+
+Photo upload/delete is handled outside the Crux effect system. The shell calls these endpoints directly.
+
+### POST /api/lessons/:id/photos
+
+Upload a photo to a lesson. Multipart form data.
+
+**Request**: `multipart/form-data`
+- `photo`: Image file (JPEG/PNG, max 5MB after client-side compression)
+
+**Response** (201 Created):
+```json
+{
+  "id": "01JRZ1...",
+  "url": "https://r2.example.com/user123/lesson456/photo789.jpg",
+  "created_at": "2026-04-11T14:31:00Z"
+}
+```
+
+**Validation**:
+- File must be JPEG or PNG
+- Max 5MB
+- Lesson must exist and belong to user
+
+**Errors**:
+- 400: Invalid file type or size
+- 401: Unauthorized
+- 404: Lesson not found
+
+---
+
+### DELETE /api/lessons/:id/photos/:photo_id
+
+Remove a photo from a lesson.
+
+**Response** (204 No Content)
+
+**Side effects**: Photo object deleted from R2.
+
+**Errors**:
+- 401: Unauthorized
+- 404: Lesson or photo not found

--- a/specs/269-teacher-capture/data-model.md
+++ b/specs/269-teacher-capture/data-model.md
@@ -1,0 +1,138 @@
+# Data Model: Teacher Assignment Capture
+
+## Entities
+
+### Lesson
+
+A record of a single teaching session. Lightweight — designed for speed of capture.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| id | String (ULID) | Yes | Server-generated |
+| user_id | String | Yes | From JWT `sub` claim |
+| date | Date (YYYY-MM-DD) | Yes | Defaults to today, editable |
+| notes | String | No | Free text, max 10,000 chars |
+| created_at | DateTime (RFC3339) | Yes | Server-generated |
+| updated_at | DateTime (RFC3339) | Yes | Server-managed |
+
+**Validation rules**:
+- `date`: Must be a valid date, cannot be in the future (allow today and past dates)
+- `notes`: Max 10,000 characters (generous — this replaces a notebook page)
+- At least one of `notes` or photos must be present (enforced at application level, not DB)
+
+### LessonPhoto
+
+A photo attachment belonging to a lesson. Stored as an object in Cloudflare R2; the DB holds metadata only.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| id | String (ULID) | Yes | Server-generated |
+| lesson_id | String | Yes | Foreign key to lessons.id |
+| user_id | String | Yes | From JWT `sub` claim |
+| storage_key | String | Yes | R2 object key (e.g., `{user_id}/{lesson_id}/{id}.jpg`) |
+| created_at | DateTime (RFC3339) | Yes | Server-generated |
+
+**Relationships**:
+- Lesson 1 → N LessonPhoto (cascade delete: deleting a lesson deletes its photos)
+- LessonPhoto is owned by a user (scoped queries)
+
+## Database Schema
+
+### Migration: Create lessons table
+
+```sql
+CREATE TABLE IF NOT EXISTS lessons (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    date TEXT NOT NULL,
+    notes TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_lessons_user_date
+    ON lessons(user_id, date DESC);
+```
+
+### Migration: Create lesson_photos table
+
+```sql
+CREATE TABLE IF NOT EXISTS lesson_photos (
+    id TEXT PRIMARY KEY NOT NULL,
+    lesson_id TEXT NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    storage_key TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (lesson_id) REFERENCES lessons(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_lesson_photos_lesson_id
+    ON lesson_photos(lesson_id);
+```
+
+## Column Indexing
+
+Following the project pattern of positional `SELECT_COLUMNS`:
+
+**Lessons**:
+```
+0: id
+1: user_id
+2: date
+3: notes
+4: created_at
+5: updated_at
+```
+
+**LessonPhotos**:
+```
+0: id
+1: lesson_id
+2: user_id
+3: storage_key
+4: created_at
+```
+
+## State Transitions
+
+Lesson has no complex state machine — it supports CRUD operations only:
+
+```
+[Not exists] → Create → [Exists] → Edit → [Exists]
+                                   → Delete → [Not exists]
+```
+
+Photo lifecycle:
+```
+[Not exists] → Upload (shell) → [Stored in R2 + DB record] → Delete → [Removed from R2 + DB]
+```
+
+## Core Domain Types
+
+```
+Lesson {
+    id: String,
+    date: NaiveDate,
+    notes: Option<String>,
+    photos: Vec<LessonPhoto>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+LessonPhoto {
+    id: String,
+    storage_key: String,
+    url: String,          // Derived: R2 public URL from storage_key
+    created_at: DateTime<Utc>,
+}
+
+CreateLesson {
+    date: NaiveDate,
+    notes: Option<String>,
+}
+
+UpdateLesson {
+    date: Option<NaiveDate>,
+    notes: Option<String>,
+}
+```

--- a/specs/269-teacher-capture/plan.md
+++ b/specs/269-teacher-capture/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Teacher Assignment Capture
+
+**Branch**: `269-teacher-capture` | **Date**: 2026-04-11 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/269-teacher-capture/spec.md`
+
+## Summary
+
+Introduce a **Lesson** entity — a lightweight record of a teaching session (date, notes, photos). This is the core Layer 1 (Capture) feature: musicians capture raw lesson information in under 30 seconds, with no forced organisation. The lesson entity is standalone in this iteration; item linking is deferred to a follow-up feature.
+
+Technical approach: new Crux domain module (events, model, effects), new API endpoints with Turso persistence, photo storage in Cloudflare R2 with shell-managed uploads (outside Crux's JSON-only HTTP), and new UI screens on both web (Leptos) and iOS (SwiftUI).
+
+## Technical Context
+
+**Language/Version**: Rust stable 1.89.0 (core, API, web), Swift 6.0 (iOS)  
+**Primary Dependencies**: crux_core 0.17.0-rc3, axum 0.8, leptos 0.8, SwiftUI, UniFFI  
+**Storage**: Turso (libsql) for lesson metadata, Cloudflare R2 for photos  
+**Testing**: cargo test (core + API), Playwright (E2E), just ios-swift-check (iOS)  
+**Target Platform**: Web (WASM/CSR) + iOS 17+  
+**Project Type**: Multi-crate workspace + iOS app  
+**Performance Goals**: Lesson capture in <30s user time, lesson list renders instantly for <1000 lessons  
+**Constraints**: Crux HTTP is JSON-only (no multipart), 1MB body limit, photos handled by shell  
+**Scale/Scope**: Single user, ~100 lessons/year typical, 1-5 photos per lesson
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | ✅ Pass | Follows existing entity patterns (items, sessions, routines). Single responsibility per module. |
+| II. Testing Standards | ✅ Pass | Core unit tests for lesson events/effects, API integration tests, E2E tests for user flows. Boundary tested at core↔shell and API layers. |
+| III. UX Consistency | ✅ Pass | Uses existing component library (Card, Button, TextField, TextArea). Pencil designs follow glassmorphism language. |
+| IV. Performance | ✅ Pass | Lesson list is small dataset (<1000). Photos stored externally, not in DB. No N+1 queries (photos joined on lesson fetch). |
+| V. Architecture Integrity | ✅ Pass | Core is pure (events → effects, no I/O). Photo upload handled by shell, not core. API handles persistence independently. |
+| VI. Inclusive Design | ✅ Pass | Minimal decisions to start (date auto-filled, one text field). No forced structure. Predictable flow. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/269-teacher-capture/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: technical decisions
+├── data-model.md        # Phase 1: entity schemas
+├── quickstart.md        # Phase 1: verification steps
+├── contracts/
+│   └── api.md           # Phase 1: API endpoint contracts
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+  intrada-core/
+    src/
+      domain/
+        lesson.rs          # NEW: Lesson event handling, model updates
+        types.rs           # MODIFIED: Add Lesson, LessonPhoto, CreateLesson, UpdateLesson
+        mod.rs             # MODIFIED: Add lesson module
+      validation.rs        # MODIFIED: Add lesson validation rules
+      http.rs              # MODIFIED: Add lesson API request builders
+      view_model.rs        # MODIFIED: Add lessons to ViewModel
+
+  intrada-api/
+    src/
+      migrations.rs        # MODIFIED: Add lessons + lesson_photos tables
+      db/
+        lessons.rs         # NEW: Lesson DB queries (CRUDL + photo queries)
+        mod.rs             # MODIFIED: Add lessons module
+      routes/
+        lessons.rs         # NEW: Lesson API routes + photo upload
+        mod.rs             # MODIFIED: Mount lesson routes
+      storage.rs           # NEW: R2 client for photo upload/delete
+
+  intrada-web/
+    src/
+      views/
+        lessons.rs         # NEW: Lessons list + detail + capture form views
+        mod.rs             # MODIFIED: Add lessons module
+      components/
+        photo_upload.rs    # NEW: Photo upload component (file input + preview)
+        mod.rs             # MODIFIED: Add photo_upload
+
+  shared/                  # MODIFIED: Lesson types flow through UniFFI/BCS bridge
+  shared_types/            # AUTO: Facet typegen generates Swift types
+
+ios/Intrada/
+  Features/Lessons/
+    LessonListView.swift       # NEW: Lessons list screen
+    LessonDetailView.swift     # NEW: Lesson detail screen
+    LessonCaptureView.swift    # NEW: Capture form screen
+    PhotoCaptureView.swift     # NEW: Camera/photo picker + upload
+```
+
+**Structure Decision**: Follows existing multi-crate pattern. Lesson is a new domain module in core, new route group in API, new view group in web and iOS. Photo upload is a new shell-level capability (not a Crux effect) in both web and iOS shells.

--- a/specs/269-teacher-capture/quickstart.md
+++ b/specs/269-teacher-capture/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: Teacher Assignment Capture
+
+## Prerequisites
+
+- Rust stable (1.89.0+)
+- `just` command runner
+- Turso database with auth token
+- Cloudflare R2 bucket (for photos)
+- iOS: Xcode 16+, iOS 17+ simulator
+
+## Verification Steps
+
+### 1. Core compiles and tests pass
+
+```bash
+cargo test -p intrada-core
+cargo clippy -p intrada-core -- -D warnings
+```
+
+Verify:
+- [ ] Lesson events (create, update, delete, list, fetch) are handled
+- [ ] Lesson model updates correctly on each event
+- [ ] ViewModel includes lessons list and lesson detail
+- [ ] Validation rejects future dates and oversized notes
+
+### 2. API compiles and tests pass
+
+```bash
+cargo test -p intrada-api
+```
+
+Verify:
+- [ ] Migrations run (lessons + lesson_photos tables created)
+- [ ] POST /api/lessons creates a lesson and returns 201
+- [ ] GET /api/lessons returns user-scoped lessons in reverse date order
+- [ ] GET /api/lessons/:id returns a single lesson with photos
+- [ ] PUT /api/lessons/:id updates lesson fields
+- [ ] DELETE /api/lessons/:id removes lesson and cascades to photos
+- [ ] POST /api/lessons/:id/photos accepts multipart upload
+- [ ] DELETE /api/lessons/:id/photos/:photo_id removes photo
+- [ ] All endpoints reject unauthenticated requests with 401
+- [ ] All endpoints scope by user_id
+
+### 3. Web shell renders lessons UI
+
+```bash
+trunk serve
+```
+
+Verify:
+- [ ] "Log Lesson" entry point visible from Library screen
+- [ ] Capture form shows date (today), notes field, photo upload
+- [ ] Saving a lesson navigates to lesson list/detail
+- [ ] Lesson list shows entries in reverse chronological order
+- [ ] Lesson detail shows date, notes, photos
+- [ ] Edit updates lesson, delete removes with confirmation
+- [ ] Photo upload works via file picker
+- [ ] Photo thumbnails display, tappable to full-size
+
+### 4. iOS shell renders lessons UI
+
+```bash
+just typegen
+just ios-swift-check
+just ios-smoke-test
+```
+
+Verify:
+- [ ] "Log Lesson" entry point visible from Library screen
+- [ ] Capture form shows date (today), notes field, camera/photo picker
+- [ ] Saving a lesson navigates to lesson list/detail
+- [ ] Lesson list shows entries in reverse chronological order
+- [ ] Lesson detail shows date, notes, photos
+- [ ] Edit and delete work correctly
+- [ ] Photo capture from camera works
+- [ ] Photo selection from photo library works
+- [ ] Photos display as thumbnails, tappable to full-size
+
+### 5. E2E tests pass
+
+```bash
+cd e2e && npx playwright test
+```
+
+Verify:
+- [ ] Create lesson with notes only
+- [ ] Create lesson with photo only
+- [ ] Edit lesson (change notes, change date)
+- [ ] Delete lesson with confirmation
+- [ ] Lesson list ordering is correct
+- [ ] Lesson persists across page reload
+
+### 6. Cross-platform parity
+
+- [ ] Mobile and desktop layouts match Pencil designs
+- [ ] iOS and web show the same data
+- [ ] Design system tokens used throughout (no raw colours)

--- a/specs/269-teacher-capture/research.md
+++ b/specs/269-teacher-capture/research.md
@@ -1,0 +1,71 @@
+# Research: Teacher Assignment Capture
+
+## Decision 1: Photo Storage Strategy
+
+**Decision**: Use Cloudflare R2 for photo storage, accessed via the API server on Fly.io.
+
+**Rationale**: 
+- Turso (libsql/SQLite) is not suitable for binary blob storage — row size limits and query performance degrade with large payloads.
+- Cloudflare R2 is already in the ecosystem (web shell deployed via Cloudflare Workers) and has an S3-compatible API.
+- R2 has no egress fees, which is ideal for photo retrieval.
+- Photos are stored as objects keyed by `{user_id}/{lesson_id}/{photo_id}.jpg`. The DB stores only the object key, not the binary data.
+
+**Alternatives considered**:
+- *Base64 in DB*: Simple but hits Turso row size limits (~1MB), inflates payload by 33%, and degrades query performance on large datasets. Rejected.
+- *Local device storage only*: No cross-device access, no backup. Rejected.
+- *Direct shell-to-R2 upload via presigned URL*: More complex (requires presigned URL generation endpoint), but better for very large files. Deferred — not needed for compressed lesson photos.
+
+## Decision 2: Photo Upload Flow Through Crux Architecture
+
+**Decision**: Photo upload is handled by the shell directly, outside the Crux effect system. Core manages photo metadata only.
+
+**Rationale**:
+- Crux's HTTP capability is JSON-only (`body_json()`). There is no multipart/binary support.
+- The current request body limit is 1MB, insufficient for raw photos.
+- The shell (iOS: native camera/photo picker, web: file input) captures the photo, compresses it, and uploads via a dedicated multipart API endpoint (`POST /api/lessons/{id}/photos`).
+- After upload, the shell dispatches an event to core to refresh lesson data, which includes photo metadata (URLs/keys) from the normal JSON API.
+- Core never handles binary photo data — it only sees photo metadata in the lesson model.
+
+**Alternatives considered**:
+- *Base64 in JSON via Crux HTTP*: Would require increasing body limit, encoding/decoding overhead, and makes core handle binary concerns. Rejected.
+- *Custom Crux capability for file uploads*: Over-engineered for this feature. Rejected.
+
+## Decision 3: Photo Compression
+
+**Decision**: Shell compresses photos to max 2048px longest edge, JPEG quality 80%, before upload.
+
+**Rationale**:
+- Lesson photos are reference material (handwritten notes, sheet music annotations), not high-art photography. 2048px is more than sufficient for readability.
+- At JPEG 80%, a 2048px photo is typically 200-500KB — well within reasonable upload limits.
+- Compression happens on-device before upload, reducing bandwidth and storage costs.
+
+**Alternatives considered**:
+- *Server-side compression*: Wastes bandwidth uploading full-resolution images. Rejected.
+- *No compression*: 10MB+ photos from modern phone cameras would be wasteful. Rejected.
+
+## Decision 4: Lesson Navigation Placement
+
+**Decision**: "Log Lesson" accessible via a prominent action button on the Library screen (both platforms), not a new tab.
+
+**Rationale**:
+- Adding a new tab to the bottom navigation changes the app's information architecture significantly — too much for an M-sized feature.
+- Lessons are closely related to the Library (they produce items that live there eventually). A button on the Library screen keeps them discoverable without restructuring navigation.
+- The lessons list is accessible from the same entry point (tap "Log Lesson" or "View Lessons" from Library).
+- This can be promoted to a tab or dedicated section later if lessons prove to be heavily used.
+
+**Alternatives considered**:
+- *New bottom tab*: Changes IA, affects all screens, requires design system updates across both platforms. Deferred.
+- *Floating action button*: iOS doesn't have a strong FAB convention. Rejected.
+- *Inside settings/profile*: Too hidden — contradicts FR-001 ("not buried inside Library"). Rejected.
+
+## Decision 5: Lesson Entity Scope
+
+**Decision**: Lesson is a standalone entity with no item relationships in this iteration.
+
+**Rationale**:
+- Per spec, item linking is explicitly deferred to a follow-up feature.
+- This keeps the data model simple: `lessons` table + `lesson_photos` table, no junction tables.
+- The lesson entity can be extended with relationships later without breaking changes.
+
+**Alternatives considered**:
+- *Pre-build the junction table*: Adds unused schema. Rejected per YAGNI.

--- a/specs/269-teacher-capture/spec.md
+++ b/specs/269-teacher-capture/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Teacher Assignment Capture
+
+**Feature Branch**: `269-teacher-capture`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "Quick-capture flow optimised for post-lesson entry. Capture the lesson as a single entity — date, notes, photos. Pure Layer 1: capture what happened, organise later. Item linking deferred to a follow-up feature."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Capture a lesson (Priority: P1)
+
+A musician has just finished a lesson. They open intrada and create a new lesson entry — today's date, a brain dump of everything that happened ("worked on thirds, keep wrist relaxed, new Chopin étude — focus on RH arpeggios very slow"), and a photo of the teacher's handwritten annotations. The whole capture takes under 30 seconds. They put the phone away and head home.
+
+**Why this priority**: This is the true Layer 1 (Capture) value. The notebook replacement. If a musician can capture the raw lesson quickly, nothing is lost — they can organise later. One notes field, no categories, no structure forced at capture time.
+
+**Independent Test**: Can be fully tested by creating a lesson entry with notes and/or a photo, verifying it persists, and viewing it later.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on any screen, **When** they tap a "Log Lesson" action, **Then** a streamlined capture form appears with date (defaulting to today), notes, and photo attachment.
+2. **Given** the capture form is open, **When** the user writes notes and saves, **Then** a lesson entry is created and visible in the lessons list.
+3. **Given** the capture form is open, **When** the user attaches one or more photos, **Then** the photos are stored with the lesson and viewable later.
+4. **Given** the user saves a lesson with only a photo (no notes), **Then** the lesson is saved successfully — notes are not required.
+
+---
+
+### User Story 2 - Review and edit a past lesson (Priority: P2)
+
+A musician opens a lesson from last week. They re-read their notes and the photo of the teacher's annotations. They add a line they forgot: "also mentioned practising with metronome at 60 BPM." They save the edit.
+
+**Why this priority**: Capture is often incomplete in the moment. Allowing edits means the lesson entry becomes a living record that can be enriched over time, not a one-shot form.
+
+**Independent Test**: Can be tested by creating a lesson, reopening it, editing the notes, saving, and verifying the changes persist.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is viewing a lesson, **When** they tap "Edit", **Then** the notes and photos become editable.
+2. **Given** the user is editing a lesson, **When** they modify notes or add/remove photos and save, **Then** the changes are persisted.
+3. **Given** the user is editing a lesson, **When** they change the date, **Then** the lesson reorders correctly in the list.
+
+---
+
+### User Story 3 - Browse past lessons (Priority: P3)
+
+A musician wants to look back at what their teacher said three weeks ago. They open the lessons list, scan by date, and tap to review the full notes and photos.
+
+**Why this priority**: The value of capture compounds over time — lessons become a searchable history of teacher guidance. This supports Layer 4 (Show) by making the teaching relationship visible.
+
+**Independent Test**: Can be tested by creating several lessons across different dates and browsing through them.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has multiple lessons, **When** they open the lessons list, **Then** lessons are displayed in reverse chronological order with date and notes preview.
+2. **Given** the user is browsing lessons, **When** they tap a lesson, **Then** they see the full detail: date, notes, and photos.
+3. **Given** the user has no lessons, **When** they open the lessons list, **Then** an empty state prompts them to log their first lesson.
+
+---
+
+### Edge Cases
+
+- What happens when a lesson has no notes (only photos)? — Allowed; photos alone are a valid capture.
+- What happens when a lesson has no photos (only notes)? — Allowed; notes alone are a valid capture.
+- What happens when a lesson has neither notes nor photos? — Not allowed; at least one of notes or photos is required.
+- What happens when the user deletes a lesson? — Lesson is permanently removed after confirmation. No cascading effects (item linking is a future feature).
+- What happens when the user loses connectivity mid-capture? — Form state is preserved locally; lesson syncs when connectivity returns.
+- What happens when photos are very large (>10MB each)? — Photos are compressed/resized before storage (e.g., 2048px longest edge).
+- What happens when the user creates a lesson for a past date? — Allowed; date is editable for late entries.
+- What happens when two lessons have the same date? — Allowed; a musician might have multiple lessons in one day (different teachers, morning/afternoon).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a "Log Lesson" entry point via a prominent action on the Library screen.
+- **FR-002**: System MUST capture the following fields per lesson: date (required, defaults to today), notes (free text), and photo attachments (zero or more).
+- **FR-003**: At least one of notes or photos MUST be provided to save a lesson.
+- **FR-004**: System MUST support attaching multiple photos per lesson from camera or photo library.
+- **FR-005**: System MUST display attached photos in the lesson detail view, tappable to view full-size.
+- **FR-006**: System MUST allow removing or adding photos when editing a lesson.
+- **FR-007**: System MUST display lessons in a chronological list with date and notes preview.
+- **FR-008**: System MUST preserve form state if the user navigates away mid-capture.
+- **FR-009**: System MUST allow editing a lesson after creation (update date, notes, add/remove photos).
+- **FR-010**: System MUST allow deleting a lesson with a confirmation prompt.
+
+### Key Entities
+
+- **Lesson**: A new first-class entity representing a single teaching session. Has a date, notes (free text), and zero or more photo attachments. Owned by a user. No relationship to library items in this iteration.
+
+## Design *(include if feature has UI)*
+
+### Existing Components Used
+
+- **CardView** — container for lesson detail sections
+- **ButtonView** — primary action (save), secondary action (edit, delete)
+- **EmptyStateView** — when no lessons exist, prompt to log first lesson
+- **Form fields** — text area, date picker
+
+### New Components Needed
+
+- **LessonCaptureForm**: Minimal capture form — date picker (defaulting to today), notes text area (the hero field, auto-focused), photo attachment area. Optimised for speed.
+- **LessonCard**: List item for the lessons list — shows date and notes preview (truncated). Photo indicator icon when photos are attached.
+- **LessonDetailView**: Full view of a captured lesson — date, notes, photo gallery, and edit/delete actions.
+- **PhotoGallery**: Horizontal scrollable strip of photo thumbnails, tappable to view full-size. Supports add/remove in edit mode.
+
+### Wireframe / Layout Description
+
+**Lesson Capture Form (full-screen on mobile, modal on desktop)**:
+- Date field (today pre-filled, tappable to change)
+- Notes field (prominent, auto-focused, multi-line — the hero field)
+- Photo attachment area (camera/gallery buttons, thumbnail strip of attached photos)
+- Save button
+
+**Lessons List**:
+- Reverse chronological list of lesson cards
+- Each card: date, notes preview (truncated), photo indicator
+- Empty state: "Log your first lesson" prompt
+
+**Lesson Detail View**:
+- Date heading
+- Notes section (full text)
+- Photo gallery (horizontal thumbnail strip, tappable to view full-size)
+- Edit and delete actions
+
+### Responsive Behaviour
+
+- **Mobile (iOS primary)**: Full-screen capture form. Native camera/photo picker. Lessons accessible from a prominent entry point. Photo gallery as horizontal scroll.
+- **Desktop (web)**: Modal for capture. Lessons list as a dedicated page. Photo gallery as a horizontal strip. Same content and flow.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can capture a lesson (date + notes or photo) in under 30 seconds.
+- **SC-002**: Users can find and review any past lesson within 3 taps from the home screen.
+- **SC-003**: Zero data loss — all captured lessons and photos persist across app restarts and sync to the server.
+- **SC-004**: Users can edit a lesson and verify changes persist immediately.
+
+## Assumptions
+
+- Lessons are a lightweight entity — the goal is speed of capture, not comprehensive structure. A lesson with only a date and a photo is valid.
+- Photo storage uses an external object store (not SQLite). The specific mechanism is an implementation detail.
+- Lessons do not replace sessions. A lesson is a record of *teaching received*; a session is a record of *practice done*. They are complementary but separate concepts.
+- The lessons list is a new navigational concept. Its placement (tab, section, or entry point) is a design decision to be refined, but it must be reachable without navigating through the library.
+- Item linking (deriving library items from lessons, inline quick-add) is explicitly deferred to a follow-up feature. This feature is pure capture.
+
+## Future Work (out of scope)
+
+- **Inline quick-add**: Type item names within a lesson to create minimal library items, with the option to expand and fill in details later. Separate issue.
+- **Lesson–item linking**: Link existing library items to a lesson. Depends on inline quick-add or a dedicated linking flow.
+- **Lesson link on item detail**: Show originating lesson on a library item's detail view.

--- a/specs/269-teacher-capture/tasks.md
+++ b/specs/269-teacher-capture/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Teacher Assignment Capture
+
+**Input**: Design documents from `/specs/269-teacher-capture/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/api.md
+**Scope**: iOS + Core + API only. Web shell deferred to a follow-up.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project initialisation — no new files needed, branch already exists.
+
+- [x] T001 Verify branch `269-teacher-capture` is checked out and up-to-date with main
+
+---
+
+## Phase 2: Foundational (Core + API Backend)
+
+**Purpose**: All backend infrastructure that MUST be complete before any UI work. This includes the full Lesson domain in core, API endpoints, database schema, and R2 storage client.
+
+**⚠️ CRITICAL**: No user story UI work can begin until this phase is complete.
+
+### Core Domain
+
+- [x] T002 [P] Add Lesson, LessonPhoto, CreateLesson, and UpdateLesson types with Facet derives in `crates/intrada-core/src/domain/types.rs`
+- [x] T003 [P] Add lesson validation rules (date not in future, notes max 10,000 chars, at least one of notes or photos required) in `crates/intrada-core/src/validation.rs`
+- [x] T004 Add LessonEvent enum and handle_lesson_event function in `crates/intrada-core/src/domain/lesson.rs` — events: FetchLessons, FetchLesson(id), Add(CreateLesson), Update(id, UpdateLesson), Delete(id), SetLessons(response), SetLesson(response), LessonCreated(response), LessonUpdated(response), LessonDeleted(response)
+- [x] T005 Register lesson module in `crates/intrada-core/src/domain/mod.rs` and wire LessonEvent into the top-level Event enum
+- [x] T006 Add lesson HTTP request builders (list, get, create, update, delete) in `crates/intrada-core/src/http.rs`
+- [x] T007 Add lessons list and current lesson to ViewModel in `crates/intrada-core/src/view_model.rs`
+
+### API Backend
+
+- [x] T008 [P] Add lessons and lesson_photos table migrations in `crates/intrada-api/src/migrations.rs` — follow schema from data-model.md
+- [x] T009 [P] Create R2 storage client (upload, delete, generate public URL) in `crates/intrada-api/src/storage.rs` — uses S3-compatible API with env vars R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME
+- [x] T010 Create lesson DB queries (list_lessons, get_lesson, insert_lesson, update_lesson, delete_lesson, insert_lesson_photo, delete_lesson_photo, list_lesson_photos) in `crates/intrada-api/src/db/lessons.rs` — follow SELECT_COLUMNS and col! macro pattern from items.rs
+- [x] T011 Register lessons DB module in `crates/intrada-api/src/db/mod.rs`
+- [x] T012 Add R2 storage client to AppState in `crates/intrada-api/src/main.rs` or `crates/intrada-api/src/routes/mod.rs`
+- [x] T013 Create lesson API routes (POST, GET list, GET by id, PUT, DELETE /api/lessons + POST, DELETE /api/lessons/:id/photos) in `crates/intrada-api/src/routes/lessons.rs` — photo endpoints use axum Multipart extractor, validate at least one of notes or photos on create
+- [x] T014 Mount lesson routes in `crates/intrada-api/src/routes/mod.rs`
+
+### Type Generation
+
+- [x] T015 Run `just typegen` to generate Swift types from new Lesson/LessonPhoto Facet types, verify output in `shared_types/`
+
+**Checkpoint**: `cargo test` and `cargo clippy` pass for all crates. API serves lesson CRUD endpoints. Core handles lesson events and emits correct HTTP effects.
+
+---
+
+## Phase 3: User Story 1 — Capture a Lesson (Priority: P1) 🎯 MVP
+
+**Goal**: A musician can open a capture form on iOS, write notes and/or attach photos, save, and see the lesson persisted.
+
+**Independent Test**: Create a lesson with notes, verify it saves. Create a lesson with a photo, verify the photo persists. Relaunch the app, verify the lesson is still there.
+
+- [x] T016 [P] [US1] Create PhotoCaptureView (camera + photo library picker, image compression to 2048px, upload to API) in `ios/Intrada/Features/Lessons/PhotoCaptureView.swift`
+- [x] T017 [US1] Create LessonCaptureView (date picker defaulting to today, notes text area, photo capture integration, save button, preserve form state on navigate away via UserDefaults) in `ios/Intrada/Features/Lessons/LessonCaptureView.swift`
+- [x] T018 [US1] Add "Log Lesson" button to Library view in `ios/Intrada/Features/Library/LibraryView.swift` — prominent action
+- [x] T019 [US1] Wire photo upload to call POST /api/lessons/:id/photos directly from shell (URLSession), then dispatch event to refresh lesson data in `ios/Intrada/Features/Lessons/LessonCaptureView.swift`
+- [x] T020 [US1] Create basic LessonDetailView (date heading, notes, photo gallery) in `ios/Intrada/Features/Lessons/LessonDetailView.swift` — navigate here after save to confirm capture worked
+- [x] T021 [US1] Run `just ios-swift-check` to verify iOS compiles
+
+**Checkpoint**: User can create a lesson with notes and/or photos on iOS. Lesson data persists to API. Photos stored in R2.
+
+---
+
+## Phase 4: User Story 2 — Review and Edit a Past Lesson (Priority: P2)
+
+**Goal**: A musician can open a saved lesson, view it, enter edit mode, modify notes/date, add/remove photos, and save changes.
+
+**Independent Test**: Create a lesson, reopen it, edit the notes, save, verify changes persist. Add a photo to an existing lesson. Remove a photo. Change the date.
+
+- [x] T022 [US2] Add edit mode to LessonDetailView (editable fields, photo management, save) in `ios/Intrada/Features/Lessons/LessonDetailView.swift` — detail view created in T020
+- [x] T023 [US2] Add delete lesson with `.confirmationDialog` (titleVisibility: .visible) in `ios/Intrada/Features/Lessons/LessonDetailView.swift`
+- [x] T024 [US2] Run `just ios-swift-check` to verify iOS compiles
+
+**Checkpoint**: User can view, edit, and delete lessons on iOS. Photo add/remove works in edit mode.
+
+---
+
+## Phase 5: User Story 3 — Browse Past Lessons (Priority: P3)
+
+**Goal**: A musician can see all their lessons in a list, ordered by date, tap to view detail, and see an empty state when no lessons exist.
+
+**Independent Test**: Create 3+ lessons with different dates, open the lessons list, verify reverse chronological order. Delete all lessons, verify empty state appears.
+
+- [x] T025 [US3] Create LessonListView (reverse chronological list: date, notes preview, photo indicator, NavigationSplitView on iPad) in `ios/Intrada/Features/Lessons/LessonListView.swift`
+- [x] T026 [US3] Add EmptyStateView to LessonListView when no lessons exist in `ios/Intrada/Features/Lessons/LessonListView.swift`
+- [x] T027 [US3] Add navigation from lesson list to detail (NavigationLink) and `.navigationTitle("Lessons")` (large on root, inline on pushed) in `ios/Intrada/Features/Lessons/LessonListView.swift`
+- [x] T028 [US3] Run `just ios-swift-check` to verify iOS compiles
+
+**Checkpoint**: Full browse experience works on iOS. List → detail → edit flow is complete.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Ensure quality and documentation.
+
+- [x] T029 [P] Add core unit tests for lesson event handling (create, update, delete, list, fetch) in `crates/intrada-core/` test module
+- [x] T030 [P] Add API integration tests for lesson endpoints in `crates/intrada-api/` test module
+- [x] T031 Verify iOS visual parity against Pencil designs in `design/intrada.pen`
+- [x] T032 Verify all design system tokens used (no raw colours or spacing) across iOS lesson views
+- [x] T033 Run `just ios-smoke-test` to verify full flow on simulator
+- [x] T034 Update `docs/roadmap.md` — mark #267 as in progress, note iOS-first delivery
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — already complete
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Foundational — can start immediately after
+- **US2 (Phase 4)**: Depends on Foundational — logically follows US1
+- **US3 (Phase 5)**: Depends on Foundational — independent of US1/US2
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (Capture)**: Needs foundational core + API. No dependency on other stories.
+- **US2 (Edit)**: Needs foundational core + API. Logically depends on US1 (detail view created there).
+- **US3 (Browse)**: Needs foundational core + API. Independent of US1/US2 (list view is separate).
+
+### Parallel Opportunities
+
+```
+Phase 2 (Foundational):
+  Parallel: T002 + T003 (types + validation — different files)
+  Parallel: T008 + T009 (migrations + R2 client — different files)
+  Sequential: T004 → T005 → T006 → T007 (core event chain)
+  Sequential: T010 → T011 → T012 → T013 → T014 (API chain)
+
+Phase 6 (Polish):
+  Parallel: T029 + T030 (core tests + API tests)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (core domain + API + DB)
+2. Complete Phase 3: US1 — Capture form on iOS
+3. **STOP and VALIDATE**: Can you create a lesson with notes and a photo? Does it persist?
+4. Deploy/demo — this alone delivers the "notebook replacement" value
+
+### Incremental Delivery
+
+1. Foundational → Core + API ready
+2. US1 (Capture) → MVP — musicians can log lessons on iOS ✓
+3. US2 (Edit) → Lessons become living records ✓
+4. US3 (Browse) → Full lesson history experience ✓
+5. Polish → Tests, smoke test, docs ✓
+6. **Future**: Web shell implementation (deferred)
+
+---
+
+## Notes
+
+- **iOS-only scope**: Web shell tasks deferred to a follow-up feature
+- Photo upload is shell-managed (not Crux effect) — iOS uses URLSession
+- Photos compressed client-side to 2048px max edge before upload
+- R2 storage requires new env vars: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME
+- iOS views MUST use `.navigationTitle()`, `CardView`, `ButtonView(variant:)`, `EmptyStateView` per CLAUDE.md
+- Destructive actions (delete) require `.confirmationDialog` with `titleVisibility: .visible`
+- Run `just typegen` after any Facet type changes, `just ios-swift-check` after Swift edits


### PR DESCRIPTION
## Summary

- Introduces a **Lesson** entity — a lightweight record of a teaching session (date, notes, photos)
- Pure Layer 1 (Capture): musicians can log a lesson in under 30 seconds, no forced organisation
- Full Crux architecture: core domain → API → iOS shell, with photo storage via Cloudflare R2

## Changes

### Core (`intrada-core`)
- New `domain/lesson.rs` — Lesson, LessonPhoto types + LessonEvent handler
- CreateLesson/UpdateLesson DTOs, validation (date not future, notes max 10k chars)
- HTTP request builders for lesson CRUD
- ViewModel extended with LessonView, LessonPhotoView

### API (`intrada-api`)
- 4 DB migrations (lessons table, index, lesson_photos table, index)
- Full CRUDL queries in `db/lessons.rs`
- 7 API endpoints: POST/GET/PUT/DELETE lessons + POST/DELETE photos
- Cloudflare R2 storage client for photo upload/delete
- Body limit increased to 6MB for photo uploads

### iOS
- `LessonCaptureView` — date picker, notes text area, save button
- `LessonDetailView` — view/edit/delete with confirmation dialog
- `LessonListView` — reverse chronological, NavigationSplitView, empty state
- `PhotoCaptureView` — camera + photo library, client-side compression (2048px), multipart upload
- "Log Lesson" button added to Library toolbar

### Specs
- Full SpecKit artifacts: spec, plan, research, data-model, contracts, tasks, checklist

## What's deferred
- Item linking (inline quick-add from lessons) — separate issue
- Web shell — iOS-first delivery
- Lesson search/filter

## Test plan
- [x] `cargo test` — 247 tests pass
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt` — clean
- [x] `just ios-swift-check` — builds (iPhone + iPad)
- [ ] Manual test: create lesson with notes on iOS simulator
- [ ] Manual test: edit lesson, change date and notes
- [ ] Manual test: delete lesson with confirmation
- [ ] Manual test: photo capture and upload (device only)
- [ ] Manual test: lesson list ordering and empty state

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)