### PR TITLE
feat(web): Add/Edit Item sheets — Mail-compose nav pattern

### DIFF
--- a/crates/intrada-web/src/views/add_form.rs
+++ b/crates/intrada-web/src/views/add_form.rs
@@ -27,6 +27,13 @@ pub fn AddLibraryItemForm(
     /// `in_sheet` is true; ignored otherwise (route mode navigates instead).
     #[prop(optional, into)]
     on_dismiss: Option<Callback<()>>,
+    /// Optional ref to the underlying `<form>` element. The sheet that owns
+    /// this form passes one in so its nav-bar Save action can trigger
+    /// `requestSubmit()` — the form's existing `on:submit` handler then
+    /// runs validation + dispatch. The bottom in-form button still works
+    /// the same; this just adds a second trigger.
+    #[prop(optional, into)]
+    form_ref: Option<NodeRef<leptos::html::Form>>,
 ) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
@@ -57,8 +64,14 @@ pub fn AddLibraryItemForm(
     let dismiss_save = on_dismiss;
     let dismiss_cancel = on_dismiss;
 
+    // Allow either an externally-passed form ref (sheet mode, so the
+    // sheet's nav Save can trigger requestSubmit) or our own internal one
+    // for route mode.
+    let form_ref = form_ref.unwrap_or_default();
+
     let form_body = view! {
         <form
+            node_ref=form_ref
             class="space-y-4"
             on:submit=move |ev: ev::SubmitEvent| {
                 ev.prevent_default();
@@ -176,10 +189,12 @@ pub fn AddLibraryItemForm(
                         // Tags — chip-based input with autocomplete
                         <TagInput id="add-tags" tags=tags available_tags=all_tags_signal field_name="tags" errors=errors />
 
-                        // Buttons — hero-size primary (full-width on mobile,
-                        // matches Pencil "Add to Library" CTA) with the
-                        // Cancel as a secondary text-style affordance below.
-                        <div class="flex flex-col gap-3 pt-2">
+                        // Hero-size primary CTA — Pencil "Add piece" frame
+                        // (MFuDt) shows this as the sticky bottom action.
+                        // The sheet's nav-bar Save provides a second submit
+                        // trigger that calls requestSubmit() on the form.
+                        // No bottom Cancel — sheet's nav Cancel handles it.
+                        <div class="flex flex-col pt-2">
                             <Button
                                 variant=ButtonVariant::Primary
                                 button_type="submit"
@@ -187,15 +202,22 @@ pub fn AddLibraryItemForm(
                                 full_width=true
                                 loading=Signal::derive(move || is_submitting.get())
                             >
-                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
+                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Add to Library" }}
                             </Button>
-                            <Button variant=ButtonVariant::Secondary full_width=true on_click=Callback::new(move |_| {
-                                if let Some(cb) = dismiss_cancel {
-                                    cb.run(());
-                                } else {
-                                    navigate_cancel("/", NavigateOptions::default());
-                                }
-                            })>"Cancel"</Button>
+                            // Sheet mode: nav Cancel handles dismiss. Route
+                            // mode: keep the explicit Cancel so the user has
+                            // a way back without browser-back.
+                            {(!in_sheet).then(|| view! {
+                                <div class="mt-3">
+                                    <Button variant=ButtonVariant::Secondary full_width=true on_click=Callback::new(move |_| {
+                                        if let Some(cb) = dismiss_cancel {
+                                            cb.run(());
+                                        } else {
+                                            navigate_cancel("/", NavigateOptions::default());
+                                        }
+                                    })>"Cancel"</Button>
+                                </div>
+                            })}
                         </div>
                     </div>
                 </form>

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -285,17 +285,36 @@ pub fn DetailView() -> impl IntoView {
                             "Delete"
                         </Button>
 
-                        <BottomSheet
-                            open=edit_sheet_open
-                            on_close=close_edit_sheet
-                            nav_title="Edit Item".to_string()
-                        >
-                            <EditLibraryItemForm
-                                item_id=item_id.clone()
-                                in_sheet=true
-                                on_dismiss=close_edit_sheet
-                            />
-                        </BottomSheet>
+                        // Edit sheet — Mail-compose nav pattern (Cancel
+                        // | Edit Item | Save). Save triggers the form's
+                        // submit via the shared form ref; the bottom
+                        // "Save Changes" CTA in the form does the same.
+                        {
+                            let edit_form_ref = NodeRef::<leptos::html::Form>::new();
+                            let on_save_edit = Callback::new(move |_| {
+                                if let Some(form) = edit_form_ref.get() {
+                                    let _ = form.request_submit();
+                                }
+                            });
+                            let submitting_signal = Signal::derive(move || is_submitting.get());
+                            view! {
+                                <BottomSheet
+                                    open=edit_sheet_open
+                                    on_close=close_edit_sheet
+                                    nav_title="Edit Item".to_string()
+                                    nav_action_label="Save".to_string()
+                                    on_nav_action=on_save_edit
+                                    nav_action_disabled=submitting_signal
+                                >
+                                    <EditLibraryItemForm
+                                        item_id=item_id.clone()
+                                        in_sheet=true
+                                        on_dismiss=close_edit_sheet
+                                        form_ref=edit_form_ref
+                                    />
+                                </BottomSheet>
+                            }
+                        }
                     }.into_any()
                 } else if is_loading.get() {
                     // Data still loading — show skeleton placeholder

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -32,6 +32,11 @@ pub fn EditLibraryItemForm(
     /// `in_sheet` is true; ignored otherwise (route mode navigates instead).
     #[prop(optional, into)]
     on_dismiss: Option<Callback<()>>,
+    /// Optional ref to the underlying `<form>` element. The sheet that owns
+    /// this form passes one in so its nav-bar Save action can trigger
+    /// `requestSubmit()`. See `AddLibraryItemForm` for the same pattern.
+    #[prop(optional, into)]
+    form_ref: Option<NodeRef<leptos::html::Form>>,
 ) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
@@ -137,8 +142,11 @@ pub fn EditLibraryItemForm(
 
     let cancel_href = back_href.clone();
 
+    let form_ref = form_ref.unwrap_or_default();
+
     let form_view = view! {
         <form
+            node_ref=form_ref
             class="space-y-4"
             on:submit={
                         let item_id = item_id.clone();
@@ -258,9 +266,11 @@ pub fn EditLibraryItemForm(
                         // Tags — chip-based input with autocomplete
                         <TagInput id="edit-tags" tags=tags available_tags=all_tags_signal field_name="tags" errors=errors />
 
-                        // Buttons — hero-size primary stacked over a
-                        // full-width secondary Cancel on mobile.
-                        <div class="flex flex-col gap-3 pt-2">
+                        // Hero-size primary CTA — sheet's nav-bar Save also
+                        // triggers submit via requestSubmit() on the form ref.
+                        // Bottom Cancel only in route mode; sheet's nav
+                        // Cancel handles dismiss in sheet mode.
+                        <div class="flex flex-col pt-2">
                             <Button
                                 variant=ButtonVariant::Primary
                                 button_type="submit"
@@ -268,19 +278,23 @@ pub fn EditLibraryItemForm(
                                 full_width=true
                                 loading=Signal::derive(move || is_submitting.get())
                             >
-                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save" }}
+                                {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save Changes" }}
                             </Button>
-                            <Button variant=ButtonVariant::Secondary full_width=true on_click={
-                                let cancel_href = cancel_href.clone();
-                                let navigate = navigate.clone();
-                                Callback::new(move |_| {
-                                    if let Some(cb) = on_dismiss {
-                                        cb.run(());
-                                    } else {
-                                        navigate(&cancel_href, NavigateOptions::default());
-                                    }
-                                })
-                            }>"Cancel"</Button>
+                            {(!in_sheet).then(|| view! {
+                                <div class="mt-3">
+                                    <Button variant=ButtonVariant::Secondary full_width=true on_click={
+                                        let cancel_href = cancel_href.clone();
+                                        let navigate = navigate.clone();
+                                        Callback::new(move |_| {
+                                            if let Some(cb) = on_dismiss {
+                                                cb.run(());
+                                            } else {
+                                                navigate(&cancel_href, NavigateOptions::default());
+                                            }
+                                        })
+                                    }>"Cancel"</Button>
+                                </div>
+                            })}
                         </div>
                     </div>
                 </form>

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -277,12 +277,36 @@ pub fn LibraryListView() -> impl IntoView {
         </div>
         </PullToRefresh>
 
+        <AddItemSheet open=add_sheet_open on_close=close_add_sheet is_submitting=is_submitting />
+    }
+}
+
+/// Wraps `<AddLibraryItemForm>` inside a `<BottomSheet>` configured for the
+/// iOS Mail-compose pattern: Cancel on the left of the nav bar, Save on
+/// the right (triggers form submission via the form's NodeRef).
+#[component]
+fn AddItemSheet(
+    open: RwSignal<bool>,
+    on_close: Callback<()>,
+    is_submitting: IsSubmitting,
+) -> impl IntoView {
+    let form_ref = NodeRef::<leptos::html::Form>::new();
+    let on_save = Callback::new(move |_| {
+        if let Some(form) = form_ref.get() {
+            let _ = form.request_submit();
+        }
+    });
+    let submitting_signal = Signal::derive(move || is_submitting.get());
+    view! {
         <BottomSheet
-            open=add_sheet_open
-            on_close=close_add_sheet
+            open=open
+            on_close=on_close
             nav_title="Add Item".to_string()
+            nav_action_label="Save".to_string()
+            on_nav_action=on_save
+            nav_action_disabled=submitting_signal
         >
-            <AddLibraryItemForm in_sheet=true on_dismiss=close_add_sheet />
+            <AddLibraryItemForm in_sheet=true on_dismiss=on_close form_ref=form_ref />
         </BottomSheet>
     }
 }

--- a/e2e/tests/add-item.spec.ts
+++ b/e2e/tests/add-item.spec.ts
@@ -27,7 +27,7 @@ test.describe("add library item", () => {
     await page.locator("#add-tags").fill("classical, beethoven, sonata");
 
     // Submit the form
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Add to Library" }).click();
 
     // Should redirect to library and show the new item. Library rows
     // are spans/links post-2026-refresh, not headings — assert against
@@ -64,7 +64,7 @@ test.describe("add library item", () => {
     await page.locator("#add-key").fill("C Major");
 
     // Submit
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Add to Library" }).click();
 
     // Should appear in library list — All tab is the default, no tab
     // switch needed.
@@ -88,7 +88,7 @@ test.describe("add library item", () => {
 
     // Fill title but leave composer empty, then try to submit
     await page.locator("#add-title").fill("Test Piece");
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Add to Library" }).click();
 
     // Should still be on the add form (native validation blocks submission)
     await expect(
@@ -103,7 +103,7 @@ test.describe("add library item", () => {
     await page.locator("#add-title").fill("Test Piece");
     await page.locator("#add-composer").fill("Test Composer");
     await page.locator("#add-bpm").fill("9999");
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Add to Library" }).click();
 
     // Custom validation error for BPM should appear
     await expect(page.getByText("BPM must be between")).toBeVisible();

--- a/e2e/tests/edit-item.spec.ts
+++ b/e2e/tests/edit-item.spec.ts
@@ -57,7 +57,7 @@ test.describe("edit library item", () => {
     await page.locator("#edit-title").fill("Clair de Lune (Revised)");
 
     // Save
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Save Changes" }).click();
 
     // Should redirect back to detail with updated title
     await expect(


### PR DESCRIPTION
## Summary

- Brings the Add Item and Edit Item flows in line with the iOS Mail-compose nav pattern (Cancel | Title | Save) used by the session review sheet (#388) — matches Pencil's "Add piece" frame (MFuDt).
- Reuses the existing `BottomSheet` nav-action plumbing; the form keeps its bottom hero CTA so both submit paths work.
- Renames the bottom CTAs from the ambiguous "Save" to "Add to Library" / "Save Changes" per Pencil.

## Changes

- **Form refs**: `AddLibraryItemForm` + `EditLibraryItemForm` accept an optional `form_ref: NodeRef<HtmlFormElement>`. The owning sheet uses it to call `form.request_submit()` from the nav-bar Save, firing the form's existing `on:submit` handler (validation + dispatch unchanged).
- **Bottom Cancel**: only renders when `!in_sheet` — the sheet's nav Cancel handles dismiss.
- **library_list.rs**: new `<AddItemSheet>` helper wraps `AddLibraryItemForm` in a `BottomSheet` with `nav_action_disabled` bound to `is_submitting`.
- **detail.rs**: edit sheet uses the same form_ref + request_submit pattern inlined (the `item_id` closure capture made a generic helper awkward).
- **E2E**: button locators updated for the new labels — all 7 add/edit specs pass.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `playwright test add-item.spec.ts edit-item.spec.ts` — 7/7 pass
- [ ] Manual: open Add Item sheet, type a piece, hit nav Save → row appears in list
- [ ] Manual: open Edit Item sheet, change the title, hit nav Save → detail reflects change
- [ ] Manual: nav Cancel dismisses without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)