### PR TITLE
fix(api): remove FK and existence check for multi-machine Turso compat

### DIFF
--- a/crates/intrada-api/src/db/lessons.rs
+++ b/crates/intrada-api/src/db/lessons.rs
@@ -193,6 +193,14 @@ pub async fn update_lesson(
 }
 
 pub async fn delete_lesson(conn: &Connection, id: &str, user_id: &str) -> Result<bool, ApiError> {
+    // Explicit child-row delete — FK cascade is disabled (Turso compatibility),
+    // so application code owns the cleanup.
+    conn.execute(
+        "DELETE FROM lesson_photos WHERE lesson_id = ?1 AND user_id = ?2",
+        libsql::params![id, user_id],
+    )
+    .await?;
+
     let rows_affected = conn
         .execute(
             "DELETE FROM lessons WHERE id = ?1 AND user_id = ?2",
@@ -216,27 +224,25 @@ pub async fn insert_lesson_photo(
     let now = Utc::now();
     let now_str = now.to_rfc3339();
 
-    // Use INSERT...SELECT to atomically verify the lesson exists and belongs
-    // to the user. This avoids a separate read query, which can fail under
-    // libsql connection-level read-after-write inconsistency.
-    let rows_affected = conn
-        .execute(
-            "INSERT INTO lesson_photos (id, lesson_id, user_id, storage_key, created_at)
-             SELECT ?1, ?2, ?3, ?4, ?5
-             WHERE EXISTS (SELECT 1 FROM lessons WHERE id = ?2 AND user_id = ?3)",
-            libsql::params![
-                id.as_str(),
-                lesson_id,
-                user_id,
-                storage_key,
-                now_str.as_str()
-            ],
-        )
-        .await?;
-
-    if rows_affected == 0 {
-        return Err(ApiError::NotFound(format!("Lesson not found: {lesson_id}")));
-    }
+    // Plain INSERT — no lesson existence check. Turso's remote HTTP
+    // connections have cross-connection read-after-write inconsistency
+    // (and with multi-machine Fly.io, cross-machine too). Any read of
+    // the lessons table — SELECT, INSERT...SELECT WHERE EXISTS, or FK
+    // constraint check — can fail to see a just-created lesson.
+    //
+    // Security: user_id comes from the JWT and is stored on the photo
+    // row, so ownership is enforced at read time.
+    conn.execute(
+        "INSERT INTO lesson_photos (id, lesson_id, user_id, storage_key, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params![
+            id.as_str(),
+            lesson_id,
+            user_id,
+            storage_key,
+            now_str.as_str()
+        ],
+    )
+    .await?;
 
     Ok(LessonPhoto {
         id,

--- a/crates/intrada-api/src/db/routines.rs
+++ b/crates/intrada-api/src/db/routines.rs
@@ -361,10 +361,8 @@ pub async fn delete_routine(conn: &Connection, id: &str, user_id: &str) -> Resul
         return Ok(false);
     }
 
-    // Now safe to delete entries — we confirmed ownership above.
-    // PRAGMA foreign_keys = ON is set on every connection (see AppState::connect),
-    // so ON DELETE CASCADE will handle this automatically. We keep the explicit
-    // delete as a belt-and-suspenders safety net.
+    // Explicit child-row delete — FK cascade is disabled (Turso compatibility),
+    // so application code owns the cleanup.
     conn.execute(
         "DELETE FROM routine_entries WHERE routine_id = ?1",
         libsql::params![id],

--- a/crates/intrada-api/src/db/sessions.rs
+++ b/crates/intrada-api/src/db/sessions.rs
@@ -448,9 +448,8 @@ pub async fn delete_session(conn: &Connection, id: &str, user_id: &str) -> Resul
         return Ok(false);
     }
 
-    // PRAGMA foreign_keys = ON is set on every connection (see AppState::connect),
-    // so ON DELETE CASCADE will handle this automatically. We keep the explicit
-    // delete as a belt-and-suspenders safety net, matching delete_routine's pattern.
+    // Explicit child-row delete — FK cascade is disabled (Turso compatibility),
+    // so application code owns the cleanup.
     conn.execute(
         "DELETE FROM setlist_entries WHERE session_id = ?1",
         libsql::params![id],

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -25,10 +25,11 @@ async fn main() {
 
     let conn = db.connect().expect("Failed to create database connection");
 
-    // Enable foreign key enforcement — SQLite disables this by default per connection.
-    conn.execute("PRAGMA foreign_keys = ON", ())
-        .await
-        .expect("Failed to enable PRAGMA foreign_keys");
+    // FK enforcement is intentionally OFF. Turso's remote HTTP protocol
+    // checks FK constraints via a parent-table read, which suffers the same
+    // cross-connection consistency issue that caused photo upload 404s.
+    // All cascade deletes are handled explicitly in application code
+    // (delete_session, delete_routine, delete_lesson).
 
     tracing::info!("Running migrations...");
     migrations::run_migrations(&conn)

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -96,8 +96,7 @@ async fn delete_lesson(
     let conn = state.conn();
 
     // Delete photos from R2 if storage is configured. Log but don't fail
-    // the request on R2 errors — DB is the source of truth and the lesson
-    // delete below cascades the photo rows.
+    // the request on R2 errors — DB is the source of truth.
     if let Ok(r2) = state.r2() {
         let keys = db::lessons::list_photo_storage_keys(&conn, &id, &user_id).await?;
         for key in keys {

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -32,9 +32,8 @@ async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
 
     let conn = db.connect().expect("Failed to connect to test database");
 
-    conn.execute("PRAGMA foreign_keys = ON", ())
-        .await
-        .expect("Failed to enable PRAGMA foreign_keys");
+    // FK enforcement OFF to match prod (Turso compatibility).
+    // All cascade deletes are handled explicitly in application code.
 
     migrations::run_migrations_direct(&conn)
         .await


### PR DESCRIPTION
## Summary

Follow-up to #287 — photo uploads still 404 because Fly.io runs **multiple machines**, each with its own Turso HTTP connection. The single-connection fix only guarantees consistency within one process.

Root cause: Turso's remote HTTP protocol has no cross-connection read-your-own-writes guarantee. Any read of the parent table — SELECT, INSERT...SELECT WHERE EXISTS, or FK constraint check — can fail on a different machine's connection.

Changes:
- Remove `PRAGMA foreign_keys = ON` — FK checks do parent-table reads that hit the same consistency issue
- Use plain `INSERT VALUES` for photo upload — no existence check, no FK check, no reads at all
- Add explicit `DELETE FROM lesson_photos` in `delete_lesson` since FK cascade is now off
- Update stale cascade comments in `delete_session` and `delete_routine` (both already had explicit child-row deletes)

Security: user_id from JWT is stored on the photo row and enforced at read time. Worst case of a bogus lesson_id is an orphaned photo row that's never displayed.

## Also recommended

Scale Fly.io to a single machine (`fly scale count 1`) for belt-and-suspenders — this app doesn't need multi-machine concurrency and it avoids the cross-connection issue entirely.

## Test plan

- [x] `cargo test -p intrada-api` — all 63 tests pass (including cascade delete tests)
- [x] `cargo clippy` + `cargo fmt` clean
- [ ] Deploy and verify photo upload succeeds on iOS immediately after creating a lesson
- [ ] Verify lesson delete still cleans up photo rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)