### PR TITLE
feat(web): add clear button to library search

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -650,11 +650,38 @@ body {
 .search-bar-input::placeholder {
   color: var(--color-text-muted);
 }
-/* Hide WebKit's built-in search input X — we'll build a proper clear
-   affordance when the search logic actually lands. */
+/* Hide WebKit's built-in search input X — we render our own .search-bar-clear
+   button so it works consistently across browsers and styles to the design. */
 .search-bar-input::-webkit-search-cancel-button {
   -webkit-appearance: none;
   appearance: none;
+}
+
+/* Clear (×) button rendered to the right of .search-bar-input when the
+   query is non-empty. Same visual language as .input-clear but sized to
+   sit inside the .search-bar's 44px row without crowding. */
+.search-bar-clear {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-surface-hover);
+  color: var(--color-text-secondary);
+  border: none;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.search-bar-clear:hover {
+  background: var(--color-text-muted);
+  color: var(--color-text-primary);
+}
+.search-bar-clear:active {
+  transform: scale(0.92);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -148,6 +148,23 @@ pub fn LibraryListView() -> impl IntoView {
                         }
                     }
                 />
+                <Show when=move || !query.get().is_empty()>
+                    <button
+                        type="button"
+                        class="search-bar-clear"
+                        aria-label="Clear search"
+                        // mousedown fires before the input loses focus, so we
+                        // can clear without blurring (which would hide the
+                        // clear button before our click fires on iOS).
+                        on:mousedown=move |ev| {
+                            ev.prevent_default();
+                            query.set(String::new());
+                        }
+                        on:touchstart=move |_| query.set(String::new())
+                    >
+                        "×"
+                    </button>
+                </Show>
             </div>
 
             // Type tabs — All / Pieces / Exercises. Underline-style with a


### PR DESCRIPTION
## Summary
- Library search bar (`crates/intrada-web/src/views/library_list.rs`) had no clear affordance. The CSS comment noted *"we'll build a proper clear affordance when the search logic actually lands"* — search landed in #380, so this fills the gap.
- Adds a × button on the right when the query is non-empty, mirroring the existing TextField clear pattern (mousedown + touchstart, `prevent_default` to avoid blurring the input on iOS, which would hide the button before our click fired).
- New `.search-bar-clear` CSS sized to fit the 44px search row.

## Out of scope (intentionally)
- **Autocomplete** uses different markup (Tailwind classes directly, no `.input-wrapper`) and warrants a separate refactor — happy to follow up.
- **TextArea** — multi-line clear is rarely useful, skipped.

## Test plan
- [x] Confirmed via runtime DOM inspection: empty state has no clear; typing makes it appear with `aria-label="Clear search"`; mousedown clears the value and hides the button
- [x] `cargo fmt --check` + `cargo clippy -p intrada-web --target wasm32-unknown-unknown -- -D warnings` clean
- [ ] Manual smoke on desktop browser
- [ ] Manual smoke on iPhone (touchstart path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)