### PR TITLE
feat(design): phase 3b — Library → AccentRow + bar mapping + search bar

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -550,6 +550,45 @@ body {
   border-radius: 12px;
 }
 
+/* Search bar — visual primitive sitting above filterable lists.
+   Currently non-functional (no search logic wired up); the input is
+   present so the screen matches the 2026 refresh designs. The font
+   size is 16px to suppress iOS zoom-on-focus. */
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  height: 44px;
+  padding: 0 0.875rem;
+  border-radius: 12px;
+  background-color: var(--color-surface-secondary);
+}
+.search-bar-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+.search-bar-input {
+  flex: 1 1 0%;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  font-family: var(--font-body);
+  font-size: 16px;
+  color: var(--color-text-primary);
+  min-width: 0;
+}
+.search-bar-input::placeholder {
+  color: var(--color-text-muted);
+}
+/* Hide WebKit's built-in search input X — we'll build a proper clear
+   affordance when the search logic actually lands. */
+.search-bar-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* ═══════════════════════════════════════════════════════════════════════
    Typography Utilities
    ═══════════════════════════════════════════════════════════════════════

--- a/crates/intrada-web/src/components/icon.rs
+++ b/crates/intrada-web/src/components/icon.rs
@@ -27,6 +27,7 @@ pub enum IconName {
     Play,
     Plus,
     RotateCcw,
+    Search,
     Star,
     X,
 }
