### PR TITLE
debug(api): log user_id on lesson create and photo upload

### DIFF
--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -66,6 +66,7 @@ async fn create_lesson(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
+    tracing::info!(user_id = %user_id, "create_lesson");
     validation::validate_create_lesson(&input)?;
     let conn = state.connect().await?;
     let r2 = state.r2()?;
@@ -137,6 +138,7 @@ async fn upload_photo(
     Path(id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    tracing::info!(user_id = %user_id, lesson_id = %id, "upload_photo");
     let r2 = state.r2()?;
     let conn = state.connect().await?;
 


### PR DESCRIPTION
## Summary

Temporary debug logging to diagnose why photo uploads return 404 immediately after lesson creation.

Adds `tracing::info!` with `user_id` on both `create_lesson` and `upload_photo` handlers. Once merged and deployed, the Fly.io logs will show whether the two paths are using different user_ids — which would confirm the auth mismatch theory.

**This is diagnostic — remove the logging once the root cause is found.**

## Test plan

- [ ] Merge, deploy to Fly.io
- [ ] Create a lesson, attempt photo upload
- [ ] Check `fly logs` for `create_lesson user_id=X` and `upload_photo user_id=Y`
- [ ] If X != Y, we found the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)