### PR TITLE
fix(api): reuse single DB connection for read-your-own-writes consistency

### DIFF
--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -76,7 +76,7 @@ async fn main() {
         }
     };
 
-    let state = AppState::new(db, allowed_origin, auth_config, r2);
+    let state = AppState::new(conn, allowed_origin, auth_config, r2);
     let router = routes::api_router(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());

--- a/crates/intrada-api/src/routes/health.rs
+++ b/crates/intrada-api/src/routes/health.rs
@@ -11,18 +11,7 @@ pub fn router() -> Router<AppState> {
 }
 
 async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
-    let conn = match state.connect().await {
-        Ok(conn) => conn,
-        Err(_) => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({
-                    "status": "degraded",
-                    "database": "error"
-                })),
-            );
-        }
-    };
+    let conn = state.conn();
 
     match conn.query("SELECT 1", ()).await {
         Ok(_) => (

--- a/crates/intrada-api/src/routes/items.rs
+++ b/crates/intrada-api/src/routes/items.rs
@@ -22,7 +22,7 @@ async fn list_items(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<Item>>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let items = db::items::list_items(&conn, &user_id).await?;
     Ok(Json(items))
 }
@@ -32,7 +32,7 @@ async fn get_item(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Item>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let item = db::items::get_item(&conn, &id, &user_id)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))?;
@@ -45,7 +45,7 @@ async fn create_item(
     Json(input): Json<CreateItem>,
 ) -> Result<(StatusCode, Json<Item>), ApiError> {
     validation::validate_create_item(&input)?;
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let item = db::items::insert_item(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(item)))
 }
