### PR TITLE
feat(ios): TextField clear button + focus-scroll (Tier 1 polish)

### DIFF
--- a/crates/intrada-web/Cargo.toml
+++ b/crates/intrada-web/Cargo.toml
@@ -21,7 +21,7 @@ gloo-net = { version = "0.7", features = ["http", "json"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window", "Storage", "ClipboardEvent", "DataTransfer", "PointerEvent", "Element", "DomRect", "HtmlElement", "TouchEvent", "Touch", "TouchList", "AddEventListenerOptions"] }
+web-sys = { version = "0.3", features = ["Window", "Storage", "ClipboardEvent", "DataTransfer", "PointerEvent", "Element", "DomRect", "HtmlElement", "TouchEvent", "Touch", "TouchList", "AddEventListenerOptions", "ScrollIntoViewOptions", "ScrollLogicalPosition", "ScrollBehavior"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1163,3 +1163,54 @@ html:not([data-platform="ios"]) .context-menu-backdrop,
 html:not([data-platform="ios"]) .context-menu {
   display: none;
 }
+
+
+/* ═══════════════════════════════════════════════════════════════════════
+   TextField clear button (audit Tier 1)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Wraps <input> + the absolute clear button. Lets the button overlay the
+   right edge of the input without affecting layout. */
+.input-wrapper {
+  position: relative;
+}
+
+/* Inputs inside .input-wrapper need extra right padding so user-typed
+   text doesn't run under the clear button's tap area. The clear button
+   width + a comfortable visual gap. */
+.input-base--with-clear {
+  padding-right: 2.25rem;
+}
+
+.input-clear {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface-hover);
+  color: var(--color-text-secondary);
+  border: none;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  /* Slightly larger hit area than the visible circle so it's easy to tap
+     on touch devices. Uses an inset shadow trick rather than padding so
+     the visible circle stays 1.5rem. */
+  box-shadow: 0 0 0 0.5rem transparent;
+}
+
+.input-clear:hover {
+  background: var(--color-text-muted);
+  color: var(--color-text-primary);
+}
+
+.input-clear:active {
+  transform: translateY(-50%) scale(0.92);
+}

--- a/crates/intrada-web/src/components/text_field.rs
+++ b/crates/intrada-web/src/components/text_field.rs
@@ -1,10 +1,21 @@
 use std::collections::HashMap;
 
+use leptos::ev;
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlElement, ScrollIntoViewOptions, ScrollLogicalPosition};
 
 use crate::components::FormFieldError;
 
 /// Shared text input field with label and validation error display.
+///
+/// Adds two iOS-native polish behaviours:
+/// - **Clear button**: a small "×" appears on the right when the field has
+///   content; tapping clears it. Matches the native UITextField clear-mode.
+/// - **Focus-scroll**: on focus, scrolls the input into view (centred in
+///   its scroll container). Insurance for nested-scroll setups (main scroll
+///   container + BottomSheet body) where iOS WebKit's default scroll-into-
+///   view-when-keyboard-appears can fail.
 #[component]
 pub fn TextField(
     id: &'static str,
@@ -24,6 +35,15 @@ pub fn TextField(
     let error_id = format!("{id}-error");
     let has_error = move || errors.get().contains_key(field_name);
 
+    let on_focus = move |ev: ev::FocusEvent| {
+        if let Some(target) = ev.target().and_then(|t| t.dyn_into::<HtmlElement>().ok()) {
+            let opts = ScrollIntoViewOptions::new();
+            opts.set_block(ScrollLogicalPosition::Center);
+            opts.set_behavior(web_sys::ScrollBehavior::Smooth);
+            target.scroll_into_view_with_scroll_into_view_options(&opts);
+        }
+    };
+
     view! {
         <div>
             <label class="form-label" for=id>
@@ -32,17 +52,37 @@ pub fn TextField(
             {hint.map(|h| view! {
                 <p class="hint-text">{h}</p>
             })}
-            <input
-                id=id
-                type=input_type
-                inputmode=input_mode.unwrap_or("")
-                class="input-base"
-                placeholder=placeholder.unwrap_or("")
-                bind:value=value
-                required=required
-                aria-describedby=error_id.clone()
-                aria-invalid=move || if has_error() { "true" } else { "false" }
-            />
+            <div class="input-wrapper">
+                <input
+                    id=id
+                    type=input_type
+                    inputmode=input_mode.unwrap_or("")
+                    class="input-base input-base--with-clear"
+                    placeholder=placeholder.unwrap_or("")
+                    bind:value=value
+                    required=required
+                    aria-describedby=error_id.clone()
+                    aria-invalid=move || if has_error() { "true" } else { "false" }
+                    on:focus=on_focus
+                />
+                <Show when=move || !value.get().is_empty()>
+                    <button
+                        type="button"
+                        class="input-clear"
+                        aria-label="Clear field"
+                        // mousedown fires before the input loses focus, so we
+                        // can clear without the input blurring (which would
+                        // hide the clear button before our click fires on iOS).
+                        on:mousedown=move |ev| {
+                            ev.prevent_default();
+                            value.set(String::new());
+                        }
+                        on:touchstart=move |_| value.set(String::new())
+                    >
+                        "×"
+                    </button>
+                </Show>
+            </div>
             <FormFieldError field=field_name errors=errors error_id=error_id />
         </div>
     }


### PR DESCRIPTION
## Summary

Two iOS-native polish behaviours on TextField:

1. **Clear button** — small ``×`` appears on the right when the input has content; tapping clears it. Matches the native UITextField clear-mode. Wrapper adds extra right padding so user-typed text doesn't run under the button's tap area. Visible on all platforms (it's useful UX everywhere, not iOS-specific).
2. **Focus-scroll** — on focus, the input scrolls itself into view (centred in its scroll container, smoothly). Insurance for our nested-scroll setup (``<main>`` is ``position: fixed`` + ``overflow-y: auto``, BottomSheet body is also ``overflow-y: auto``) where iOS WebKit's default "scroll input into view when keyboard appears" sometimes fails.

## Note on the rest of the planned Tier 1 batch

I'd quoted four items, but on inspection three were already done or N/A:

| Original item | Status |
|---|---|
| Toast positioning above safe area | N/A — Toast component only used in design catalogue, no deployed views |
| Disclosure chevrons (›) on iOS list rows | Already in place via ``[data-platform="ios"] .library-list li a::after { content: "›"; }`` |
| ``inputmode="numeric"`` triggers iOS num pad | Already wired on the only numeric inputs (BPM in add/edit forms) |
| TextField clear button + focus-scroll | This PR |

Smaller scope than I'd estimated, but more honest.

## Implementation note

The clear button uses ``on:mousedown`` rather than ``on:click`` so the action fires *before* the input's blur — otherwise the input would lose focus, the ``Show`` would unmount the button, and the click would never land. ``on:touchstart`` for the iOS code path.

## Test plan

- [ ] All 28 E2E tests pass in CI
- [ ] Type into any text field → ``×`` appears at the right
- [ ] Tap the ``×`` → field clears, button disappears, input still focused
- [ ] On the device: focus an input near the bottom of a BottomSheet form → input scrolls into view above the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)