### PR TITLE
fix(ios): enable photo upload on lesson capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,13 @@ PORT=3001
 # CORS allowed origin (should match the Trunk dev server URL)
 ALLOWED_ORIGIN=http://localhost:8080
 
+# Cloudflare R2 photo storage (optional — photo upload disabled without these)
+# See SETUP.md §4 for how to create the bucket and API token.
+# R2_ACCOUNT_ID=your-cloudflare-account-id
+# R2_ACCESS_KEY_ID=your-r2-access-key
+# R2_SECRET_ACCESS_KEY=your-r2-secret-key
+# R2_BUCKET_NAME=intrada-photos
+# R2_PUBLIC_URL=https://photos.intrada.com
+
 # Compile-time API base URL for the web shell (empty = relative, uses Trunk proxy)
 INTRADA_API_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,10 @@ mismatch (i8 vs u32 variant indices), corrupting the BCS byte stream.
 `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN` (required), `CLERK_ISSUER_URL` (required
 in prod), `ALLOWED_ORIGIN` (default `http://localhost:8080`), `PORT` (default 3001)
 
+### R2 photo storage (optional — API starts without it, photo endpoints return 500)
+`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`,
+`R2_PUBLIC_URL`. See `SETUP.md` §4 for provisioning steps.
+
 ### Web (compile-time)
 `CLERK_PUBLISHABLE_KEY`, `INTRADA_API_URL` (default `https://intrada-api.fly.dev`)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,11 +9,19 @@ This document covers the external accounts, secrets, and configuration needed to
 │  Cloudflare Workers │ ─────────────→ │  Fly.io (Axum)   │ ────────────→ │  Turso   │
 │  (static WASM app)  │   REST API     │  intrada-api     │               │  (SQLite) │
 └─────────────────────┘                └──────────────────┘               └──────────┘
+                                              │
+                                              │  S3 API
+                                              ▼
+                                       ┌──────────────┐
+                                       │ Cloudflare R2 │
+                                       │ (photo store) │
+                                       └──────────────┘
 ```
 
 - **Frontend**: Leptos CSR + WASM, deployed as static files to Cloudflare Workers
 - **API**: Axum 0.8 REST server, deployed to Fly.io via Docker
 - **Database**: Turso (managed libsql/SQLite), accessed via HTTP
+- **Object storage**: Cloudflare R2 for lesson photos, accessed via S3-compatible API
 
 ## 1. Cloudflare Workers (Frontend)
 
@@ -142,7 +150,63 @@ curl https://intrada-api.fly.dev/api/health
 # Expected: {"status":"ok","database":"ok"}
 ```
 