@@ -57,7 +57,7 @@ async fn update_item(
     Json(input): Json<UpdateItem>,
 ) -> Result<Json<Item>, ApiError> {
     validation::validate_update_item(&input)?;
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let item = db::items::update_item(&conn, &id, &user_id, &input)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))?;
@@ -69,7 +69,7 @@ async fn delete_item(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let deleted = db::items::delete_item(&conn, &id, &user_id).await?;
     if deleted {
         Ok(Json(serde_json::json!({ "message": "Item deleted" })))

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -42,7 +42,7 @@ async fn list_lessons(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<Lesson>>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let r2 = state.r2()?;
     let lessons = db::lessons::list_lessons(&conn, &user_id, r2).await?;
     Ok(Json(lessons))
@@ -53,7 +53,7 @@ async fn get_lesson(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Lesson>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let r2 = state.r2()?;
     let lesson = db::lessons::get_lesson(&conn, &id, &user_id, r2)
         .await?
@@ -67,7 +67,7 @@ async fn create_lesson(
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
     validation::validate_create_lesson(&input)?;
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let r2 = state.r2()?;
     let lesson = db::lessons::insert_lesson(&conn, &user_id, &input, r2).await?;
     Ok((StatusCode::CREATED, Json(lesson)))
@@ -80,7 +80,7 @@ async fn update_lesson(
     Json(input): Json<UpdateLesson>,
 ) -> Result<Json<Lesson>, ApiError> {
     validation::validate_update_lesson(&input)?;
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let r2 = state.r2()?;
     let lesson = db::lessons::update_lesson(&conn, &id, &user_id, &input, r2)
         .await?
@@ -93,7 +93,7 @@ async fn delete_lesson(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
 
     // Delete photos from R2 if storage is configured. Log but don't fail
     // the request on R2 errors — DB is the source of truth and the lesson
@@ -138,7 +138,7 @@ async fn upload_photo(
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
     let r2 = state.r2()?;
-    let conn = state.connect().await?;
+    let conn = state.conn();
 
     // Extract the photo field from multipart
     let field = multipart
@@ -188,7 +188,7 @@ async fn delete_photo(
     AuthUser(user_id): AuthUser,
     Path((id, photo_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
 
     // Get storage key before deleting from DB
     let storage_key = db::lessons::get_lesson_photo_storage_key(&conn, &photo_id, &id, &user_id)

--- a/crates/intrada-api/src/routes/routines.rs
+++ b/crates/intrada-api/src/routes/routines.rs
@@ -32,7 +32,7 @@ async fn list_routines(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<Routine>>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let routines = db::routines::list_routines(&conn, &user_id).await?;
     Ok(Json(routines))
 }
@@ -42,7 +42,7 @@ async fn get_routine(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Routine>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let routine = db::routines::get_routine(&conn, &id, &user_id)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Routine not found: {id}")))?;
@@ -63,7 +63,7 @@ async fn create_routine(
     // Validate each entry has required fields and valid item_type
     validate_entries(&input.entries)?;
 
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let routine = db::routines::insert_routine(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(routine)))
 }
@@ -83,7 +83,7 @@ async fn update_routine(
     // Validate each entry has required fields and valid item_type
     validate_entries(&input.entries)?;
 
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let routine = db::routines::update_routine(&conn, &id, &user_id, &input)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Routine not found: {id}")))?;
@@ -95,7 +95,7 @@ async fn delete_routine(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let deleted = db::routines::delete_routine(&conn, &id, &user_id).await?;
     if deleted {
         Ok(Json(serde_json::json!({ "message": "Routine deleted" })))

--- a/crates/intrada-api/src/routes/sessions.rs
+++ b/crates/intrada-api/src/routes/sessions.rs
@@ -22,7 +22,7 @@ async fn list_sessions(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<PracticeSession>>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let sessions = db::sessions::list_sessions(&conn, &user_id).await?;
     Ok(Json(sessions))
 }
@@ -32,7 +32,7 @@ async fn get_session(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<PracticeSession>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let session = db::sessions::get_session(&conn, &id, &user_id)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Session not found: {id}")))?;
@@ -68,7 +68,7 @@ async fn save_session(
         )?;
     }
 
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let session = db::sessions::insert_session(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(session)))
 }
@@ -78,7 +78,7 @@ async fn delete_session(
     AuthUser(user_id): AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let conn = state.connect().await?;
+    let conn = state.conn();
     let deleted = db::sessions::delete_session(&conn, &id, &user_id).await?;
     if deleted {
         Ok(Json(serde_json::json!({ "message": "Session deleted" })))

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -1,6 +1,4 @@
-use std::sync::Arc;
-
-use libsql::{Connection, Database};
+use libsql::Connection;
 
 use crate::auth::AuthConfig;
 use crate::error::ApiError;
@@ -8,7 +6,11 @@ use crate::storage::R2Client;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub db: Arc<Database>,
+    /// Single shared database connection. Turso's remote HTTP connections
+    /// don't share replication state across `db.connect()` calls, so a new
+    /// connection can fail to see rows written by a previous one. Reusing
+    /// one connection guarantees read-your-own-writes consistency.
+    conn: Connection,
     pub allowed_origin: String,
     pub auth_config: Option<AuthConfig>,
     pub r2: Option<R2Client>,
@@ -16,13 +18,13 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(
-        db: Database,
+        conn: Connection,
         allowed_origin: String,
         auth_config: Option<AuthConfig>,
         r2: Option<R2Client>,
     ) -> Self {
         Self {
-            db: Arc::new(db),
+            conn,
             allowed_origin,
             auth_config,
             r2,
@@ -36,13 +38,12 @@ impl AppState {
             .ok_or_else(|| ApiError::Internal("Photo storage (R2) is not configured".into()))
     }
 
-    /// Create a new database connection with PRAGMA foreign_keys = ON.
+    /// Return the shared database connection.
     ///
-    /// SQLite disables foreign key enforcement by default on each new connection,
-    /// so this must be called for every connection to ensure ON DELETE CASCADE works.
-    pub async fn connect(&self) -> Result<Connection, ApiError> {
-        let conn = self.db.connect()?;
-        conn.execute("PRAGMA foreign_keys = ON", ()).await?;
-        Ok(conn)
+    /// `Connection` is `Clone` (wraps an `Arc`), so this is cheap. All
+    /// handlers share the same underlying HTTP session to Turso, which
+    /// ensures read-your-own-writes consistency across requests.
+    pub fn conn(&self) -> Connection {
+        self.conn.clone()
     }
 }

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -40,7 +40,7 @@ async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
         .await
         .expect("Failed to run migrations");
 
-    let state = AppState::new(db, "http://localhost:3000".to_string(), auth_config, None);
+    let state = AppState::new(conn, "http://localhost:3000".to_string(), auth_config, None);
     routes::api_router(state)
 }
 


### PR DESCRIPTION
## Summary

- Photo uploads still 404ing after #286 — the `INSERT...SELECT WHERE EXISTS` also fails because it's a read on a new connection
- Root cause: Turso's `new_remote` (pure HTTP) creates independent HTTP sessions per `db.connect()` call with no shared replication state — reads on a new connection can miss rows written by a previous one
- Fix: store a single `Connection` in `AppState` (it wraps `Arc`, clone is cheap) so all request handlers share the same HTTP session, guaranteeing read-your-own-writes consistency
- FK pragma moved to startup (run once) instead of per-connection

Ref: [Turso data consistency docs](https://docs.turso.tech/reference/data-consistency), [serverless RYOW fix](https://sylvainsimao.com/blog/fixing-turso-read-after-write-consistency-in-serverless/)

## Test plan

- [x] `cargo test -p intrada-api` — all 63 tests pass
- [x] `cargo clippy` + `cargo fmt` clean
- [ ] Deploy to staging and verify photo upload succeeds on iOS after creating a new lesson
- [ ] Verify all existing CRUD operations still work (items, sessions, routines, lessons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)