### PR TITLE
feat(ios): library Edit form opens as a BottomSheet from Detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ ios/fastlane/README.md
 ios/build/
 ios/DerivedData/
 ios/Gemfile.lock
+crates/intrada-web/test-results/

--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -237,6 +237,11 @@ pub fn BottomSheet(
                     </div>
                 })}
                 <div class="bottom-sheet-body">
+                    // NOTE: children stay mounted even when the sheet is
+                    // closed (just translated off-screen). Tests querying
+                    // page-wide for elements that also exist inside the
+                    // sheet (e.g. "Cancel" button) need to scope to <main>
+                    // to avoid matching the off-screen sheet contents.
                     {children()}
                 </div>
             </div>

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -7,9 +7,10 @@ use leptos_router::NavigateOptions;
 use intrada_core::{Event, ItemEvent, ViewModel};
 
 use crate::components::{
-    parse_target_bpm, BackLink, Button, ButtonVariant, Card, FieldLabel, SkeletonBlock,
-    SkeletonLine, TempoProgressChart, TypeBadge,
+    parse_target_bpm, BackLink, BottomSheet, Button, ButtonVariant, Card, FieldLabel,
+    SkeletonBlock, SkeletonLine, TempoProgressChart, TypeBadge,
 };
+use crate::views::EditLibraryItemForm;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::helpers::{format_date_short, format_datetime_short};
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -25,6 +26,8 @@ pub fn DetailView() -> impl IntoView {
     let navigate = use_navigate();
 
     let show_delete_confirm = RwSignal::new(false);
+    let edit_sheet_open = RwSignal::new(false);
+    let close_edit_sheet = Callback::new(move |_| edit_sheet_open.set(false));
 
     view! {
         <div class="detail-view space-y-4">
@@ -55,7 +58,7 @@ pub fn DetailView() -> impl IntoView {
                     } = item;
 
                     let tempo_for_history = tempo.clone();
-                    let edit_href = format!("/library/{}/edit", item_id);
+                    let id_for_edit_sheet = item_id.clone();
                     let id_for_delete = item_id.clone();
                     let type_for_badge = item_type;
                     let core_for_delete = core.clone();
@@ -249,9 +252,13 @@ pub fn DetailView() -> impl IntoView {
 
                         // Action buttons (FR-009, FR-011)
                         <div class="flex flex-col sm:flex-row gap-3">
-                            <A href=edit_href attr:class="cta-link">
+                            <button
+                                type="button"
+                                class="cta-link"
+                                on:click=move |_| edit_sheet_open.set(true)
+                            >
                                 "Edit"
-                            </A>
+                            </button>
                             <Button
                                 variant=ButtonVariant::DangerOutline
                                 disabled=Signal::derive(move || is_submitting.get())
@@ -260,6 +267,18 @@ pub fn DetailView() -> impl IntoView {
                                 "Delete"
                             </Button>
                         </div>
+
+                        <BottomSheet
+                            open=edit_sheet_open
+                            on_close=close_edit_sheet
+                            nav_title="Edit Item".to_string()
+                        >
+                            <EditLibraryItemForm
+                                item_id=id_for_edit_sheet.clone()
+                                in_sheet=true
+                                on_dismiss=close_edit_sheet
+                            />
+                        </BottomSheet>
                     }.into_any()
                 } else if is_loading.get() {
                     // Data still loading — show skeleton placeholder

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -18,13 +18,27 @@ use intrada_web::types::{IsLoading, IsSubmitting, ItemType, SharedCore};
 use intrada_web::validation::{validate_library_form, FormData};
 
 #[component]
-pub fn EditLibraryItemForm() -> impl IntoView {
+pub fn EditLibraryItemForm(
+    /// When provided, edit this item ID directly (sheet mode). When None,
+    /// fall back to reading from URL params (route mode).
+    #[prop(optional, into)]
+    item_id: Option<String>,
+    /// When rendered inside a BottomSheet, drop the back-link / page heading
+    /// / card chrome — the sheet provides its own. Cancel + Save call
+    /// `on_dismiss` instead of navigating.
+    #[prop(optional)]
+    in_sheet: bool,
+    /// Fired when the user successfully saves or cancels. Required when
+    /// `in_sheet` is true; ignored otherwise (route mode navigates instead).
+    #[prop(optional, into)]
+    on_dismiss: Option<Callback<()>>,
+) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
     let params = use_params_map();
-    let id = params.read().get("id").unwrap_or_default();
+    let id = item_id.unwrap_or_else(|| params.read().get("id").unwrap_or_default());
     let navigate = use_navigate();
 
     // Find item to pre-populate — use get_untracked() since we only need
@@ -38,47 +52,59 @@ pub fn EditLibraryItemForm() -> impl IntoView {
 
     // If item not found and still loading, show skeleton then re-check
     if item.is_none() {
-        let id = id.clone();
+        let id_for_loading = id.clone();
+        let loading_inner = move || {
+            if is_loading.get() {
+                view! {
+                    <div class="space-y-4 animate-pulse">
+                        <SkeletonLine width="w-1/3" height="h-6" />
+                        <SkeletonLine width="w-full" height="h-10" />
+                        <SkeletonLine width="w-full" height="h-10" />
+                        <SkeletonLine width="w-2/3" height="h-10" />
+                        <SkeletonBlock height="h-24" />
+                    </div>
+                }
+                .into_any()
+            } else {
+                // Check if item appeared after loading completed
+                let id = id_for_loading.clone();
+                let item_found = view_model.get().items.iter().any(|i| i.id == id);
+                if item_found && !in_sheet {
+                    // Data loaded — redirect to self to re-render with item data
+                    let url = format!("/library/{}/edit", id);
+                    let navigate = use_navigate();
+                    navigate(
+                        &url,
+                        NavigateOptions {
+                            replace: true,
+                            ..Default::default()
+                        },
+                    );
+                    ().into_any()
+                } else {
+                    view! {
+                        <div class="text-center py-8">
+                            <p class="text-secondary mb-4">"Item not found."</p>
+                            <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
+                                "← Back to Library"
+                            </A>
+                        </div>
+                    }
+                    .into_any()
+                }
+            }
+        };
+        if in_sheet {
+            return view! { <div>{loading_inner}</div> }.into_any();
+        }
         return view! {
             <div class="sm:max-w-2xl sm:mx-auto">
                 <BackLink label="Cancel" href="/".to_string() />
                 <PageHeading text="Edit Library Item" />
-                {move || {
-                    if is_loading.get() {
-                        view! {
-                            <Card>
-                                <div class="space-y-4 animate-pulse">
-                                    <SkeletonLine width="w-1/3" height="h-6" />
-                                    <SkeletonLine width="w-full" height="h-10" />
-                                    <SkeletonLine width="w-full" height="h-10" />
-                                    <SkeletonLine width="w-2/3" height="h-10" />
-                                    <SkeletonBlock height="h-24" />
-                                </div>
-                            </Card>
-                        }.into_any()
-                    } else {
-                        // Check if item appeared after loading completed
-                        let item_found = view_model.get().items.iter().any(|i| i.id == id);
-                        if item_found {
-                            // Data loaded — redirect to self to re-render with item data
-                            let url = format!("/library/{}/edit", id);
-                            let navigate = use_navigate();
-                            navigate(&url, NavigateOptions { replace: true, ..Default::default() });
-                            ().into_any()
-                        } else {
-                            view! {
-                                <div class="text-center py-8">
-                                    <p class="text-secondary mb-4">"Item not found."</p>
-                                    <A href="/" attr:class="text-accent-text hover:text-accent-hover font-medium">
-                                        "← Back to Library"
-                                    </A>
-                                </div>
-                            }.into_any()
-                        }
-                    }
-                }}
+                <Card>{loading_inner}</Card>
             </div>
-        }.into_any();
+        }
+        .into_any();
     }
 
     let item = item.expect("item confirmed Some above");
@@ -111,16 +137,10 @@ pub fn EditLibraryItemForm() -> impl IntoView {
 
     let cancel_href = back_href.clone();
 
-    view! {
-        <div class="sm:max-w-2xl sm:mx-auto">
-            <BackLink label="Cancel" href=back_href />
-
-            <PageHeading text="Edit Library Item" />
-
-            <Card>
-                <form
-                    class="space-y-4"
-                    on:submit={
+    let form_view = view! {
+        <form
+            class="space-y-4"
+            on:submit={
                         let item_id = item_id.clone();
                         move |ev: ev::SubmitEvent| {
                             ev.prevent_default();
@@ -192,8 +212,12 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                             let core_ref = core.borrow();
                             let effects = core_ref.process_event(event);
                             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                            let detail_url = format!("/library/{}", item_id);
-                            navigate(&detail_url, NavigateOptions { replace: true, ..Default::default() });
+                            if let Some(cb) = on_dismiss {
+                                cb.run(());
+                            } else {
+                                let detail_url = format!("/library/{}", item_id);
+                                navigate(&detail_url, NavigateOptions { replace: true, ..Default::default() });
+                            }
                         }
                     }
                 >
@@ -247,13 +271,28 @@ pub fn EditLibraryItemForm() -> impl IntoView {
                                 let cancel_href = cancel_href.clone();
                                 let navigate = navigate.clone();
                                 Callback::new(move |_| {
-                                    navigate(&cancel_href, NavigateOptions::default());
+                                    if let Some(cb) = on_dismiss {
+                                        cb.run(());
+                                    } else {
+                                        navigate(&cancel_href, NavigateOptions::default());
+                                    }
                                 })
                             }>"Cancel"</Button>
                         </div>
                     </div>
                 </form>
-            </Card>
-        </div>
-    }.into_any()
+    };
+
+    if in_sheet {
+        form_view.into_any()
+    } else {
+        view! {
+            <div class="sm:max-w-2xl sm:mx-auto">
+                <BackLink label="Cancel" href=back_href />
+                <PageHeading text="Edit Library Item" />
+                <Card>{form_view}</Card>
+            </div>
+        }
+        .into_any()
+    }
 }

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -13,8 +13,11 @@ test.describe("detail view", () => {
     ).toBeVisible();
     await expect(page.getByText("Claude Debussy")).toBeVisible();
 
-    // Type badge
-    await expect(page.getByText("Piece", { exact: true })).toBeVisible();
+    // Type badge — scope to <main> to avoid matching the "Piece" tab button
+    // inside the (DOM-present-but-off-screen) Edit sheet's TypeTabs.
+    await expect(
+      page.getByRole("main").getByText("Piece", { exact: true })
+    ).toBeVisible();
 
     // Key, Tempo, Notes
     await expect(page.getByText("Db Major")).toBeVisible();
@@ -23,12 +26,20 @@ test.describe("detail view", () => {
       page.getByText("Third movement of Suite bergamasque")
     ).toBeVisible();
 
-    // Tags
-    await expect(page.getByText("impressionist")).toBeVisible();
-    await expect(page.getByText("piano")).toBeVisible();
+    // Tags — scope to <main> to skip the duplicate TagInput inside the
+    // off-screen Edit sheet (which is mounted but translated out of view).
+    await expect(
+      page.getByRole("main").getByText("impressionist")
+    ).toBeVisible();
+    await expect(page.getByRole("main").getByText("piano")).toBeVisible();
 
-    // Action buttons (Edit and Delete — "Log Session" removed in setlist model)
-    await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+    // Action buttons (Edit and Delete — "Log Session" removed in setlist model).
+    // Edit is now a <button> that opens an inline BottomSheet (iOS-native
+    // pattern); .first() because the sheet's Cancel button below also
+    // matches role=button when it's later opened.
+    await expect(
+      page.getByRole("button", { name: "Edit" })
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Delete" })
     ).toBeVisible();
@@ -49,8 +60,9 @@ test.describe("detail view", () => {
       page.getByText("Are you sure you want to delete this item?")
     ).toBeVisible();
 
-    // Cancel — should dismiss confirmation
-    await page.getByRole("button", { name: "Cancel" }).click();
+    // Cancel — should dismiss confirmation. Scope to <main> because the
+    // off-screen Edit sheet also has Cancel buttons (sheet nav + form).
+    await page.getByRole("main").getByRole("button", { name: "Cancel" }).click();
     await expect(
       page.getByText("Are you sure you want to delete this item?")
     ).not.toBeVisible();

--- a/e2e/tests/edit-item.spec.ts
+++ b/e2e/tests/edit-item.spec.ts
@@ -13,11 +13,12 @@ test.describe("edit library item", () => {
     ).toBeVisible();
 
     // Click Edit link
-    await page.getByRole("link", { name: "Edit" }).click();
+    await page.getByRole("button", { name: "Edit" }).click();
 
     // Should be on the edit form
+    // Sheet is open with "Edit Item" in its nav title
     await expect(
-      page.getByRole("heading", { name: "Edit Library Item" })
+      page.getByRole("heading", { name: "Edit Item" })
     ).toBeVisible();
 
     // Fields should be pre-populated
@@ -38,9 +39,10 @@ test.describe("edit library item", () => {
 
     // Navigate to piece detail then edit
     await page.getByRole("heading", { name: "Clair de Lune" }).click();
-    await page.getByRole("link", { name: "Edit" }).click();
+    await page.getByRole("button", { name: "Edit" }).click();
+    // Sheet is open with "Edit Item" in its nav title
     await expect(
-      page.getByRole("heading", { name: "Edit Library Item" })
+      page.getByRole("heading", { name: "Edit Item" })
     ).toBeVisible();
 
     // Clear and change the title
@@ -61,16 +63,22 @@ test.describe("edit library item", () => {
 
     // Navigate to piece detail then edit
     await page.getByRole("heading", { name: "Clair de Lune" }).click();
-    await page.getByRole("link", { name: "Edit" }).click();
+    await page.getByRole("button", { name: "Edit" }).click();
+    // Sheet is open with "Edit Item" in its nav title
     await expect(
-      page.getByRole("heading", { name: "Edit Library Item" })
+      page.getByRole("heading", { name: "Edit Item" })
     ).toBeVisible();
 
-    // Change the title but cancel
+    // Change the title but cancel via the sheet's Cancel button (in the
+    // sheet nav). .first() because the form also has a Cancel button at
+    // the bottom; either works but the nav button comes first in the DOM.
     await page.locator("#edit-title").fill("CHANGED TITLE");
-    await page.getByRole("link", { name: "Cancel" }).click();
+    await page.getByRole("button", { name: "Cancel" }).first().click();
 
-    // Should be back on the detail page with the ORIGINAL title
+    // Sheet should close and detail page still shows the ORIGINAL title
+    await expect(page.locator(".bottom-sheet")).not.toHaveClass(
+      /bottom-sheet--open/
+    );
     await expect(
       page.getByRole("heading", { name: "Clair de Lune", level: 2 })
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Same pattern as the Add migration in #329: validates the BottomSheet primitive with a second use case and continues closing the "forms-as-routes" gap from the iOS HIG audit.

- **EditLibraryItemForm** gains optional ``item_id``, ``in_sheet``, and ``on_dismiss`` props. In sheet mode it drops the chrome (BackLink + PageHeading + Card) and routes Save/Cancel through the callback. The loading-state branch handles in-sheet too.
- **DetailView** "Edit" CTA changed from ``<A href>`` to ``<button>`` opening a BottomSheet. ``/library/:id/edit`` route preserved for deep links.
- **E2E**: edit-item.spec.ts and detail.spec.ts updated for the new role + sheet semantics. Detail-view assertions scoped to ``<main>`` to skip duplicate accessible names from the off-screen Edit sheet (which stays mounted but translated). All 28 tests pass locally.

## Test plan

- [ ] All 28 E2E tests pass in CI
- [ ] On the device: tap a library item → detail view → tap Edit → sheet slides up with form pre-populated → save closes sheet and shows updated detail
- [ ] Cancel from sheet nav, swipe down on handle, and backdrop tap all dismiss
- [ ] Form is fully scrollable inside the sheet
- [ ] ``/library/:id/edit`` URL still works as a route for deep links (form renders with chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)