### PR TITLE
refactor(web): extract <RatingChips> primitive

### DIFF
--- a/crates/intrada-web/src/components/item_reflection_sheet.rs
+++ b/crates/intrada-web/src/components/item_reflection_sheet.rs
@@ -2,7 +2,9 @@ use leptos::prelude::*;
 
 use intrada_core::{Event, ItemKind, SessionEvent};
 
-use crate::components::{BottomSheet, Button, ButtonSize, ButtonVariant, InlineTypeIndicator};
+use crate::components::{
+    BottomSheet, Button, ButtonSize, ButtonVariant, InlineTypeIndicator, RatingChips,
+};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, ItemType, SharedCore};
 use intrada_web::validation::validate_achieved_tempo_input;
@@ -199,40 +201,14 @@ pub fn ItemReflectionSheet(
                 </div>
 
                 <div class="border-t border-border-default pt-4 space-y-4">
-                    // Rating chips — 1..=5, toggleable. Same shape/markup as
-                    // the summary screen so the two surfaces feel like one
-                    // family.
+                    // Rating chips — local signal, no dispatch yet (the
+                    // sheet defers UpdateEntryScore until Continue/Skip).
                     <div>
                         <p class="text-sm text-secondary mb-2">"How did it go?"</p>
-                        <div class="flex items-center gap-2">
-                            {(1u8..=5).map(|n| {
-                                let class_fn = move || {
-                                    if score.get() == Some(n) {
-                                        "w-9 h-9 rounded-full text-sm font-semibold bg-accent text-primary shadow-md motion-safe:transition-all motion-safe:duration-150"
-                                    } else {
-                                        "w-9 h-9 rounded-full text-sm font-semibold bg-surface-primary text-primary/60 hover:bg-surface-hover hover:text-primary motion-safe:transition-all motion-safe:duration-150"
-                                    }
-                                };
-                                let aria_label = format!("Rate {} out of 5", n);
-                                let aria_pressed = move || if score.get() == Some(n) { "true" } else { "false" };
-                                view! {
-                                    <button
-                                        type="button"
-                                        class=class_fn
-                                        aria-label=aria_label
-                                        aria-pressed=aria_pressed
-                                        on:click=move |_| {
-                                            // Toggle off when re-tapping the
-                                            // currently-selected rating.
-                                            let new_score = if score.get_untracked() == Some(n) { None } else { Some(n) };
-                                            score.set(new_score);
-                                        }
-                                    >
-                                        {n.to_string()}
-                                    </button>
-                                }
-                            }).collect::<Vec<_>>()}
-                        </div>
+                        <RatingChips
+                            selected=score
+                            on_change=Callback::new(move |next: Option<u8>| score.set(next))
+                        />
                     </div>
 
                     // Tempo (BPM) — number input matching summary screen

--- a/crates/intrada-web/src/components/mod.rs
+++ b/crates/intrada-web/src/components/mod.rs
@@ -28,6 +28,7 @@ pub mod page_add_button;
 pub mod page_heading;
 pub mod progress_ring;
 pub mod pull_to_refresh;
+pub mod rating_chips;
 pub mod routine_loader;
 pub mod routine_save_form;
 pub mod section_label;
@@ -78,6 +79,7 @@ pub use page_add_button::PageAddButton;
 pub use page_heading::PageHeading;
 pub use progress_ring::ProgressRing;
 pub use pull_to_refresh::PullToRefresh;
+pub use rating_chips::RatingChips;
 // RoutineLoader is currently unused — kept around for the planned routine
 // flows revisit (see PR conversation). Re-export when something needs it.
 pub use routine_save_form::RoutineSaveForm;

--- a/crates/intrada-web/src/components/rating_chips.rs
+++ b/crates/intrada-web/src/components/rating_chips.rs
@@ -1,0 +1,63 @@
+use leptos::prelude::*;
+
+/// 1–5 rating chips with toggle-to-clear behaviour. The signature
+/// 36px-circle (`w-9 h-9`) row used wherever the user picks a self-rating
+/// — post-session summary and the mid-session reflection sheet are the
+/// current consumers.
+///
+/// Re-tapping the currently-selected value fires `on_change(None)`. The
+/// component is purely presentational: it doesn't own state, doesn't talk
+/// to the core, doesn't manage focus. Consumers wire `selected` from
+/// wherever the source of truth lives (a local signal, a view-model
+/// snapshot, etc.) and `on_change` does the persistence.
+#[component]
+pub fn RatingChips(
+    /// Currently-selected rating, 1–5, or `None`.
+    #[prop(into)]
+    selected: Signal<Option<u8>>,
+    /// Fired when the user picks a rating, or clears it by re-tapping
+    /// the selected one. Receives the new value (`Some(n)` or `None`).
+    on_change: Callback<Option<u8>>,
+    /// Prefix for the `aria-label` of each chip — defaults to `"Rate"`,
+    /// rendering e.g. `"Rate 4 out of 5"`. Pass `"Rate confidence"` on
+    /// the summary screen so screen readers announce the chip's purpose.
+    ///
+    /// Constrained to `&'static str` while we only have static-string
+    /// callers — switch to `Signal<String>` (or an `AttributeValue`) the
+    /// moment a runtime label (e.g. i18n, item-name interpolation) is
+    /// needed.
+    #[prop(optional, default = "Rate")]
+    aria_label_prefix: &'static str,
+) -> impl IntoView {
+    view! {
+        <div class="flex items-center gap-2">
+            {(1u8..=5).map(|n| {
+                let is_selected = move || selected.get() == Some(n);
+                let class_fn = move || {
+                    if is_selected() {
+                        "w-9 h-9 rounded-full text-sm font-semibold bg-accent text-primary shadow-md motion-safe:transition-all motion-safe:duration-150"
+                    } else {
+                        "w-9 h-9 rounded-full text-sm font-semibold bg-surface-primary text-primary/60 hover:bg-surface-hover hover:text-primary motion-safe:transition-all motion-safe:duration-150"
+                    }
+                };
+                let aria_label = format!("{aria_label_prefix} {n} out of 5");
+                let aria_pressed = move || if is_selected() { "true" } else { "false" };
+                view! {
+                    <button
+                        type="button"
+                        class=class_fn
+                        aria-label=aria_label
+                        aria-pressed=aria_pressed
+                        on:click=move |_| {
+                            // Toggle: re-tapping the selected value clears it.
+                            let next = if selected.get_untracked() == Some(n) { None } else { Some(n) };
+                            on_change.run(next);
+                        }
+                    >
+                        {n.to_string()}
+                    </button>
+                }
+            }).collect::<Vec<_>>()}
+        </div>
+    }
+}

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -4,7 +4,8 @@ use intrada_core::{CompletionStatus, EntryStatus, Event, RoutineEvent, SessionEv
 use intrada_web::validation::validate_achieved_tempo_input;
 
 use crate::components::{
-    AccentBar, Button, ButtonVariant, Icon, IconName, RoutineSaveForm, StatCard, StatTone,
+    AccentBar, Button, ButtonVariant, Icon, IconName, RatingChips, RoutineSaveForm, StatCard,
+    StatTone,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -206,45 +207,30 @@ pub fn SessionSummary() -> impl IntoView {
                                                         }
                                                     />
                                                 </div>
-                                                // Score buttons — only for completed entries
+                                                // Score chips — only for completed entries.
+                                                // Toggle + dispatch logic lives in the parent
+                                                // because the source of truth is the view model
+                                                // entry, not a local signal.
                                                 {if is_completed {
                                                     let entry_id_score = entry_id_for_score.clone();
                                                     let core_score_btns = core_score_inner.clone();
+                                                    let on_change = Callback::new(move |new_score: Option<u8>| {
+                                                        let event = Event::Session(SessionEvent::UpdateEntryScore {
+                                                            entry_id: entry_id_score.clone(),
+                                                            score: new_score,
+                                                        });
+                                                        let core_ref = core_score_btns.borrow();
+                                                        let effects = core_ref.process_event(event);
+                                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                                    });
                                                     Some(view! {
                                                         <div class="flex items-center gap-2">
                                                             <span class="text-xs text-muted mr-1">"Confidence:"</span>
-                                                            {(1u8..=5).map(|n| {
-                                                                let entry_id_n = entry_id_score.clone();
-                                                                let core_n = core_score_btns.clone();
-                                                                let is_selected = current_score == Some(n);
-                                                                let btn_class = if is_selected {
-                                                                    "w-9 h-9 rounded-full text-sm font-semibold bg-accent text-primary shadow-md motion-safe:transition-all motion-safe:duration-150"
-                                                                } else {
-                                                                    "w-9 h-9 rounded-full text-sm font-semibold bg-surface-primary text-primary/60 hover:bg-surface-hover hover:text-primary motion-safe:transition-all motion-safe:duration-150"
-                                                                };
-                                                                let aria_label = format!("Rate confidence {} out of 5", n);
-                                                                let aria_pressed = if is_selected { "true" } else { "false" };
-                                                                view! {
-                                                                    <button
-                                                                        class=btn_class
-                                                                        aria-label=aria_label
-                                                                        aria-pressed=aria_pressed
-                                                                        on:click=move |_| {
-                                                                            // Toggle: if same score is clicked, clear it
-                                                                            let new_score = if current_score == Some(n) { None } else { Some(n) };
-                                                                            let event = Event::Session(SessionEvent::UpdateEntryScore {
-                                                                                entry_id: entry_id_n.clone(),
-                                                                                score: new_score,
-                                                                            });
-                                                                            let core_ref = core_n.borrow();
-                                                                            let effects = core_ref.process_event(event);
-                                                                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                                                        }
-                                                                    >
-                                                                        {n.to_string()}
-                                                                    </button>
-                                                                }
-                                                            }).collect::<Vec<_>>()}
+                                                            <RatingChips
+                                                                selected=Signal::derive(move || current_score)
+                                                                on_change=on_change
+                                                                aria_label_prefix="Rate confidence"
+                                                            />
                                                         </div>
                                                     })
                                                 } else {

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -12,7 +12,7 @@ use crate::components::{
     ContextMenu, ContextMenuAction, DayCell, DetailGroup, DetailRow, DropIndicator, EmptyState,
     FieldLabel, FormFieldError, IconName, InlineTypeIndicator, ItemReflectionSheet,
     ItemReflectionTarget, LibraryItemCard, LibraryTypeTabs, LineChart, PageHeading, ProgressRing,
-    RoutineSaveForm, SectionLabel, SetlistEntryRow, SkeletonBlock, SkeletonCardList,
+    RatingChips, RoutineSaveForm, SectionLabel, SetlistEntryRow, SkeletonBlock, SkeletonCardList,
     SkeletonItemCard, SkeletonLine, StatCard, StatTone, SwipeActions, TagInput, TempoProgressChart,
     TextArea, TextField, TransitionPrompt, TypeBadge, TypeTabs, WeekStrip,
 };
@@ -268,6 +268,7 @@ pub fn DesignCatalogue() -> impl IntoView {
                             <li><a href="#tag-input" class="text-accent-text hover:text-primary">"Tag Input"</a></li>
                             <li><a href="#field-label" class="text-accent-text hover:text-primary">"Field Label"</a></li>
                             <li><a href="#form-field-error" class="text-accent-text hover:text-primary">"Form Field Error"</a></li>
+                            <li><a href="#rating-chips" class="text-accent-text hover:text-primary">"Rating Chips"</a></li>
                             <li><a href="#line-chart" class="text-accent-text hover:text-primary">"Line Chart"</a></li>
                             <li><a href="#tempo-chart" class="text-accent-text hover:text-primary">"Tempo Progress Chart"</a></li>
                         </ul>
@@ -1174,6 +1175,15 @@ pub fn DesignCatalogue() -> impl IntoView {
                 </Card>
             </section>
 
+            // ── Rating Chips ──────────────────────────────────────────
+            <section id="rating-chips">
+                <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Rating Chips"</h3>
+                <Card>
+                    <p class="text-xs text-faint mb-3">"1\u{2013}5 self-rating chips with toggle-to-clear. Re-tapping the selected chip fires `on_change(None)`. Used by the post-session summary and the mid-session reflection sheet."</p>
+                    <RatingChipsDemo />
+                </Card>
+            </section>
+
             // ── Navigation ────────────────────────────────────────────
             <section id="navigation">
                 <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Navigation"</h3>
@@ -1720,6 +1730,28 @@ fn ItemReflectionSheetDemo() -> impl IntoView {
                 position_label=Signal::derive(move || position_label.get())
                 on_advance=on_advance
             />
+        </div>
+    }
+}
+
+/// Catalogue demo: RatingChips with a local signal — re-tap clears the
+/// selection. Mirrors how both the summary screen and the reflection
+/// sheet wire it up.
+#[component]
+fn RatingChipsDemo() -> impl IntoView {
+    let score = RwSignal::new(Option::<u8>::None);
+    view! {
+        <div class="space-y-3">
+            <RatingChips
+                selected=score
+                on_change=Callback::new(move |next: Option<u8>| score.set(next))
+            />
+            <p class="text-xs text-muted">
+                {move || match score.get() {
+                    Some(n) => format!("Selected: {n}"),
+                    None => "No selection".to_string(),
+                }}
+            </p>
         </div>
     }
 }


### PR DESCRIPTION
## Summary

Picks up the `[Suggestion]`-tier follow-up flagged in the PR #399 self-review: extract a `<RatingChips>` primitive so the post-session summary and the mid-session reflection sheet share one chip implementation. The 1–5 chip markup + toggle-to-clear logic was duplicated across both surfaces.

## API

```rust
#[component]
pub fn RatingChips(
    #[prop(into)] selected: Signal<Option<u8>>,
    on_change: Callback<Option<u8>>,
    #[prop(optional, default = "Rate")] aria_label_prefix: &'static str,
)
```

- `Signal<Option<u8>>` is the least-common-denominator that handles both consumers — summary reads a snapshot from the view-model, the sheet has a local persistent signal. Both produce a Signal cleanly.
- `&'static str` aria prefix matches the two static callers ("Rate" / "Rate confidence"). Doc comment notes the migration path (`Signal<String>` / `AttributeValue`) for when a runtime label is needed.
- The component owns the toggle-to-clear branching — re-tapping the selected chip fires `on_change(None)`.

## Migrations

- **`session_summary.rs`** — passes `Signal::derive(move || current_score)` and an `on_change` callback that dispatches `UpdateEntryScore` directly. Free win: per-chip `entry_id_score.clone()` + `Rc` clone collapsed from 5 → 1.
- **`item_reflection_sheet.rs`** — passes the local `score` `RwSignal` directly (`#[prop(into)]` coerces); `on_change` just calls `score.set(next)`. Dispatch is still deferred to Continue/Skip per the PR #399 design.

## Catalogue

`<RatingChipsDemo>` showcasing toggle-to-clear against a local signal with a "Selected: N" / "No selection" status line. TOC entry under "Forms & Data".

## Self-review

Ran `superpowers:code-reviewer` — no critical or important findings. Two cosmetic suggestions applied:
- Doc comment dimension was wrong ("9px-circle" → "36px-circle / `w-9 h-9`").
- Forward-compat note on the `&'static str` constraint.
- Dropped redundant `Signal::derive(move || score.get())` in the sheet + catalogue demo — `RwSignal<T>` already coerces via `#[prop(into)]`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `cargo test -p intrada-core` — 253 pass (unchanged — UI-only refactor)
- [x] Visual: catalogue demo renders + selecting + re-tapping clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)