### PR TITLE
feat(design): phase 4 — forms refresh (borderless inputs, uppercase labels, hero submit)

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -250,15 +250,18 @@ body {
 }
 
 /* Form input base — shared styling for text inputs and textareas.
-   Includes focus ring, placeholder color, and consistent sizing. */
+   2026 refresh: borderless, surface-secondary fill, 12px radius, 16px
+   font (suppresses iOS zoom-on-focus), generous 48px min-height. The
+   focus state uses a 2px box-shadow ring instead of changing a border. */
 @utility input-base {
   width: 100%;
-  border-radius: var(--radius-input);
-  border: 1px solid var(--color-border-input);
-  background-color: var(--color-surface-input);
-  padding: 0.625rem 0.75rem; /* py-2.5 px-3 */
-  font-size: 0.875rem; /* text-sm */
-  line-height: 1.25rem;
+  border-radius: 12px;
+  border: 0;
+  background-color: var(--color-surface-secondary);
+  padding: 0.875rem 1rem;     /* 14px / 16px */
+  min-height: 48px;
+  font-size: 1rem;            /* 16px — prevents iOS zoom-on-focus */
+  line-height: 1.5;
   color: var(--color-text-primary);
 
   &::placeholder {
@@ -266,29 +269,27 @@ body {
   }
 
   &:focus {
-    border-color: var(--color-accent-focus);
     outline: none;
-    box-shadow: 0 0 0 1px var(--color-accent-focus);
+    box-shadow: 0 0 0 2px var(--color-accent-focus);
   }
 }
 
-/* Form input error state — coral border + ring for invalid fields
-   (audit #19). */
+/* Form input error state — coral box-shadow ring for invalid fields
+   (audit #19). 2026 refresh inputs are borderless, so the validation
+   state shows as a 2px ring rather than a colour-shift border. */
 @utility input-error {
-  border-color: var(--color-danger-text);
+  box-shadow: 0 0 0 2px var(--color-danger-text);
   &:focus {
-    border-color: var(--color-danger-text);
-    box-shadow: 0 0 0 1px var(--color-danger-text);
+    box-shadow: 0 0 0 2px var(--color-danger-text);
   }
 }
 
-/* Form input success state — green border + ring for validated fields
-   (audit #19). */
+/* Form input success state — green box-shadow ring for validated
+   fields (audit #19). */
 @utility input-success {
-  border-color: var(--color-success-text);
+  box-shadow: 0 0 0 2px var(--color-success-text);
   &:focus {
-    border-color: var(--color-success-text);
-    box-shadow: 0 0 0 1px var(--color-success-text);
+    box-shadow: 0 0 0 2px var(--color-success-text);
   }
 }
 
@@ -640,14 +641,17 @@ body {
   letter-spacing: 0.05em; /* tracking-wider */
 }
 
-/* Form label — block label above inputs. */
+/* Form label — block label above inputs. 2026 refresh: uppercase,
+   letterspaced, smaller, muted — was previously the iOS-only
+   treatment, now universal so web and mobile match Pencil. */
 @utility form-label {
   display: block;
-  font-size: 0.875rem; /* text-sm */
-  line-height: 1.25rem;
-  font-weight: 500; /* font-medium */
-  color: var(--color-text-label);
-  margin-bottom: 0.25rem; /* mb-1 */
+  font-size: 0.75rem;       /* 12px */
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.0625rem; /* 1px */
+  margin-bottom: 0.5rem;     /* 8px */
 }
 
 /* Hint text — helper text below form fields. */
@@ -902,16 +906,6 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   opacity: 0.6;
   transform: scale(0.97);
   transition: opacity 80ms ease-out, transform 80ms ease-out;
-}
-
-/* Tighter form label-input spacing on iOS — desktop's mb-1 (4px) feels
-   stretched on a phone. Form labels get smaller, denser. */
-[data-platform="ios"] .form-label {
-  margin-bottom: 0.125rem;
-  font-size: 0.8125rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--color-text-muted);
 }
 
 /* On iOS, the back link is just a chevron — text label would duplicate

--- a/crates/intrada-web/src/views/add_form.rs
+++ b/crates/intrada-web/src/views/add_form.rs
@@ -8,8 +8,8 @@ use leptos_router::NavigateOptions;
 use intrada_core::{CreateItem, Event, ItemEvent, ItemKind, ViewModel};
 
 use crate::components::{
-    AutocompleteTextField, BackLink, Button, ButtonVariant, Card, PageHeading, TagInput, TextArea,
-    TextField, TypeTabs,
+    AutocompleteTextField, BackLink, Button, ButtonSize, ButtonVariant, Card, PageHeading,
+    TagInput, TextArea, TextField, TypeTabs,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::helpers::{parse_tempo, unique_composers, unique_tags};
@@ -176,16 +176,20 @@ pub fn AddLibraryItemForm(
                         // Tags — chip-based input with autocomplete
                         <TagInput id="add-tags" tags=tags available_tags=all_tags_signal field_name="tags" errors=errors />
 
-                        // Buttons
-                        <div class="flex flex-col sm:flex-row gap-3 pt-2">
+                        // Buttons — hero-size primary (full-width on mobile,
+                        // matches Pencil "Add to Library" CTA) with the
+                        // Cancel as a secondary text-style affordance below.
+                        <div class="flex flex-col gap-3 pt-2">
                             <Button
                                 variant=ButtonVariant::Primary
                                 button_type="submit"
+                                size=ButtonSize::Hero
                                 loading=Signal::derive(move || is_submitting.get())
+                                attr:class="w-full"
                             >
                                 {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
                             </Button>
-                            <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
+                            <Button variant=ButtonVariant::Secondary attr:class="w-full" on_click=Callback::new(move |_| {
                                 if let Some(cb) = dismiss_cancel {
                                     cb.run(());
                                 } else {

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -9,8 +9,8 @@ use leptos_router::NavigateOptions;
 use intrada_core::{Event, ItemEvent, UpdateItem, ViewModel};
 
 use crate::components::{
-    AutocompleteTextField, BackLink, Button, ButtonVariant, Card, PageHeading, SkeletonBlock,
-    SkeletonLine, TagInput, TextArea, TextField, TypeTabs,
+    AutocompleteTextField, BackLink, Button, ButtonSize, ButtonVariant, Card, PageHeading,
+    SkeletonBlock, SkeletonLine, TagInput, TextArea, TextField, TypeTabs,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::helpers::{parse_tempo, parse_tempo_display, unique_composers, unique_tags};
@@ -258,16 +258,19 @@ pub fn EditLibraryItemForm(
                         // Tags — chip-based input with autocomplete
                         <TagInput id="edit-tags" tags=tags available_tags=all_tags_signal field_name="tags" errors=errors />
 
-                        // Buttons
-                        <div class="flex flex-col sm:flex-row gap-3 pt-2">
+                        // Buttons — hero-size primary stacked over a
+                        // full-width secondary Cancel on mobile.
+                        <div class="flex flex-col gap-3 pt-2">
                             <Button
                                 variant=ButtonVariant::Primary
                                 button_type="submit"
+                                size=ButtonSize::Hero
                                 loading=Signal::derive(move || is_submitting.get())
+                                attr:class="w-full"
                             >
                                 {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
                             </Button>
-                            <Button variant=ButtonVariant::Secondary on_click={
+                            <Button variant=ButtonVariant::Secondary attr:class="w-full" on_click={
                                 let cancel_href = cancel_href.clone();
                                 let navigate = navigate.clone();
                                 Callback::new(move |_| {


### PR DESCRIPTION
## Summary

Brings every form input across the app into the 2026 refresh language. Single set of token changes touches Add Library Item, Edit Library Item, RoutineSaveForm inline, RoutineEdit (via `TextField`), and the inline achieved-tempo input on session summary.

## Token-level changes (`input.css`)

- **`.input-base` rebuilt** — border removed, `surface-secondary` fill (white/5), 12px radius, 14/16px padding, 48px min-height, 16px font (suppresses iOS zoom-on-focus). Focus state uses a 2px box-shadow ring instead of changing a border colour.
- **`.input-error` / `.input-success`** swap from `border-color` to matching `box-shadow` rings so the validation state shows through the borderless inputs.
- **`.form-label`** adopts the previous iOS-only treatment universally: 12px uppercase letterspaced muted. Pencil shows TITLE / COMPOSER / DIFFICULTY / TARGET TEMPO / NOTES — labels are now tiny IA cues rather than competing with the input text.
- **`[data-platform="ios"] .form-label` override removed** — redundant.

## View-level changes

- `add_form.rs` and `edit_form.rs` switch their primary Save button to `ButtonSize::Hero` (48px / 16px / weight 600), full-width, with `Cancel` stacked as a secondary below. Matches Pencil's "Add to Library" CTA layout.

## Test plan

- [ ] iOS sim — `/library/new` (Add Item sheet): labels read as uppercase letterspaced, inputs are tall borderless surfaces with 16px text (no keyboard zoom on focus), Save is the full-width hero CTA, Cancel is full-width secondary below
- [ ] iOS sim — focus an input: 2px accent ring appears, no border colour shift
- [ ] iOS sim — trigger a validation error: 2px coral ring appears
- [ ] iOS sim — `/library/:id/edit` (Edit Item sheet): same layout as Add
- [ ] iOS sim — Routine save form (sessions/new → expand "Save as Routine"): inputs adopt new look but Save button stays at default inline size (sub-form, not page CTA)
- [ ] iOS sim — Session summary inline tempo input: borderless input with new look
- [ ] Web ≥sm — same forms, no broken layouts
- [ ] CI green: `add-item.spec.ts`, `edit-item.spec.ts`, `routines.spec.ts` all continue to pass (no selector changes — labels/inputs by id, buttons by name)

## Out of scope

- **DifficultyDots** component — Pencil shows a 5-dot difficulty selector but the data model has no difficulty field. Defer until we add the field in core.
- **TYPE selector restyling** — Pencil shows two large filled buttons; current TypeTabs (sliding underline from #342) is functionally equivalent. Leaving as-is.
- **RoutineSaveForm Save button** stays at default size — small inline sub-form, not a page-level CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)