### PR TITLE
fix(ios): detail title gets large-title bump + app header padding tokens

### DIFF
--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -34,7 +34,7 @@ pub fn AppHeader() -> impl IntoView {
 
     view! {
         <header class="glass-chrome border-b border-border-default" role="banner">
-            <div class="max-w-4xl mx-auto px-4 sm:px-6 py-4 sm:py-5 flex items-center justify-between">
+            <div class="max-w-4xl mx-auto px-card sm:px-card-comfortable py-card sm:py-card-comfortable flex items-center justify-between">
                 <div>
                     <A href="/" attr:class="no-underline">
                         <h1 class="text-2xl sm:text-3xl font-bold tracking-tight text-primary">"Intrada"</h1>

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -104,7 +104,7 @@ pub fn DetailView() -> impl IntoView {
                         <Card>
                             <div class="flex items-start justify-between gap-3 mb-6">
                                 <div>
-                                    <h2 class="text-2xl font-bold text-primary">{title}</h2>
+                                    <h2 class="text-2xl font-bold text-primary font-heading">{title}</h2>
                                     {if !subtitle.is_empty() {
                                         Some(view! {
                                             <p class="text-lg text-muted mt-1">{subtitle.clone()}</p>


### PR DESCRIPTION
## Summary
Two small audit follow-ups left over after PR-A (#338), PR-B (#339), PR-C (#340).

* **\`detail.rs:107\` h2 was missing \`font-heading\` class.** The iOS large-title bump rule (\`[data-platform="ios"] h2.font-heading { font-size: 1.875rem }\`) only fires when the heading has that class. Without it the detail screen's title rendered at the small web size on iOS, undermining the whole iOS-feel of the detail surface.
* **\`app_header.rs\` raw Tailwind padding → spacing tokens.** Was \`px-4 sm:px-6 py-4 sm:py-5\`; now \`px-card sm:px-card-comfortable py-card sm:py-card-comfortable\` to match every other card surface in the app. Header is hidden on iOS so this is web-only — slight increase in vertical padding on sm+ (20→24px).

## Deliberately not in this PR
- **Forms-as-grouped-containers** — still want this but it's a bigger refactor (form fields would need to land inside a single rounded card on iOS, with hairline separators), and most forms are inside BottomSheets which already provide the grouped chrome. Worth a dedicated PR with Pencil first.
- **PageHeading dynamic content** — making the prop \`String\` instead of \`&'static str\` would let detail.rs use it, but detail's title also has an inline TypeBadge which PageHeading doesn't slot for. Net work without a clear win.

## Test plan
- [ ] **iOS device**: open any item from the Library; the title at the top of the detail card now renders at the iOS large-title size (matches the \"Practice\" / \"Routines\" page headings).
- [ ] **Web**: app header has consistent padding with the cards beneath it (slight increase from the previous 20px to 24px vertical on sm+, no jarring change).