### PR TITLE
fix(api): support multiple CORS origins (unblocks Tauri iOS dev)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ TURSO_AUTH_TOKEN=your-token-here
 # API server port (default: 3001, Fly.io sets 8080 in production)
 PORT=3001
 
-# CORS allowed origin (should match the Trunk dev server URL)
-ALLOWED_ORIGIN=http://localhost:8080
+# CORS allowed origins, comma-separated. Local dev needs:
+#   http://localhost:8080 — web (Trunk dev server)
+#   tauri://localhost     — Tauri iOS WebView page origin (NOT the devUrl)
+ALLOWED_ORIGIN=http://localhost:8080,tauri://localhost
 
 # Cloudflare R2 photo storage (optional — photo upload disabled without these)
 # See SETUP.md §4 for how to create the bucket and API token.

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -6,20 +6,30 @@ mod sessions;
 
 use axum::http::{header, HeaderValue, Method};
 use axum::Router;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 
 use crate::state::AppState;
 
 pub fn api_router(state: AppState) -> Router {
+    // ALLOWED_ORIGIN supports comma-separated values so a single API server
+    // can serve multiple frontends. In particular, the Tauri iOS WebView
+    // page origin is `tauri://localhost` (not the devUrl), so local dev
+    // needs both `http://localhost:8080` (web) and `tauri://localhost` (iOS).
+    let origins: Vec<HeaderValue> = state
+        .allowed_origin
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            s.parse::<HeaderValue>()
+                .unwrap_or_else(|_| panic!("Invalid ALLOWED_ORIGIN value: {s}"))
+        })
+        .collect();
+
     let cors = CorsLayer::new()
-        .allow_origin(
-            state
-                .allowed_origin
-                .parse::<HeaderValue>()
-                .expect("Invalid ALLOWED_ORIGIN value"),
-        )
+        .allow_origin(AllowOrigin::list(origins))
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -13,15 +13,21 @@ use intrada_api::state::{AppState, Db};
 /// Create a fresh Axum router backed by a temporary SQLite database file.
 /// Each call returns an isolated database — tests don't share state.
 pub async fn setup_test_app() -> Router {
-    setup_test_app_inner(None).await
+    setup_test_app_inner(None, "http://localhost:3000").await
 }
 
 /// Create a test router with auth enabled using the given `AuthConfig`.
 pub async fn setup_test_app_with_auth(auth_config: AuthConfig) -> Router {
-    setup_test_app_inner(Some(auth_config)).await
+    setup_test_app_inner(Some(auth_config), "http://localhost:3000").await
 }
 
