### PR TITLE
fix(ios): make <main> the scroll container so iOS bouncing works

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -541,10 +541,16 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   -webkit-tap-highlight-color: transparent;
 }
 
-/* SF Pro system font stack + disable double-tap-to-zoom across the whole page.
-   overscroll-behavior is intentionally NOT set here — native iOS apps have
-   the elastic bounce at scroll edges, and WKWebView has no pull-to-refresh
-   gesture to disable. */
+/* SF Pro system font stack + disable double-tap-to-zoom. body is fixed
+   to viewport height with overflow hidden — the actual scroll happens in
+   <main> below. This is required because Tauri's WKWebView doesn't bounce
+   the body element, but inner overflow:auto regions DO bounce natively. */
+[data-platform="ios"] html,
+[data-platform="ios"] body {
+  height: 100%;
+  overflow: hidden;
+}
+
 [data-platform="ios"] body {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif;
   touch-action: manipulation;
@@ -579,10 +585,28 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   padding-bottom: env(safe-area-inset-bottom);
 }
 
-/* Main content: clear Dynamic Island at top, full tab bar height at bottom. */
+/* Main is the scroll container on iOS. Fills viewport height with native
+   overscroll bouncing. Padding clears Dynamic Island at top and tab bar
+   at bottom. The wrapping <div class="relative z-0 min-h-screen"> ensures
+   main has a defined height to fill. */
 [data-platform="ios"] main {
+  height: 100%;
+  overflow-y: auto;
   padding-top: max(env(safe-area-inset-top), 1rem);
   padding-bottom: calc(4rem + env(safe-area-inset-bottom) + 0.5rem);
+}
+
+/* The wrapper div between body and main needs to fill body so main has
+   a defined 100% height to inherit. */
+[data-platform="ios"] body > div.relative {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+[data-platform="ios"] body > div.relative > main {
+  flex: 1;
+  min-height: 0;
 }
 
 /* No text selection on navigation chrome — preserve it on readable content */

--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -4,9 +4,22 @@ use leptos::prelude::*;
 const PULL_THRESHOLD: f64 = 80.0;
 const MAX_PULL: f64 = 120.0;
 
+/// Returns the scrollTop of the closest ancestor scroll container (`<main>`).
+/// On iOS our scroll container is `<main>` (body is fixed); on other platforms
+/// the body scrolls so we fall back to `window.scrollY`.
+fn scroll_top() -> f64 {
+    document()
+        .query_selector("main")
+        .ok()
+        .flatten()
+        .map(|el| el.scroll_top() as f64)
+        .filter(|&top| top >= 0.0)
+        .unwrap_or_else(|| window().scroll_y().unwrap_or(0.0))
+}
+
 /// Wraps content with iOS-style pull-to-refresh.
 ///
-/// Listens for touch/pointer pulls when the page is scrolled to top.
+/// Listens for touch/pointer pulls when the scroll container is at the top.
 /// Past `PULL_THRESHOLD` the on_refresh callback fires; the spinner
 /// stays visible while `is_refreshing` is true.
 ///
@@ -21,11 +34,11 @@ pub fn PullToRefresh(
     let pointer_start_y = RwSignal::new(None::<f64>);
 
     let on_pointerdown = move |ev: ev::PointerEvent| {
-        // Only respond to touch (not mouse), and only when at the top of the page
+        // Only respond to touch (not mouse), and only when at the top of the scroll
         if ev.pointer_type() != "touch" {
             return;
         }
-        if window().scroll_y().unwrap_or(0.0) > 0.0 {
+        if scroll_top() > 0.0 {
             return;
         }
         pointer_start_y.set(Some(ev.client_y() as f64));
@@ -37,7 +50,7 @@ pub fn PullToRefresh(
             return;
         };
         // Bail if user has scrolled away from the top mid-drag
-        if window().scroll_y().unwrap_or(0.0) > 0.0 {
+        if scroll_top() > 0.0 {
             pointer_start_y.set(None);
             pull_distance.set(0.0);
             return;

--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -13,7 +13,6 @@ fn scroll_top() -> f64 {
         .ok()
         .flatten()
         .map(|el| el.scroll_top() as f64)
-        .filter(|&top| top >= 0.0)
         .unwrap_or_else(|| window().scroll_y().unwrap_or(0.0))
 }
 


### PR DESCRIPTION
## Summary

Stacked on #320. Fixes the "scroll stops dead at the end" issue on iOS — and also a prerequisite for pull-to-refresh actually working.

## Root cause

Confirmed via Web Inspector:
- \`overscroll-behavior\` was \`auto\` on body (CSS not the issue)
- Inline-overriding \`overscrollBehavior = 'auto'\` on body/html had no effect
- The bounce is suppressed at the **WKWebView level** — the underlying \`WKScrollView\` for the document doesn't bounce

But this is a known WKWebView quirk: **inner \`overflow:auto\` regions DO bounce natively**, even when the document doesn't. The spec (§5 of \`tauri-leptos-ios-shell.md\`) anticipated this: "App root is non-scrolling. Inner regions scroll."

## Fix

Restructure scroll on iOS:
- \`html, body\`: \`height: 100%, overflow: hidden\` — fixed to viewport
- \`main\`: \`height: 100%, overflow-y: auto\` — the scroll container with native bounce
- Existing safe-area padding on main carried over
- Added a flex rule so the wrapping \`<div class="relative z-0 min-h-screen">\` properly fills body so main has a defined 100% height to inherit

\`PullToRefresh\` updated to read scroll position from \`<main>\` instead of \`window.scrollY\` (with fallback to window for web).

## Test plan

- [ ] CI passes
- [ ] \`just ios-dev-device\` — scroll the library list to bottom: should bounce back elastically
- [ ] Pull-to-refresh visible and functional at top of library list
- [ ] Tab bar stays fixed at bottom during scroll (it's \`fixed bottom-0\`)
- [ ] Status bar safe area still respected at top
- [ ] Web (\`localhost:8080\`) — body still scrolls normally, no behavioural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)