### PR TITLE
feat(design): phase 3d — Analytics → StatCard refresh + SectionLabels

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -411,9 +411,7 @@ body {
 .detail-group::before {
   content: '';
   position: absolute;
-  top: 12px;
-  bottom: 12px;
-  left: 0;
+  inset: 0 auto 0 0;
   width: 4px;
   background: var(--bar-gradient-gold);
 }
@@ -464,9 +462,7 @@ body {
 .stat-card-faint::before {
   content: '';
   position: absolute;
-  top: 12px;
-  bottom: 12px;
-  left: 0;
+  inset: 0 auto 0 0;
   width: 4px;
   background: var(--bar-gradient-gold);
 }

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -380,7 +380,10 @@ body {
 
 /* SectionLabel — uppercase letter-spaced label sitting above grouped
    content (DETAILS / RECENT ACTIVITY / NOTES / THIS WEEK). Pairs with
-   DetailGroup but also works standalone above any list. */
+   DetailGroup but also works standalone above any list. The
+   margin-bottom only applies in normal block flow — DetailGroup uses
+   `gap: 12px` on its flex parent which supersedes margin between items
+   so this doesn't double-up. */
 .section-label {
   font-family: var(--font-body);
   font-size: 0.6875rem;     /* 11px */
@@ -388,6 +391,7 @@ body {
   letter-spacing: 0.0625rem; /* 1px */
   text-transform: uppercase;
   color: var(--color-text-muted);
+  margin-bottom: 0.75rem;   /* 12px — matches the old .card-title spacing */
 }
 
 /* DetailGroup — card containing a SectionLabel + grouped rows + the

--- a/crates/intrada-web/src/views/analytics.rs
+++ b/crates/intrada-web/src/views/analytics.rs
@@ -6,7 +6,8 @@ use leptos::prelude::*;
 use leptos_router::components::A;
 
 use crate::components::{
-    Card, EmptyState, Icon, IconName, LineChart, PageHeading, SkeletonBlock, StatCard,
+    AccentBar, Card, EmptyState, Icon, IconName, LineChart, PageHeading, SectionLabel,
+    SkeletonBlock, StatCard, StatTone,
 };
 use intrada_web::core_bridge::init_core;
 use intrada_web::types::{IsLoading, IsSubmitting};
@@ -77,19 +78,45 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
     } = analytics;
 
     let streak_display = format!("{}", streak.current_days);
+    // Weekly hours formatted as a single decimal — matches the Pencil
+    // "8.5" style. Whole-hour values render as "5", not "5.0".
+    let hours_decimal = weekly.total_minutes as f64 / 60.0;
+    let hours_display = if hours_decimal.fract() == 0.0 {
+        format!("{:.0}", hours_decimal)
+    } else {
+        format!("{:.1}", hours_decimal)
+    };
+    let items_display = format!("{}", weekly.items_covered);
 
     view! {
         <div class="space-y-6">
-            // ── Streak stat card (single, no longer in 3-column grid) ──
-            <StatCard
-                title="Streak"
-                value=streak_display
-                subtitle="days"
-            />
+            // ── Top stat row — three StatCard refresh variants. The
+            // tone of the value text (accent purple / warm gold / white)
+            // mirrors the gradient bar on the left of each card so a
+            // stat's category reads at a glance.
+            <div class="grid grid-cols-3 gap-3">
+                <StatCard
+                    title="Day Streak"
+                    value=streak_display
+                    bar=AccentBar::Gold
+                    tone=StatTone::Accent
+                />
+                <StatCard
+                    title="Hrs This Week"
+                    value=hours_display
+                    bar=AccentBar::Blue
+                    tone=StatTone::WarmAccent
+                />
+                <StatCard
+                    title="Items This Week"
+                    value=items_display
+                    bar=AccentBar::Gold
+                />
+            </div>
 
             // ── Weekly Summary Card ──────────────────────────────
             <Card>
-                <h3 class="card-title">"This Week"</h3>
+                <SectionLabel text="This Week" />
                 <WeekComparisonRow weekly=weekly.clone() />
                 // ── Neglected + Score Changes (2-col on desktop, stacked on mobile)
                 <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -100,7 +127,7 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
 
             // ── US2: Practice History Chart ──────────────────────
             <Card>
-                <h3 class="card-title">"Practice History (28 days)"</h3>
+                <SectionLabel text="Practice History (28 days)" />
                 {if daily_totals.iter().all(|d| d.minutes == 0) {
                     view! {
                         <p class="text-sm text-muted text-center py-8">
@@ -120,7 +147,7 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
 
             // ── US3: Most Practised Items ────────────────────────
             <Card>
-                <h3 class="card-title">"Most Practised"</h3>
+                <SectionLabel text="Most Practised" />
                 {if top_items.is_empty() {
                     view! {
                         <p class="text-sm text-muted text-center py-4">
@@ -173,7 +200,7 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
 
             // ── US4: Score Trends ────────────────────────────────
             <Card>
-                <h3 class="card-title">"Score Trends"</h3>
+                <SectionLabel text="Score Trends" />
                 {if score_trends.is_empty() {
                     view! {
                         <p class="text-sm text-muted text-center py-4">


### PR DESCRIPTION
## Summary

Brings the Analytics dashboard's chrome into the 2026 refresh language. Existing sections (Weekly Summary, Practice History chart, Most Practised, Score Trends) all keep their current data and behaviour — only the framing changes.

## What changes

- **Top stat row** swaps from a single Streak StatCard to three refresh-variant StatCards in a 3-column grid:
  - "Day Streak" — `streak.current_days`, accent purple tone, gold bar
  - "Hrs This Week" — weekly minutes → decimal hours (`"8.5"`, whole hours render as `"5"`), warm gold tone, blue bar
  - "Items This Week" — `weekly.items_covered`, default white, gold bar
- **Section headings** — `h3.card-title` swapped for `SectionLabel` on the four major sections (This Week / Practice History / Most Practised / Score Trends). Uppercase letterspaced label matches Pencil and the new visual language.
- **`.section-label` gains `margin-bottom: 0.75rem`** for use inside block-flow containers (`Card`, etc.) so it spaces correctly without callers remembering an `mt-3`. `DetailGroup`'s flex `gap` supersedes the margin so its layout stays unchanged.

## Out of scope

- Most Practised list rows and Score Trends dot-charts left as-is — they're functional and unique enough that swapping them to AccentRow would lose information. Will revisit during Phase 5 cleanup if it feels inconsistent on the sim.
- Adding a true "Recent Activity" section per Pencil — analytics view doesn't currently carry recent-session data, so out of scope.
- Adding a real "Pieces Learned" cumulative count (Pencil shows "23 Pieces Learned" all-time) — would need new core data; using "Items This Week" as the closest available proxy for now.

## Test plan

- [ ] iOS sim — `/analytics` shows three stat cards in a row at the top with gold/blue/gold bars and accent/warm/default value tones
- [ ] iOS sim — section labels read as uppercase letterspaced ("THIS WEEK", "PRACTICE HISTORY", "MOST PRACTISED", "SCORE TRENDS")
- [ ] iOS sim — empty state still shows "No session data yet" and "Start a Session" link
- [ ] Web ≥sm — same chrome treatment, no broken layouts
- [ ] CI green: existing analytics E2E still finds "This Week", "Streak" (substring of "Day Streak"), and "Most Practised"

🤖 Generated with [Claude Code](https://claude.com/claude-code)