### PR TITLE
feat(design): phase 3c — page heading bumped to 34px universal

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -596,6 +596,20 @@ body {
    prefer these utilities over ad-hoc Tailwind class strings.
    ═══════════════════════════════════════════════════════════════════════ */
 
+/* Page title — top-level page heading used by `<PageHeading>`.
+   2026 refresh moved this from `text-2xl` (24px) on web / `text-3xl`
+   (30px) on iOS to a single 34px Source Serif weight 700 across every
+   surface, matching the iOS UINavigationBar large-title scale that
+   the Pencil designs use as the page anchor. */
+@utility page-title {
+  font-family: var(--font-heading);
+  font-size: 2.125rem;        /* 34px */
+  line-height: 2.5rem;        /* 40px */
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
 /* Card / subsection heading — e.g. "Practice History", "Most Practised". */
 @utility card-title {
   font-size: 0.875rem; /* text-sm */
@@ -888,15 +902,6 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   opacity: 0.6;
   transform: scale(0.97);
   transition: opacity 80ms ease-out, transform 80ms ease-out;
-}
-
-/* Larger, more prominent page heading on iOS — emulates the iOS
-   "large title" pattern (without the collapse-on-scroll JS, which is
-   nice-to-have follow-up). Targets the PageHeading component's <h2>. */
-[data-platform="ios"] h2.font-heading {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
-  letter-spacing: -0.02em;
 }
 
 /* Tighter form label-input spacing on iOS — desktop's mb-1 (4px) feels

--- a/crates/intrada-web/src/components/page_heading.rs
+++ b/crates/intrada-web/src/components/page_heading.rs
@@ -2,9 +2,10 @@ use leptos::prelude::*;
 
 /// Shared page-level heading with consistent styling.
 ///
-/// Uses the serif heading font (Source Serif 4) to signal "music space"
-/// (audit #9). When a `subtitle` is provided, a description paragraph is
-/// rendered beneath the heading.
+/// Uses Source Serif 4 to signal "music space" (audit #9), bumped to
+/// the 34px iOS large-title scale by the 2026 refresh — see the
+/// `.page-title` utility in `input.css`. When a `subtitle` is
+/// provided, a description paragraph renders beneath the heading.
 ///
 /// An optional `trailing` slot sits on the title's row at the trailing
 /// edge — used for nav-bar-style page actions (e.g. an "Add" button).
@@ -23,7 +24,7 @@ pub fn PageHeading(
     view! {
         <div>
             <div class=format!("flex items-center justify-between gap-3 {row_mb}")>
-                <h2 class="text-2xl font-bold text-primary font-heading">{text}</h2>
+                <h2 class="page-title">{text}</h2>
                 {trailing.map(|t| t())}
             </div>
             {subtitle.map(|sub| view! {


### PR DESCRIPTION
## Summary

Per the 2026 refresh, every top-level page title scales up to the iOS large-title size on every surface — not just iOS.

- New `.page-title` utility in `input.css`: 34px / line-height 40px / weight 700 / -0.02em letter-spacing / Source Serif. Applied through the `<PageHeading>` component's `<h2>`.
- Old `text-2xl font-bold ... font-heading` Tailwind soup on the heading collapses to a single `class="page-title"`.
- The `[data-platform="ios"] h2.font-heading` override that bumped iOS to 30px is removed — redundant now that the universal default matches what the override used to give and goes bigger.

## Visual impact

Every page that uses `<PageHeading>` (Library, Practice, Routines, Analytics, plus the inner detail/edit/etc. screens) now leads with the large 34px serif title. Big visible change for one tiny diff.

## Test plan

- [ ] iOS sim — Library, Practice, Routines, Analytics all show the 34px Source Serif page title; spacing reads as the iOS UINavigationBar large-title pattern
- [ ] Web ≥sm — same heading scale (no purple cast, neutral background)
- [ ] No regressions in trailing slot — the `+` actions on Library / Routines / Sessions still vertically centre against the bigger title
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)