### PR TITLE
chore(web): track env vars in build.rs to prevent stale WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
           curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.18/tailwindcss-linux-x64
           chmod +x tailwindcss-linux-x64
           mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
-      - name: Force rebuild when env vars change
-        run: touch crates/intrada-web/src/clerk_bindings.rs
       - name: Build WASM (release)
         working-directory: crates/intrada-web
         env:

--- a/crates/intrada-web/build.rs
+++ b/crates/intrada-web/build.rs
@@ -1,0 +1,9 @@
+// Tells cargo to rebuild this crate whenever these env vars change. Without
+// this, `option_env!` reads the value at first compile and bakes it into a
+// const — subsequent .env or shell env changes don't trigger a rebuild,
+// leading to stale WASM artifacts that point at the wrong API URL or use a
+// stale Clerk key.
+fn main() {
+    println!("cargo:rerun-if-env-changed=INTRADA_API_URL");
+    println!("cargo:rerun-if-env-changed=CLERK_PUBLISHABLE_KEY");
+}


### PR DESCRIPTION
## Summary

Fixes the recurring "stale WASM" trap where changing \`INTRADA_API_URL\` or \`CLERK_PUBLISHABLE_KEY\` in \`.env\` doesn't actually rebuild the WASM. \`option_env!\` is a compile-time macro that bakes values into a \`const\`, but cargo doesn't know to track those env vars as build dependencies. Result: edit \`.env\`, run \`just ios-dev\`, get stale behavior.

\`build.rs\` declares the dependency explicitly:

\`\`\`rust
fn main() {
    println!("cargo:rerun-if-env-changed=INTRADA_API_URL");
    println!("cargo:rerun-if-env-changed=CLERK_PUBLISHABLE_KEY");
}
\`\`\`

Now cargo invalidates the build whenever either env var changes — \`.env\` edits Just Work on next \`just ios-dev\`.

Also removes the workaround in \`ci.yml\` that touched \`clerk_bindings.rs\` to force a rebuild — no longer needed.

## Test plan

- [ ] CI passes (the removed touch step doesn't break anything)
- [ ] Local: edit \`.env\` → \`just ios-dev\` → trunk rebuilds (you'll see "Compiling intrada-web", not just a fast "Done")

🤖 Generated with [Claude Code](https://claude.com/claude-code)