### PR TITLE
feat(design): phase 3a — Routines page → AccentRow primitive

### DIFF
--- a/crates/intrada-web/src/views/routines.rs
+++ b/crates/intrada-web/src/views/routines.rs
@@ -3,13 +3,13 @@ use leptos_router::components::A;
 use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
-use intrada_core::{Event, RoutineEvent, RoutineView, ViewModel};
+use intrada_core::{Event, ItemKind, RoutineEvent, RoutineView, ViewModel};
 
 use crate::components::{
-    Button, ButtonVariant, ContextMenu, ContextMenuAction, EmptyState, GroupedList, GroupedListRow,
-    IconName, PageHeading, SkeletonCardList, SwipeActions,
+    AccentBar, AccentRow, ContextMenu, ContextMenuAction, EmptyState, Icon, IconName, PageHeading,
+    SkeletonCardList, SwipeActions,
 };
-use intrada_web::core_bridge::{process_effects, process_effects_with_core};
+use intrada_web::core_bridge::process_effects_with_core;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// Management page for saved routines — lists all routines with edit/delete actions.
@@ -44,20 +44,25 @@ pub fn RoutinesListView() -> impl IntoView {
                         </EmptyState>
                     }.into_any()
                 } else {
-                    let routine_count = vm.routines.len();
                     view! {
-                        <GroupedList aria_label="Saved routines">
-                            {vm.routines.into_iter().map(|routine| {
-                                view! {
-                                    <GroupedListRow>
-                                        <RoutineRow routine=routine />
-                                    </GroupedListRow>
-                                }
+                        <ul class="space-y-2 list-none p-0" role="list" aria-label="Saved routines">
+                            {vm.routines.into_iter().map(|routine| view! {
+                                <li>
+                                    <RoutineRow routine=routine />
+                                </li>
                             }).collect::<Vec<_>>()}
-                        </GroupedList>
-                        <p class="text-sm text-muted mt-4">
-                            {format!("{} routine{}", routine_count, if routine_count == 1 { "" } else { "s" })}
-                        </p>
+                        </ul>
+                        // Inline "add another" link mirrors the Pencil design — a
+                        // discrete text link rather than a second hero button so the
+                        // primary CTA stays in the header / empty state.
+                        <div class="mt-4">
+                            <A
+                                href="/sessions/new"
+                                attr:class="text-sm font-medium text-accent-text hover:text-accent-hover"
+                            >
+                                "Create New Routine"
+                            </A>
+                        </div>
                     }.into_any()
                 }
             }}
@@ -65,29 +70,54 @@ pub fn RoutinesListView() -> impl IntoView {
     }
 }
 
-/// A single routine row with name, entry count, edit link, and delete action.
+/// Build the meta line shown under the routine title — "N items" or
+/// "N pieces · M exercises" depending on the mix.
+///
+/// Pencil shows "3 pieces · 20 min" but `RoutineEntryView` carries no
+/// duration today, so we surface the type breakdown instead. Total
+/// duration is a #TODO once we model item duration in core.
+fn routine_meta_line(routine: &RoutineView) -> String {
+    let (pieces, exercises) = routine
+        .entries
+        .iter()
+        .fold((0usize, 0usize), |(p, e), entry| match entry.item_type {
+            ItemKind::Piece => (p + 1, e),
+            ItemKind::Exercise => (p, e + 1),
+        });
+    match (pieces, exercises) {
+        (0, 0) => "Empty".to_string(),
+        (p, 0) => format!("{} {}", p, if p == 1 { "piece" } else { "pieces" }),
+        (0, e) => format!("{} {}", e, if e == 1 { "exercise" } else { "exercises" }),
+        (p, e) => format!(
+            "{} {} \u{00B7} {} {}",
+            p,
+            if p == 1 { "piece" } else { "pieces" },
+            e,
+            if e == 1 { "exercise" } else { "exercises" }
+        ),
+    }
+}
+
+/// A single routine row — name + meta line, full-row tap to edit. The
+/// Edit / Delete affordances live in the swipe gesture and long-press
+/// context menu, matching the iOS list pattern. No accent bar (`bar=
+/// AccentBar::None`) — the routine list is uniform-type so bars would
+/// flatten into noise instead of carrying signal.
 #[component]
 fn RoutineRow(routine: RoutineView) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
-    let confirm_delete = RwSignal::new(false);
 
     let id = routine.id.clone();
-    let id_for_delete = routine.id.clone();
     let id_for_swipe = routine.id.clone();
     let id_for_menu_delete = routine.id.clone();
     let name = routine.name.clone();
