### PR TITLE
fix(ios): show HTTP status in photo upload errors

### DIFF
--- a/ios/Intrada/Views/Lessons/PhotoCaptureView.swift
+++ b/ios/Intrada/Views/Lessons/PhotoCaptureView.swift
@@ -148,10 +148,17 @@ struct PhotoCaptureView: View {
         body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
         request.httpBody = body
 
-        let (_, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200...299).contains(httpResponse.statusCode) else {
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let body = String(data: responseData, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "PhotoUpload",
+                code: httpResponse.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP \(httpResponse.statusCode): \(body)"]
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

- Photo upload errors showed a generic `NSURLErrorDomain -1011` which hid the actual API response
- Now shows the HTTP status code and response body (e.g. "HTTP 404: Lesson not found: ...")
- Needed to debug why photo uploads return 404 after lesson creation

## Test plan

- [ ] Trigger a photo upload failure — error message should show the HTTP status and API error body
- [ ] Successful upload still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)