### PR TITLE
chore(web): drop glass-card glassmorphism, unify 2026 surface family

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -138,11 +138,18 @@ html {
   --color-chart-bar: oklch(50.5% 0.24 274 / 40%);       /* accent/40 — bar fills */
 
   /* ── Radius tokens ── */
-  --radius-card: var(--radius-xl);
+  --radius-card: var(--radius-xl);     /* 12px — legacy chrome (grouped-list, sheets) */
+  --radius-surface: 10px;              /* 2026 surface family — card, detail-group, stat-card-faint, accent-row */
   --radius-button: var(--radius-lg);
   --radius-input: var(--radius-lg);
   --radius-badge: var(--radius-md);
   --radius-pill: 9999px;
+
+  /* ── Shadow tokens ──
+     `--shadow-card` is the subtle 1px elevation shared by the 2026
+     surface family (.card, .accent-row, .detail-group, .stat-card-faint).
+     The Tailwind `shadow-lg` is still used by interactive overlays. */
+  --shadow-card: 0 1px 4px rgb(0 0 0 / 9%);
 
   /* ── Spacing tokens (audit #7) ──
      Semantic spacing scale for component padding and gaps.
@@ -209,19 +216,18 @@ body {
    Use them in Leptos view! macros like any Tailwind class.
    ═══════════════════════════════════════════════════════════════════════ */
 
-/* Glassmorphism card — the primary container style.
-   Fallback: solid dark indigo for browsers without backdrop-filter.
-   Enhanced: translucent white + blur when supported. */
-@utility glass-card {
-  background-color: var(--color-surface-fallback);
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-card);
-  box-shadow: var(--shadow-lg);
-
-  @supports (backdrop-filter: blur(1px)) {
-    background-color: var(--color-surface-primary);
-    backdrop-filter: blur(12px);
-  }
+/* Card — primary container surface for the 2026 design language.
+   Whisper-soft surface (white/3) with a subtle 1px shadow, matching
+   the `.detail-group` and `.stat-card-faint` siblings. No backdrop
+   blur, no border — the surface tone alone provides the containment.
+   The previous `.glass-card` glassmorphism variant has been removed;
+   the look was load-bearing in the old design language but reads
+   busy alongside the flatter session / summary / detail surfaces
+   that landed in 2026. */
+@utility card {
+  background-color: var(--color-surface-faint);
+  border-radius: var(--radius-surface);
+  box-shadow: var(--shadow-card);
 }
 
 /* Glassmorphism chrome — header and bottom tab bar.
@@ -369,9 +375,9 @@ body {
   gap: 12px;
   min-height: 60px;
   padding: 0 16px;
-  border-radius: 10px;
+  border-radius: var(--radius-surface);
   background-color: var(--color-surface-faint);
-  box-shadow: 0 1px 4px rgb(0 0 0 / 9%);
+  box-shadow: var(--shadow-card);
 }
 .accent-row::before {
   content: '';
@@ -444,9 +450,9 @@ body {
   flex-direction: column;
   gap: 12px;
   padding: 12px 16px 12px 20px;
-  border-radius: 10px;
+  border-radius: var(--radius-surface);
   background-color: var(--color-surface-faint);
-  box-shadow: 0 1px 4px rgb(0 0 0 / 9%);
+  box-shadow: var(--shadow-card);
 }
 .detail-group::before {
   content: '';
@@ -481,12 +487,11 @@ body {
   font-weight: 500;
 }
 
-/* StatCard — refresh variant. The surface drops from white/12 to the
-   whisper-soft white/3, an inset gradient bar appears on the left, and
-   the value text can carry an accent / warm-accent tone (signals the
-   stat's category at a glance: streak = accent, hours = gold, etc).
-   The classic glass-card variant is still available — opt in by setting
-   `bar` on the Leptos component. */
+/* StatCard — refresh variant. Adds an inset gradient bar on the left
+   and lets the value text carry an accent / warm-accent tone (signals
+   the stat's category at a glance: streak = accent, hours = gold,
+   etc). The classic variant uses the plain `.card` surface — opt in
+   by setting `bar` on the Leptos component to get this refresh look. */
 .stat-card-faint {
   position: relative;
   overflow: hidden;
@@ -495,9 +500,9 @@ body {
   align-items: center;
   gap: 0.25rem;
   padding: 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-surface);
   background-color: var(--color-surface-faint);
-  box-shadow: 0 1px 4px rgb(0 0 0 / 9%);
+  box-shadow: var(--shadow-card);
 }
 .stat-card-faint::before {
   content: '';
@@ -1467,12 +1472,6 @@ nav[aria-label="Mobile navigation"] {
   line-height: 2rem;
   font-weight: 700;
   letter-spacing: -0.02em;
-}
-
-/* Cards within detail view: flatter, sharper border */
-[data-platform="ios"] .detail-view .glass-card {
-  border-radius: var(--radius-card);
-  border: 1px solid var(--color-border-default);
 }
 
 /* Action buttons: full-width vertical stack at bottom */

--- a/crates/intrada-web/src/components/card.rs
+++ b/crates/intrada-web/src/components/card.rs
@@ -1,13 +1,13 @@
 use leptos::prelude::*;
 
-/// Shared card container with glassmorphism styling — semi-transparent with backdrop blur.
-/// Falls back to solid semi-opaque background when backdrop-filter is not supported.
-///
-/// Uses the `glass-card` design token utility (see `input.css`).
+/// Shared card container — whisper-soft surface with a subtle 1px shadow.
+/// Matches the `.detail-group` and `.stat-card-faint` siblings in the 2026
+/// design language. No glassmorphism / backdrop-blur — see the `.card`
+/// utility comment in `input.css` for why.
 #[component]
 pub fn Card(children: Children) -> impl IntoView {
     view! {
-        <div class="glass-card p-card sm:p-card-comfortable">
+        <div class="card p-card sm:p-card-comfortable">
             {children()}
         </div>
     }

--- a/crates/intrada-web/src/components/stat_card.rs
+++ b/crates/intrada-web/src/components/stat_card.rs
@@ -16,11 +16,12 @@ pub enum StatTone {
 /// A small stat display card for analytics metrics (e.g., streak, weekly total).
 ///
 /// Two visual modes:
-/// - **Classic** (`bar=AccentBar::None` or omit): the original glass-card
-///   chrome with compact padding. Used everywhere today.
-/// - **2026 refresh** (`bar=AccentBar::Gold | Blue`): whisper-soft
-///   surface with a 4px gradient bar inset on the left and the value
-///   text in the matching tone. Used by the new Piece Detail stat row.
+/// - **Classic** (`bar=AccentBar::None` or omit): plain `.card` chrome
+///   (the 2026 surface — whisper-soft + subtle shadow) with compact
+///   padding. Used everywhere today.
+/// - **2026 refresh** (`bar=AccentBar::Gold | Blue`): same surface plus
+///   a 4px gradient bar inset on the left and the value text in the
+///   matching tone. Used by the new Piece Detail stat row.
 #[component]
 pub fn StatCard(
     title: &'static str,
@@ -65,7 +66,7 @@ pub fn StatCard(
     } else {
         // Classic variant — unchanged from previous design system
         view! {
-            <div class="glass-card p-card-compact text-center">
+            <div class="card p-card-compact text-center">
                 <p class="field-label">{title}</p>
                 <p class="text-2xl font-bold text-primary mt-1">{value}</p>
                 {subtitle.map(|s| view! {

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -230,7 +230,7 @@ pub fn DesignCatalogue() -> impl IntoView {
             </p>
 
             // ── Table of Contents ─────────────────────────────────────
-            <nav class="glass-card p-4 sm:p-6" aria-label="Catalogue navigation">
+            <nav class="card p-4 sm:p-6" aria-label="Catalogue navigation">
                 <h3 class="text-sm font-semibold text-primary mb-3">"Contents"</h3>
                 <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1">
                     <div>
@@ -247,7 +247,7 @@ pub fn DesignCatalogue() -> impl IntoView {
                     <div>
                         <p class="text-xs font-medium text-muted uppercase mb-1">"Components"</p>
                         <ul class="space-y-0.5 text-sm">
-                            <li><a href="#glass-card" class="text-accent-text hover:text-primary">"Glass Card"</a></li>
+                            <li><a href="#card" class="text-accent-text hover:text-primary">"Card"</a></li>
                             <li><a href="#stat-card" class="text-accent-text hover:text-primary">"Stat Card"</a></li>
                             <li><a href="#library-item-card" class="text-accent-text hover:text-primary">"Library Item Card"</a></li>
                             <li><a href="#buttons" class="text-accent-text hover:text-primary">"Buttons"</a></li>
@@ -532,11 +532,11 @@ pub fn DesignCatalogue() -> impl IntoView {
                 <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Composite Utilities"</h3>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="space-y-2">
-                        <div class="glass-card p-4">
-                            <p class="text-sm text-secondary">"Content inside glass-card"</p>
+                        <div class="card p-4">
+                            <p class="text-sm text-secondary">"Content inside card"</p>
                         </div>
-                        <p class="text-xs text-faint text-center">"glass-card"</p>
-                        <p class="text-xs text-faint text-center">"Glassmorphism + fallback + border + shadow"</p>
+                        <p class="text-xs text-faint text-center">"card"</p>
+                        <p class="text-xs text-faint text-center">"Whisper-soft surface + 1px shadow"</p>
                     </div>
                     <div class="space-y-2">
                         <div class="glass-chrome border border-border-default p-4">
@@ -633,12 +633,13 @@ pub fn DesignCatalogue() -> impl IntoView {
             // COMPONENTS — Containers
             // ══════════════════════════════════════════════════════════
 
-            // ── Glass Card ────────────────────────────────────────────
-            <section id="glass-card">
-                <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Glass Card"</h3>
+            // ── Card ──────────────────────────────────────────────────
+            <section id="card">
+                <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Card"</h3>
+                <p class="text-xs text-faint mb-4">"The 2026 design surface — whisper-soft (white/3) with a subtle 1px shadow. Replaces the previous glassmorphism / backdrop-blur card; the flat tone reads cleaner alongside the 2026 session, summary, and detail surfaces. Same surface family as `.detail-group` and `.stat-card-faint`."</p>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <Card>
-                        <p class="text-sm text-secondary">"Default glass-card with standard padding."</p>
+                        <p class="text-sm text-secondary">"Default card with standard padding."</p>
                     </Card>
                     <Card>
                         <h3 class="text-lg font-semibold text-primary mb-2">"With heading"</h3>
@@ -657,7 +658,7 @@ pub fn DesignCatalogue() -> impl IntoView {
             // ── Stat Cards ────────────────────────────────────────────
             <section id="stat-card">
                 <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Stat Card"</h3>
-                <p class="text-xs font-medium text-muted uppercase mb-2">"Classic — glass-card chrome"</p>
+                <p class="text-xs font-medium text-muted uppercase mb-2">"Classic — plain card surface"</p>
                 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
                     <StatCard title="Current Streak" value="7 days".to_string() subtitle="Best: 14 days" />
                     <StatCard title="This Week" value="3h 45m".to_string() />

--- a/specs/design-system.md
+++ b/specs/design-system.md
@@ -90,27 +90,23 @@ These tokens are referenced in SVG attributes via `var()` in `line_chart.rs`.
 
 These `@utility` classes combine multiple CSS properties into single class names. Use them in Leptos `view!` macros like any Tailwind class.
 
-### `glass-card`
+### `card`
 
-The primary container style. Uses glassmorphism with progressive enhancement.
+The primary container surface for the 2026 design language. Replaces the previous `glass-card` glassmorphism utility — see the historical-context comment in `input.css` for why.
 
 ```css
-@utility glass-card {
-  background-color: var(--color-surface-fallback);   /* solid fallback */
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-card);
-  box-shadow: var(--shadow-lg);
-
-  @supports (backdrop-filter: blur(1px)) {
-    background-color: var(--color-surface-primary);   /* translucent */
-    backdrop-filter: blur(12px);
-  }
+@utility card {
+  background-color: var(--color-surface-faint);
+  border-radius: var(--radius-surface);
+  box-shadow: var(--shadow-card);
 }
 ```
 
-**Usage:** `<div class="glass-card p-4 sm:p-6">` — add padding and any additional classes alongside.
+**Usage:** `<div class="card p-card sm:p-card-comfortable">` — add padding and any additional classes alongside.
 
-**Components using this:** `Card`, `StatCard`
+**Surface family:** `card`, `accent-row`, `detail-group`, `stat-card-faint` all share `--color-surface-faint`, `--radius-surface` (10px), `--shadow-card`. The `accent-row` / `detail-group` / `stat-card-faint` variants layer a 4px gradient bar on top.
+
+**Components using this:** `Card`, `StatCard` (classic variant).
 
 ### `glass-chrome`
 
@@ -188,8 +184,8 @@ All components live in `crates/intrada-web/src/components/`.
 
 | Component | File | Props | Description |
 |-----------|------|-------|-------------|
-| `Card` | `card.rs` | `children` | Generic glassmorphism container. Uses `glass-card`. |
-| `StatCard` | `stat_card.rs` | `title`, `value`, `subtitle?` | Metric display card for analytics. Uses `glass-card`. |
+| `Card` | `card.rs` | `children` | Generic content container. Uses the `card` utility (whisper-soft surface, subtle shadow). |
+| `StatCard` | `stat_card.rs` | `title`, `value`, `subtitle?`, `bar?`, `tone?` | Metric display card for analytics. Classic variant uses the `card` utility; refresh variant adds a gradient accent bar. |
 | `LibraryItemCard` | `library_item_card.rs` | `item: LibraryItemView` | Library list item with title, metadata, tags, type badge. Uses token-based surface colours. |
 
 ### Form Components
@@ -229,13 +225,11 @@ All components live in `crates/intrada-web/src/components/`.
 
 ## Design Patterns
 
-### Glassmorphism (Progressive Enhancement)
+### Glassmorphism (Legacy — chrome only)
 
-All glassmorphism uses a two-tier approach:
-1. **Fallback:** Solid semi-transparent background (works everywhere)
-2. **Enhanced:** Translucent white/gray + `backdrop-filter: blur(12px)` via `@supports`
+The 2026 design language dropped glassmorphism for content surfaces in favour of the flat `card` family. The remaining glass-style surfaces are **chrome** (the app header / bottom tab bar via `glass-chrome`, plus the bottom sheet / context menu / grouped-list-row in iOS-feel mode), where the translucent + blur effect still earns its keep as a navigation cue.
 
-This is encapsulated in the `glass-card` and `glass-chrome` utilities.
+For all other surfaces, use the `card` utility or one of its accent-bar siblings (`accent-row`, `detail-group`, `stat-card-faint`).
 
 ### Motion Safety
 
@@ -264,7 +258,7 @@ bg-linear-to-br from-gray-950 via-indigo-950 to-purple-950
 
 ### When to use which token
 
-- **Adding a new card/container:** Use `glass-card` + padding classes
+- **Adding a new card/container:** Use the `card` utility + padding classes (or an accent-bar sibling: `accent-row`, `detail-group`, `stat-card-faint`)
 - **Adding a new form input:** Use `input-base` class
 - **Referencing colours in Rust/Leptos:** Use Tailwind classes like `text-text-muted`, `bg-surface-primary`, `border-border-default`
 - **Referencing colours in SVG attributes:** Use `var(--color-chart-*)` or `var(--color-*)` directly


### PR DESCRIPTION
## Summary

The 2026 design language has been progressively replacing the glassmorphism / backdrop-blur card with flatter "whisper-soft" surfaces (`.detail-group`, `.stat-card-faint`, `.accent-row`). The last legacy holdout was the `glass-card` utility itself, used by `<Card>` (forms, analytics sections, detail loading) and the classic variant of `<StatCard>`. This branch rips it out and unifies the four 2026 surfaces on a shared token pair.

## Changes

**CSS (`input.css`)**
- `@utility glass-card` (white/12 + `backdrop-blur(12px)` + border + `shadow-lg` + gray-900/80 fallback) → replaced with `@utility card` (`surface-faint` + 1px shadow + `radius-surface`, no blur, no border).
- New tokens **`--shadow-card`** and **`--radius-surface`** consolidate what was previously duplicated 4× across the surface family. `.card`, `.accent-row`, `.detail-group`, `.stat-card-faint` all read from the tokens.
- Dropped `[data-platform="ios"] .detail-view .glass-card` override — the band-aid is moot now (new surface has no border).

**Components**
- `<Card>` uses `class="card p-card sm:p-card-comfortable"`.
- `<StatCard>` classic variant uses `class="card p-card-compact ..."`.
- Doc comments updated.

**Catalogue (`design_catalogue.rs`)**
- TOC: "Glass Card" → "Card", anchor `#glass-card` → `#card`.
- Section + showcase copy rewritten.
- Catalogue's own TOC nav surface now uses the new `card` utility.

**Spec doc (`specs/design-system.md`)**
- `### glass-card` rewritten as `### card`.
- Component table updated.
- "Glassmorphism (Progressive Enhancement)" → "Glassmorphism (Legacy — chrome only)" — the chrome surfaces (header, tab bar, sheets, context menu) still earn the blur treatment as a navigation cue; content surfaces don't.

## Self-review

Ran `superpowers:code-reviewer` against this branch. Two `[Important]` findings, both addressed:
1. Shadow duplication across 4 surfaces → `--shadow-card` token.
2. Radius inconsistency (12px on `.card` vs 10px on siblings) → `--radius-surface` (10px) applied to all four.

Reviewer also flagged a future-PR target: `.bottom-sheet`, `.grouped-list-row`, `.context-menu` are the last three surfaces still rendering the old glassmorphism stack. They're chrome (navigation cues) — the spec doc's new "Glassmorphism (Legacy — chrome only)" section documents the policy that those may stay.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] Visual verification via preview server: design catalogue Card section, Stat Card section (classic + refresh), Analytics page (Card per section wrapper), Detail view (StatCard refresh + DetailGroup). All flat, consistent, no glass blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)