-    let entry_count = routine.entry_count;
-    let entries = routine.entries.clone();
+    let meta = routine_meta_line(&routine);
     let edit_href = format!("/routines/{}/edit", id);
     let edit_href_for_menu = edit_href.clone();
 
-    // Direct-delete callback used by both the iOS swipe-to-delete gesture
-    // and the long-press context menu's Delete action. Skips the in-card
-    // confirmation banner — the swipe / long-press gesture is itself the
-    // deliberate confirmation, matching native UISwipeActionsConfiguration.
     let core_for_gesture = core.clone();
     let direct_delete = Callback::new(move |routine_id: String| {
         let event = Event::Routine(RoutineEvent::DeleteRoutine { id: routine_id });
@@ -123,83 +153,20 @@ fn RoutineRow(routine: RoutineView) -> impl IntoView {
     ];
 
     view! {
-        {move || {
-            if confirm_delete.get() {
-                let core_del = core.clone();
-                let id_del = id_for_delete.clone();
-                view! {
-                    <div class="p-card sm:p-card-comfortable">
-                        <p class="text-sm text-danger-text mb-3">"Delete this routine? This cannot be undone."</p>
-                        <div class="flex gap-2">
-                            <Button
-                                variant=ButtonVariant::Danger
-                                loading=Signal::derive(move || is_submitting.get())
-                                on_click=Callback::new(move |_| {
-                                    let event = Event::Routine(RoutineEvent::DeleteRoutine { id: id_del.clone() });
-                                    let core_ref = core_del.borrow();
-                                    let effects = core_ref.process_event(event);
-                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                })
-                            >
-                                {move || if is_submitting.get() { "Deleting\u{2026}" } else { "Confirm Delete" }}
-                            </Button>
-                            <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
-                                confirm_delete.set(false);
-                            })>
-                                "Cancel"
-                            </Button>
+        <ContextMenu actions=menu_actions>
+            <SwipeActions on_delete=Callback::new(move |_| {
+                direct_delete.run(id_for_swipe.clone());
+            })>
+                <A href=edit_href attr:class="block no-underline">
+                    <AccentRow bar=AccentBar::None>
+                        <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                            <span class="text-sm font-semibold text-primary truncate">{name}</span>
+                            <span class="text-xs text-muted">{meta}</span>
                         </div>
-                    </div>
-                }.into_any()
-            } else {
-                let name = name.clone();
-                let entries = entries.clone();
-                let edit_href = edit_href.clone();
-                let menu_actions = menu_actions.clone();
-                let id_for_swipe = id_for_swipe.clone();
-                view! {
-                    <ContextMenu actions=menu_actions>
-                        <SwipeActions on_delete=Callback::new(move |_| {
-                            direct_delete.run(id_for_swipe.clone());
-                        })>
-                            <div class="p-card sm:p-card-comfortable space-y-3">
-                                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                                        <div class="flex-1 min-w-0">
-                                            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                                                <span class="text-sm font-medium text-primary">{name}</span>
-                                                <span class="inline-flex items-center rounded-full bg-badge-piece-bg px-2 py-0.5 text-xs font-medium text-accent-text">
-                                                    {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
-                                                </span>
-                                            </div>
-                                        </div>
-                                        <div class="flex gap-3 sm:ml-4">
-                                            <A href=edit_href attr:class="text-xs text-accent-text hover:text-accent-hover font-medium">
-                                                "Edit"
-                                            </A>
-                                            <button
-                                                class="text-xs text-danger-text hover:text-danger-hover font-medium"
-                                                on:click=move |_| { confirm_delete.set(true); }
-                                            >
-                                                "Delete"
-                                            </button>
-                                        </div>
-                                    </div>
-                                    // Entry details
-                                    <div class="mt-1 pt-2 space-y-1.5">
-                                        {entries.into_iter().map(|entry| {
-                                            view! {
-                                                <div class="flex items-center gap-2 text-xs">
-                                                    <span class="text-primary">{entry.item_title}</span>
-                                                    <span class="text-faint">{entry.item_type.to_string()}</span>
-                                                </div>
-                                            }
-                                        }).collect::<Vec<_>>()}
-                                    </div>
-                            </div>
-                        </SwipeActions>
-                    </ContextMenu>
-                }.into_any()
-            }
-        }}
+                        <Icon name=IconName::ChevronRight class="w-4 h-4 text-faint shrink-0" />
+                    </AccentRow>
+                </A>
+            </SwipeActions>
+        </ContextMenu>
     }
 }

