### PR TITLE
chore(design): phase 5 — drop dead .library-list CSS + spec status update

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1209,56 +1209,6 @@ nav[aria-label="Mobile navigation"] {
   border-radius: 0;
 }
 
-/* Grouped list container — single column, one rounded card wrapping all rows */
-[data-platform="ios"] .library-list {
-  display: block;
-  background-color: var(--color-surface-primary);
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-card);
-  overflow: hidden;
-  backdrop-filter: blur(12px);
-  gap: 0;
-}
-
-/* Each row: strip the individual glass-card, add a bottom separator */
-[data-platform="ios"] .library-list li {
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-  backdrop-filter: none;
-  border-bottom: 1px solid var(--color-border-default);
-}
-
-[data-platform="ios"] .library-list li:last-child {
-  border-bottom: none;
-}
-
-/* Row link: horizontal flex with tight padding + disclosure chevron */
-[data-platform="ios"] .library-list li a {
-  display: flex;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  gap: 0.5rem;
-}
-
-/* Content area fills remaining space */
-[data-platform="ios"] .library-list li a > div {
-  flex: 1;
-  min-width: 0;
-}
-
-/* Disclosure chevron */
-[data-platform="ios"] .library-list li a::after {
-  content: "›";
-  font-size: 1.375rem;
-  line-height: 1;
-  color: var(--color-text-faint);
-  flex-shrink: 0;
-  margin-left: 0.25rem;
-}
-
-
 /* ═══════════════════════════════════════════════════════════════════════
    iOS Detail View (Phase 2b)
    Native iOS styling for the library detail screen — flatter cards,

--- a/specs/design-refresh-2026.md
+++ b/specs/design-refresh-2026.md
@@ -1,6 +1,11 @@
 # Design Refresh 2026
 
-> Status: Plan. No code yet. Last updated 2026-04-29.
+> Status: Phases 0-2, 3a-3e, 4, 5 shipped. Phase 3c (Practice/Active session)
+> deferred pending routing decision. Last updated 2026-05-01.
+>
+> Shipped PRs: #348 (phases 0+1), #349 (phase 2), #350 (3a Routines),
+> #351 (3b Library), #352 (3c PageHeading), #353 (3d Analytics),
+> #354 (3e Detail), #355 (phase 4 Forms), this PR (phase 5 cleanup).
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Closes the visual-rebuild track for the 2026 design refresh.

The Library list switched away from the `.library-list` class in phase 3b (#351) — rows now use `<AccentRow>` via the rebuilt `LibraryItemCard`. The CSS rules in `input.css` that styled the old class on iOS (single rounded card wrapping all rows, hairline separators, disclosure-chevron pseudo-element) are dead weight. **~50 lines gone.**

Spec doc status block updated to reflect what actually shipped: phases 0-2, 3a-3e, 4 are merged on main; this PR closes out phase 5 cleanup; **phase 3c (Practice/Active session rebuild) is deferred** pending the routing decision noted in the original spec.

## Audit findings

Audit confirmed nothing else is dead:
- Every other CSS token in `input.css` is referenced by either a component or another utility
- Catalogue `<h3>` section headings stay — they're TOC anchors, not grouped-content labels
- `"purple cast"` / pre-refresh references in comments are intentional historical context for future maintainers
- `TypeBadge` boxed pattern is still validly used (Add form's type selector)

## Test plan

- [ ] iOS sim — `/library` still renders correctly (no visual regression — the CSS rules removed were already not applied since the class wasn't emitted)
- [ ] CI green

## What's left after this PR

- **Phase 3c — Practice/Active session rebuild** — deferred pending the routing decision (Pencil shows Practice tab as active-session state; today it shows session history)
- **Search filtering on Library** — visual-only today
- **DifficultyDots** — needs core data field first
- **Pre-selecting items** for "Start Practice" from the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)