### PR TITLE
ci: skip api-docker-build for PRs that don't touch the API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,28 @@ env:
   RUST_VERSION: "1.89.0"
 
 jobs:
+  # Detects which paths changed in the PR — used by api-docker-build to skip
+  # when only frontend/iOS files changed (the docker build can't break in those
+  # cases). Runs cheaply (~5s) on every event.
+  changes:
+    name: Path Changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'Dockerfile'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/intrada-api/**'
+              - 'crates/intrada-core/**'
+              - '.github/workflows/ci.yml'
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -157,12 +179,13 @@ jobs:
 
   api-docker-build:
     # Catches Dockerfile / workspace-scoping bugs on PRs that would otherwise
-    # only surface when the Deploy API job runs on main. PRs use --exclude
-    # intrada-mobile workarounds for the GTK issue; the Deploy build path
-    # (Dockerfile + cargo chef) doesn't have that workaround, and a regression
-    # there only shows up post-merge.
+    # only surface when the Deploy API job runs on main. Only runs when paths
+    # that could affect the build change — most PRs (frontend/iOS only) skip
+    # this and stay fast. Always runs on main pushes (gates deploy).
     name: API Docker Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.api == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

The \`api-docker-build\` job (added in #323) adds ~14min uncached / ~2-3min cached to every PR. Most PRs touch frontend/iOS code only and can't break the deploy build path — running the docker build for them is wasted CI time.

## How it works

New \`changes\` job at the top of the workflow uses [\`dorny/paths-filter@v3\`](https://github.com/dorny/paths-filter) to detect whether relevant paths changed:

- \`Dockerfile\`
- workspace \`Cargo.toml\` / \`Cargo.lock\`
- \`crates/intrada-api/**\`
- \`crates/intrada-core/**\` (intrada-api depends on it)
- \`.github/workflows/ci.yml\`

\`api-docker-build\` now has:

\`\`\`yaml
needs: changes
if: github.event_name == 'push' || needs.changes.outputs.api == 'true'
\`\`\`

So:
- **PR with frontend-only changes**: \`changes\` runs (~5s), \`api-docker-build\` skipped → fast
- **PR touching API/Dockerfile/workspace**: \`api-docker-build\` runs as normal → safety net intact
- **Push to main**: \`api-docker-build\` always runs (gates \`deploy-api\` correctly)

## Trade-off

Skipped checks count as "neutral" in branch protection. If \`api-docker-build\` is set as a *required* check, GitHub may block PR merge when the job is skipped. Currently it's not required (just added in the previous PR), so no impact. If we want to make it required later, we can add a "skip-success" aggregating job at that time.

## Test plan

- [ ] CI passes on this PR (touches \`.github/workflows/ci.yml\` so api-docker-build SHOULD run)
- [ ] After merge, next frontend-only PR sees fast CI (no docker build)
- [ ] Next API-touching PR sees docker build run

🤖 Generated with [Claude Code](https://claude.com/claude-code)