### PR TITLE
fix(api): drop FK constraints from routine_entries and setlist_entries

### DIFF
--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -290,6 +290,81 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0043_recreate_lesson_photos_lesson_id_index",
         "CREATE INDEX IF NOT EXISTS idx_lesson_photos_lesson_id ON lesson_photos(lesson_id);",
     ),
+    // Drop FK on routine_entries.routine_id — same Turso failure mode as
+    // lesson_photos (see #294). Orphan safety: delete_routine and
+    // update_routine already delete child rows explicitly.
+    (
+        "0044_create_routine_entries_new",
+        "CREATE TABLE IF NOT EXISTS routine_entries_new (
+            id TEXT PRIMARY KEY NOT NULL,
+            routine_id TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            item_title TEXT NOT NULL,
+            item_type TEXT NOT NULL,
+            position INTEGER NOT NULL
+        );",
+    ),
+    (
+        "0045_copy_routine_entries_to_new",
+        "INSERT INTO routine_entries_new (id, routine_id, item_id, item_title, item_type, position)
+         SELECT id, routine_id, item_id, item_title, item_type, position FROM routine_entries;",
+    ),
+    (
+        "0046_drop_old_routine_entries",
+        "DROP TABLE routine_entries;",
+    ),
+    (
+        "0047_rename_routine_entries_new",
+        "ALTER TABLE routine_entries_new RENAME TO routine_entries;",
+    ),
+    (
+        "0048_recreate_routine_entries_routine_id_index",
+        "CREATE INDEX IF NOT EXISTS idx_routine_entries_routine_id ON routine_entries(routine_id);",
+    ),
+    // Drop FK on setlist_entries.session_id — same Turso failure mode.
+    // Orphan safety: delete_session already deletes child rows explicitly.
+    // New schema must include every column added across 0006 + 0019-0025
+    // (score, intention, rep_target, rep_count, rep_target_reached,
+    // rep_history, planned_duration_secs, achieved_tempo).
+    (
+        "0049_create_setlist_entries_new",
+        "CREATE TABLE IF NOT EXISTS setlist_entries_new (
+            id TEXT PRIMARY KEY NOT NULL,
+            session_id TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            item_title TEXT NOT NULL,
+            item_type TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            duration_secs INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            notes TEXT,
+            score INTEGER,
+            intention TEXT,
+            rep_target INTEGER,
+            rep_count INTEGER,
+            rep_target_reached INTEGER,
+            rep_history TEXT,
+            planned_duration_secs INTEGER,
+            achieved_tempo INTEGER
+        );",
+    ),
+    (
+        "0050_copy_setlist_entries_to_new",
+        "INSERT INTO setlist_entries_new (id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes, score, intention, rep_target, rep_count, rep_target_reached, rep_history, planned_duration_secs, achieved_tempo)
+         SELECT id, session_id, item_id, item_title, item_type, position, duration_secs, status, notes, score, intention, rep_target, rep_count, rep_target_reached, rep_history, planned_duration_secs, achieved_tempo FROM setlist_entries;",
+    ),
+    (
+        "0051_drop_old_setlist_entries",
+        "DROP TABLE setlist_entries;",
+    ),
+    (
+        "0052_rename_setlist_entries_new",
+        "ALTER TABLE setlist_entries_new RENAME TO setlist_entries;",
+    ),
+    (
+        "0053_recreate_setlist_entries_session_id_index",
+        "CREATE INDEX IF NOT EXISTS idx_setlist_entries_session_id ON setlist_entries(session_id);",
+    ),
 ];
 
 /// Run migrations via libsql_migration (production path — tracks applied state).


### PR DESCRIPTION
## Summary
- Completes the FK audit kicked off by #294. `routine_entries.routine_id` and `setlist_entries.session_id` both carry `ON DELETE CASCADE` FKs that exhibit the same Turso cross-connection failure mode.
- Drops both via the table-swap dance — 5 single-statement migrations per table (0044-0048, 0049-0053).
- Orphan safety already covered in application code:
  - `delete_routine`, `update_routine` → explicit `DELETE FROM routine_entries WHERE routine_id = ?`
  - `delete_session` → explicit `DELETE FROM setlist_entries WHERE session_id = ?`

## Stacked on #294
Base branch is `fix/lesson-photos-drop-fk` (PR #294) so migration numbering continues from 0043 → 0044. Will rebase onto main after #294 merges.

## Notes for reviewer
- `setlist_entries` new-table schema must include every column added across 0006 + 0019-0025 (8 added columns). Double-check the column list against `ENTRY_COLUMNS` in `db/sessions.rs:121` — they match.
- No schema change for the tables themselves beyond removing the FK — all columns, types, and defaults preserved.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-api -- -D warnings`
- [x] `cargo test -p intrada-api` (all API tests pass — routines and sessions tests exercise the rebuilt tables end-to-end)
- [ ] After deploy, create a routine and session flow through iOS; verify no `SQLITE_CONSTRAINT` in logs.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)