### PR TITLE
fix(api): drop FK constraint from lesson_photos

### DIFF
--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -254,6 +254,42 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0038_index_lesson_photos_lesson_id",
         "CREATE INDEX IF NOT EXISTS idx_lesson_photos_lesson_id ON lesson_photos(lesson_id);",
     ),
+    // Drop the FK constraint from lesson_photos. Turso's remote engine
+    // enforces FK regardless of the client-side `PRAGMA foreign_keys` —
+    // and the FK parent-table read fails across Fly machines / replicas
+    // that haven't yet observed a just-created lesson row, causing photo
+    // upload 500s. SQLite can't ALTER TABLE DROP CONSTRAINT, so we do
+    // the table-swap dance across 5 single-statement migrations.
+    //
+    // Orphan safety: `user_id` is on each row and `delete_lesson` deletes
+    // child photos explicitly (be44d1a), so removing the FK doesn't leak.
+    (
+        "0039_create_lesson_photos_new",
+        "CREATE TABLE IF NOT EXISTS lesson_photos_new (
+            id TEXT PRIMARY KEY NOT NULL,
+            lesson_id TEXT NOT NULL,
+            user_id TEXT NOT NULL DEFAULT '',
+            storage_key TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );",
+    ),
+    (
+        "0040_copy_lesson_photos_to_new",
+        "INSERT INTO lesson_photos_new (id, lesson_id, user_id, storage_key, created_at)
+         SELECT id, lesson_id, user_id, storage_key, created_at FROM lesson_photos;",
+    ),
+    (
+        "0041_drop_old_lesson_photos",
+        "DROP TABLE lesson_photos;",
+    ),
+    (
+        "0042_rename_lesson_photos_new",
+        "ALTER TABLE lesson_photos_new RENAME TO lesson_photos;",
+    ),
+    (
+        "0043_recreate_lesson_photos_lesson_id_index",
+        "CREATE INDEX IF NOT EXISTS idx_lesson_photos_lesson_id ON lesson_photos(lesson_id);",
+    ),
 ];
 
 /// Run migrations via libsql_migration (production path — tracks applied state).


### PR DESCRIPTION
## Summary
- Production photo uploads still 500 with `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` despite be44d1a removing `PRAGMA foreign_keys = ON` — Turso's remote engine enforces the FK regardless.
- SQLite can't `ALTER TABLE DROP CONSTRAINT`, so drop the FK via the table-swap dance across five single-statement migrations (enforced one-stmt-per-entry by `each_migration_contains_single_statement`).
- Orphan safety: already covered — `user_id` stored per-row, `delete_lesson` explicitly deletes child photos (be44d1a).

## Why this and not a pragma
be44d1a assumed that *not* setting `PRAGMA foreign_keys = ON` leaves FKs disabled (SQLite's documented default). Production disagrees: Turso's remote server-side engine ignores the client pragma. Only removing the FK from the schema actually stops the constraint check.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-api -- -D warnings`
- [x] `cargo test -p intrada-api` (all API tests pass, including the `each_migration_contains_single_statement` guard)
- [ ] Deploy to Fly; verify photo upload from iOS works against a freshly-created lesson with no more `SQLITE_CONSTRAINT` in logs.

## Follow-up
- jonyardley/intrada#295 tracks auditing the remaining FK constraints (`sessions`, `routines`, `setlist_entries`, etc.) for the same failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)