### PR TITLE
fix(e2e): dismiss reflection sheet after Next/Finish in session specs

### DIFF
--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -56,8 +56,10 @@ test.describe("sessions page", () => {
     // (Focus mode hides the heading, so check item indicator instead)
     await expect(page.getByText("Item 1 of 1")).toBeVisible();
 
-    // Finish the session (single item = "Finish Session" button)
+    // Finish the session (single item = "Finish Session" button) — opens
+    // the mid-session reflection sheet; skip the capture to advance.
     await page.getByRole("button", { name: "Finish Session" }).click();
+    await page.getByRole("button", { name: "Skip scoring" }).click();
 
     // Should be on the summary page
     await expect(page.getByText("Session Complete")).toBeVisible();
@@ -98,8 +100,9 @@ test.describe("sessions page", () => {
     // Should advance to second item
     await expect(page.getByText("Item 2 of 2")).toBeVisible();
 
-    // Finish the session (last item)
+    // Finish the session (last item) — opens reflection sheet, skip to advance.
     await page.getByRole("button", { name: "Finish Session" }).click();
+    await page.getByRole("button", { name: "Skip scoring" }).click();
 
     // Summary should show both items
     await expect(page.getByText("Session Complete")).toBeVisible();
@@ -150,14 +153,18 @@ test.describe("sessions page", () => {
     // First item
     await expect(page.getByText("Item 1 of 2")).toBeVisible();
 
-    // Next Item (not last, so button says "Next Item")
+    // Next Item (not last, so button says "Next Item") — opens reflection
+    // sheet; skip the capture to advance to the next item.
     await page.getByRole("button", { name: "Next Item" }).click();
+    await page.getByRole("button", { name: "Skip scoring" }).click();
 
     // Second item
     await expect(page.getByText("Item 2 of 2")).toBeVisible();
 
-    // Now it's the last item, so button says "Finish Session"
+    // Now it's the last item, so button says "Finish Session" — same flow:
+    // opens sheet, skip to advance to summary.
     await page.getByRole("button", { name: "Finish Session" }).click();
+    await page.getByRole("button", { name: "Skip scoring" }).click();
 
     // Summary
     await expect(page.getByText("Session Complete")).toBeVisible();


### PR DESCRIPTION
## Summary

Fixes the E2E Tests check on #399. Targets `feat/item-reflection-sheet` so a merge here flows into that PR.

The three failing tests in `e2e/tests/sessions.spec.ts` (`create a session via the setlist flow`, `multi-item session with skip`, `multi-item session with Next Item navigation`) all click `Next Item` / `Finish Session` and expect the session to advance immediately. After #399 those CTAs now open the new `ItemReflectionSheet`; the click no longer advances on its own.

Fix: add a `Skip scoring` tap inside the sheet after each `Next Item` / `Finish Session` click. This dismisses the sheet without recording reflection data and lets the test continue. The Continue path (with form input) is left as a manual check per the PR's own test plan — the e2e tests just need to verify session flow regression coverage.

## Note on the PR description

#399's description says:
> ⚠️ **Pre-existing e2e infra failure**: the suite is currently broken on `main` too (`Failed to load routines: JSON serialization error` on every test). Not introduced by this PR; tracking separately.

That isn't accurate — main's E2E Tests job passed on 9fb8767 (the base of #399). The failure was introduced by the reflection sheet wiring. No `Failed to load routines` string exists in the codebase or e2e specs, and the actual run shows the timing matches `Next Item` / `Finish Session` selectors hanging on a sheet that wasn't being dismissed. (May be worth amending the PR body once this fix lands so the audit trail is right.)

## Test plan

- [ ] Re-run E2E Tests on #399 once this is merged into `feat/item-reflection-sheet`.
- [ ] Manually verify the three updated specs locally: `cd e2e && npx playwright test sessions.spec.ts`.

https://claude.ai/code/session_01MCtn7vT4C8Vdi2rKbE5fTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtn7vT4C8Vdi2rKbE5fTt)_