### PR TITLE
feat(observability): wire Sentry into api, web, and mobile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,10 @@ ALLOWED_ORIGIN=http://localhost:8080,tauri://localhost
 
 # Compile-time API base URL for the web shell (empty = relative, uses Trunk proxy)
 INTRADA_API_URL=
+
+# Sentry APM/error reporting (optional — unset = disabled)
+# - SENTRY_DSN: API server, read at runtime by intrada-api
+# - SENTRY_DSN_MOBILE: Tauri Rust host, baked at compile time (rebuild required to change)
+# Web DSN is inlined in crates/intrada-web/index.html (DSNs are public by Sentry's design).
+# SENTRY_DSN=
+# SENTRY_DSN_MOBILE=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +562,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1555,6 +1579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2884,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,6 +3001,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3049,7 +3119,7 @@ dependencies = [
  "futures-lite",
  "infer",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_qs 0.15.0",
@@ -3099,7 +3169,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3123,6 +3193,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -3145,7 +3216,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -3489,6 +3560,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rsa",
  "rust-s3",
+ "sentry",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3518,6 +3590,7 @@ dependencies = [
 name = "intrada-mobile"
 version = "0.1.0"
 dependencies = [
+ "sentry",
  "serde",
  "serde_json",
  "tauri",
@@ -4546,6 +4619,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,6 +4772,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4814,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4733,6 +4871,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4777,8 +4916,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -4794,6 +4952,15 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4831,6 +4998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,6 +5023,22 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5517,10 +5706,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
@@ -5616,9 +5806,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5898,21 +6088,29 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -6028,6 +6226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6119,11 +6323,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -6144,6 +6360,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.10",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6303,6 +6546,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework-sys"
 version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6366,6 +6622,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ac94aab850a23d7507307cc505332ed2bafd36c65930dfc5c43610f9e9b477"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.2",
+ "rustls 0.23.37",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tower",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b803539b9ec0bde4ad759bf07190f6c24062363d519790ac2552dd5a6b21232"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e09c2dadaaa7b2a6dd5e84650b70bbdba504e318a2059a7ff0b9eedc51ef336"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56de6f8c10ed1b74543b9654b99d3d9a2d876bd5996f3ecd60afdc30ef40ad0e"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382b8f029465d2e2da7ef25bd08110e91817cfe9e2849ac0547359e0ae50f27e"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tower"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83ec6e0890d678b012e901b891f07c73e489cee8dc51b8cbafd50ece3a09ee8"
+dependencies = [
+ "axum 0.8.8",
+ "http 1.4.0",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77782d2a65e141f20020ec59552aaf9449aeea64bd7624e20c114b8474c4a9ee"
+dependencies = [
+ "bitflags 2.11.0",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c69667ff14f47aad798e6be2ad8409e350b3ab0b8d72b338b462ed35f7bcc4"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -7865,7 +8234,7 @@ dependencies = [
  "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -8117,8 +8486,17 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "web-time",
+]
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -8428,6 +8806,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8463,6 +8869,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -8825,6 +9237,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/SETUP.md
+++ b/SETUP.md
@@ -206,7 +206,55 @@ fly logs | grep R2
 R2 is optional locally. Without the env vars, the API starts with photo upload
 disabled. To test photos locally, add the R2 variables to your `.env` file.
 
-## 5. CI/CD Pipeline (GitHub Actions)
+## 5. Sentry (Error reporting + APM)
+
+One Sentry project per surface. DSNs are public (Sentry's security model expects
+them embedded in client code), but the Rust SDK reads them via env vars so
+projects can be swapped without code changes.
+
+### Projects
+
+| Surface | Sentry platform | DSN delivery |
+|---------|----------------|--------------|
+| `intrada-api` | Rust | `SENTRY_DSN` env var (Fly secret) |
+| `intrada-mobile` | Rust | `SENTRY_DSN_MOBILE` env var, baked at compile time via `option_env!` |
+| `intrada-web` | Browser JavaScript | inlined in `crates/intrada-web/index.html` |
+
+Each project tags events with `environment = development | production | ios`
+(determined at runtime), and `release = $GIT_SHA` when set at build time.
+Performance tracing is sampled at 10% (`traces_sample_rate = 0.1`).
+
+### Set the API DSN as a Fly.io secret
+
+```bash
+fly secrets set SENTRY_DSN="https://...@...ingest.de.sentry.io/..." -a intrada-api
+```
+
+The API will pick it up on next deploy. Without it, Sentry init is a no-op.
+
+### Set the mobile DSN locally
+
+Add to your `.env` file at the repo root:
+
+```
+SENTRY_DSN_MOBILE=https://...@...ingest.de.sentry.io/...
+```
+
+`just ios-dev` will pick it up via `set dotenv-load`. Changing the value
+triggers a rebuild thanks to `cargo:rerun-if-env-changed` in `build.rs`.
+
+### Web DSN
+
+The web DSN is inlined in `crates/intrada-web/index.html`. To swap projects,
+edit that file directly. There is no `.env` value for it.
+
+### Verifying
+
+After the next deploy, trigger a test event from each surface (e.g. visit a
+404 route, force a panic in a debug build) and confirm it appears in the
+matching Sentry project's Issues tab.
+
+## 6. CI/CD Pipeline (GitHub Actions)
 
 The single workflow `.github/workflows/ci.yml` handles both CI and deployment:
 
@@ -239,7 +287,7 @@ fly tokens create deploy -a intrada-api
 
 Add the output as the `FLY_API_TOKEN` secret in GitHub Actions.
 
-## 6. Local Development
+## 7. Local Development
 
 ### Prerequisites
 
@@ -332,3 +380,7 @@ Use this when setting up from scratch:
 - [ ] `fly logs | grep R2` shows "R2 photo storage configured"
 - [ ] Frontend deployed to Cloudflare Workers
 - [ ] Frontend CORS requests to API work
+- [ ] Sentry projects created (api, web, mobile)
+- [ ] `SENTRY_DSN` set on Fly.io
+- [ ] Web DSN inlined in `crates/intrada-web/index.html`
+- [ ] Test event sent from each surface, visible in matching Sentry project

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -34,6 +34,10 @@ rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustl
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Sentry: server-side error reporting + APM. Init from SENTRY_DSN env var.
+# rustls (not native-tls) to match the rest of the API stack.
+sentry = { version = "0.48", default-features = false, features = ["backtrace", "contexts", "panic", "tracing", "tower-axum-matched-path", "reqwest", "rustls"] }
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -3,13 +3,39 @@ use intrada_api::migrations;
 use intrada_api::routes;
 use intrada_api::state::{AppState, Db};
 use intrada_api::storage::R2Client;
+use tracing_subscriber::prelude::*;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
+    // Sentry first, so panics + tracing events from startup are captured.
+    // No-op when SENTRY_DSN is unset (local dev without Sentry).
+    let _sentry_guard = std::env::var("SENTRY_DSN").ok().map(|dsn| {
+        sentry::init((
+            dsn,
+            sentry::ClientOptions {
+                release: option_env!("GIT_SHA").map(Into::into),
+                environment: Some(
+                    if cfg!(debug_assertions) {
+                        "development"
+                    } else {
+                        "production"
+                    }
+                    .into(),
+                ),
+                traces_sample_rate: 0.1,
+                send_default_pii: false,
+                ..Default::default()
+            },
+        ))
+    });
+
+    let env_filter =
+        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into());
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(sentry::integrations::tracing::layer())
         .init();
 
     let database_url = std::env::var("TURSO_DATABASE_URL").expect("TURSO_DATABASE_URL must be set");

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod sessions;
 
 use axum::http::{header, HeaderValue, Method};
 use axum::Router;
+use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::Level;
@@ -41,6 +42,11 @@ pub fn api_router(state: AppState) -> Router {
         .nest("/api", api_routes())
         .layer(cors)
         .layer(trace)
+        // Sentry layers: per-request hub + HTTP transaction (route-aware via
+        // the `tower-axum-matched-path` feature). NewSentryLayer must wrap
+        // SentryHttpLayer so each request gets an isolated hub.
+        .layer(SentryHttpLayer::new().enable_transaction())
+        .layer(NewSentryLayer::new_from_top())
         .with_state(state)
 }
 

--- a/crates/intrada-mobile/src-tauri/Cargo.toml
+++ b/crates/intrada-mobile/src-tauri/Cargo.toml
@@ -16,5 +16,10 @@ tauri-plugin-deep-link = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# Sentry: Rust-side panics in the Tauri host. WebView errors are captured
+# separately by the browser SDK loaded in intrada-web/index.html.
+# DSN is baked at compile time via SENTRY_DSN_MOBILE — unset = no init.
+sentry = { version = "0.48", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls"] }
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/crates/intrada-mobile/src-tauri/build.rs
+++ b/crates/intrada-mobile/src-tauri/build.rs
@@ -1,3 +1,7 @@
 fn main() {
+    // Pair with `option_env!` reads in src/lib.rs so changing the env after
+    // a build doesn't yield stale binaries.
+    println!("cargo:rerun-if-env-changed=SENTRY_DSN_MOBILE");
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
     tauri_build::build()
 }

--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -1,8 +1,33 @@
+// SENTRY_DSN_MOBILE is baked at compile time. Pair with the rerun-if-env-changed
+// directive in build.rs so changing the env doesn't yield stale binaries.
+const SENTRY_DSN: Option<&str> = option_env!("SENTRY_DSN_MOBILE");
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Note: data-platform="ios" is set by index.html based on
     // location.protocol === 'tauri:'. Setup-time eval here was racing page
     // load on physical devices and silently failed.
+
+    let _sentry_guard = SENTRY_DSN.filter(|s| !s.is_empty()).map(|dsn| {
+        sentry::init((
+            dsn,
+            sentry::ClientOptions {
+                release: option_env!("GIT_SHA").map(Into::into),
+                environment: Some(
+                    if cfg!(debug_assertions) {
+                        "development"
+                    } else {
+                        "production"
+                    }
+                    .into(),
+                ),
+                traces_sample_rate: 0.1,
+                send_default_pii: false,
+                ..Default::default()
+            },
+        ))
+    });
+
     tauri::Builder::default()
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_deep_link::init())

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -15,19 +15,22 @@
             integrity="sha384-PLfi4Yv8UxpzFBe4XEbS8M1qAx+z/qs3jf7AY1XQorhPeW9SM5VarsX3+Is0NPNf"
             crossorigin="anonymous"></script>
     <script>
-      if (window.Sentry) {
+      // Skip on plain-http localhost (web dev) to match the api/mobile
+      // opt-in pattern and save event quota. iOS production WebView is also
+      // hosted at `tauri://localhost`, so the protocol check matters.
+      (function () {
+        if (!window.Sentry) return;
+        var isWebDev = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+          && location.protocol !== 'tauri:';
+        if (isWebDev) return;
         Sentry.init({
           dsn: "https://2a33748d4de845f26e3711629e47b38f@o4511313186979840.ingest.de.sentry.io/4511313298980944",
-          environment: (function () {
-            if (location.protocol === 'tauri:') return 'ios';
-            if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return 'development';
-            return 'production';
-          })(),
+          environment: location.protocol === 'tauri:' ? 'ios' : 'production',
           tracesSampleRate: 0.1,
           sendDefaultPii: false,
           integrations: [Sentry.browserTracingIntegration()],
         });
-      }
+      })();
     </script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -4,6 +4,32 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Intrada</title>
+
+    <!-- Sentry browser SDK. Loaded synchronously in <head> so it's ready
+         before any other script runs — catches errors from the inline
+         scripts below (data-platform setup, press feedback, Clerk bridge)
+         and from the WASM panic hook. The DSN is public by design (Sentry's
+         security model expects it embedded in client code); environment is
+         tagged at runtime so dev/prod/ios events are filterable in the UI. -->
+    <script src="https://browser.sentry-cdn.com/10.51.0/bundle.tracing.min.js"
+            integrity="sha384-PLfi4Yv8UxpzFBe4XEbS8M1qAx+z/qs3jf7AY1XQorhPeW9SM5VarsX3+Is0NPNf"
+            crossorigin="anonymous"></script>
+    <script>
+      if (window.Sentry) {
+        Sentry.init({
+          dsn: "https://2a33748d4de845f26e3711629e47b38f@o4511313186979840.ingest.de.sentry.io/4511313298980944",
+          environment: (function () {
+            if (location.protocol === 'tauri:') return 'ios';
+            if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') return 'development';
+            return 'production';
+          })(),
+          tracesSampleRate: 0.1,
+          sendDefaultPii: false,
+          integrations: [Sentry.browserTracingIntegration()],
+        });
+      }
+    </script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary

- Sentry error reporting + APM across all three surfaces (api / web / mobile)
- Per-surface DSN: `SENTRY_DSN` runtime env (api, Fly secret), `SENTRY_DSN_MOBILE` `option_env!` (mobile, compile-time bake), inlined in `index.html` (web)
- All three tag `environment` dynamically (`development` | `production` | `ios`) and `release = $GIT_SHA` when set; traces sampled at 10%, no PII

## Implementation notes

- **API**: `sentry` 0.48 with `tower-axum-matched-path` for route-aware transactions + `sentry-tracing` layer forwarding WARN+ events. Init returns a guard held until end of `main()`.
- **Mobile**: same crate, init in `lib.rs` `run()`. `build.rs` declares `cargo:rerun-if-env-changed=SENTRY_DSN_MOBILE` to avoid stale binaries when the env changes.
- **Web**: `@sentry/browser` v10.51.0 loaded with SRI in `<head>` so it's ready before any other script — catches errors from inline scripts (Clerk bridge, press-feedback hook), the WASM panic hook, and runtime exceptions.
- All three init steps are no-ops when their DSN is unset (no breakage for local dev without Sentry).

## What's NOT in this PR

- **Source map / WASM debuginfo upload** — would need a `SENTRY_AUTH_TOKEN` GitHub secret + a CI step. Easy follow-up; without it, web stack traces show minified/wasm-mangled symbols.
- **Tauri TestFlight CI wiring** — iOS workflow is on hold (#300). Mobile DSN is wired locally via `.env` for `just ios-dev`.

## Verification

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo clippy --workspace --exclude intrada-mobile -- -D warnings`
- ✅ `cargo test -p intrada-api` (69 passed)
- ✅ `cargo check -p intrada-mobile`
- ✅ `trunk build` succeeds
- ✅ Live test event from local `trunk serve` POSTed to `ingest.de.sentry.io` returned 200; DOM eval confirmed `Sentry.getClient()` initialised with correct DSN, environment=`development`, tracesSampleRate=0.1

## Post-merge actions for @jonyardley

1. `fly secrets set SENTRY_DSN="<api dsn>" -a intrada-api` — API will pick it up on next deploy
2. (Optional) Add `SENTRY_DSN_MOBILE=...` to local `.env` so `just ios-dev` reports panics from the Tauri host
3. Trigger a test error from each surface in production and confirm it lands in the matching Sentry project

## Test plan

- [ ] CI green (test, clippy, fmt, wasm-build, wasm-test, e2e)
- [ ] After merge + deploy: `fly secrets set SENTRY_DSN=...` then visit a route to trigger any traced request → check `intrada-api` project for transaction
- [ ] Visit prod web app, force a console error, check `intrada-web` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)