### PR TITLE
feat(ios): swipe-to-delete + long-press menu on routine rows

### DIFF
--- a/crates/intrada-web/src/views/routines.rs
+++ b/crates/intrada-web/src/views/routines.rs
@@ -1,10 +1,15 @@
 use leptos::prelude::*;
 use leptos_router::components::A;
+use leptos_router::hooks::use_navigate;
+use leptos_router::NavigateOptions;
 
 use intrada_core::{Event, RoutineEvent, RoutineView, ViewModel};
 
-use crate::components::{Button, ButtonVariant, Card, PageHeading, SkeletonCardList};
-use intrada_web::core_bridge::process_effects;
+use crate::components::{
+    Button, ButtonVariant, Card, ContextMenu, ContextMenuAction, PageHeading, SkeletonCardList,
+    SwipeActions,
+};
+use intrada_web::core_bridge::{process_effects, process_effects_with_core};
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// Management page for saved routines — lists all routines with edit/delete actions.
@@ -71,10 +76,51 @@ fn RoutineRow(routine: RoutineView) -> impl IntoView {
 
     let id = routine.id.clone();
     let id_for_delete = routine.id.clone();
+    let id_for_swipe = routine.id.clone();
+    let id_for_menu_delete = routine.id.clone();
     let name = routine.name.clone();
     let entry_count = routine.entry_count;
     let entries = routine.entries.clone();
     let edit_href = format!("/routines/{}/edit", id);
+    let edit_href_for_menu = edit_href.clone();
+
+    // Direct-delete callback used by both the iOS swipe-to-delete gesture
+    // and the long-press context menu's Delete action. Skips the in-card
+    // confirmation banner — the swipe / long-press gesture is itself the
+    // deliberate confirmation, matching native UISwipeActionsConfiguration.
+    let core_for_gesture = core.clone();
+    let direct_delete = Callback::new(move |routine_id: String| {
+        let event = Event::Routine(RoutineEvent::DeleteRoutine { id: routine_id });
+        let effects = {
+            let core_ref = core_for_gesture.borrow();
+            core_ref.process_event(event)
+        };
+        process_effects_with_core(
+            &core_for_gesture,
+            effects,
+            &view_model,
+            &is_loading,
+            &is_submitting,
+        );
+    });
+
+    let menu_actions = vec![
+        ContextMenuAction {
+            label: "Edit".to_string(),
+            destructive: false,
+            on_select: Callback::new(move |_| {
+                let navigate = use_navigate();
+                navigate(&edit_href_for_menu, NavigateOptions::default());
+            }),
+        },
+        ContextMenuAction {
+            label: "Delete".to_string(),
+            destructive: true,
+            on_select: Callback::new(move |_| {
+                direct_delete.run(id_for_menu_delete.clone());
+            }),
+        },
+    ];
 
     view! {
         <Card>
@@ -110,41 +156,49 @@ fn RoutineRow(routine: RoutineView) -> impl IntoView {
                     let name = name.clone();
                     let entries = entries.clone();
                     let edit_href = edit_href.clone();
+                    let menu_actions = menu_actions.clone();
+                    let id_for_swipe = id_for_swipe.clone();
                     view! {
-                        <div class="space-y-3">
-                            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                                <div class="flex-1 min-w-0">
-                                    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                                        <span class="text-sm font-medium text-primary">{name}</span>
-                                        <span class="inline-flex items-center rounded-full bg-badge-piece-bg px-2 py-0.5 text-xs font-medium text-accent-text">
-                                            {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
-                                        </span>
+                        <ContextMenu actions=menu_actions>
+                            <SwipeActions on_delete=Callback::new(move |_| {
+                                direct_delete.run(id_for_swipe.clone());
+                            })>
+                                <div class="space-y-3">
+                                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                                        <div class="flex-1 min-w-0">
+                                            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                                                <span class="text-sm font-medium text-primary">{name}</span>
+                                                <span class="inline-flex items-center rounded-full bg-badge-piece-bg px-2 py-0.5 text-xs font-medium text-accent-text">
+                                                    {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div class="flex gap-3 sm:ml-4">
+                                            <A href=edit_href attr:class="text-xs text-accent-text hover:text-accent-hover font-medium">
+                                                "Edit"
+                                            </A>
+                                            <button
+                                                class="text-xs text-danger-text hover:text-danger-hover font-medium"
+                                                on:click=move |_| { confirm_delete.set(true); }
+                                            >
+                                                "Delete"
+                                            </button>
+                                        </div>
+                                    </div>
+                                    // Entry details
+                                    <div class="mt-1 pt-2 space-y-1.5">
+                                        {entries.into_iter().map(|entry| {
+                                            view! {
+                                                <div class="flex items-center gap-2 text-xs">
+                                                    <span class="text-primary">{entry.item_title}</span>
+                                                    <span class="text-faint">{entry.item_type.to_string()}</span>
+                                                </div>
+                                            }
+                                        }).collect::<Vec<_>>()}
                                     </div>
                                 </div>
-                                <div class="flex gap-3 sm:ml-4">
-                                    <A href=edit_href attr:class="text-xs text-accent-text hover:text-accent-hover font-medium">
-                                        "Edit"
-                                    </A>
-                                    <button
-                                        class="text-xs text-danger-text hover:text-danger-hover font-medium"
-                                        on:click=move |_| { confirm_delete.set(true); }
-                                    >
-                                        "Delete"
-                                    </button>
-                                </div>
-                            </div>
-                            // Entry details
-                            <div class="mt-1 pt-2 space-y-1.5">
-                                {entries.into_iter().map(|entry| {
-                                    view! {
-                                        <div class="flex items-center gap-2 text-xs">
-                                            <span class="text-primary">{entry.item_title}</span>
-                                            <span class="text-faint">{entry.item_type.to_string()}</span>
-                                        </div>
-                                    }
-                                }).collect::<Vec<_>>()}
-                            </div>
-                        </div>
+                            </SwipeActions>
+                        </ContextMenu>
                     }.into_any()
                 }
             }}


### PR DESCRIPTION
## Summary

Applies the ``SwipeActions`` and ``ContextMenu`` primitives (built and merged in #331) to ``RoutineRow``, giving routine list rows the same iOS-native gesture set as library list rows:

- **Tap** → existing behaviour (Edit link / Delete button)
- **Swipe left** → reveal Delete button; full-swipe commits with light haptic
- **Long-press** → context menu with Edit + Delete

Both swipe and context-menu Delete fire the routine deletion event **directly** (no in-card confirmation banner) — the gesture itself is the deliberate confirmation, matching native ``UISwipeActionsConfiguration`` behaviour and what library rows do.

The existing in-card Delete + "Are you sure?" confirmation banner stays as the **web fallback** — that's the right pattern when no swipe gesture is available.

## Why not migrate session_new and routine_edit forms to BottomSheet?

Looked at both as the natural next "form to migrate" candidates. Neither fits:

- **session_new** isn't a form — it's a multi-step flow (preset selection → setlist builder → active session). Sheet would be wrong.
- **routine_edit** has drag-reorder for entries inside it. Drag-inside-sheet would conflict with the sheet's own drag-to-dismiss gesture.

So this PR pivots to spreading the existing primitives instead of migrating more forms.

## Test plan

- [ ] All 28 E2E tests pass in CI (no test changes needed — RoutineRow's accessible structure unchanged)
- [ ] On the device:
  - [ ] Swipe a routine row left → Delete button reveals; full-swipe commits with haptic
  - [ ] Long-press a routine row → context menu with Edit + Delete; tap Edit navigates to edit, tap Delete deletes
  - [ ] Tap row Edit link / Delete button still work as before (web fallback)
  - [ ] Vertical scroll on the routines list still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)