### PR TITLE
fix(deploy): runtime base → debian:trixie-slim to match builder glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ RUN cargo chef cook --release --recipe-path recipe.json --bin intrada-api
 COPY . .
 RUN cargo build --release --bin intrada-api
 
-# Runtime image — no Rust toolchain needed
-FROM debian:bookworm-slim AS runtime
+# Runtime image — no Rust toolchain needed.
+# Trixie matches the cargo-chef builder's glibc (binary built against glibc 2.38+
+# crashes on bookworm's 2.36 with `version `GLIBC_2.38' not found`).
+FROM debian:trixie-slim AS runtime
 WORKDIR /app
 # Install CA certificates for HTTPS connections to Turso
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What's broken

Production API has been crash-looping with:

\`\`\`
/usr/local/bin/intrada-api: /lib/x86_64-linux-gnu/libc.so.6:
version \`GLIBC_2.38' not found
\`\`\`

Fly machine has exhausted its 10 restart attempts → API is down.

## Why

The Dockerfile builds in \`lukemathwalker/cargo-chef:latest-rust-1\` (a moving tag) and runs in \`debian:bookworm-slim\` (pinned). The builder image rolled to a trixie-based base (glibc 2.39), but the runtime stayed on bookworm (glibc 2.36). The release binary now demands a glibc symbol the runtime can't provide.

## Fix

One-line change: runtime base → \`debian:trixie-slim\`. CA cert install command is identical on trixie. Trixie has been Debian stable since August 2025, so this also matches current best practice.

## Why trixie over the alternatives

- **Pinning builder to bookworm** (\`latest-rust-1-bookworm\`) — works, but bookworm is now old-stable; this just delays the same problem
- **Static musl build** — sturdier (no glibc at all) but bigger lift; can do later if we want a slimmer/distroless runtime

## Verified

- \`docker build .\` succeeds end-to-end
- \`docker run --rm intrada-api:trixie-test\` panics on \`TURSO_DATABASE_URL must be set\` (i.e. binary loaded past the dynamic linker — no GLIBC error)

## Test plan

- [ ] CI green
- [ ] After merge: \`fly deploy\` (or wait for the deploy-api job to fire) and confirm machine reaches the running state with health check passing
- [ ] Confirm \`/api/sessions\` returns 200 from prod

## Stacks

This unblocks #358 (Sentry wiring) — merge this first so the Sentry deploy lands on a healthy API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)