### PR TITLE
fix(ios): make <main> the scroll container so iOS bouncing works

### DIFF
--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -1,20 +1,11 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Note: data-platform="ios" is set by index.html based on
+    // location.protocol === 'tauri:'. Setup-time eval here was racing page
+    // load on physical devices and silently failed.
     tauri::Builder::default()
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_deep_link::init())
-        .setup(|_app| {
-            // Set data-platform="ios" so CSS [data-platform="ios"] selectors apply.
-            // initializationScript is not available in Tauri 2 JSON config.
-            #[cfg(target_os = "ios")]
-            {
-                use tauri::Manager;
-                _app.get_webview_window("main")
-                    .expect("main window not found")
-                    .eval("document.documentElement.setAttribute('data-platform','ios')")?;
-            }
-            Ok(())
-        })
         .run(tauri::generate_context!())
         .expect("error while running intrada");
 }

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -10,6 +10,16 @@
     <link data-trunk rel="rust" data-wasm-opt="z" href="Cargo.toml" />
     <link data-trunk rel="css" href="tailwind-output.css" />
     <script>
+      // Set data-platform="ios" early so [data-platform="ios"] CSS applies
+      // before first paint — no flicker. Tauri WebView always serves pages
+      // from the tauri:// protocol; in a regular browser it's http(s):.
+      // Replaces the lib.rs setup-hook eval which was racing page load on
+      // device.
+      if (location.protocol === 'tauri:') {
+        document.documentElement.setAttribute('data-platform', 'ios');
+      }
+    </script>
+    <script>
       // Auth helper bridge — used by WASM via wasm_bindgen(inline_js)
       // Skip if already defined (E2E tests inject a mock via addInitScript)
       if (!window.__intrada_auth) window.__intrada_auth = {

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -541,10 +541,16 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   -webkit-tap-highlight-color: transparent;
 }
 
-/* SF Pro system font stack + disable double-tap-to-zoom across the whole page.
-   overscroll-behavior is intentionally NOT set here — native iOS apps have
-   the elastic bounce at scroll edges, and WKWebView has no pull-to-refresh
-   gesture to disable. */
+/* SF Pro system font stack + disable double-tap-to-zoom. body is fixed
+   to viewport height with overflow hidden — the actual scroll happens in
+   <main> below. This is required because Tauri's WKWebView doesn't bounce
+   the body element, but inner overflow:auto regions DO bounce natively. */
+[data-platform="ios"] html,
+[data-platform="ios"] body {
+  height: 100%;
+  overflow: hidden;
+}
+
 [data-platform="ios"] body {
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif;
   touch-action: manipulation;
@@ -579,10 +585,28 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   padding-bottom: env(safe-area-inset-bottom);
 }
 
-/* Main content: clear Dynamic Island at top, full tab bar height at bottom. */
+/* Main is the scroll container on iOS. Fills viewport height with native
+   overscroll bouncing. Padding clears Dynamic Island at top and tab bar
+   at bottom. The wrapping <div class="relative z-0 min-h-screen"> ensures
+   main has a defined height to fill. */
 [data-platform="ios"] main {
+  height: 100%;
+  overflow-y: auto;
   padding-top: max(env(safe-area-inset-top), 1rem);
   padding-bottom: calc(4rem + env(safe-area-inset-bottom) + 0.5rem);
+}
+
+/* The wrapper div between body and main needs to fill body so main has
+   a defined 100% height to inherit. */
+[data-platform="ios"] body > div.relative {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+[data-platform="ios"] body > div.relative > main {
+  flex: 1;
+  min-height: 0;
 }
 
 /* No text selection on navigation chrome — preserve it on readable content */

--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -4,9 +4,22 @@ use leptos::prelude::*;
 const PULL_THRESHOLD: f64 = 80.0;
 const MAX_PULL: f64 = 120.0;
 
+/// Returns the scrollTop of the closest ancestor scroll container (`<main>`).
+/// On iOS our scroll container is `<main>` (body is fixed); on other platforms
+/// the body scrolls so we fall back to `window.scrollY`.
+fn scroll_top() -> f64 {
+    document()
+        .query_selector("main")
+        .ok()
+        .flatten()
+        .map(|el| el.scroll_top() as f64)
+        .filter(|&top| top >= 0.0)
+        .unwrap_or_else(|| window().scroll_y().unwrap_or(0.0))
+}
+
 /// Wraps content with iOS-style pull-to-refresh.
 ///
-/// Listens for touch/pointer pulls when the page is scrolled to top.
+/// Listens for touch/pointer pulls when the scroll container is at the top.
 /// Past `PULL_THRESHOLD` the on_refresh callback fires; the spinner
 /// stays visible while `is_refreshing` is true.
 ///
@@ -21,11 +34,11 @@ pub fn PullToRefresh(
     let pointer_start_y = RwSignal::new(None::<f64>);
 
     let on_pointerdown = move |ev: ev::PointerEvent| {
-        // Only respond to touch (not mouse), and only when at the top of the page
+        // Only respond to touch (not mouse), and only when at the top of the scroll
         if ev.pointer_type() != "touch" {
             return;
         }
-        if window().scroll_y().unwrap_or(0.0) > 0.0 {
+        if scroll_top() > 0.0 {
             return;
         }
         pointer_start_y.set(Some(ev.client_y() as f64));
@@ -37,7 +50,7 @@ pub fn PullToRefresh(
             return;
         };
         // Bail if user has scrolled away from the top mid-drag
-        if window().scroll_y().unwrap_or(0.0) > 0.0 {
+        if scroll_top() > 0.0 {
             pointer_start_y.set(None);
             pull_distance.set(0.0);
             return;

--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -13,7 +13,6 @@ fn scroll_top() -> f64 {
         .ok()
         .flatten()
         .map(|el| el.scroll_top() as f64)
-        .filter(|&top| top >= 0.0)
         .unwrap_or_else(|| window().scroll_y().unwrap_or(0.0))
 }
 


### PR DESCRIPTION
## Summary

Re-opened (was #321, auto-closed when the stacked base branch was deleted after merging #320). All commits intact.

Fixes the "scroll stops dead at the end" issue on iOS — and a prerequisite for pull-to-refresh actually working.

## Root cause

Confirmed via Web Inspector:
- \`overscroll-behavior\` was \`auto\` on body (CSS not the issue)
- Inline-overriding \`overscrollBehavior = 'auto'\` had no effect
- The bounce is suppressed at the **WKWebView level** — the underlying \`WKScrollView\` for the document doesn't bounce

But: **inner \`overflow:auto\` regions DO bounce natively**, even when the document doesn't. The spec (§5 of \`tauri-leptos-ios-shell.md\`) anticipated this: "App root is non-scrolling. Inner regions scroll."

## Fix

- \`html, body\`: \`height: 100%, overflow: hidden\` (iOS only)
- \`main\`: \`height: 100%, overflow-y: auto\` — the scroll container with native bounce
- Wrapping \`<div class="relative z-0 min-h-screen">\` becomes flex column to give main a defined parent height
- \`PullToRefresh\`: reads scroll position from \`<main>\` (with fallback to \`window.scrollY\` for web)

## Test plan

- [ ] CI passes
- [ ] \`just ios-dev-device\` — scroll the library list to bottom: should bounce back elastically
- [ ] Pull-to-refresh visible and functional at top of library list
- [ ] Tab bar stays fixed at bottom
- [ ] Web (\`localhost:8080\`) — no behavioural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)