### PR TITLE
feat(mobile): tab bar — iOS 26 Liquid Glass approximation in CSS

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -638,9 +638,56 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   display: none;
 }
 
-/* Tab bar: grow height to accommodate safe area so icons aren't compressed.
-   h-16 (64px) is the icon area; safe-area-inset-bottom (≈34px on iPhone 16)
-   extends below for the home indicator. */
+/* Mobile tab bar — iOS 26 Liquid Glass approximation, pure CSS.
+   Applied to the nav element directly (not gated to data-platform=ios)
+   so mobile Safari and Android Chrome get the same look as the Tauri
+   iOS shell. The bar is `sm:hidden` so this only fires when it's
+   actually visible.
+
+   Real Liquid Glass uses GPU refraction (SVG feDisplacementMap chained
+   into backdrop-filter) which WebKit doesn't support. What we *can*
+   get on WebKit: heavier blur + saturation boost so underlying colours
+   bleed through vibrantly, a faint top-of-bar light gradient, and a
+   specular hairline that reads as light catching the rim. Together
+   these are noticeably closer to UITabBar than the previous flat 12px
+   blur. The native-UIToolbar route is tracked separately if we ever
+   need true refraction. */
+nav[aria-label="Mobile navigation"] {
+  background-color: oklch(15.6% 0.011 261.692 / 50%);
+  background-image: linear-gradient(
+    to bottom,
+    oklch(100% 0 0 / 5%) 0%,
+    oklch(100% 0 0 / 0%) 70%
+  );
+
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  backdrop-filter: blur(40px) saturate(180%);
+
+  /* Replace the Tailwind border-t with a layered shadow: an inset
+     specular highlight inside the top edge, plus a hairline outside
+     to separate the bar from content scrolling beneath. */
+  border-top: 0;
+  box-shadow:
+    inset 0 1px 0 oklch(100% 0 0 / 8%),
+    0 -1px 0 oklch(100% 0 0 / 4%);
+}
+
+/* Reduced-motion users: drop the saturation boost (still get blur for
+   legibility, but no colour shift). Keeps the WCAG "Animation from
+   interactions" intent — the bar shouldn't shimmer as content scrolls
+   past. */
+@media (prefers-reduced-motion: reduce) {
+  nav[aria-label="Mobile navigation"] {
+    -webkit-backdrop-filter: blur(40px);
+    backdrop-filter: blur(40px);
+  }
+}
+
+/* Tab bar height on iOS — bump to accommodate the home-indicator
+   safe-area so icons aren't compressed. Mobile Safari + Android handle
+   the safe-area via the existing pb-safe utility, but the Tauri shell
+   needs the explicit height bump because pb-safe alone shrinks the
+   icon area inside the fixed h-16. */
 [data-platform="ios"] nav[aria-label="Mobile navigation"] {
   height: calc(4rem + env(safe-area-inset-bottom));
   padding-bottom: env(safe-area-inset-bottom);


### PR DESCRIPTION
## Summary

Pushes the mobile tab bar's chrome closer to UITabBar's iOS 26 look without a native plugin. Real Liquid Glass uses GPU refraction (SVG feDisplacementMap chained into backdrop-filter) which WebKit doesn't support, so we get as close as CSS-only allows on the same WebKit engine the Tauri shell uses.

- 40px blur + 180% saturation (was 12px, no saturation) — underlying warm content reads as colour through the bar instead of muddy grey
- Lower-opacity base tint (50% vs the previous chrome token at 60%) so more of the blur surface shows through
- Faint top-of-bar light gradient + inset specular hairline replace the flat border-t — reads as light catching the rim
- Reduced-motion variant drops the saturation boost (no shimmer as content scrolls past)

Applied universally to the Mobile navigation `nav` element so mobile Safari and Android Chrome get the same look as the Tauri iOS shell. The bar is `sm:hidden` so it only fires when actually visible.

## Context

A floating-pill variant was tried in development and reverted — the side gutters showed content underneath in a way that read as messy with our list-card layouts. Sticking with edge-to-edge for now.

The native UIToolbar route (true refraction via Tauri Swift plugin) is documented and deferred — recommend revisiting in 3–6 months when the Tauri plugin ecosystem catches up. See the Liquid Glass research thread.

## Test plan

- [ ] iOS Tauri sim — bar shows visibly more colour bleeding through (notice the warm indigo gradient under the bar reads warmer than before)
- [ ] iOS Tauri sim — top edge has a subtle bright hairline (specular highlight) instead of the previous flat dark border
- [ ] Mobile Safari (responsive mode or real device) — same glass treatment fires
- [ ] Reduced-motion enabled — saturation boost drops, blur stays, no shimmer as content scrolls underneath
- [ ] Desktop ≥640px — bar is hidden (`sm:hidden`), no regression to header navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)