### PR TITLE
fix(ios): scroll rework — position:fixed main + disable pinch-zoom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,26 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  api-docker-build:
+    # Catches Dockerfile / workspace-scoping bugs on PRs that would otherwise
+    # only surface when the Deploy API job runs on main. PRs use --exclude
+    # intrada-mobile workarounds for the GTK issue; the Deploy build path
+    # (Dockerfile + cargo chef) doesn't have that workaround, and a regression
+    # there only shows up post-merge.
+    name: API Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Build intrada-api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: intrada-api:ci-smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
@@ -176,7 +196,7 @@ jobs:
   deploy-api:
     name: Deploy API to Fly.io
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt, typegen, wasm-build, wasm-test, e2e]
+    needs: [test, clippy, fmt, typegen, wasm-build, wasm-test, e2e, api-docker-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-# Build dependencies — this is the caching Docker layer
-RUN cargo chef cook --release --recipe-path recipe.json
+# Build dependencies — this is the caching Docker layer.
+# --bin intrada-api scopes to only intrada-api's dependency graph, excluding
+# crates/intrada-mobile's Tauri/GTK chain (gdk-sys etc.) which doesn't build
+# in this minimal Rust container.
+RUN cargo chef cook --release --recipe-path recipe.json --bin intrada-api
 # Build application
 COPY . .
 RUN cargo build --release --bin intrada-api

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -17,6 +17,16 @@
       // device.
       if (location.protocol === 'tauri:') {
         document.documentElement.setAttribute('data-platform', 'ios');
+        // Native iOS apps don't have pinch-zoom on the page. Override the
+        // viewport meta to disable it inside the Tauri WebView only —
+        // regular browser users keep their accessibility zoom.
+        const viewport = document.querySelector('meta[name=viewport]');
+        if (viewport) {
+          viewport.setAttribute(
+            'content',
+            'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover'
+          );
+        }
       }
     </script>
     <script>

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -547,7 +547,7 @@ html.router-outlet-0.router-back::view-transition-new(root) {
    the body element, but inner overflow:auto regions DO bounce natively. */
 [data-platform="ios"] html,
 [data-platform="ios"] body {
-  height: 100%;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -585,28 +585,16 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   padding-bottom: env(safe-area-inset-bottom);
 }
 
-/* Main is the scroll container on iOS. Fills viewport height with native
-   overscroll bouncing. Padding clears Dynamic Island at top and tab bar
-   at bottom. The wrapping <div class="relative z-0 min-h-screen"> ensures
-   main has a defined height to fill. */
+/* Main is the scroll container on iOS — pulled out of document flow with
+   position: fixed so the wrapping <div class="min-h-screen"> can't fight
+   it. inset:0 fills the viewport. Inner overflow:auto bounces natively
+   in WKWebView (the body itself doesn't bounce in Tauri). */
 [data-platform="ios"] main {
-  height: 100%;
+  position: fixed;
+  inset: 0;
   overflow-y: auto;
   padding-top: max(env(safe-area-inset-top), 1rem);
   padding-bottom: calc(4rem + env(safe-area-inset-bottom) + 0.5rem);
-}
-
-/* The wrapper div between body and main needs to fill body so main has
-   a defined 100% height to inherit. */
-[data-platform="ios"] body > div.relative {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-[data-platform="ios"] body > div.relative > main {
-  flex: 1;
-  min-height: 0;
 }
 
 /* No text selection on navigation chrome — preserve it on readable content */


### PR DESCRIPTION
## Summary

#322's flex-based scroll restructure caused regressions on device:
- Scrolling broken
- Weird re-rendering
- Pinch zoomed the whole page

Root cause: the flex layout I added (\`body > div.relative { display: flex }\` + \`main { flex: 1, min-height: 0 }\`) fought with the wrapping div's existing \`min-h-screen\` Tailwind class. Sometimes main got squished, sometimes it grew unbounded.

## Fix

Cleaner approach — pull main out of document flow entirely:

\`\`\`css
[data-platform="ios"] html, body {
  height: 100dvh;
  overflow: hidden;
}

[data-platform="ios"] main {
  position: fixed;
  inset: 0;
  overflow-y: auto;
  /* safe-area padding */
}
\`\`\`

\`position: fixed\` means main is sized relative to the viewport, ignoring whatever Tailwind classes are on its parent. The wrapping \`min-h-screen\` div becomes empty (everything inside main is now in the fixed-position layer); the \`<BottomTabBar>\` is also fixed-positioned so it stays anchored to the viewport bottom. No flex, no min-height fights.

Also: \`100dvh\` (dynamic viewport height) instead of \`100%\` for more reliable resolution in WKWebView.

## Pinch zoom

Native iOS apps don't pinch-zoom on the page. Updated \`index.html\` script to override the viewport meta in Tauri context only:

\`\`\`js
viewport.setAttribute('content',
  'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover');
\`\`\`

Web users (browser) keep their accessibility zoom — only Tauri WebView is locked.

## Test plan

- [ ] CI passes
- [ ] \`just ios-dev-device\` — library list scrolls smoothly with bounce at edges
- [ ] No re-render flicker
- [ ] Pinch gesture does nothing (no zoom in/out)
- [ ] Tab bar stays fixed during scroll
- [ ] Web (\`localhost:8080\`) — no behavioural change, page can still scroll/zoom normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)