### PR TITLE
chore(observability): bump Sentry traces_sample_rate to 1.0 (temporary)

### DIFF
--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -22,7 +22,10 @@ async fn main() {
                     }
                     .into(),
                 ),
-                traces_sample_rate: 0.1,
+                // Bumped from 0.1 → 1.0 while traffic is single-digit-user
+                // (just @jonyardley testing). Dial back to 0.1 (or 0.01) once
+                // real traffic arrives — every transaction counts against quota.
+                traces_sample_rate: 1.0,
                 send_default_pii: false,
                 ..Default::default()
             },

--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -21,7 +21,10 @@ pub fn run() {
                     }
                     .into(),
                 ),
-                traces_sample_rate: 0.1,
+                // Mobile host has no auto-instrumented transactions today,
+                // so this is mostly moot — kept aligned with api/web for when
+                // we add manual spans. See main.rs for the rationale.
+                traces_sample_rate: 1.0,
                 send_default_pii: false,
                 ..Default::default()
             },

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -26,7 +26,10 @@
         Sentry.init({
           dsn: "https://2a33748d4de845f26e3711629e47b38f@o4511313186979840.ingest.de.sentry.io/4511313298980944",
           environment: location.protocol === 'tauri:' ? 'ios' : 'production',
-          tracesSampleRate: 0.1,
+          // Bumped from 0.1 → 1.0 while traffic is single-digit-user (just
+          // @jonyardley testing). Dial back to 0.1 (or 0.01) once real
+          // traffic arrives — every transaction counts against quota.
+          tracesSampleRate: 1.0,
           sendDefaultPii: false,
           integrations: [Sentry.browserTracingIntegration()],
         });


### PR DESCRIPTION
## Summary

Temporarily raise \`traces_sample_rate\` from \`0.1\` → \`1.0\` across api / web / mobile so APM data populates Sentry's Insights view while traffic is small.

At 0.1 with only @jonyardley exercising the app, near-zero transactions land — making it look like APM isn't wired (it is).

## When to dial back

Revert to \`0.1\` (or as low as \`0.01\`) once we're past the "is anyone even using this?" phase. Every transaction counts against Sentry quota. A follow-up issue or scheduled cleanup PR is fine.

## Test plan

- [ ] CI green
- [ ] After deploy: visit a few API routes + load the web app, then check **Insights → Backend** (intrada-api) and **Insights → Frontend** (intrada-web) — transactions should appear within a couple of minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)