### PR TITLE
fix(web): stop WeekStrip dragging on mouse hover

### DIFF
--- a/crates/intrada-web/src/components/week_strip.rs
+++ b/crates/intrada-web/src/components/week_strip.rs
@@ -199,6 +199,13 @@ pub fn WeekStrip(
     };
 
     let handle_pointer_move = move |ev: PointerEvent| {
+        // On desktop, pointermove fires on hover (no button pressed). Without
+        // this guard, hovering across the strip would translate the track —
+        // the bug users described as "the mouse catches the calendar slider".
+        // Touch is unaffected: touch pointermove only fires while pressed.
+        if ev.buttons() == 0 {
+            return;
+        }
         if snap_target.get_untracked() != 0 || gesture_abandoned.get_untracked() {
             return;
         }


### PR DESCRIPTION
## Summary
- On desktop, `pointermove` fires on hover (buttons not pressed). The handler had no "is the pointer down" guard, so hovering across the strip computed a large delta from stale start coords, committed a gesture, and translated the track — the "mouse catches the slider" behaviour Jon flagged after #380.
- Fix: early-return when `ev.buttons() == 0`. Touch isn't affected (touch `pointermove` only fires while pressed).
- Chevron `< >` buttons already exist on desktop; no UI change needed.

## Test plan
- [x] Verified in dev preview: synthetic `pointermove` with `buttons: 0` leaves the transform unchanged
- [x] Verified click+drag still works: `pointerdown` (buttons=1) + `pointermove` produces `translateX(calc(-33.333% + 80px))` and snaps correctly on release
- [x] `cargo fmt --check` + `cargo clippy -p intrada-web --target wasm32-unknown-unknown -- -D warnings` clean
- [ ] Manual smoke on desktop browser
- [ ] Manual smoke on iPhone (touch path, regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)