### PR TITLE
chore(design): polish backlog pass 1 — Routines + icon, Most Practised AccentRow

### DIFF
--- a/crates/intrada-web/src/views/analytics.rs
+++ b/crates/intrada-web/src/views/analytics.rs
@@ -6,7 +6,7 @@ use leptos::prelude::*;
 use leptos_router::components::A;
 
 use crate::components::{
-    AccentBar, Card, EmptyState, Icon, IconName, LineChart, PageHeading, SectionLabel,
+    AccentBar, AccentRow, Card, EmptyState, Icon, IconName, LineChart, PageHeading, SectionLabel,
     SkeletonBlock, StatCard, StatTone,
 };
 use intrada_web::core_bridge::init_core;
@@ -159,8 +159,12 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
                         </p>
                     }.into_any()
                 } else {
+                    // Each row is an AccentRow with bar=None — token
+                    // consistency with the rest of the refresh, but no
+                    // gold/blue stripe (the list is uniform "top items"
+                    // with rank as the differentiator, not type).
                     view! {
-                        <ul class="space-y-2">
+                        <ul class="space-y-2 list-none p-0">
                             {top_items.into_iter().enumerate().map(|(i, item)| {
                                 let hours = item.total_minutes / 60;
                                 let mins = item.total_minutes % 60;
@@ -170,26 +174,28 @@ fn AnalyticsDashboard(analytics: AnalyticsView) -> impl IntoView {
                                     format!("{}m", mins)
                                 };
                                 view! {
-                                    <li class="flex items-center justify-between py-1.5 border-b border-border-default/50 last:border-0">
-                                        <div class="flex items-center gap-2 min-w-0">
-                                            <span class="text-xs text-faint w-5 text-right shrink-0">
+                                    <li>
+                                        <AccentRow bar=AccentBar::None>
+                                            <span class="text-xs font-medium text-faint w-5 text-right shrink-0 tabular-nums">
                                                 {format!("{}.", i + 1)}
                                             </span>
-                                            <span class="text-sm text-primary truncate">
-                                                {item.item_title.clone()}
-                                            </span>
-                                            <span class="text-xs text-faint shrink-0">
-                                                {item.item_type.to_string()}
-                                            </span>
-                                        </div>
-                                        <div class="flex items-center gap-3 shrink-0 ml-2">
-                                            <span class="text-xs text-muted">
-                                                {format!("{} sessions", item.session_count)}
-                                            </span>
-                                            <span class="text-sm font-medium text-accent-text">
+                                            <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                                                <span class="text-sm font-semibold text-primary truncate">
+                                                    {item.item_title.clone()}
+                                                </span>
+                                                <span class="text-xs text-muted">
+                                                    {format!(
+                                                        "{} \u{00B7} {} session{}",
+                                                        item.item_type,
+                                                        item.session_count,
+                                                        if item.session_count == 1 { "" } else { "s" }
+                                                    )}
+                                                </span>
+                                            </div>
+                                            <span class="text-sm font-medium text-accent-text shrink-0 tabular-nums">
                                                 {time}
                                             </span>
-                                        </div>
+                                        </AccentRow>
                                     </li>
                                 }
                             }).collect::<Vec<_>>()}

--- a/crates/intrada-web/src/views/routines.rs
+++ b/crates/intrada-web/src/views/routines.rs
@@ -20,7 +20,24 @@ pub fn RoutinesListView() -> impl IntoView {
 
     view! {
         <div>
-            <PageHeading text="Routines" subtitle="Save and reuse your favourite practice structures." />
+            <PageHeading
+                text="Routines"
+                subtitle="Save and reuse your favourite practice structures."
+                trailing=Box::new(move || view! {
+                    // Trailing + action mirrors the Library page heading.
+                    // Navigates to the session builder (where routines are
+                    // born — see the Save-as-Routine flow). On iOS the
+                    // cta-link--page-add modifier collapses to icon-only.
+                    <A
+                        href="/sessions/new"
+                        attr:class="cta-link cta-link--page-add shrink-0"
+                        attr:aria-label="New Routine"
+                    >
+                        <Icon name=IconName::Plus class="cta-link-icon" />
+                        <span class="cta-link-label">"New Routine"</span>
+                    </A>
+                }.into_any())
+            />
 
             {move || {
                 if is_loading.get() {


### PR DESCRIPTION
First pass on the design-refresh polish backlog (#374). Two atomic visual items, no behaviour changes.

## Changes

**Routines page header gets the \`+\` icon** — mirrors Library's \`cta-link--page-add\` pattern. On iOS the modifier collapses the pill to icon-only; on web it shows "New Routine" as a labelled pill. Links to \`/sessions/new\` (same target as the empty-state CTA and the inline "Create New Routine" link below the list — three entry points serving different reading patterns).

**Analytics Most Practised list → AccentRow** — each top-item row swaps from the bordered \`<li>\` pattern to \`AccentRow\` with \`bar=None\` for token consistency. Rank number on the left (tabular-nums), title + type/session-count meta line in the middle, total time on the right. Uses the surface-faint chrome and 10px radius like the rest of the AccentRow surfaces.

## Skipped

The third checklist item in #374 (Forms TYPE selector restyle) turned out to be a non-issue — \`TypeTabs\` already renders as a filled segmented pill with accent on active; the polish backlog description had it wrong. No code change needed.

## Test plan

- [ ] iOS sim — \`/routines\`: \`+\` icon visible top-right of the page heading; tapping navigates to \`/sessions/new\`
- [ ] iOS sim — \`/analytics\`: Most Practised rows render as AccentRows (60px tall, no bar, surface-faint chrome) with rank + title + meta + time layout
- [ ] Web ≥sm — Routines header shows "New Routine" pill (not icon-only); same Most Practised rendering
- [ ] CI green

Closes part of #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)