### PR TITLE
refactor(web): rework session summary to match Pencil design

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -699,13 +699,14 @@ body {
   justify-content: center;
 }
 
-/* Sticky toolbar pinned to the bottom of the viewport with safe-area
-   padding so it never sits under the iOS home indicator. The page
-   itself reserves space via `pb-32` on the builder root, so the
-   toolbar overlays the page bottom without occluding the last row.
+/* Sticky bottom action bar — shared chrome between the session builder
+   ("Tap items… / Review session"), the session summary ("Save Session /
+   Discard"), and any future surface that needs a persistent footer
+   action. The page reserves space via `pb-32` (or similar) on its root
+   so the bar overlays the bottom edge without occluding content.
    On mobile we sit *above* the global BottomTabBar (h-16 = 64px).
    On sm+ the tab bar is hidden, so we drop back to bottom: 0. */
-.builder-toolbar {
+.action-bar {
   position: fixed;
   left: 0;
   right: 0;
@@ -721,7 +722,7 @@ body {
   border-top: 1px solid var(--color-border-default);
 }
 @media (min-width: 640px) {
-  .builder-toolbar {
+  .action-bar {
     bottom: 0;
   }
 }

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -3,7 +3,9 @@ use leptos::prelude::*;
 use intrada_core::{CompletionStatus, EntryStatus, Event, RoutineEvent, SessionEvent, ViewModel};
 use intrada_web::validation::validate_achieved_tempo_input;
 
-use crate::components::{Button, ButtonVariant, Card, Icon, IconName, RoutineSaveForm};
+use crate::components::{
+    AccentBar, Button, ButtonVariant, Icon, IconName, RoutineSaveForm, StatCard, StatTone,
+};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
@@ -26,7 +28,9 @@ pub fn SessionSummary() -> impl IntoView {
     let core_session_notes_outer = core;
 
     view! {
-        <div class="space-y-6">
+        // pb-32 reserves space for the sticky .action-bar at the bottom so
+        // the last section (Save-as-Routine button) isn't occluded.
+        <div class="space-y-6 pb-32">
             {move || {
                 let vm = view_model.get();
                 match vm.summary {
@@ -42,31 +46,73 @@ pub fn SessionSummary() -> impl IntoView {
                         let session_intention = summary.session_intention.clone();
                         let entries = summary.entries.clone();
 
-                        view! {
-                            // Summary header
-                            <Card>
-                                <div class="text-center space-y-2">
-                                    <h2 class="page-title">"Session Complete!"</h2>
-                                    <p class="text-lg text-secondary">
-                                        {format!("Total: {}", total_duration)}
-                                    </p>
-                                    {if completion_status == CompletionStatus::EndedEarly {
-                                        Some(view! {
-                                            <span class="badge badge--warning">"Ended Early"</span>
-                                        })
-                                    } else {
-                                        None
-                                    }}
-                                    {session_intention.map(|intention| view! {
-                                        <p class="text-sm text-secondary italic">{intention}</p>
-                                    })}
-                                </div>
-                            </Card>
+                        // Stat row figures: items practiced (any non-NotAttempted)
+                        // and average confidence across scored entries.
+                        let items_practiced = entries
+                            .iter()
+                            .filter(|e| e.status != EntryStatus::NotAttempted)
+                            .count();
+                        let scored: Vec<u8> = entries
+                            .iter()
+                            .filter_map(|e| e.score)
+                            .collect();
+                        let avg_score_display = if scored.is_empty() {
+                            "—".to_string()
+                        } else {
+                            let sum: u32 = scored.iter().map(|s| *s as u32).sum();
+                            let avg = sum as f64 / scored.len() as f64;
+                            format!("{avg:.1}")
+                        };
 
-                            // Entries breakdown
-                            <Card>
+                        view! {
+                            // Hero header — flat, no Card chrome (matches the
+                            // builder / review-sheet vocabulary). page-title
+                            // for the celebratory beat, subtitle for context.
+                            <div class="text-center space-y-2">
+                                <h2 class="page-title">"Session Complete"</h2>
+                                <p class="text-sm text-secondary">
+                                    "Great work! Review your session below."
+                                </p>
+                                {if completion_status == CompletionStatus::EndedEarly {
+                                    Some(view! {
+                                        <span class="badge badge--warning">"Ended Early"</span>
+                                    })
+                                } else {
+                                    None
+                                }}
+                                {session_intention.map(|intention| view! {
+                                    <p class="text-sm text-secondary italic">{intention}</p>
+                                })}
+                            </div>
+
+                            // Stat row — Duration / Items Practiced / Avg
+                            // Confidence. Uses the StatCard refresh variant
+                            // with inset accent bars per Pencil.
+                            <div class="grid grid-cols-3 gap-3">
+                                <StatCard
+                                    title="Duration"
+                                    value=total_duration
+                                    bar=AccentBar::Gold
+                                />
+                                <StatCard
+                                    title="Items"
+                                    value=items_practiced.to_string()
+                                    bar=AccentBar::Blue
+                                    tone=StatTone::Accent
+                                />
+                                <StatCard
+                                    title="Avg"
+                                    value=avg_score_display
+                                    subtitle="out of 5"
+                                    bar=AccentBar::Gold
+                                    tone=StatTone::WarmAccent
+                                />
+                            </div>
+
+                            // Items practiced — flat section with header,
+                            // each entry is its own surface-secondary card.
+                            <div class="space-y-3">
                                 <h3 class="section-title">"Items Practiced"</h3>
-                                <div class="space-y-3">
                                     {entries.into_iter().map(|entry| {
                                         let entry_id = entry.id.clone();
                                         let entry_id_for_score = entry.id.clone();
@@ -255,11 +301,10 @@ pub fn SessionSummary() -> impl IntoView {
                                             </div>
                                         }
                                     }).collect::<Vec<_>>()}
-                                </div>
-                            </Card>
+                            </div>
 
-                            // Practice notes
-                            <Card>
+                            // Session Notes — flat, no Card chrome.
+                            <div class="space-y-3">
                                 <h3 class="section-title">"Session Notes"</h3>
                                 <textarea
                                     rows="3"
@@ -275,9 +320,11 @@ pub fn SessionSummary() -> impl IntoView {
                                         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                                     }
                                 />
-                            </Card>
+                            </div>
 
-                            // Save as Routine
+                            // Save as Routine — kept in place for now;
+                            // re-evaluate position when the routines flow
+                            // is reworked (see #390).
                             {
                                 let core_save_routine = core_routine_save.clone();
                                 view! {
@@ -290,27 +337,6 @@ pub fn SessionSummary() -> impl IntoView {
                                 }
                             }
 
-                            // Actions
-                            <div class="flex gap-3">
-                                <Button variant=ButtonVariant::Primary on_click=Callback::new(move |_| {
-                                    let now = chrono::Utc::now();
-                                    let event = Event::Session(SessionEvent::SaveSession { now });
-                                    let core_ref = core_save.borrow();
-                                    let effects = core_ref.process_event(event);
-                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                })>
-                                    "Save Session"
-                                </Button>
-                                <Button variant=ButtonVariant::DangerOutline on_click=Callback::new(move |_| {
-                                    let event = Event::Session(SessionEvent::DiscardSession);
-                                    let core_ref = core_discard.borrow();
-                                    let effects = core_ref.process_event(event);
-                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                })>
-                                    "Discard"
-                                </Button>
-                            </div>
-
                             // Error display
                             {move || {
                                 let vm = view_model.get();
@@ -320,6 +346,39 @@ pub fn SessionSummary() -> impl IntoView {
                                     }
                                 })
                             }}
+
+                            // Sticky bottom action bar — Save Session
+                            // (primary, fills) + Discard (danger outline,
+                            // sized to its label). Same chrome as the
+                            // builder toolbar (.action-bar utility).
+                            <div class="action-bar" role="toolbar" aria-label="Session actions">
+                                <div class="flex-1">
+                                    <Button
+                                        variant=ButtonVariant::Primary
+                                        full_width=true
+                                        on_click=Callback::new(move |_| {
+                                            let now = chrono::Utc::now();
+                                            let event = Event::Session(SessionEvent::SaveSession { now });
+                                            let core_ref = core_save.borrow();
+                                            let effects = core_ref.process_event(event);
+                                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                        })
+                                    >
+                                        "Save Session"
+                                    </Button>
+                                </div>
+                                <Button
+                                    variant=ButtonVariant::DangerOutline
+                                    on_click=Callback::new(move |_| {
+                                        let event = Event::Session(SessionEvent::DiscardSession);
+                                        let core_ref = core_discard.borrow();
+                                        let effects = core_ref.process_event(event);
+                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                    })
+                                >
+                                    "Discard"
+                                </Button>
+                            </div>
                         }.into_any()
                     }
                     None => {

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -205,7 +205,7 @@ pub fn SetlistBuilder() -> impl IntoView {
         // Sticky bottom toolbar — count + duration + Review CTA.
         // Tappable area extends across the count column so the user can
         // also expand the sheet by tapping the summary text.
-        <div class="builder-toolbar" role="toolbar" aria-label="Setlist summary">
+        <div class="action-bar" role="toolbar" aria-label="Setlist summary">
             <button
                 type="button"
                 class="builder-toolbar-summary"

--- a/crates/intrada-web/src/views/session_summary.rs
+++ b/crates/intrada-web/src/views/session_summary.rs
@@ -4,7 +4,7 @@ use leptos_router::NavigateOptions;
 
 use intrada_core::{SessionStatusView, ViewModel};
 
-use crate::components::{PageHeading, SessionSummary};
+use crate::components::SessionSummary;
 
 /// Session summary view: wraps SessionSummary, redirects after save/discard.
 #[component]
@@ -40,10 +40,8 @@ pub fn SessionSummaryView() -> impl IntoView {
         }
     });
 
-    view! {
-        <div>
-            <PageHeading text="Session Summary" />
-            <SessionSummary />
-        </div>
-    }
+    // No <PageHeading> wrapper here — the SessionSummary component renders
+    // its own "Session Complete" hero header (Pencil intent: a single
+    // celebratory anchor rather than a generic page title above it).
+    view! { <SessionSummary /> }
 }

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -60,7 +60,7 @@ test.describe("sessions page", () => {
     await page.getByRole("button", { name: "Finish Session" }).click();
 
     // Should be on the summary page
-    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Session Complete")).toBeVisible();
 
     // Save the session
     await page.getByRole("button", { name: "Save Session" }).click();
@@ -102,7 +102,7 @@ test.describe("sessions page", () => {
     await page.getByRole("button", { name: "Finish Session" }).click();
 
     // Summary should show both items
-    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Session Complete")).toBeVisible();
     await expect(page.getByText("Items Practiced")).toBeVisible();
   });
 
@@ -160,7 +160,7 @@ test.describe("sessions page", () => {
     await page.getByRole("button", { name: "Finish Session" }).click();
 
     // Summary
-    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Session Complete")).toBeVisible();
 
     // Save
     await page.getByRole("button", { name: "Save Session" }).click();
@@ -192,7 +192,7 @@ test.describe("sessions page", () => {
     await page.getByRole("button", { name: "End Early" }).click();
 
     // Should see summary with "Ended Early" indicator
-    await expect(page.getByText("Session Complete!")).toBeVisible();
+    await expect(page.getByText("Session Complete")).toBeVisible();
     await expect(page.getByText("Ended Early")).toBeVisible();
   });
 });


### PR DESCRIPTION
Rebuilds the session summary screen against Pencil frame \`kOorB\` (Mobile / Session Summary). Replaces the chrome-heavy nested-Card stack the user flagged earlier with the flat layout Pencil intends.

## Before / after (visual)

**Before**: stacked `<Card>` wrappers around Header / Items Practiced / Session Notes, redundant \"Session Summary\" page heading above \"Session Complete!\", inline Save/Discard buttons mid-page.

**After**: single hero anchor (\"Session Complete\" — no exclamation per Pencil), subtitle, 3-stat row across the top, flat section headers, sticky bottom action bar.

## What changed

- **Hero**: \"Session Complete\" + \"Great work! Review your session below.\" (no Card wrapper).
- **Stat row**: Duration / Items practiced / Avg confidence — uses StatCard refresh variant with inset accent bars. Avg is computed from completed entries that have a score; \"—\" when none.
- **Items Practiced + Session Notes**: flat sections, no Card wrappers. Each per-entry block keeps its surface-secondary tile (Pencil shows it that way — the controls inside read as grouped).
- **Sticky action bar**: Save Session (primary, fills) + Discard (danger outline) at the bottom, sits above the BottomTabBar on mobile, drops to bottom: 0 on sm+.
- **Drop the redundant `<PageHeading text=\"Session Summary\">`** from the view wrapper — Pencil shows a single celebratory anchor.

## CSS: rename `.builder-toolbar` → `.action-bar`

Both the session builder and the summary now use the same chrome — same fixed positioning, blur, safe-area, mobile/desktop offset behaviour. Renamed the utility to reflect the broader role. Builder-specific classes (`.builder-toolbar-summary*`) keep their names.

Per CLAUDE.md: extend, don't clone.

## E2E

Four assertions updated from `\"Session Complete!\"` to `\"Session Complete\"` to match the new copy. Otherwise unchanged.

## Out of scope

\"Save as Routine\" stays in place for now — Pencil doesn't show it on this screen, but moving it touches the routines flow which has its own follow-up issue (#390).

## Test plan

- [x] cargo fmt + clippy clean
- [x] e2e: 25 pass, 2 intentionally skipped
- [x] Visual snapshot vs Pencil frame `kOorB` — aligned
- [ ] Manual smoke on iOS device (sticky bar above safe area + tab bar; stat row reads at iOS scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)