### PR TITLE
docs(claude.md): selective opt-in adoption of Superpowers skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,24 @@ If unsure between tiers, go one tier lighter. Drift up if scope expands.
 | New auth provider | 3 | Auth + multi-crate |
 | Migrate persistence layer | 3 | Architectural |
 
+### Optional skills (Superpowers, opt-in only)
+
+The [Superpowers](https://github.com/obra/superpowers) plugin provides ~14 auto-triggering skills + a methodology. We don't adopt it whole — its "always TDD, multi-stage subagent review, formal plans for everything" philosophy conflicts with the tier system above. But three of its skills are useful **when invoked deliberately**:
+
+- **`test-driven-development`** — opt in for **non-UI Tier 2 / all Tier 3** work. Skip for visual / gesture / styling work where verification is on-device. The "watch the test fail before writing the code" discipline is what's valuable; the "delete code written before tests" rule is too strict for our pace.
+- **`requesting-code-review`** — opt in **before opening any Tier 3 PR**, and for Tier 2 PRs touching auth / DB / FFI. Acts as a pre-flight checklist: does the diff match the spec, are tests passing, are there obvious quality issues. Cheaper than discovering them post-merge.
+- **`using-git-worktrees`** — opt in when **two or more PR branches are in flight at once** (e.g., the recent #329 / #330 / #331 sequence). Prevents the rebase-conflict tangles that happen when squash-merges land while you're still working on the next branch.
+
+**Do NOT enable** the rest of the methodology by default — `brainstorming`, `writing-plans`, `subagent-driven-development`, `executing-plans`, `finishing-a-development-branch`, `systematic-debugging`. Those collapse the tier system into one-size-fits-all heavyweight ceremony, which we explicitly don't want.
+
+If you're unsure whether a skill applies, default to the tier system. The skills are sharper tools for specific situations, not replacements for "match ceremony to scope".
+
+**Install (Claude Code):** `/plugin install superpowers@claude-plugins-official`
+
+**Invoke selectively:** Tell the agent which skill to apply (e.g., "use test-driven-development for this"). Superpowers' default behaviour is to auto-trigger skills based on context — when invoking a single skill deliberately, also tell it to skip the others (e.g., "use just test-driven-development, no plan or subagent review needed").
+
+**Re-evaluate** after the next 3 PRs that use any of these skills: did they catch a real issue, or did they add ceremony for its own sake? Expand scope, drop a skill, or trial another from the Superpowers set based on what we observe.
+
 ### Always
 1. Find the roadmap item in `docs/roadmap.md`. No item = discuss first.
 2. Check priority on the [project board](https://github.com/users/jonyardley/projects/2).


### PR DESCRIPTION
## Summary

Adds an "Optional skills" subsection to the Workflow section of CLAUDE.md, whitelisting three specific [Superpowers](https://github.com/obra/superpowers) skills as opt-in tools without adopting the full methodology.

**Whitelisted:**
- ``test-driven-development`` — non-UI Tier 2 / all Tier 3 work
- ``requesting-code-review`` — before Tier 3 PRs and sensitive Tier 2
- ``using-git-worktrees`` — when 2+ PR branches are in flight

**Explicitly excluded** (with reasoning): ``brainstorming``, ``writing-plans``, ``subagent-driven-development``, ``executing-plans``, ``finishing-a-development-branch``, ``systematic-debugging``. Their auto-triggering behaviour collapses our existing tier system into one-size-fits-all heavyweight ceremony, which conflicts with the project's "match ceremony to scope" rule.

Includes an install command, invoke-selectively guidance, and a re-evaluate-after-3-PRs commitment so this doesn't become a permanent-but-unused recommendation.

## Why these three specifically

Looking back at recent work:

| Recent issue | Which skill would have caught it |
|---|---|
| Empty-state period regression broke E2E tests in #327 | ``requesting-code-review`` |
| Pull-to-refresh CSS bug took 6+ iterations to find | Partial — ``test-driven-development`` would have failed-test-first the indicator visibility |
| Branch tangles when squash-merges landed during work on the next PR (#327→#329→#330) | ``using-git-worktrees`` (default isolation) |

## Why not the full methodology

The honest take: the full Superpowers loop (brainstorm → plan → TDD → 2-stage subagent review → finishing skill) is fundamentally incompatible with the existing tier system, which says **explicitly** "match ceremony to scope. Default to less. Tier 1: just do it." Adopting the full methodology would mean rewriting the tier system. This PR keeps the tier system intact and adds Superpowers as sharper tools for specific situations.

## Test plan

- [ ] Read the new section. Decide whether the scope (which skills, when) matches your intent.
- [ ] Decide whether the install command should be made part of project setup, or stay as a per-developer choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)