### PR TITLE
fix(api): self-heal shared DB connection on rot

### DIFF
--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -1,7 +1,7 @@
 use intrada_api::auth;
 use intrada_api::migrations;
 use intrada_api::routes;
-use intrada_api::state::AppState;
+use intrada_api::state::{AppState, Db};
 use intrada_api::storage::R2Client;
 
 #[tokio::main]
@@ -77,7 +77,7 @@ async fn main() {
         }
     };
 
-    let state = AppState::new(conn, allowed_origin, auth_config, r2);
+    let state = AppState::new(Db::new(db, conn), allowed_origin, auth_config, r2);
     let router = routes::api_router(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());

--- a/crates/intrada-api/src/routes/health.rs
+++ b/crates/intrada-api/src/routes/health.rs
@@ -11,22 +11,46 @@ pub fn router() -> Router<AppState> {
 }
 
 async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
-    let conn = state.conn();
-
-    match conn.query("SELECT 1", ()).await {
-        Ok(_) => (
+    // Try the cached connection first.
+    if state.conn().query("SELECT 1", ()).await.is_ok() {
+        return (
             StatusCode::OK,
-            Json(serde_json::json!({
-                "status": "ok",
-                "database": "ok"
-            })),
-        ),
-        Err(_) => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({
-                "status": "degraded",
-                "database": "error"
-            })),
-        ),
+            Json(serde_json::json!({ "status": "ok", "database": "ok" })),
+        );
+    }
+
+    // The shared HTTP session may have rotted (idle timeout, machine
+    // suspend/resume, etc.). Rebuild it once and retry — if this succeeds,
+    // every subsequent request also recovers, since they all read from the
+    // same slot.
+    tracing::warn!("DB health probe failed on cached connection; reconnecting");
+    match state.reconnect() {
+        Ok(fresh) => match fresh.query("SELECT 1", ()).await {
+            Ok(_) => {
+                tracing::info!("DB reconnect succeeded");
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "status": "ok",
+                        "database": "ok",
+                        "reconnected": true,
+                    })),
+                )
+            }
+            Err(err) => {
+                tracing::error!(?err, "DB query still failing after reconnect");
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({ "status": "degraded", "database": "error" })),
+                )
+            }
+        },
+        Err(err) => {
+            tracing::error!(?err, "Failed to rebuild DB connection");
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({ "status": "degraded", "database": "error" })),
+            )
+        }
     }
 }

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -1,16 +1,53 @@
-use libsql::Connection;
+use std::sync::{Arc, RwLock};
+
+use libsql::{Connection, Database};
 
 use crate::auth::AuthConfig;
 use crate::error::ApiError;
 use crate::storage::R2Client;
 
+/// Shared, self-healing database handle.
+///
+/// Turso's remote HTTP connections don't share replication state across
+/// `db.connect()` calls, so we reuse a single `Connection` to guarantee
+/// read-your-own-writes consistency. But that single HTTP session can rot
+/// (idle timeout, machine suspend/resume, network blip) and never recovers
+/// on its own. `Db` keeps the underlying `Database` so we can rebuild the
+/// `Connection` on demand when a query fails.
+#[derive(Clone)]
+pub struct Db {
+    db: Arc<Database>,
+    conn: Arc<RwLock<Connection>>,
+}
+
+impl Db {
+    pub fn new(db: Database, conn: Connection) -> Self {
+        Self {
+            db: Arc::new(db),
+            conn: Arc::new(RwLock::new(conn)),
+        }
+    }
+
+    /// Cheap clone of the current shared connection.
+    pub fn conn(&self) -> Connection {
+        self.conn
+            .read()
+            .expect("db connection lock poisoned")
+            .clone()
+    }
+
+    /// Rebuild the shared connection from the underlying `Database`.
+    /// Subsequent `conn()` calls observe the new connection.
+    pub fn reconnect(&self) -> Result<Connection, libsql::Error> {
+        let fresh = self.db.connect()?;
+        *self.conn.write().expect("db connection lock poisoned") = fresh.clone();
+        Ok(fresh)
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
-    /// Single shared database connection. Turso's remote HTTP connections
-    /// don't share replication state across `db.connect()` calls, so a new
-    /// connection can fail to see rows written by a previous one. Reusing
-    /// one connection guarantees read-your-own-writes consistency.
-    conn: Connection,
+    db: Db,
     pub allowed_origin: String,
     pub auth_config: Option<AuthConfig>,
     pub r2: Option<R2Client>,
@@ -18,13 +55,13 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(
-        conn: Connection,
+        db: Db,
         allowed_origin: String,
         auth_config: Option<AuthConfig>,
         r2: Option<R2Client>,
     ) -> Self {
         Self {
-            conn,
+            db,
             allowed_origin,
             auth_config,
             r2,
@@ -44,6 +81,12 @@ impl AppState {
     /// handlers share the same underlying HTTP session to Turso, which
     /// ensures read-your-own-writes consistency across requests.
     pub fn conn(&self) -> Connection {
-        self.conn.clone()
+        self.db.conn()
+    }
+
+    /// Rebuild the shared connection. Use after a query fails so subsequent
+    /// requests get a working session instead of a permanently-broken one.
+    pub fn reconnect(&self) -> Result<Connection, libsql::Error> {
+        self.db.reconnect()
     }
 }

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -8,7 +8,7 @@ use tower::ServiceExt;
 use intrada_api::auth::AuthConfig;
 use intrada_api::migrations;
 use intrada_api::routes;
-use intrada_api::state::AppState;
+use intrada_api::state::{AppState, Db};
 
 /// Create a fresh Axum router backed by a temporary SQLite database file.
 /// Each call returns an isolated database — tests don't share state.
@@ -39,7 +39,12 @@ async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
         .await
         .expect("Failed to run migrations");
 
-    let state = AppState::new(conn, "http://localhost:3000".to_string(), auth_config, None);
+    let state = AppState::new(
+        Db::new(db, conn),
+        "http://localhost:3000".to_string(),
+        auth_config,
+        None,
+    );
     routes::api_router(state)
 }
 


### PR DESCRIPTION
## Summary
- The single shared `libsql::Connection` from cb02bdf never reconnects if its HTTP session dies (idle timeout, Fly machine suspend/resume, network blip), causing persistent 503s across every route — matches today's production incident.
- Wrap the connection in an `Arc<RwLock<Connection>>` alongside the `Database` so it can be rebuilt on demand without sacrificing read-your-own-writes.
- Health check now retries once with a fresh connection on query failure; recovery propagates to every other handler because they all read from the same slot.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-api -- -D warnings`
- [x] `cargo test -p intrada-api` (all API tests pass)
- [ ] Observe behaviour in prod: after deploy, first failing health probe should log `DB health probe failed on cached connection; reconnecting` followed by `DB reconnect succeeded`, and subsequent requests should recover.

## Caveats / follow-ups
- Worst case window of one Fly health-check interval (~60s) where requests can still 503 between rot and next probe. A follow-up could wrap `state.conn()` callsites in a one-shot retry to close that gap — kept out of this PR to stay small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)