### PR TITLE
fix(api): eliminate read-after-write race in photo upload

### DIFF
--- a/crates/intrada-api/src/db/lessons.rs
+++ b/crates/intrada-api/src/db/lessons.rs
@@ -216,17 +216,27 @@ pub async fn insert_lesson_photo(
     let now = Utc::now();
     let now_str = now.to_rfc3339();
 
-    conn.execute(
-        "INSERT INTO lesson_photos (id, lesson_id, user_id, storage_key, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-        libsql::params![
-            id.as_str(),
-            lesson_id,
-            user_id,
-            storage_key,
-            now_str.as_str()
-        ],
-    )
-    .await?;
+    // Use INSERT...SELECT to atomically verify the lesson exists and belongs
+    // to the user. This avoids a separate read query, which can fail under
+    // libsql connection-level read-after-write inconsistency.
+    let rows_affected = conn
+        .execute(
+            "INSERT INTO lesson_photos (id, lesson_id, user_id, storage_key, created_at)
+             SELECT ?1, ?2, ?3, ?4, ?5
+             WHERE EXISTS (SELECT 1 FROM lessons WHERE id = ?2 AND user_id = ?3)",
+            libsql::params![
+                id.as_str(),
+                lesson_id,
+                user_id,
+                storage_key,
+                now_str.as_str()
+            ],
+        )
+        .await?;
+
+    if rows_affected == 0 {
+        return Err(ApiError::NotFound(format!("Lesson not found: {lesson_id}")));
+    }
 
     Ok(LessonPhoto {
         id,

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -142,6 +142,26 @@ async fn upload_photo(
     let r2 = state.r2()?;
     let conn = state.connect().await?;
 
+    // Debug: check what's actually in the DB for this lesson ID
+    let mut debug_rows = conn
+        .query(
+            "SELECT id, user_id FROM lessons WHERE id = ?1",
+            libsql::params![id.as_str()],
+        )
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    if let Some(row) = debug_rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        let db_id: String = row.get(0).unwrap_or_default();
+        let db_user_id: String = row.get(1).unwrap_or_default();
+        tracing::info!(db_id = %db_id, db_user_id = %db_user_id, request_user_id = %user_id, "upload_photo_debug: lesson found by id");
+    } else {
+        tracing::warn!(lesson_id = %id, "upload_photo_debug: lesson NOT found by id alone");
+    }
+
     // Verify lesson exists and belongs to user
     db::lessons::get_lesson(&conn, &id, &user_id, r2)
         .await?

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -66,7 +66,6 @@ async fn create_lesson(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
-    tracing::info!(user_id = %user_id, "create_lesson");
     validation::validate_create_lesson(&input)?;
     let conn = state.connect().await?;
     let r2 = state.r2()?;
@@ -138,34 +137,8 @@ async fn upload_photo(
     Path(id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
-    tracing::info!(user_id = %user_id, lesson_id = %id, "upload_photo");
     let r2 = state.r2()?;
     let conn = state.connect().await?;
-
-    // Debug: check what's actually in the DB for this lesson ID
-    let mut debug_rows = conn
-        .query(
-            "SELECT id, user_id FROM lessons WHERE id = ?1",
-            libsql::params![id.as_str()],
-        )
-        .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-    if let Some(row) = debug_rows
-        .next()
-        .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?
-    {
-        let db_id: String = row.get(0).unwrap_or_default();
-        let db_user_id: String = row.get(1).unwrap_or_default();
-        tracing::info!(db_id = %db_id, db_user_id = %db_user_id, request_user_id = %user_id, "upload_photo_debug: lesson found by id");
-    } else {
-        tracing::warn!(lesson_id = %id, "upload_photo_debug: lesson NOT found by id alone");
-    }
-
-    // Verify lesson exists and belongs to user
-    db::lessons::get_lesson(&conn, &id, &user_id, r2)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
 
     // Extract the photo field from multipart
     let field = multipart

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -66,6 +66,7 @@ async fn create_lesson(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
+    tracing::info!(user_id = %user_id, "create_lesson");
     validation::validate_create_lesson(&input)?;
     let conn = state.connect().await?;
     let r2 = state.r2()?;
@@ -137,6 +138,7 @@ async fn upload_photo(
     Path(id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
+    tracing::info!(user_id = %user_id, lesson_id = %id, "upload_photo");
     let r2 = state.r2()?;
     let conn = state.connect().await?;
 


### PR DESCRIPTION
## Summary

- Photo uploads were failing with 404 ("Lesson not found") seconds after the lesson was created with a 201 response
- Root cause: the `upload_photo` handler did a separate `SELECT` to verify lesson ownership before inserting the photo — under libsql's remote HTTP connection layer, this read could miss recently-written data
- Replaced the two-step read-then-write with an atomic `INSERT...SELECT WHERE EXISTS` that verifies lesson ownership inline, eliminating the read-after-write dependency entirely
- Cleaned up debug logging from investigation commits

## Test plan

- [x] `cargo test -p intrada-api` — all 63 tests pass
- [x] `cargo clippy` + `cargo fmt` clean
- [ ] Deploy to staging and verify photo upload succeeds on iOS after creating a new lesson
- [ ] Verify uploading a photo for a non-existent lesson returns 404
- [ ] Verify uploading a photo for another user's lesson returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)