-async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
+/// Create a test router with a custom allowed-origin string (supports
+/// comma-separated values to exercise multi-origin CORS).
+pub async fn setup_test_app_with_origin(allowed_origin: &str) -> Router {
+    setup_test_app_inner(None, allowed_origin).await
+}
+
+async fn setup_test_app_inner(auth_config: Option<AuthConfig>, allowed_origin: &str) -> Router {
     let tmp_dir = std::env::temp_dir();
     let db_path = tmp_dir.join(format!("intrada_test_{}.db", ulid::Ulid::new()));
 
@@ -41,7 +47,7 @@ async fn setup_test_app_inner(auth_config: Option<AuthConfig>) -> Router {
 
     let state = AppState::new(
         Db::new(db, conn),
-        "http://localhost:3000".to_string(),
+        allowed_origin.to_string(),
         auth_config,
         None,
     );

--- a/crates/intrada-api/tests/cors_test.rs
+++ b/crates/intrada-api/tests/cors_test.rs
@@ -1,0 +1,107 @@
+//! CORS tests for the API router.
+//!
+//! Verifies that `ALLOWED_ORIGIN` correctly handles single and multi-origin
+//! values. Particularly important for the Tauri iOS WebView whose page
+//! origin is `tauri://localhost` (not the configured devUrl).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Method, Request};
+use tower::ServiceExt;
+
+use common::setup_test_app_with_origin;
+
+/// Send a request with a given Origin header and return the value of the
+/// `Access-Control-Allow-Origin` response header (if any).
+async fn cors_origin_for(allowed_origin: &str, request_origin: &str) -> Option<String> {
+    let app = setup_test_app_with_origin(allowed_origin).await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/items")
+        .header("Origin", request_origin)
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    response
+        .headers()
+        .get("access-control-allow-origin")
+        .map(|v| v.to_str().unwrap().to_string())
+}
+
+#[tokio::test]
+async fn single_origin_value_is_allowed() {
+    let allow = cors_origin_for("http://localhost:8080", "http://localhost:8080").await;
+    assert_eq!(allow.as_deref(), Some("http://localhost:8080"));
+}
+
+#[tokio::test]
+async fn multiple_origins_both_allowed() {
+    let allowed = "http://localhost:8080,tauri://localhost";
+
+    let web = cors_origin_for(allowed, "http://localhost:8080").await;
+    assert_eq!(web.as_deref(), Some("http://localhost:8080"));
+
+    let ios = cors_origin_for(allowed, "tauri://localhost").await;
+    assert_eq!(ios.as_deref(), Some("tauri://localhost"));
+}
+
+#[tokio::test]
+async fn disallowed_origin_gets_no_cors_header() {
+    let allow = cors_origin_for("http://localhost:8080", "https://evil.example.com").await;
+    assert!(
+        allow.is_none(),
+        "Expected no Access-Control-Allow-Origin for disallowed origin, got {allow:?}"
+    );
+}
+
+#[tokio::test]
+async fn whitespace_around_commas_is_trimmed() {
+    let allowed = "  http://localhost:8080 , tauri://localhost  ";
+
+    let web = cors_origin_for(allowed, "http://localhost:8080").await;
+    assert_eq!(web.as_deref(), Some("http://localhost:8080"));
+
+    let ios = cors_origin_for(allowed, "tauri://localhost").await;
+    assert_eq!(ios.as_deref(), Some("tauri://localhost"));
+}
+
+#[tokio::test]
+async fn empty_segments_are_ignored() {
+    // Trailing/leading commas and double commas should not produce empty
+    // entries that error out.
+    let allowed = ",,http://localhost:8080,,tauri://localhost,,";
+
+    let web = cors_origin_for(allowed, "http://localhost:8080").await;
+    assert_eq!(web.as_deref(), Some("http://localhost:8080"));
+}
+
+#[tokio::test]
+async fn preflight_request_returns_cors_headers_for_allowed_origin() {
+    let app = setup_test_app_with_origin("tauri://localhost").await;
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/api/items")
+        .header("Origin", "tauri://localhost")
+        .header("Access-Control-Request-Method", "POST")
+        .header(
+            "Access-Control-Request-Headers",
+            "content-type,authorization",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let headers = response.headers();
+
+    assert_eq!(
+        headers
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("tauri://localhost"),
+    );
+    let allow_methods = headers
+        .get("access-control-allow-methods")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(allow_methods.contains("POST"));
+}


### PR DESCRIPTION
## Summary

The Tauri 2 mobile WebView page origin is **\`tauri://localhost\`**, not the configured \`devUrl\`. Confirmed via Safari Web Inspector: \`location.origin === "tauri://localhost"\`. Requests from the iOS app to the API hit CORS rejection because the API only allows a single origin (\`http://localhost:8080\` for local dev).

## Fix

Parse \`ALLOWED_ORIGIN\` as a comma-separated list and use \`AllowOrigin::list\`. Single-value usage still works as a degenerate list of one, so production deployments are unaffected unless they want to add additional origins.

\`.env.example\` updated with both local dev origins documented.

## Why this matters

Without this, you can't load any data in the Tauri iOS shell during local dev. Web (browser at \`localhost:8080\`) works fine; iOS app fails every API request with \`TypeError: Load failed\` and console error \`Origin tauri://localhost is not allowed by Access-Control-Allow-Origin\`.

## Production note

When the iOS app ships, \`ALLOWED_ORIGIN\` on Fly.io will need \`tauri://localhost\` added. Worth a follow-up to update the Fly.io secret.

## Test plan

- [ ] CI passes
- [ ] Local: with both this and #311, restart \`just dev-api\` and \`just ios-dev\` — iOS app loads data
- [ ] Web (\`localhost:8080\` in browser) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)