### PR TITLE
feat(ios): outline/solid tab-bar icons + 44px BottomSheet cancel

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -964,12 +964,20 @@ html:not([data-platform="ios"]) .pull-to-refresh-indicator {
 
 .bottom-sheet-cancel {
   justify-self: start;
+  /* iOS minimum touch target — was 0.25rem 0 padding which gave a ~20px tap
+     zone on a destructive nav action. 44px min-height + horizontal padding
+     keeps the target generous without visually bulking the button (no
+     background, the chrome is just text). */
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  margin-left: -0.5rem;
   color: var(--color-accent-text);
   font-size: 1rem;
   font-weight: 400;
   background: none;
   border: none;
-  padding: 0.25rem 0;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
 }

--- a/crates/intrada-web/src/components/bottom_tab_bar.rs
+++ b/crates/intrada-web/src/components/bottom_tab_bar.rs
@@ -5,8 +5,12 @@ use leptos_router::hooks::use_location;
 
 /// Mobile bottom tab bar for primary navigation.
 ///
-/// Shows Library, Sessions, and Analytics tabs. Hidden on `sm:` and wider
-/// where the header nav is visible instead.
+/// Shows Library / Practice / Routines / Analytics tabs. Hidden on `sm:`
+/// and wider where the header nav is visible instead.
+///
+/// Icons follow the iOS convention: outline (stroke) for the inactive
+/// tabs, solid (fill) for the active one. Sizing matches the iOS tab
+/// bar (~24px icon, 12px label).
 #[component]
 pub fn BottomTabBar() -> impl IntoView {
     let location = use_location();
@@ -45,7 +49,7 @@ pub fn BottomTabBar() -> impl IntoView {
             aria-label="Mobile navigation"
         >
             <div class="flex h-full items-center justify-around">
-                // Library tab
+                // Library tab — music note
                 <A
                     href="/"
                     attr:class=move || {
@@ -58,20 +62,15 @@ pub fn BottomTabBar() -> impl IntoView {
                     attr:aria-current=move || if is_library_active() { Some("page") } else { None }
                     on:click=move |_| { has_tapped.set(true); haptics::haptic_selection(); }
                 >
-                    // Music note icon (SVG)
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true"
-                    >
-                        <path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z" />
-                    </svg>
+                    {move || if is_library_active() {
+                        view! { <MusicNoteIconSolid /> }.into_any()
+                    } else {
+                        view! { <MusicNoteIconOutline /> }.into_any()
+                    }}
                     <span class="text-xs font-medium">"Library"</span>
                 </A>
 
-                // Sessions tab
+                // Practice tab — clock
                 <A
                     href="/sessions"
                     attr:class=move || {
@@ -84,24 +83,15 @@ pub fn BottomTabBar() -> impl IntoView {
                     attr:aria-current=move || if is_sessions_active() { Some("page") } else { None }
                     on:click=move |_| { has_tapped.set(true); haptics::haptic_selection(); }
                 >
-                    // Clock/timer icon (SVG)
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true"
-                    >
-                        <path
-                            fill-rule="evenodd"
-                            d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
-                            clip-rule="evenodd"
-                        />
-                    </svg>
+                    {move || if is_sessions_active() {
+                        view! { <ClockIconSolid /> }.into_any()
+                    } else {
+                        view! { <ClockIconOutline /> }.into_any()
+                    }}
                     <span class="text-xs font-medium">"Practice"</span>
                 </A>
 
-                // Routines tab
+                // Routines tab — list
                 <A
                     href="/routines"
                     attr:class=move || {
@@ -114,24 +104,15 @@ pub fn BottomTabBar() -> impl IntoView {
                     attr:aria-current=move || if is_routines_active() { Some("page") } else { None }
                     on:click=move |_| { has_tapped.set(true); haptics::haptic_selection(); }
                 >
-                    // List/template icon (SVG)
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true"
-                    >
-                        <path
-                            fill-rule="evenodd"
-                            d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-                            clip-rule="evenodd"
-                        />
-                    </svg>
+                    {move || if is_routines_active() {
+                        view! { <RoutinesIconSolid /> }.into_any()
+                    } else {
+                        view! { <RoutinesIconOutline /> }.into_any()
+                    }}
                     <span class="text-xs font-medium">"Routines"</span>
                 </A>
 
-                // Analytics tab
+                // Analytics tab — bar chart
                 <A
                     href="/analytics"
                     attr:class=move || {
@@ -144,19 +125,153 @@ pub fn BottomTabBar() -> impl IntoView {
                     attr:aria-current=move || if is_analytics_active() { Some("page") } else { None }
                     on:click=move |_| { has_tapped.set(true); haptics::haptic_selection(); }
                 >
-                    // Chart/bar-chart icon (SVG)
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="h-5 w-5"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true"
-                    >
-                        <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
-                    </svg>
+                    {move || if is_analytics_active() {
+                        view! { <ChartIconSolid /> }.into_any()
+                    } else {
+                        view! { <ChartIconOutline /> }.into_any()
+                    }}
                     <span class="text-xs font-medium">"Analytics"</span>
                 </A>
             </div>
         </nav>
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Tab bar icons
+//
+// Heroicons v2 outline + solid pairs at 24×24, sized via h-6 w-6 to match
+// the iOS tab bar's ~24px icon convention. Outline = stroke 1.5, no fill;
+// solid = fill currentColor. Active vs inactive state swaps the variant.
+// ════════════════════════════════════════════════════════════════════════
+
+#[component]
+fn MusicNoteIconOutline() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+        </svg>
+    }
+}
+
+#[component]
+fn MusicNoteIconSolid() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path fill-rule="evenodd" d="M19.952 1.651a.75.75 0 01.298.599V16.303a3 3 0 01-2.176 2.884l-1.32.377a2.553 2.553 0 11-1.402-4.911l2.32-.662A1.5 1.5 0 0018.75 12.55v-2.66l-9 2.571v4.69a3 3 0 01-2.176 2.884l-1.32.377a2.553 2.553 0 11-1.402-4.911l2.32-.662A1.5 1.5 0 008.25 13.054V5.25a.75.75 0 01.544-.721l10.5-3a.75.75 0 01.658.122z" clip-rule="evenodd" />
+        </svg>
+    }
+}
+
+#[component]
+fn ClockIconOutline() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+    }
+}
+
+#[component]
+fn ClockIconSolid() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zM12.75 6a.75.75 0 00-1.5 0v6c0 .414.336.75.75.75h4.5a.75.75 0 000-1.5h-3.75V6z" clip-rule="evenodd" />
+        </svg>
+    }
+}
+
+#[component]
+fn RoutinesIconOutline() -> impl IntoView {
+    // Queue-list shape: a top "header" rule with three rows below — reads
+    // unambiguously as "saved routine / template" rather than a generic
+    // hamburger menu.
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z" />
+        </svg>
+    }
+}
+
+#[component]
+fn RoutinesIconSolid() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path d="M5.625 3.75a2.625 2.625 0 100 5.25h12.75a2.625 2.625 0 000-5.25H5.625zM3.75 11.25a.75.75 0 000 1.5h16.5a.75.75 0 000-1.5H3.75zM3 15.75a.75.75 0 01.75-.75h16.5a.75.75 0 010 1.5H3.75a.75.75 0 01-.75-.75zM3.75 18.75a.75.75 0 000 1.5h16.5a.75.75 0 000-1.5H3.75z" />
+        </svg>
+    }
+}
+
+#[component]
+fn ChartIconOutline() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+        </svg>
+    }
+}
+
+#[component]
+fn ChartIconSolid() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path d="M18.375 2.25c-1.035 0-1.875.84-1.875 1.875v15.75c0 1.035.84 1.875 1.875 1.875h.75c1.035 0 1.875-.84 1.875-1.875V4.125c0-1.036-.84-1.875-1.875-1.875h-.75zM9.75 8.625c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-.75a1.875 1.875 0 01-1.875-1.875V8.625zM3 13.125c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v6.75c0 1.035-.84 1.875-1.875 1.875h-.75A1.875 1.875 0 013 19.875v-6.75z" />
+        </svg>
     }
 }


### PR DESCRIPTION
## Summary
First of three PRs from the iOS layout audit. Quick wins on the tab bar and bottom sheet — high-confidence, low-risk changes that immediately remove some of the most visible "this is a web app in a WebView" cues.

- **Tab bar icons**: outline (stroke) when inactive, solid (fill) when active — Heroicons v2 paths at 24×24, sized `h-6 w-6` to match the iOS tab bar's ~24pt convention. Was a constant-fill 20px shape.
- **BottomSheet cancel button**: now meets iOS 44px minimum touch target. Was `padding: 0.25rem 0` only — about a 20px tap zone on what's effectively a destructive nav action.

PR-B (lists rework — `<GroupedList>` primitive + Sessions/Detail swipe-to-delete parity with Library/Routines) and PR-C (forms grouped containers + design token cleanup) are queued separately.

## Test plan
- [ ] Tab bar icons swap outline↔solid as you navigate between Library/Practice/Routines/Analytics on iOS device
- [ ] Active icon weight feels right next to the label (not too heavy, not too thin)
- [ ] BottomSheet "Cancel" button feels comfortably tappable (44pt vs the old hairline target)
- [ ] No layout shift in the tab bar from icon size change (20→24px)