### PR TITLE
feat(ios): Phase 2b — iOS grouped list rows for library

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -597,6 +597,67 @@ html.router-outlet-0.router-back::view-transition-new(root) {
 
 
 /* ═══════════════════════════════════════════════════════════════════════
+   iOS Library List (Phase 2b)
+   Transforms the web grid of glass cards into a native iOS grouped list.
+   All rules scoped to [data-platform="ios"].
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Hide the desktop hero intro — iOS doesn't need an onboarding explanation */
+[data-platform="ios"] .library-hero {
+  display: none;
+}
+
+/* Grouped list container — single column, one rounded card wrapping all rows */
+[data-platform="ios"] .library-list {
+  display: block;
+  background-color: var(--color-surface-primary);
+  border: 1px solid var(--color-border-card);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  backdrop-filter: blur(12px);
+  gap: 0;
+}
+
+/* Each row: strip the individual glass-card, add a bottom separator */
+[data-platform="ios"] .library-list li {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+[data-platform="ios"] .library-list li:last-child {
+  border-bottom: none;
+}
+
+/* Row link: horizontal flex with tight padding + disclosure chevron */
+[data-platform="ios"] .library-list li a {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  gap: 0.5rem;
+}
+
+/* Content area fills remaining space */
+[data-platform="ios"] .library-list li a > div {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Disclosure chevron */
+[data-platform="ios"] .library-list li a::after {
+  content: "›";
+  font-size: 1.375rem;
+  line-height: 1;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+  margin-left: 0.25rem;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════
    Metronome Loading Animation (audit #17)
    ═══════════════════════════════════════════════════════════════════════ */
 

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -13,7 +13,7 @@ pub fn LibraryListView() -> impl IntoView {
     view! {
         <div class="space-y-6">
             // Hero section with CTA
-            <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+            <div class="library-hero flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                 <PageHeading
                     text="Welcome to Intrada"
                     subtitle="Organize your music library, track your practice pieces and exercises, and build better practice habits."
@@ -44,7 +44,7 @@ pub fn LibraryListView() -> impl IntoView {
                     {move || {
                         if is_loading.get() {
                             view! {
-                                <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                <ul class="library-list grid grid-cols-1 sm:grid-cols-2 gap-3">
                                     <SkeletonItemCard />
                                     <SkeletonItemCard />
                                     <SkeletonItemCard />
@@ -67,7 +67,7 @@ pub fn LibraryListView() -> impl IntoView {
                                 }.into_any()
                             } else {
                                 view! {
-                                    <ul class="grid grid-cols-1 sm:grid-cols-2 gap-3" role="list" aria-label="Library items">
+                                    <ul class="library-list grid grid-cols-1 sm:grid-cols-2 gap-3" role="list" aria-label="Library items">
                                         {vm.items.into_iter().map(|item| {
                                             view! {
                                                 <LibraryItemCard item=item />


### PR DESCRIPTION
## Summary

Transforms the Library screen from a web-style grid of glass cards into a native iOS grouped list.

**Before**: 2-column grid on desktop, 1-column grid on mobile, each item a standalone glassmorphism card with rounded corners.

**After (iOS only)**: Single column, one rounded container wrapping all rows, hairline separators between rows, disclosure chevron (›) on each row. Desktop web unchanged.

### Changes

**`library_list.rs`**
- `library-list` class added to both `<ul>` elements (real list + skeleton)
- `library-hero` class added to the hero div so the onboarding intro text can be hidden on iOS (native apps don't need it — users know what app they're in)

**`input.css`**
- `.library-hero` hidden on iOS
- `.library-list` on iOS: `display: block` overrides Tailwind grid, single glass container wraps all rows
- `.library-list li` on iOS: strips per-row glass-card, adds `border-bottom` separator
- `.library-list li:last-child` on iOS: no bottom border
- `.library-list li a` on iOS: horizontal flex, tighter padding (0.75rem 1rem), chevron via `::after`

All rules scoped to `[data-platform="ios"]` — zero impact on desktop web or iPhone Safari.

## Test plan

- [ ] `just ios-dev` — library list shows as a grouped list with row separators and chevrons
- [ ] Desktop (`localhost:8080`) — unchanged (glass card grid)
- [ ] Empty state still shows correctly on iOS
- [ ] Skeleton loading state uses the same grouped container

🤖 Generated with [Claude Code](https://claude.com/claude-code)