--- a/e2e/tests/routines.spec.ts
+++ b/e2e/tests/routines.spec.ts
@@ -32,40 +32,19 @@ test.describe("routines page", () => {
     // Should show the routine name
     await expect(page.getByText("Morning Warm-up")).toBeVisible();
 
-    // Should show the item count badge
-    await expect(page.getByText("2 items")).toBeVisible();
+    // Type-breakdown meta line replaces the previous "N items" badge —
+    // STUB_ROUTINE has one piece + one exercise.
+    await expect(page.getByText("1 piece · 1 exercise")).toBeVisible();
 
-    // Should show Edit and Delete controls
-    await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Delete" })
-    ).toBeVisible();
-  });
-
-  test("delete routine with confirmation", async ({ page, mockApi }) => {
-    mockApi.routines = createSeedRoutinesWithStub();
-
-    await page.goto("/routines");
-    await expect(page.getByText("Morning Warm-up")).toBeVisible();
-
-    // Click Delete — should show confirmation
-    await page.getByRole("button", { name: "Delete" }).click();
-    await expect(
-      page.getByText("Delete this routine? This cannot be undone.")
-    ).toBeVisible();
-
-    // Cancel — should dismiss
-    await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(
-      page.getByText("Delete this routine? This cannot be undone.")
-    ).not.toBeVisible();
-
-    // Delete again and confirm
-    await page.getByRole("button", { name: "Delete" }).click();
-    await page.getByRole("button", { name: "Confirm Delete" }).click();
-
-    // Should show empty state
-    await expect(page.getByText("No saved routines yet")).toBeVisible();
+    // The whole row is a tap target linking to the edit screen — Edit /
+    // Delete affordances live in the swipe gesture and long-press
+    // context menu, not inline buttons. We verify the link target here;
+    // gesture-based actions are validated at the core/event layer.
+    const row = page.getByRole("link").filter({ hasText: "Morning Warm-up" });
+    await expect(row).toHaveAttribute(
+      "href",
+      /\/routines\/[A-Z0-9]+\/edit$/
+    );
   });
 
   test("save routine from session builder", async ({ page }) => {


### PR DESCRIPTION
## Summary

First production pillar to adopt the 2026 refresh primitives, per `specs/design-refresh-2026.md`. Validates the AccentRow pattern on the smallest list before rolling out to Library / Sessions / Analytics / Detail.

## What changes

- **Routine rows** swap from the verbose `GroupedList` card (title + expanded entry list + inline Edit/Delete buttons + count badge) to a single 60px `AccentRow` with `bar=None`. The list is uniform-type (all routines), so the spec calls for no bars to avoid them flattening into noise.

- **Meta line** under the title now shows the item-type breakdown ("3 pieces · 2 exercises") instead of the previous "N items" badge. Pencil shows "3 pieces · 20 min" but `RoutineEntryView` carries no duration today — the breakdown is the closest signal we can give until duration lands in core. (#TODO noted.)

- **Edit / Delete UX**: inline buttons removed. Edit via tap on the whole row; Delete via the existing swipe-to-delete or long-press context menu. The in-card confirmation banner is also gone — the gesture is itself the confirmation, matching native `UISwipeActionsConfiguration`.

- **Inline "Create New Routine"** text link below the list mirrors the Pencil design — discrete add-another link rather than a second hero button so the primary CTA stays in the empty-state / header.

## E2E updates

- Drop the inline Delete-confirmation flow test (no longer applicable; gesture-based delete is hard to simulate in Playwright, and the underlying `RoutineEvent::DeleteRoutine` path is still covered by core unit tests).
- Update the row-display test to assert the new meta line and the row's link target instead of Edit / Delete buttons.

## Test plan

- [ ] iOS sim — `/routines` with seed data: 60px AccentRow per routine, no left bar, name + meta line, chevron on right; swipe-left reveals Delete; long-press shows Edit / Delete menu
- [ ] iOS sim — tap a row → navigates to `/routines/:id/edit`
- [ ] iOS sim — empty state still shows the existing CTA; "Create New Routine" link only appears when routines exist
- [ ] Web ≥sm — same AccentRow rendering, no broken layouts
- [ ] E2E green (routines.spec.ts updated for the new flow)

## Out of scope

- Adding a `+` icon action to the page header (Pencil shows one but it's a separate detail; existing empty-state CTA still works).
- Bringing duration into `RoutineEntryView` so the meta line can match Pencil exactly. Tracked as #TODO in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)