@@ -154,6 +155,11 @@ pub fn Icon(
         IconName::RotateCcw => view! {
             <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
             <path d="M3 3v5h5" />
+        }
+        .into_any(),
+        IconName::Search => view! {
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
         }
         .into_any(),
         IconName::Star => view! {

--- a/crates/intrada-web/src/components/library_item_card.rs
+++ b/crates/intrada-web/src/components/library_item_card.rs
@@ -3,124 +3,66 @@ use leptos_router::components::A;
 use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
-use intrada_core::LibraryItemView;
+use intrada_core::{ItemKind, LibraryItemView};
 
-use crate::components::{ContextMenu, ContextMenuAction, SwipeActions, TypeBadge};
+use crate::components::{
+    AccentBar, AccentRow, ContextMenu, ContextMenuAction, Icon, IconName, InlineTypeIndicator,
+    SwipeActions,
+};
+use intrada_web::types::ItemType;
 
+/// A single library list row.
+///
+/// 2026 refresh shape: 60px AccentRow with the gradient bar mapped to
+/// item type — gold for pieces, blue for exercises. Title + composer
+/// (subtitle) on the left, InlineTypeIndicator + chevron on the right.
+/// The richer metadata (key, tempo, tags) that used to render in this
+/// row now lives on the detail page so the list reads at a glance.
 #[component]
 pub fn LibraryItemCard(
     item: LibraryItemView,
     /// Optional swipe-to-delete callback. When provided (typically in the
-    /// library list on iOS), wraps the card in a SwipeActions container
+    /// library list on iOS), wraps the row in a SwipeActions container
     /// that reveals a trailing Delete action on left-swipe.
     #[prop(optional, into)]
     on_delete: Option<Callback<String>>,
 ) -> impl IntoView {
-    let LibraryItemView {
-        id,
-        title,
-        subtitle,
-        item_type,
-        key,
-        tempo,
-        tags,
-        latest_achieved_tempo,
-        ..
-    } = item;
+    let id = item.id.clone();
+    let title = item.title.clone();
+    let subtitle = item.subtitle.clone();
+    let item_kind = item.item_type;
 
-    let has_subtitle = !subtitle.is_empty();
-    let has_key_or_tempo = key.is_some() || tempo.is_some() || latest_achieved_tempo.is_some();
-    let has_tags = !tags.is_empty();
-    let href = format!("/library/{id}");
-
-    // Build combined tempo display: "♩ 108 / 120 BPM" (achieved / target),
-    // "♩ 108 BPM" (achieved only), or "♩ 120 BPM" (target only)
-    let tempo_display = match (latest_achieved_tempo, &tempo) {
-        (Some(achieved), Some(target)) => Some(format!("{achieved} / {target}")),
-        (Some(achieved), None) => Some(format!("{achieved} BPM")),
-        (None, Some(_)) => None, // handled by existing tempo.map below
-        (None, None) => None,
+    let (bar, indicator_type) = match item_kind {
+        ItemKind::Piece => (AccentBar::Gold, ItemType::Piece),
+        ItemKind::Exercise => (AccentBar::Blue, ItemType::Exercise),
     };
 
-    let id_for_delete = id.clone();
-    let body = view! {
-        <A href=href attr:class="block p-card sm:p-card-comfortable">
-            <div class="flex items-start justify-between gap-3">
-                    <div class="min-w-0 flex-1">
-                        // Identity cluster: title + composer tightly grouped (audit #12)
-                        <h3 class="text-base font-semibold text-primary truncate">{title}</h3>
-                        {if has_subtitle {
-                            Some(view! {
-                                <p class="text-sm text-muted mt-1 truncate">{subtitle}</p>
-                            })
-                        } else {
-                            None
-                        }}
-                        // Metadata: key/tempo with larger gap from identity cluster
-                        {if has_key_or_tempo {
-                            Some(view! {
-                                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-3 text-xs text-faint">
-                                    {key.map(|k| {
-                                        view! {
-                                            <span class="flex items-center gap-1">
-                                                <span aria-hidden="true">"♯"</span>{k}
-                                            </span>
-                                        }
-                                    })}
-                                    {if let Some(combined) = tempo_display {
-                                        // Achieved tempo exists — show combined display
-                                        Some(view! {
-                                            <span class="flex items-center gap-1">
-                                                <span aria-hidden="true">"♩"</span>{combined}
-                                            </span>
-                                        })
-                                    } else {
-                                        // No achieved tempo — show target only (existing behaviour)
-                                        tempo.map(|t| {
-                                            view! {
-                                                <span class="flex items-center gap-1">
-                                                    <span aria-hidden="true">"♩"</span>{t}
-                                                </span>
-                                            }
-                                        })
-                                    }}
-                                </div>
-                            })
-                        } else {
-                            None
-                        }}
-                        // Tags: consistent gap from metadata
-                        {if has_tags {
-                            Some(view! {
-                                <div class="flex flex-wrap gap-1.5 mt-2">
-                                    {tags.into_iter().map(|tag| {
-                                        view! {
-                                            <span class="inline-flex items-center rounded-full border border-border-default px-2 py-0.5 text-xs text-muted">
-                                                {tag}
-                                            </span>
-                                        }
-                                    }).collect::<Vec<_>>()}
-                                </div>
-                            })
-                        } else {
-                            None
-                        }}
-                    </div>
-                    <TypeBadge item_type=item_type />
+    let href = format!("/library/{id}");
+    let id_for_swipe = id.clone();
+    let id_for_menu_delete = id.clone();
+    let edit_href = format!("/library/{id}/edit");
+
+    let row = view! {
+        <A href=href attr:class="block no-underline">
+            <AccentRow bar=bar>
+                <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                    <span class="text-sm font-semibold text-primary truncate">{title}</span>
+                    {if !subtitle.is_empty() {
+                        Some(view! {
+                            <span class="text-xs text-muted truncate">{subtitle}</span>
+                        })
+                    } else {
+                        None
+                    }}
                 </div>
-            </A>
+                <InlineTypeIndicator item_type=indicator_type />
+                <Icon name=IconName::ChevronRight class="w-4 h-4 text-faint shrink-0" />
+            </AccentRow>
+        </A>
     };
 
     if let Some(cb) = on_delete {
-        let id_for_swipe = id_for_delete.clone();
-        let id_for_edit = id_for_delete.clone();
-        let id_for_menu_delete = id_for_delete;
-        let cb_for_menu_delete = cb;
-        let edit_href = format!("/library/{id_for_edit}/edit");
-
-        // Long-press context menu offering Edit and Delete shortcuts.
-        // Edit navigates to the route; Delete reuses the same callback as
-        // the swipe-to-delete so behaviour stays consistent.
+        let cb_for_menu = cb;
         let menu_actions = vec![
             ContextMenuAction {
                 label: "Edit".to_string(),
@@ -134,16 +76,16 @@ pub fn LibraryItemCard(
                 label: "Delete".to_string(),
                 destructive: true,
                 on_select: Callback::new(move |_| {
-                    cb_for_menu_delete.run(id_for_menu_delete.clone());
+                    cb_for_menu.run(id_for_menu_delete.clone());
                 }),
             },
         ];
 
         view! {
-            <li class="glass-card hover:bg-surface-hover motion-safe:transition-colors">
+            <li>
                 <ContextMenu actions=menu_actions>
                     <SwipeActions on_delete=Callback::new(move |_| cb.run(id_for_swipe.clone()))>
-                        {body}
+                        {row}
                     </SwipeActions>
                 </ContextMenu>
             </li>
@@ -151,9 +93,7 @@ pub fn LibraryItemCard(
         .into_any()
     } else {
         view! {
-            <li class="glass-card hover:bg-surface-hover motion-safe:transition-colors">
-                {body}
-            </li>
+            <li>{row}</li>
         }
         .into_any()
     }

--- a/crates/intrada-web/src/components/skeleton.rs
+++ b/crates/intrada-web/src/components/skeleton.rs
@@ -25,20 +25,18 @@ pub fn SkeletonBlock(
     view! { <div class=class></div> }
 }
 
-/// Skeleton matching the `LibraryItemCard` layout — title, subtitle, and metadata lines
-/// inside a glass card.
+/// Skeleton matching the 2026-refresh `LibraryItemCard` layout — a 60px
+/// AccentRow shape with title + subtitle skeleton on the left and a
+/// small type-indicator placeholder on the right.
 #[component]
 pub fn SkeletonItemCard() -> impl IntoView {
     view! {
-        <li class="glass-card p-card sm:p-card-comfortable animate-pulse">
-            <div class="flex items-start justify-between gap-3">
-                <div class="min-w-0 flex-1 space-y-3">
-                    <div class="h-5 w-2/3 rounded bg-surface-secondary"></div>
-                    <div class="h-4 w-1/2 rounded bg-surface-secondary"></div>
-                    <div class="h-3 w-1/3 rounded bg-surface-secondary"></div>
-                </div>
-                <div class="h-6 w-16 rounded-full bg-surface-secondary flex-shrink-0"></div>
+        <li class="accent-row accent-row--no-bar animate-pulse">
+            <div class="flex flex-col flex-1 min-w-0 gap-1.5">
+                <div class="h-3.5 w-2/3 rounded bg-surface-secondary"></div>
+                <div class="h-3 w-1/2 rounded bg-surface-secondary"></div>
             </div>
+            <div class="h-3 w-12 rounded-full bg-surface-secondary shrink-0"></div>
         </li>
     }
 }

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -742,18 +742,11 @@ pub fn DesignCatalogue() -> impl IntoView {
             // ── Library Item Cards ────────────────────────────────────
             <section id="library-item-card">
                 <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Library Item Card"</h3>
-                <p class="text-xs text-faint mb-3">"Content grouped semantically: [title + composer] — [key/tempo] — [tags]."</p>
-                <ul class="space-y-3">
-                    <p class="text-xs font-medium text-muted uppercase">"Full metadata (piece)"</p>
+                <p class="text-xs text-faint mb-3">"Compact 60px AccentRow — gold bar for pieces, blue for exercises. Title + composer/subtitle on the left, InlineTypeIndicator + chevron on the right. Key / tempo / tags now live on the detail page so the list reads at a glance."</p>
+                <ul class="space-y-2 list-none p-0">
                     <LibraryItemCard item=sample_piece />
-
-                    <p class="text-xs font-medium text-muted uppercase mt-6">"Full metadata (exercise)"</p>
                     <LibraryItemCard item=sample_exercise />
-
-                    <p class="text-xs font-medium text-muted uppercase mt-6">"Minimal (no subtitle, tags, key, or tempo)"</p>
                     <LibraryItemCard item=sample_minimal />
-
-                    <p class="text-xs font-medium text-muted uppercase mt-6">"Long title + many tags"</p>
                     <LibraryItemCard item=sample_long_title />
                 </ul>
             </section>

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -94,6 +94,20 @@ pub fn LibraryListView() -> impl IntoView {
                 }.into_any())
             />
 
+            // Visual search bar — non-functional placeholder for v1 of
+            // the 2026 refresh. Real client-side search needs design +
+            // UX work beyond a textbox; the input is here so the screen
+            // matches the Pencil reference. Tracked as #TODO follow-up.
+            <div class="search-bar">
+                <Icon name=IconName::Search class="search-bar-icon" />
+                <input
+                    type="search"
+                    class="search-bar-input"
+                    placeholder="Search pieces..."
+                    aria-label="Search library"
+                />
+            </div>
+
             // Library items section. The page-level <PageHeading> above
             // already supplies the visible "Library" title, so the
             // section just carries an aria-label for screen readers and
@@ -117,7 +131,7 @@ pub fn LibraryListView() -> impl IntoView {
                     {move || {
                         if is_loading.get() {
                             view! {
-                                <ul class="library-list grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                <ul class="space-y-2 list-none p-0">
                                     <SkeletonItemCard />
                                     <SkeletonItemCard />
                                     <SkeletonItemCard />
@@ -144,7 +158,7 @@ pub fn LibraryListView() -> impl IntoView {
                                 }.into_any()
                             } else {
                                 view! {
-                                    <ul class="library-list grid grid-cols-1 sm:grid-cols-2 gap-3" role="list" aria-label="Library items">
+                                    <ul class="space-y-2 list-none p-0" role="list" aria-label="Library items">
                                         {vm.items.into_iter().map(|item| {
                                             view! {
                                                 <LibraryItemCard item=item on_delete=on_delete_item />

--- a/e2e/tests/add-item.spec.ts
+++ b/e2e/tests/add-item.spec.ts
@@ -28,12 +28,16 @@ test.describe("add library item", () => {
     // Submit the form
     await page.getByRole("button", { name: "Save" }).click();
 
-    // Should redirect to library and show the new item
+    // Should redirect to library and show the new item. Library rows
+    // are spans/links post-2026-refresh, not headings — assert against
+    // the list contents directly.
     await expect(
       page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Moonlight Sonata" })
+      page
+        .getByRole("list", { name: "Library items" })
+        .getByText("Moonlight Sonata")
     ).toBeVisible();
 
     // Should now have 3 items (2 stub + 1 new)
@@ -60,9 +64,11 @@ test.describe("add library item", () => {
     // Submit
     await page.getByRole("button", { name: "Save" }).click();
 
-    // Should appear in library list
+    // Should appear in library list (rows are now links, not headings).
     await expect(
-      page.getByRole("heading", { name: "Chromatic Scale" })
+      page
+        .getByRole("list", { name: "Library items" })
+        .getByText("Chromatic Scale")
     ).toBeVisible();
   });
 

--- a/e2e/tests/detail.spec.ts
+++ b/e2e/tests/detail.spec.ts
@@ -4,8 +4,14 @@ test.describe("detail view", () => {
   test("displays all fields for a stub piece", async ({ page }) => {
     await page.goto("/");
 
-    // Navigate to Clair de Lune detail
-    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    // Navigate to Clair de Lune detail. Library rows are no longer
+    // headings post-2026-refresh — they're links inside <li>s, with
+    // title + subtitle + type indicator combined into the link's
+    // accessible name. Match by visible text instead of role=heading.
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Clair de Lune")
+      .click();
 
     // Title and composer
     await expect(
@@ -48,8 +54,11 @@ test.describe("detail view", () => {
   test("delete item with confirmation", async ({ page }) => {
     await page.goto("/");
 
-    // Navigate to Hanon No. 1
-    await page.getByRole("heading", { name: "Hanon No. 1" }).click();
+    // Navigate to Hanon No. 1 (library rows are now links, not headings).
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Hanon No. 1")
+      .click();
     await expect(
       page.getByRole("heading", { name: "Hanon No. 1", level: 2 })
     ).toBeVisible();
@@ -76,9 +85,12 @@ test.describe("detail view", () => {
       page.getByRole("heading", { name: "Library" })
     ).toBeVisible();
 
-    // Hanon No. 1 should be gone
+    // Hanon No. 1 should be gone (no longer a heading post-refresh —
+    // assert against the list contents directly).
     await expect(
-      page.getByRole("heading", { name: "Hanon No. 1" })
+      page
+        .getByRole("list", { name: "Library items" })
+        .getByText("Hanon No. 1")
     ).not.toBeVisible();
 
     // Only 1 item remaining

--- a/e2e/tests/edit-item.spec.ts
+++ b/e2e/tests/edit-item.spec.ts
@@ -7,7 +7,11 @@ test.describe("edit library item", () => {
     await page.goto("/");
 
     // Navigate to Clair de Lune detail
-    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    // Library rows are links, not headings, post-2026-refresh.
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Clair de Lune")
+      .click();
     await expect(
       page.getByRole("heading", { name: "Clair de Lune", level: 2 })
     ).toBeVisible();
@@ -38,7 +42,11 @@ test.describe("edit library item", () => {
     await page.goto("/");
 
     // Navigate to piece detail then edit
-    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    // Library rows are links, not headings, post-2026-refresh.
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Clair de Lune")
+      .click();
     await page.getByRole("button", { name: "Edit" }).click();
     // Sheet is open with "Edit Item" in its nav title
     await expect(
@@ -62,7 +70,11 @@ test.describe("edit library item", () => {
     await page.goto("/");
 
     // Navigate to piece detail then edit
-    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    // Library rows are links, not headings, post-2026-refresh.
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Clair de Lune")
+      .click();
     await page.getByRole("button", { name: "Edit" }).click();
     // Sheet is open with "Edit Item" in its nav title
     await expect(

--- a/e2e/tests/navigation.spec.ts
+++ b/e2e/tests/navigation.spec.ts
@@ -24,8 +24,12 @@ test.describe("navigation", () => {
   }) => {
     await page.goto("/");
 
-    // Click the first stub item (Clair de Lune)
-    await page.getByRole("heading", { name: "Clair de Lune" }).click();
+    // Click the first stub item (Clair de Lune). Library rows are
+    // links, not headings, post-2026-refresh.
+    await page
+      .getByRole("list", { name: "Library items" })
+      .getByText("Clair de Lune")
+      .click();
 
     // Should show the detail view with the item title
     await expect(


### PR DESCRIPTION
## Summary

Second production pillar to adopt the 2026 refresh primitives. This is where the gold/blue bar mapping actually fires — the library list is mixed-type, so every row carries a clear type signal at the left edge.

## What changes

- **`LibraryItemCard` rewritten** as a 60px AccentRow. Bar variant maps to item type: **gold = piece, blue = exercise**. Title + composer/subtitle on the left, `InlineTypeIndicator` + chevron on the right. Existing swipe-to-delete + long-press menu still wrap the row.
- **Key / tempo / tags removed from the list row** — they live on the detail page now (matches Pencil's compact list reading). Catalogue entries trimmed accordingly: the four metadata variants now show as four shape variants in the same compact form.
- **`SkeletonItemCard` rebuilt** to match the new compact AccentRow shape so the loading state doesn't visibly resize when items render.
- **Visual search bar** above the items list — non-functional in v1 (input is present so the screen matches Pencil; real client-side search is a follow-up). 16px placeholder font suppresses iOS zoom-on-focus.
- **`IconName::Search`** added (Lucide stroke style).
- **Grid → vertical stack**: the previous `grid-cols-1 sm:grid-cols-2` 2-up grid for the rich cards is replaced with a single-column `space-y-2` stack. The compact rows stack better at all widths than the multi-line cards did.

## Test plan

- [ ] iOS sim — `/` library tab: rows are 60px tall, gold bars on pieces, blue bars on exercises, type indicator on the right next to chevron
- [ ] iOS sim — search bar at the top above the list, input focusable, no zoom on focus
- [ ] iOS sim — swipe-left on a row reveals Delete; long-press shows Edit / Delete; tap navigates to `/library/:id`
- [ ] iOS sim — empty state still shows the existing CTA (Add Item)
- [ ] iOS sim — loading skeleton shows the new compact shape (no flicker resize when items load)
- [ ] Web ≥sm — same row rendering, no broken layouts; search bar full-width
- [ ] E2E green — smoke test still finds the `aria-label="Library items"` list with 2 rows

## Out of scope

- Wiring up actual search filtering against the items list — needs design + UX work beyond a textbox. Tracked as #TODO in the comment.
- Adding type-tab filtering (Pieces / Exercises) per Pencil — keeping the mixed list for now since that's where the bar mapping reads cleanest. Will revisit if user feedback wants the filter.
- Pull-to-refresh styling tweaks to match the new background — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)