### PR TITLE
feat(ios): elastic scroll bounce + tap-press feedback

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -541,12 +541,24 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   -webkit-tap-highlight-color: transparent;
 }
 
-/* SF Pro system font stack, disable root rubber-band scroll,
-   and disable double-tap-to-zoom across the whole page (native apps don't zoom) */
+/* SF Pro system font stack + disable double-tap-to-zoom across the whole page.
+   overscroll-behavior is intentionally NOT set here — native iOS apps have
+   the elastic bounce at scroll edges, and WKWebView has no pull-to-refresh
+   gesture to disable. */
 [data-platform="ios"] body {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif;
-  overscroll-behavior: none;
   touch-action: manipulation;
+}
+
+/* Universal press feedback — subtle dim on tap. Native iOS dims any
+   tappable element when pressed; pairs with the haptic feedback already
+   wired through. 80ms is fast enough to feel instant, slow enough to be
+   perceptible. */
+[data-platform="ios"] button:active,
+[data-platform="ios"] a:active,
+[data-platform="ios"] [role="button"]:active {
+  opacity: 0.6;
+  transition: opacity 80ms ease-out;
 }
 
 /* Hide the web header on iOS — tab bar handles all primary navigation. */


### PR DESCRIPTION
## Summary

Two small CSS-only iOS native-feel quick wins from #317.

### 1. Elastic scroll bounce

Removes \`overscroll-behavior: none\` from the body iOS rule. Phase 1a set this to "disable root rubber-band" — but that concern was rooted in desktop browser behaviour. WKWebView has no pull-to-refresh gesture to disable, and native iOS apps always have the elastic bounce at scroll edges. Removing the rule restores native-feeling scroll.

### 2. Universal tap-press feedback

Adds \`:active { opacity: 0.6 }\` (80ms ease-out) to \`button\`, \`a\`, and \`[role="button"]\` on iOS. Native iOS dims any tappable surface when pressed; this pairs with the haptic feedback that already fires.

Both rules platform-gated under \`[data-platform="ios"]\` — desktop web unaffected.

## Test plan

- [ ] CI passes
- [ ] \`just ios-dev\` — scroll the library list to the bottom: should bounce back elastically (not stop dead)
- [ ] \`just ios-dev\` — tap any button or list row: subtle dim during press, releases when lifted
- [ ] Web (\`localhost:8080\`) — no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)