### PR TITLE
docs: replace SpecKit workflow with tiered approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ design/           # Pencil design system (intrada.pen)
 docs/             # Product roadmap (single source of truth)
 e2e/              # Playwright E2E tests
 ios/Intrada/      # SwiftUI shell using CoreFfi (BCS bridge)
-specs/            # SpecKit design artifacts
+specs/            # Spec docs for major features (Tier 3 only — see Workflow)
 ```
 
 ## Tech Stack
@@ -167,11 +167,50 @@ visual parity is required — users should not be able to tell which platform th
 
 ## Workflow
 
-### Before starting work
+Match ceremony to scope. Default to less. Escalate only when the work demands
+it. The goal is a good outcome first time, not maximum process.
+
+### Tier 1 — Just do it
+Bug fixes, copy/text changes, style tweaks, renames, lint/clippy fixes,
+single-file refactors, dependency bumps, doc updates.
+
+No Plan mode, no spec doc. Read enough to confirm the change, make it,
+verify, ship.
+
+### Tier 2 — Plan mode only (default for most feature work)
+New component/view following existing patterns, new API endpoint following
+established conventions, adding a field to a model, new screen in existing
+navigation, anything touching 2-4 focused files.
+
+Use Plan mode to align on approach before coding. For UI work, design in
+`design/intrada.pen` after the plan, before implementing. No spec doc.
+
+### Tier 3 — Lightweight spec (rare; reserve for architectural work)
+Net-new top-level features, Crux core / FFI bridge changes, auth or DB
+schema changes, multi-week work spanning core + web + iOS, anything that
+can't be described in three sentences.
+
+Write ONE markdown doc in `specs/<feature>.md` — ~100-200 lines covering:
+problem, proposed approach, key decisions, open questions. Get alignment,
+then Pencil design (UI work), then Plan mode, then implement.
+
+Do not run the SpecKit `/speckit-*` commands. They produce multi-file
+spec/plan/tasks artifacts calibrated for multi-engineer teams; on a solo
+project they add 1-3 hours of markdown overhead per feature without
+qualitative benefit. Historical SpecKit folders under `specs/` are kept
+as reference but are no longer the workflow.
+
+### Decision rule
+If unsure between tiers, go one tier lighter. Drift up if scope expands
+during the work — don't pre-emptively over-spec.
+
+### Always (regardless of tier)
 1. Find the roadmap item in `docs/roadmap.md`. No item = discuss first.
 2. Check priority on the [project board](https://github.com/users/jonyardley/projects/2).
-3. Run SpecKit: `/speckit-specify` → `/speckit-plan` → `/speckit-tasks`.
-4. For UI work: design in `design/intrada.pen` after specify, before plan.
+3. UI work designs in `design/intrada.pen` before implementation.
+4. Pre-push: `cargo fmt && cargo clippy` must pass.
+5. After Swift/generated changes: `just ios-swift-check`.
+6. Never push to main. Always a feature branch + PR.
 
 ### After completing work
 1. Update `docs/roadmap.md`, close the GitHub issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,8 +167,7 @@ visual parity is required — users should not be able to tell which platform th
 
 ## Workflow
 
-Match ceremony to scope. Default to less. Escalate only when the work demands
-it. The goal is a good outcome first time, not maximum process.
+Match ceremony to scope. Default to less. Escalate only when work demands it.
 
 ### Tier 1 — Just do it
 Bug fixes, copy/text changes, style tweaks, renames, lint/clippy fixes,
@@ -177,40 +176,51 @@ single-file refactors, dependency bumps, doc updates.
 No Plan mode, no spec doc. Read enough to confirm the change, make it,
 verify, ship.
 
-### Tier 2 — Plan mode only (default for most feature work)
+### Tier 2 — Plan mode (default for feature work)
 New component/view following existing patterns, new API endpoint following
-established conventions, adding a field to a model, new screen in existing
-navigation, anything touching 2-4 focused files.
+established conventions, adding a field to an existing model, new screen
+in existing navigation.
 
-Use Plan mode to align on approach before coding. For UI work, design in
-`design/intrada.pen` after the plan, before implementing. No spec doc.
+For UI work: Pencil design first (see Pencil Design Workflow below), then
+Plan mode, then implement. For non-UI work: Plan mode, then implement.
+No spec doc.
 
-### Tier 3 — Lightweight spec (rare; reserve for architectural work)
+### Tier 3 — Lightweight spec (rare; architectural only)
 Net-new top-level features, Crux core / FFI bridge changes, auth or DB
-schema changes, multi-week work spanning core + web + iOS, anything that
-can't be described in three sentences.
+schema changes, multi-week work spanning core + web + iOS.
 
-Write ONE markdown doc in `specs/<feature>.md` — ~100-200 lines covering:
-problem, proposed approach, key decisions, open questions. Get alignment,
-then Pencil design (UI work), then Plan mode, then implement.
+Write ONE markdown doc in `specs/<feature>.md` (~100-200 lines: problem,
+approach, key decisions, open questions). Then Pencil for UI work, then
+Plan mode, then implement.
 
-Do not run the SpecKit `/speckit-*` commands. They produce multi-file
-spec/plan/tasks artifacts calibrated for multi-engineer teams; on a solo
-project they add 1-3 hours of markdown overhead per feature without
-qualitative benefit. Historical SpecKit folders under `specs/` are kept
-as reference but are no longer the workflow.
+Do not run `/speckit-*` slash commands. Historical SpecKit folders under
+`specs/` are reference only.
+
+### Domain sensitivity override
+Changes to auth, FFI types crossing the BCS bridge, DB schema, or
+migrations go up at least one tier regardless of file count or apparent
+size.
 
 ### Decision rule
-If unsure between tiers, go one tier lighter. Drift up if scope expands
-during the work — don't pre-emptively over-spec.
+If unsure between tiers, go one tier lighter. Drift up if scope expands.
 
-### Always (regardless of tier)
+### Examples
+
+| Task | Tier | Why |
+|------|------|-----|
+| Fix typo in a label | 1 | Trivial copy change |
+| Bump a dependency with no API change | 1 | Dep bump |
+| New "Recently practiced" view following existing list patterns | 2 | New view, established patterns |
+| Refactor `intrada-core/src/practice/session.rs` (no FFI change) | 2 | Single file, non-trivial domain logic |
+| Tweak retry backoff in `auth.rs` | 2 | Sensitivity override from Tier 1 |
+| Add `notes` field to a piece (touches FFI + DB) | 3 | Override: FFI + schema |
+| New auth provider | 3 | Auth + multi-crate |
+| Migrate persistence layer | 3 | Architectural |
+
+### Always
 1. Find the roadmap item in `docs/roadmap.md`. No item = discuss first.
 2. Check priority on the [project board](https://github.com/users/jonyardley/projects/2).
-3. UI work designs in `design/intrada.pen` before implementation.
-4. Pre-push: `cargo fmt && cargo clippy` must pass.
-5. After Swift/generated changes: `just ios-swift-check`.
-6. Never push to main. Always a feature branch + PR.
+3. Never push to main. Always a feature branch + PR.
 
 ### After completing work
 1. Update `docs/roadmap.md`, close the GitHub issue.


### PR DESCRIPTION
## Summary
- Replaces the single-path `/speckit-specify → /speckit-plan → /speckit-tasks` workflow with a three-tier model that matches ceremony to scope
- **Tier 1**: trivial work (bug fix, copy, style, rename, lint) → just do it, no Plan, no spec
- **Tier 2** (default for feature work): Plan mode + Pencil for UI work, no spec doc
- **Tier 3** (rare; architectural only): single lightweight spec doc in `specs/<feature>.md`, then Pencil, then Plan, then implement
- **Domain Sensitivity override**: auth, FFI types, DB schema, and migrations escalate at least one tier regardless of size
- Decision rule: when unsure, go one tier lighter; drift up only if scope expands
- Concrete examples table to disambiguate tier classification
- Historical SpecKit folders under `specs/` are kept as reference; no new ones get added

## Why
Researched alternatives (OpenSpec, BMAD, Kiro, Intent) and weighed them against the current SpecKit usage. SpecKit produces ~800 lines of markdown per feature and adds 1-3 hours of overhead before any code is written — calibrated for multi-engineer teams with external stakeholders, not a solo project. The Pencil design step (which has been valuable) is preserved at all tiers; the multi-file spec/plan/tasks ceremony is dropped except for genuinely large architectural work.

## Companion changes outside this diff
The agent-side memory was rewritten in lockstep so future Claude Code sessions actually follow this policy. These files live outside the repo (`~/.claude/projects/-Users-jonyardley-Dev-intrada/memory/`) and so aren't in this PR diff:

- `feedback_speckit_workflow.md` removed
- `feedback_workflow_tiers.md` added with the new tiered guidance
- `MEMORY.md` index updated

## Review iterations
- Initial commit had editorial content baked into operating rules, inconsistent Pencil ordering between tiers, fuzzy tier boundaries, and "Always" entries duplicating other CLAUDE.md sections
- Follow-up commit (`docs: address review feedback on workflow tiers`) addresses all of these and adds a concrete examples table

## Test plan
- [ ] Read the new Workflow section end-to-end and confirm it matches how I actually want to work
- [ ] Try a small change with the new flow (Tier 1 path) and confirm it feels lighter
- [ ] Try a Tier 2 feature next time one comes up and confirm Plan mode + Pencil is sufficient
- [ ] Revisit after ~2 weeks; if tier classification feels systematically wrong (>30% reclassified mid-task), refine criteria or revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)