### PR TITLE
fix(api): background DB heartbeat + quiet duplicate Sentry event

### DIFF
--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -106,7 +106,18 @@ async fn main() {
         }
     };
 
-    let state = AppState::new(Db::new(db, conn), allowed_origin, auth_config, r2);
+    let shared_db = Db::new(db, conn);
+
+    // Background liveness probe. Keeps the shared libsql session warm so
+    // Turso's silent idle-rot (machine suspend / network blip / idle
+    // timeout) doesn't surface as a 5xx on the next user request.
+    // Companion to `/health`'s on-demand reconnect (#290) — heartbeat
+    // catches rot before a probe lands; per-request retry (#291, still
+    // open) is the belt-and-suspenders for the narrow window between
+    // heartbeat ticks.
+    shared_db.spawn_heartbeat();
+
+    let state = AppState::new(shared_db, allowed_origin, auth_config, r2);
     let router = routes::api_router(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "3001".to_string());

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -8,7 +8,7 @@ use axum::http::{header, HeaderValue, Method};
 use axum::Router;
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 
 use crate::state::AppState;
@@ -36,7 +36,14 @@ pub fn api_router(state: AppState) -> Router {
 
     let trace = TraceLayer::new_for_http()
         .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
-        .on_response(DefaultOnResponse::new().level(Level::INFO));
+        .on_response(DefaultOnResponse::new().level(Level::INFO))
+        // Lower the on_failure event (default ERROR → WARN). Without this,
+        // every 5xx generates a generic `tracing::error!("response failed")`
+        // alongside the actual handler error from `error.rs`, which Sentry
+        // captures as a separate, content-free issue. WARN keeps the log
+        // line for local visibility but doesn't trip Sentry's default
+        // ERROR-only event capture.
+        .on_failure(DefaultOnFailure::new().level(Level::WARN));
 
     Router::new()
         .nest("/api", api_routes())

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -1,10 +1,19 @@
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use libsql::{Connection, Database};
 
 use crate::auth::AuthConfig;
 use crate::error::ApiError;
 use crate::storage::R2Client;
+
+/// Heartbeat interval for the background liveness probe.
+///
+/// Turso's hosted libsql sessions silently rot on idle (timeout exact
+/// value undocumented; we've seen rot well under 5 minutes after
+/// machine suspend). Pinging every 30s keeps the session warm so a
+/// real user request rarely lands on a dead connection.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Shared, self-healing database handle.
 ///
@@ -42,6 +51,45 @@ impl Db {
         let fresh = self.db.connect()?;
         *self.conn.write().expect("db connection lock poisoned") = fresh.clone();
         Ok(fresh)
+    }
+
+    /// Spawn a background task that pings the connection every
+    /// `HEARTBEAT_INTERVAL` and reconnects on failure. Runs for the
+    /// lifetime of the tokio runtime — no shutdown signal is needed
+    /// today (the task dies with the runtime). Caller doesn't need to
+    /// hold the returned `JoinHandle` unless they want explicit cancel.
+    pub fn spawn_heartbeat(&self) -> tokio::task::JoinHandle<()> {
+        let db = self.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+            // Skip the first tick — `tokio::time::interval` fires
+            // immediately by default, but startup already proved the
+            // connection works.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                if db.conn().query("SELECT 1", ()).await.is_ok() {
+                    continue;
+                }
+                tracing::warn!("DB heartbeat failed; reconnecting");
+                match db.reconnect() {
+                    Ok(fresh) => match fresh.query("SELECT 1", ()).await {
+                        Ok(_) => tracing::info!("DB heartbeat reconnect succeeded"),
+                        // WARN not ERROR — the next interval will retry,
+                        // and a real user request hitting this in the
+                        // window will surface a proper error itself.
+                        // Logging at ERROR here would double-fire Sentry
+                        // for the same incident.
+                        Err(err) => {
+                            tracing::warn!(?err, "DB heartbeat: query failing after reconnect")
+                        }
+                    },
+                    Err(err) => {
+                        tracing::warn!(?err, "DB heartbeat: failed to rebuild connection")
+                    }
+                }
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Production Sentry caught two issues from the same incident:
- **#384 / INTRADA-API-36** — \`Internal error: Hrana: stream not found\` (a libsql session rotted; surfaced by \`error.rs:20\`)
- **#383 / INTRADA-API-1** — \`response failed\` (the same 5xx, captured separately by \`tower-http\`'s \`TraceLayer\` default \`on_failure\`)

Two changes:

### 1. Background DB heartbeat task (closes #292)

\`Db::spawn_heartbeat\` fires every 30s, runs \`SELECT 1\`, calls \`Db::reconnect()\` on failure. Catches stream rot before a real user request lands on it. Skips the first interval tick (startup already proved the connection works). Reconnect-failure logs at WARN, not ERROR — a heartbeat-only recovery shouldn't trip Sentry; a user request hitting the same problem will produce its own ERROR via the existing path.

### 2. \`TraceLayer.on_failure\` level → WARN

Was ERROR by default. Without this, every 5xx generates the generic \"response failed\" event alongside the actual handler error, doubling Sentry's issue count for one incident. WARN keeps the local log line for visibility but stops Sentry's default ERROR-only capture from firing on it.

## What's still open

#291 (per-request retry helper) is the belt-and-suspenders companion for the narrow window between heartbeat ticks. Left open — will revisit if Sentry shows rot escaping the heartbeat.

## Test plan

- [x] \`cargo build -p intrada-api\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test -p intrada-api\` (69 passed)
- [x] \`cargo fmt --check\` clean
- [ ] Verify in production: heartbeat ticks visible in Fly logs every 30s; Sentry stops getting paired \`response failed\` + actual-error issues for the same incident
- [ ] Watch Sentry for ~24h after deploy — both issues should stop recurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)