### PR TITLE
debug(api): diagnostic query in upload_photo

### DIFF
--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -142,6 +142,26 @@ async fn upload_photo(
     let r2 = state.r2()?;
     let conn = state.connect().await?;
 
+    // Debug: check what's actually in the DB for this lesson ID
+    let mut debug_rows = conn
+        .query(
+            "SELECT id, user_id FROM lessons WHERE id = ?1",
+            libsql::params![id.as_str()],
+        )
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    if let Some(row) = debug_rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        let db_id: String = row.get(0).unwrap_or_default();
+        let db_user_id: String = row.get(1).unwrap_or_default();
+        tracing::info!(db_id = %db_id, db_user_id = %db_user_id, request_user_id = %user_id, "upload_photo_debug: lesson found by id");
+    } else {
+        tracing::warn!(lesson_id = %id, "upload_photo_debug: lesson NOT found by id alone");
+    }
+
     // Verify lesson exists and belongs to user
     db::lessons::get_lesson(&conn, &id, &user_id, r2)
         .await?

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -66,6 +66,7 @@ async fn create_lesson(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
+    tracing::info!(user_id = %user_id, "create_lesson");
     validation::validate_create_lesson(&input)?;
     let conn = state.connect().await?;
     let r2 = state.r2()?;
@@ -137,6 +138,7 @@ async fn upload_photo(
     Path(id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    tracing::info!(user_id = %user_id, lesson_id = %id, "upload_photo");
     let r2 = state.r2()?;
     let conn = state.connect().await?;
 


### PR DESCRIPTION
## Summary

Adds a direct `SELECT id, user_id FROM lessons WHERE id = ?1` (without user_id filter) before the existing get_lesson call. This will reveal:

- If the lesson exists with a **different user_id** → auth mismatch we missed
- If the lesson **doesn't exist at all** → Turso replication/visibility issue between connections

Temporary debug code — remove after diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)