### PR TITLE
feat(ios): trim CTA buttons + roomier form input chrome

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -676,27 +676,18 @@ html.router-outlet-0.router-back::view-transition-new(root) {
    the trailing nav-bar position as a compact accent-coloured "+" icon
    target — no background, no text label, ~44pt square.
 
-   We render BOTH the "+" icon and the text label at every callsite;
-   CSS hides whichever doesn't apply to the platform, so the markup
+   `<PageHeading>`'s trailing slot lays the action out on the title's
+   row on every platform; the `.cta-link--page-add` modifier swaps the
+   chrome on iOS only. We render BOTH the "+" icon and the text label
+   at every callsite; CSS hides whichever doesn't apply, so the markup
    stays accessible (screen readers still read the label) and the web
-   layout is unchanged. The companion .page-header-row class flips the
-   parent flex from column to row on iOS so the heading and the icon
-   sit on the same line.
-
-   The `.cta-link-icon` / `.cta-link-label` defaults sit at the bottom
-   of this stylesheet so the `[data-platform="ios"]` overrides win on
-   source order without needing `!important`. */
+   layout is unchanged. */
 .cta-link-icon {
   display: none;
 }
 
 .cta-link-label {
   display: inline;
-}
-
-[data-platform="ios"] .page-header-row {
-  flex-direction: row;
-  align-items: center;
 }
 
 [data-platform="ios"] .cta-link.cta-link--page-add {
@@ -732,11 +723,6 @@ html.router-outlet-0.router-back::view-transition-new(root) {
    Transforms the web grid of glass cards into a native iOS grouped list.
    All rules scoped to [data-platform="ios"].
    ═══════════════════════════════════════════════════════════════════════ */
-
-/* Hide the desktop hero intro — iOS doesn't need an onboarding explanation */
-[data-platform="ios"] .library-hero {
-  display: none;
-}
 
 /* Week strip — iOS uses swipe gestures for date navigation (Apple Calendar /
    Health pattern), not chevron buttons. The swipe is already wired in the

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -662,6 +662,27 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   font-size: max(16px, 1em);
 }
 
+/* iOS form input chrome — wider horizontal padding (16px) to match the
+   inset-grouped row gutters in iOS Settings/Mail; slightly more vertical
+   breathing room. The defaults (10/12) read as cramped next to the
+   GroupedList row padding once the strip is grouped. */
+[data-platform="ios"] .input-base {
+  padding: 0.6875rem 1rem; /* 11px 16px */
+}
+
+/* Primary action CTAs ("New Session", "Add Item") on iOS shouldn't
+   stretch to fill flex-col parents. The default web/Android behaviour
+   produces a full-width purple bar under the page heading — the most
+   web-app-y signal the audit flagged. align-self: flex-end shrinks the
+   button to its content width and pushes it to the trailing edge,
+   matching the iOS nav-bar trailing-action convention.
+
+   No effect on cta-link inside non-flex parents (empty states), which
+   stay centred via their own .text-center wrappers. */
+[data-platform="ios"] .cta-link {
+  align-self: flex-end;
+}
+
 
 /* ═══════════════════════════════════════════════════════════════════════
    iOS Library List (Phase 2b)

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -670,17 +670,60 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   padding: 0.6875rem 1rem; /* 11px 16px */
 }
 
-/* Primary action CTAs ("New Session", "Add Item") on iOS shouldn't
-   stretch to fill flex-col parents. The default web/Android behaviour
-   produces a full-width purple bar under the page heading — the most
-   web-app-y signal the audit flagged. align-self: flex-end shrinks the
-   button to its content width and pushes it to the trailing edge,
-   matching the iOS nav-bar trailing-action convention.
+/* Page-header "Add" CTAs on iOS: the full-width purple bar under each
+   page heading was the most web-app-y signal the audit flagged. iOS
+   apps (Calendar, Notes, Reminders, Mail) put primary "Add" actions in
+   the trailing nav-bar position as a compact accent-coloured "+" icon
+   target — no background, no text label, ~44pt square.
 
-   No effect on cta-link inside non-flex parents (empty states), which
-   stay centred via their own .text-center wrappers. */
-[data-platform="ios"] .cta-link {
-  align-self: flex-end;
+   We render BOTH the "+" icon and the text label at every callsite;
+   CSS hides whichever doesn't apply to the platform, so the markup
+   stays accessible (screen readers still read the label) and the web
+   layout is unchanged. The companion .page-header-row class flips the
+   parent flex from column to row on iOS so the heading and the icon
+   sit on the same line.
+
+   The `.cta-link-icon` / `.cta-link-label` defaults sit at the bottom
+   of this stylesheet so the `[data-platform="ios"]` overrides win on
+   source order without needing `!important`. */
+.cta-link-icon {
+  display: none;
+}
+
+.cta-link-label {
+  display: inline;
+}
+
+[data-platform="ios"] .page-header-row {
+  flex-direction: row;
+  align-items: center;
+}
+
+[data-platform="ios"] .cta-link.cta-link--page-add {
+  /* Strip pill chrome — becomes a plain accent-colour icon target. */
+  background: transparent;
+  background-color: transparent;
+  color: var(--color-accent-text);
+  box-shadow: none;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+[data-platform="ios"] .cta-link.cta-link--page-add:hover {
+  background-color: var(--color-surface-hover);
+}
+
+[data-platform="ios"] .cta-link--page-add .cta-link-icon {
+  display: block;
+  width: 1.625rem;
+  height: 1.625rem;
+}
+
+[data-platform="ios"] .cta-link--page-add .cta-link-label {
+  display: none;
 }
 
 

--- a/crates/intrada-web/src/components/icon.rs
+++ b/crates/intrada-web/src/components/icon.rs
@@ -19,6 +19,7 @@ pub enum IconName {
     ChevronUp,
     Clock,
     Minus,
+    Plus,
     RotateCcw,
     Star,
     X,
@@ -91,6 +92,11 @@ pub fn Icon(
         .into_any(),
         IconName::Minus => view! {
             <path d="M5 12h14" />
+        }
+        .into_any(),
+        IconName::Plus => view! {
+            <path d="M5 12h14" />
+            <path d="M12 5v14" />
         }
         .into_any(),
         IconName::RotateCcw => view! {

--- a/crates/intrada-web/src/components/page_heading.rs
+++ b/crates/intrada-web/src/components/page_heading.rs
@@ -2,19 +2,30 @@ use leptos::prelude::*;
 
 /// Shared page-level heading with consistent styling.
 ///
-/// Uses the serif heading font (Source Serif 4) to signal
-/// "music space" (audit #9). When a `subtitle` is provided,
-/// a description paragraph is rendered beneath the heading.
+/// Uses the serif heading font (Source Serif 4) to signal "music space"
+/// (audit #9). When a `subtitle` is provided, a description paragraph is
+/// rendered beneath the heading.
+///
+/// An optional `trailing` slot sits on the title's row at the trailing
+/// edge — used for nav-bar-style page actions (e.g. an "Add" button).
+/// The trailing slot vertically centres against the title only, not the
+/// title + subtitle group, which avoids the "button looks like it's
+/// floating below the heading" problem of putting the action in a
+/// sibling flex container outside `<PageHeading>`.
 #[component]
 pub fn PageHeading(
     text: &'static str,
     #[prop(optional)] subtitle: Option<&'static str>,
+    #[prop(optional)] trailing: Option<Children>,
 ) -> impl IntoView {
-    let heading_mb = if subtitle.is_some() { "mb-3" } else { "mb-6" };
+    let row_mb = if subtitle.is_some() { "mb-3" } else { "mb-6" };
 
     view! {
         <div>
-            <h2 class=format!("text-2xl font-bold text-primary font-heading {heading_mb}")>{text}</h2>
+            <div class=format!("flex items-center justify-between gap-3 {row_mb}")>
+                <h2 class="text-2xl font-bold text-primary font-heading">{text}</h2>
+                {trailing.map(|t| t())}
+            </div>
             {subtitle.map(|sub| view! {
                 <p class="text-sm text-secondary leading-relaxed max-w-2xl mb-6">{sub}</p>
             })}

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -93,10 +93,12 @@ pub fn LibraryListView() -> impl IntoView {
                 }.into_any())
             />
 
-            // Library section header
-            <section aria-labelledby="library-heading">
-                <div class="flex items-center justify-between mb-4">
-                    <h2 id="library-heading" class="text-lg font-semibold text-primary">"Library"</h2>
+            // Library items section. The page-level <PageHeading> above
+            // already supplies the visible "Library" title, so the
+            // section just carries an aria-label for screen readers and
+            // an inline item count.
+            <section aria-label="Library items">
+                <div class="flex justify-end mb-4">
                     <span class="text-sm text-muted">
                         {move || {
                             let count = view_model.get().items.len();

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -3,7 +3,7 @@ use leptos::prelude::*;
 use intrada_core::{Event, ItemEvent, ViewModel};
 
 use crate::components::{
-    BottomSheet, LibraryItemCard, PageHeading, PullToRefresh, SkeletonItemCard,
+    BottomSheet, Icon, IconName, LibraryItemCard, PageHeading, PullToRefresh, SkeletonItemCard,
 };
 use crate::views::AddLibraryItemForm;
 use intrada_web::core_bridge::process_effects_with_core;
@@ -72,7 +72,12 @@ pub fn LibraryListView() -> impl IntoView {
             // Hero text (hidden on iOS) + Add CTA (always visible).
             // The CTA sits OUTSIDE the .library-hero so it stays accessible
             // when the hero text is hidden on iOS.
-            <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+            //
+            // .page-header-row keeps heading + CTA on one line on iOS;
+            // the cta-link's icon / label children are CSS-swapped per
+            // platform: web shows the "Add Item" pill, iOS shows the
+            // icon-only nav action.
+            <div class="page-header-row flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                 <div class="library-hero">
                     <PageHeading
                         text="Welcome to Intrada"
@@ -81,10 +86,12 @@ pub fn LibraryListView() -> impl IntoView {
                 </div>
                 <button
                     type="button"
-                    class="cta-link shrink-0"
+                    class="cta-link cta-link--page-add shrink-0"
+                    aria-label="Add Item"
                     on:click=move |_| open_add_sheet.run(())
                 >
-                    "Add Item"
+                    <Icon name=IconName::Plus class="cta-link-icon" />
+                    <span class="cta-link-label">"Add Item"</span>
                 </button>
             </div>
 

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -69,31 +69,29 @@ pub fn LibraryListView() -> impl IntoView {
     view! {
         <PullToRefresh on_refresh=on_refresh is_refreshing=is_refreshing>
         <div class="space-y-6">
-            // Hero text (hidden on iOS) + Add CTA (always visible).
-            // The CTA sits OUTSIDE the .library-hero so it stays accessible
-            // when the hero text is hidden on iOS.
+            // Page heading matches the other top-level tabs (Practice,
+            // Routines, Analytics). The "Add Item" trailing action lives
+            // in PageHeading's trailing slot so it sits at the title's
+            // level, not floating below the subtitle.
             //
-            // .page-header-row keeps heading + CTA on one line on iOS;
-            // the cta-link's icon / label children are CSS-swapped per
+            // The cta-link's icon/label children are CSS-swapped per
             // platform: web shows the "Add Item" pill, iOS shows the
-            // icon-only nav action.
-            <div class="page-header-row flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                <div class="library-hero">
-                    <PageHeading
-                        text="Welcome to Intrada"
-                        subtitle="Organize your music library, track your practice pieces and exercises, and build better practice habits."
-                    />
-                </div>
-                <button
-                    type="button"
-                    class="cta-link cta-link--page-add shrink-0"
-                    aria-label="Add Item"
-                    on:click=move |_| open_add_sheet.run(())
-                >
-                    <Icon name=IconName::Plus class="cta-link-icon" />
-                    <span class="cta-link-label">"Add Item"</span>
-                </button>
-            </div>
+            // "+" icon-only nav action.
+            <PageHeading
+                text="Library"
+                subtitle="Your pieces and exercises."
+                trailing=Box::new(move || view! {
+                    <button
+                        type="button"
+                        class="cta-link cta-link--page-add shrink-0"
+                        aria-label="Add Item"
+                        on:click=move |_| open_add_sheet.run(())
+                    >
+                        <Icon name=IconName::Plus class="cta-link-icon" />
+                        <span class="cta-link-label">"Add Item"</span>
+                    </button>
+                }.into_any())
+            />
 
             // Library section header
             <section aria-labelledby="library-heading">

--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -90,11 +90,17 @@ pub fn SessionsListView() -> impl IntoView {
 
     view! {
         <div>
-            // Page header with "New Session" CTA
-            <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6">
+            // Page header with "New Session" CTA. The .page-header-row
+            // class lets iOS flip this from column to row so the heading
+            // and the trailing "+" icon button sit on one line — matches
+            // iOS Calendar / Notes / Reminders. The cta-link's icon /
+            // label children are CSS-swapped per platform: web shows the
+            // "New Session" pill, iOS shows the icon-only nav action.
+            <div class="page-header-row flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6">
                 <PageHeading text="Practice" subtitle="Review your session history and track how your sessions build over time." />
-                <A href="/sessions/new" attr:class="cta-link shrink-0">
-                    "New Session"
+                <A href="/sessions/new" attr:class="cta-link cta-link--page-add shrink-0" attr:aria-label="New Session">
+                    <Icon name=IconName::Plus class="cta-link-icon" />
+                    <span class="cta-link-label">"New Session"</span>
                 </A>
             </div>
 

--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -90,19 +90,25 @@ pub fn SessionsListView() -> impl IntoView {
 
     view! {
         <div>
-            // Page header with "New Session" CTA. The .page-header-row
-            // class lets iOS flip this from column to row so the heading
-            // and the trailing "+" icon button sit on one line — matches
-            // iOS Calendar / Notes / Reminders. The cta-link's icon /
-            // label children are CSS-swapped per platform: web shows the
-            // "New Session" pill, iOS shows the icon-only nav action.
-            <div class="page-header-row flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6">
-                <PageHeading text="Practice" subtitle="Review your session history and track how your sessions build over time." />
-                <A href="/sessions/new" attr:class="cta-link cta-link--page-add shrink-0" attr:aria-label="New Session">
-                    <Icon name=IconName::Plus class="cta-link-icon" />
-                    <span class="cta-link-label">"New Session"</span>
-                </A>
-            </div>
+            // PageHeading owns the title-row layout — title on left, the
+            // "New Session" trailing action on right, subtitle below
+            // both. The cta-link's icon/label children are CSS-swapped
+            // per platform: web shows the "New Session" pill, iOS shows
+            // the "+" icon-only nav action.
+            <PageHeading
+                text="Practice"
+                subtitle="Review your session history and track how your sessions build over time."
+                trailing=Box::new(|| view! {
+                    <A
+                        href="/sessions/new"
+                        attr:class="cta-link cta-link--page-add shrink-0"
+                        attr:aria-label="New Session"
+                    >
+                        <Icon name=IconName::Plus class="cta-link-icon" />
+                        <span class="cta-link-label">"New Session"</span>
+                    </A>
+                }.into_any())
+            />
 
             // Week strip navigator
             <div class="mb-6">

--- a/e2e/tests/add-item.spec.ts
+++ b/e2e/tests/add-item.spec.ts
@@ -30,7 +30,7 @@ test.describe("add library item", () => {
 
     // Should redirect to library and show the new item
     await expect(
-      page.getByRole("heading", { name: "Welcome to Intrada" })
+      page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Moonlight Sonata" })

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -73,7 +73,7 @@ test.describe("detail view", () => {
 
     // Should redirect to library
     await expect(
-      page.getByRole("heading", { name: "Welcome to Intrada" })
+      page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
 
     // Hanon No. 1 should be gone

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -15,7 +15,7 @@ test.describe("navigation", () => {
     // Navigate back to Library via header nav
     await page.getByRole("link", { name: "Library" }).click();
     await expect(
-      page.getByRole("heading", { name: "Welcome to Intrada" })
+      page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
   });
 
@@ -38,7 +38,7 @@ test.describe("navigation", () => {
     // Back link returns to library
     await page.getByRole("link", { name: "Back to Library" }).click();
     await expect(
-      page.getByRole("heading", { name: "Welcome to Intrada" })
+      page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
   });
 
@@ -63,7 +63,7 @@ test.describe("navigation", () => {
       /bottom-sheet--open/
     );
     await expect(
-      page.getByRole("heading", { name: "Welcome to Intrada" })
+      page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
   });
 

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -5,7 +5,7 @@ test("app renders with library list", async ({ page }) => {
 
   // Verify page heading is visible
   await expect(
-    page.getByRole("heading", { name: "Welcome to Intrada" })
+    page.getByRole("heading", { name: "Library" })
   ).toBeVisible();
 
   // Verify library list renders with stub data items


### PR DESCRIPTION
## Summary
PR 3 of 3 from the iOS layout audit. Two iOS-only CSS refinements that pick up what's left after PR-A (#338) and PR-B (#339).

* **\`.cta-link\` no longer stretches to fill flex-col parents on iOS.** The full-width purple "New Session" / "Add Item" bar under each page heading was the most web-app-y signal the user flagged ("large buttons"). \`align-self: flex-end\` shrinks it to content width and pushes it to the trailing edge — matches the iOS nav-bar trailing-action convention without touching any callsite.
* **\`.input-base\` gets 11px / 16px padding on iOS** (was 10px / 12px). Wider horizontal padding lines up with the inset-grouped row gutters in iOS Settings/Mail; the previous tight padding reads as cramped next to PR-B's new GroupedList row chrome.

Both rules scoped to \`[data-platform="ios"]\` — no effect on web/Android. \`cta-link\` inside non-flex parents (empty states) is unaffected because \`align-self\` only applies to flex children.

What I deliberately deferred from the audit:
- **Detail.rs PageHeading consistency** — `<PageHeading>` only takes `&'static str`; refactoring to accept dynamic content is broader than this PR's scope.
- **Forms-as-grouped-containers** — would benefit from Pencil design first; the input-padding change here is the smaller win.
- **App header padding token consistency** — header is hidden on iOS, so the impact is web-only and low priority.

## Test plan
- [ ] **iOS device**: "New Session" / "Add Item" CTAs sit at the right edge of the page header at content width — no full-width purple bar.
- [ ] **iOS device**: Form inputs (e.g. piece title in the BottomSheet add form) feel roomier; horizontal padding visibly matches the GroupedList row gutters.
- [ ] **Web/Android**: No visual change to CTAs or form inputs.
- [ ] **Empty states**: "Add Item" / "New Session" buttons in empty states still appear centred (no shift to the right).