-## 4. CI/CD Pipeline (GitHub Actions)
+## 4. Cloudflare R2 (Photo Storage)
+
+Lesson photos are stored in Cloudflare R2 (S3-compatible object storage). Without
+R2 configured, the API starts normally but photo upload/delete endpoints return 500.
+
+### Create the bucket
+
+1. Go to [Cloudflare Dashboard → R2](https://dash.cloudflare.com/?to=/:account/r2)
+2. Click **Create bucket**
+3. Name it (e.g. `intrada-photos`), select a location hint close to your Fly.io region
+
+### Enable public access
+
+Photos are served directly from R2 to the iOS app. You need a public URL:
+
+1. Open the bucket → **Settings** → **Public access**
+2. Either:
+   - **Custom domain** (recommended): add a subdomain like `photos.intrada.com` and configure the DNS record Cloudflare provides
+   - **R2.dev subdomain**: enable the `*.r2.dev` URL (quick but not production-grade)
+3. Note the public URL — this becomes `R2_PUBLIC_URL`
+
+### Create an API token
+
+1. Go to [R2 → Manage R2 API Tokens](https://dash.cloudflare.com/?to=/:account/r2/api-tokens)
+2. Click **Create API token**
+3. Permissions: **Object Read & Write** on the bucket you created
+4. Save the **Access Key ID** and **Secret Access Key**
+
+### Set Fly.io secrets
+
+```bash
+fly secrets set \
+  R2_ACCOUNT_ID="<your-cloudflare-account-id>" \
+  R2_ACCESS_KEY_ID="<access-key-from-step-above>" \
+  R2_SECRET_ACCESS_KEY="<secret-key-from-step-above>" \
+  R2_BUCKET_NAME="intrada-photos" \
+  R2_PUBLIC_URL="https://photos.intrada.com"
+```
+
+Your Cloudflare Account ID is in the dashboard sidebar (same one used for Workers).
+
+### Verify
+
+```bash
+# Check API logs after deploy
+fly logs | grep R2
+
+# Expected: "R2 photo storage configured"
+# If missing: "R2 not configured — photo upload disabled (R2_ACCOUNT_ID must be set)"
+```
+
+### Local development
+
+R2 is optional locally. Without the env vars, the API starts with photo upload
+disabled. To test photos locally, add the R2 variables to your `.env` file.
+
+## 5. CI/CD Pipeline (GitHub Actions)
 
 The single workflow `.github/workflows/ci.yml` handles both CI and deployment:
 
@@ -175,7 +239,7 @@ fly tokens create deploy -a intrada-api
 
 Add the output as the `FLY_API_TOKEN` secret in GitHub Actions.
 
-## 5. Local Development
+## 6. Local Development
 
 ### Prerequisites
 
@@ -261,5 +325,10 @@ Use this when setting up from scratch:
 - [ ] Fly.io secrets set (TURSO_DATABASE_URL, TURSO_AUTH_TOKEN, ALLOWED_ORIGIN)
 - [ ] First deploy successful (`fly deploy`)
 - [ ] Health check returns `{"status":"ok","database":"ok"}`
+- [ ] R2 bucket created in Cloudflare
+- [ ] R2 public access enabled (custom domain or r2.dev subdomain)
+- [ ] R2 API token created (Object Read & Write)
+- [ ] R2 secrets set on Fly.io (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET_NAME, R2_PUBLIC_URL)
+- [ ] `fly logs | grep R2` shows "R2 photo storage configured"
 - [ ] Frontend deployed to Cloudflare Workers
 - [ ] Frontend CORS requests to API work

--- a/ios/Intrada/Views/Lessons/LessonCaptureView.swift
+++ b/ios/Intrada/Views/Lessons/LessonCaptureView.swift
@@ -13,8 +13,7 @@ struct LessonCaptureView: View {
     @State private var isSubmitting = false
     @State private var savedLessonId: String?
 
-    /// Track lesson count to detect when core processes the create.
-    @State private var lessonCountBeforeSubmit: Int?
+    @State private var lessonIdsBeforeSubmit: Set<String>?
 
     var body: some View {
         ScrollView {
@@ -35,6 +34,7 @@ struct LessonCaptureView: View {
                     .datePickerStyle(.compact)
                     .labelsHidden()
                 }
+                .disabled(savedLessonId != nil)
 
                 // Notes — the hero field
                 TextAreaView(
@@ -43,34 +43,24 @@ struct LessonCaptureView: View {
                     placeholder: "What happened in your lesson? What did your teacher say?",
                     error: nil
                 )
+                .disabled(savedLessonId != nil)
 
                 // Photo upload — only available after save (needs lesson ID)
                 if let lessonId = savedLessonId {
                     PhotoCaptureView(lessonId: lessonId) {
-                        // Refresh lesson data after photo upload
                         core.update(.lesson(.fetchLesson(id: lessonId)))
-                    }
-                } else {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Photos")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                            .foregroundStyle(Color.textLabel)
-
-                        Text("Save the lesson first, then attach photos")
-                            .font(.caption)
-                            .foregroundStyle(Color.textMuted)
                     }
                 }
 
-                // Save button
-                ButtonView(
-                    "Save Lesson",
-                    variant: .primary,
-                    disabled: isSubmitting || notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-                    loading: isSubmitting
-                ) {
-                    submitForm()
+                if savedLessonId == nil {
+                    ButtonView(
+                        "Save Lesson",
+                        variant: .primary,
+                        disabled: isSubmitting || notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                        loading: isSubmitting
+                    ) {
+                        submitForm()
+                    }
                 }
             }
             .padding(Spacing.card)
@@ -79,14 +69,24 @@ struct LessonCaptureView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button("Cancel") { dismiss() }
+                if savedLessonId == nil {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                if savedLessonId != nil {
+                    Button("Done") { dismiss() }
+                }
             }
         }
-        .onChange(of: core.viewModel.lessons.count) { _, newCount in
-            guard isSubmitting, let before = lessonCountBeforeSubmit, newCount > before else { return }
-            toast.show("Lesson saved", variant: .success)
-            isSubmitting = false
-            dismiss()
+        .onChange(of: core.viewModel.lessons.count) { _, _ in
+            guard isSubmitting, let oldIds = lessonIdsBeforeSubmit else { return }
+
+            if let newLesson = core.viewModel.lessons.first(where: { !oldIds.contains($0.id) }) {
+                savedLessonId = newLesson.id
+                toast.show("Lesson saved — add photos or tap Done", variant: .success)
+                isSubmitting = false
+            }
         }
         .onChange(of: core.viewModel.error) { _, newError in
             guard isSubmitting, newError != nil else { return }
@@ -99,7 +99,7 @@ struct LessonCaptureView: View {
         guard !trimmedNotes.isEmpty else { return }
 
         isSubmitting = true
-        lessonCountBeforeSubmit = core.viewModel.lessons.count
+        lessonIdsBeforeSubmit = Set(core.viewModel.lessons.map(\.id))
 
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -38,6 +38,8 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait"
+        INFOPLIST_KEY_NSCameraUsageDescription: "Take photos of sheet music, lesson notes, or practice setups"
+        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "Attach photos from your library to lessons"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: "AccentColor"


### PR DESCRIPTION
## Summary

- `savedLessonId` was never assigned after save, and the view dismissed immediately — the photo capture section was unreachable
- After save: date/notes become read-only, `PhotoCaptureView` appears, toolbar switches from Cancel to Done
- Tracks lesson IDs before submit to reliably detect the newly created lesson

## Test plan

- [ ] Create a lesson with notes — form stays open after save, showing photo section
- [ ] Add a photo after save (device only)
- [ ] Tap Done to dismiss
- [ ] Cancel before save still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)