### PR TITLE
fix(ios): set data-platform in index.html to fix device platform detection

### DIFF
--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -1,20 +1,11 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Note: data-platform="ios" is set by index.html based on
+    // location.protocol === 'tauri:'. Setup-time eval here was racing page
+    // load on physical devices and silently failed.
     tauri::Builder::default()
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_deep_link::init())
-        .setup(|_app| {
-            // Set data-platform="ios" so CSS [data-platform="ios"] selectors apply.
-            // initializationScript is not available in Tauri 2 JSON config.
-            #[cfg(target_os = "ios")]
-            {
-                use tauri::Manager;
-                _app.get_webview_window("main")
-                    .expect("main window not found")
-                    .eval("document.documentElement.setAttribute('data-platform','ios')")?;
-            }
-            Ok(())
-        })
         .run(tauri::generate_context!())
         .expect("error while running intrada");
 }

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -10,6 +10,16 @@
     <link data-trunk rel="rust" data-wasm-opt="z" href="Cargo.toml" />
     <link data-trunk rel="css" href="tailwind-output.css" />
     <script>
+      // Set data-platform="ios" early so [data-platform="ios"] CSS applies
+      // before first paint — no flicker. Tauri WebView always serves pages
+      // from the tauri:// protocol; in a regular browser it's http(s):.
+      // Replaces the lib.rs setup-hook eval which was racing page load on
+      // device.
+      if (location.protocol === 'tauri:') {
+        document.documentElement.setAttribute('data-platform', 'ios');
+      }
+    </script>
+    <script>
       // Auth helper bridge — used by WASM via wasm_bindgen(inline_js)
       // Skip if already defined (E2E tests inject a mock via addInitScript)
       if (!window.__intrada_auth) window.__intrada_auth = {


### PR DESCRIPTION
## Summary

**Critical bug**: \`document.documentElement.dataset.platform\` was returning \`undefined\` on physical iOS devices. This meant **none** of our \`[data-platform="ios"]\` CSS rules were applying — scrolling stopped hard with no elastic bounce, pull-to-refresh was invisible, header was visible, double-tap zoomed... essentially most of the iOS polish from Phase 1a/1b/1c was inert on device.

## Root cause

\`lib.rs\` setup hook was doing:

\`\`\`rust
.setup(|_app| {
    #[cfg(target_os = "ios")]
    {
        _app.get_webview_window("main")
            .expect("main window not found")
            .eval("document.documentElement.setAttribute('data-platform','ios')")?;
    }
    Ok(())
})
\`\`\`

On simulator we got lucky with timing. On physical device, \`setup\` runs **before** the WebView page loads — the eval queues against a not-yet-loaded document and is lost when the real page arrives. Confirmed via Safari Web Inspector against device: \`dataset.platform === undefined\`.

## Fix

Detect Tauri context **synchronously** in \`index.html\` via \`location.protocol === 'tauri:'\` (the Tauri WebView always serves from this scheme; in a regular browser it's \`http(s):\`). Set the attribute before any CSS evaluates — no race, no flicker.

\`\`\`html
<script>
  if (location.protocol === 'tauri:') {
    document.documentElement.setAttribute('data-platform', 'ios');
  }
</script>
\`\`\`

Removed the now-dead lib.rs setup eval.

## Why we didn't catch this earlier

We've been testing primarily on the simulator, where the timing happened to work. On physical device the timing fails reliably. Worth saving this to memory: **always test on device when relying on Tauri setup-time WebView interaction**.

## Test plan

- [ ] CI passes
- [ ] \`just ios-dev-device\` — Safari Web Inspector → \`document.documentElement.dataset.platform\` returns \`"ios"\`
- [ ] Scrolling has elastic bounce at edges
- [ ] Pull-to-refresh visible at top of library list
- [ ] Header hidden, tab bar height correct
- [ ] Web (\`localhost:8080\`) — \`dataset.platform\` is \`undefined\` (correct, no iOS styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)