### PR TITLE
fix(deploy): scope chef cook to intrada-api + add PR docker build coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,26 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  api-docker-build:
+    # Catches Dockerfile / workspace-scoping bugs on PRs that would otherwise
+    # only surface when the Deploy API job runs on main. PRs use --exclude
+    # intrada-mobile workarounds for the GTK issue; the Deploy build path
+    # (Dockerfile + cargo chef) doesn't have that workaround, and a regression
+    # there only shows up post-merge.
+    name: API Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Build intrada-api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: intrada-api:ci-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
@@ -176,7 +196,7 @@ jobs:
   deploy-api:
     name: Deploy API to Fly.io
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt, typegen, wasm-build, wasm-test, e2e]
+    needs: [test, clippy, fmt, typegen, wasm-build, wasm-test, e2e, api-docker-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies — this is the caching Docker layer
-RUN cargo chef cook --release --recipe-path recipe.json
+# Build dependencies — this is the caching Docker layer.
+# --bin intrada-api scopes to only intrada-api's dependency graph, excluding
+# crates/intrada-mobile's Tauri/GTK chain (gdk-sys etc.) which doesn't build
+# in this minimal Rust container.
+RUN cargo chef cook --release --recipe-path recipe.json --bin intrada-api
 # Build application
 COPY . .
 RUN cargo build --release --bin intrada-api


### PR DESCRIPTION
## Summary

Fixes the recurring **"PR passes, main fails"** pattern that's been hitting every iOS PR for a day. Root cause + prevention in one PR.

## Root cause

The Fly.io deploy step uses our \`Dockerfile\`, which does:

\`\`\`dockerfile
RUN cargo chef cook --release --recipe-path recipe.json   # builds ALL workspace deps
COPY . .
RUN cargo build --release --bin intrada-api               # only intrada-api binary
\`\`\`

The \`cook\` step (without \`--bin\`) tries to build dependencies for the **entire workspace**, including \`crates/intrada-mobile\`'s Tauri chain (gdk-sys etc.). That GTK toolchain isn't available in the minimal Rust container, so it fails:

\`\`\`
error: failed to run custom build command for `gdk-sys v0.18.2`
\`\`\`

The PR test/clippy jobs use \`--workspace --exclude intrada-mobile\` to dodge this. The Dockerfile doesn't, and PR CI never exercises the Dockerfile.

## Fix part 1 — Dockerfile

Add \`--bin intrada-api\` to \`chef cook\`:

\`\`\`dockerfile
RUN cargo chef cook --release --recipe-path recipe.json --bin intrada-api
\`\`\`

Now cook only builds the intrada-api dependency graph (no Tauri).

## Fix part 2 — PR CI coverage

New \`api-docker-build\` job that runs \`docker build\` on every PR, with GHA layer caching. Catches Dockerfile/workspace-scoping regressions **before merge**. \`deploy-api\` now depends on it (won't even attempt deploy if image won't build).

First PR run after merge: slow (~10min, no cache). Subsequent runs benefit from layer caching.

## Test plan

- [ ] CI passes — including the new \`api-docker-build\` job
- [ ] After merge, main CI's Deploy API succeeds (this is the actual proof the fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)