### PR TITLE
feat(web): add AccentBar::Teal for Set-content rows

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -162,13 +162,19 @@ html {
 
   /* ── Accent bar gradients (2026 refresh) ──
      The 4px gradient bar inset on the left of AccentRow / DetailGroup
-     cards is the signature visual of the new design. Two variants:
+     cards is the signature visual of the new design. Three variants:
        - Gold: maps to "piece" content (warm, authoritative)
        - Blue: maps to "exercise" content (cool, technical)
-     Both as CSS gradient strings so callers can use them in
+       - Teal: maps to "set" content (mixed compositions of pieces +
+         exercises). Distinct from gold/blue so a Set row in a
+         heterogeneous library list reads as its own kind at a glance.
+         Picked at hue ~190 — cooler than the success-green (~158) so
+         it doesn't read as a success-state cue.
+     All as CSS gradient strings so callers can use them in
      `background-image:` without rebuilding the gradient each time. */
   --bar-gradient-gold: linear-gradient(180deg, #D4A050 0%, #B8860B 100%);
   --bar-gradient-blue: linear-gradient(180deg, #6B9FD4 0%, #4A7AB8 100%);
+  --bar-gradient-teal: linear-gradient(180deg, #5EBFB6 0%, #388A86 100%);
 
   /* ── Typography ──
      Heading font: Source Serif 4 — a clean transitional serif that
@@ -378,6 +384,9 @@ body {
 .accent-row--blue::before {
   background: var(--bar-gradient-blue);
 }
+.accent-row--teal::before {
+  background: var(--bar-gradient-teal);
+}
 .accent-row--no-bar::before {
   display: none;
 }
@@ -453,6 +462,9 @@ body {
 .detail-group--blue::before {
   background: var(--bar-gradient-blue);
 }
+.detail-group--teal::before {
+  background: var(--bar-gradient-teal);
+}
 .detail-group--no-bar::before {
   display: none;
 }
@@ -502,6 +514,9 @@ body {
 }
 .stat-card-faint--blue::before {
   background: var(--bar-gradient-blue);
+}
+.stat-card-faint--teal::before {
+  background: var(--bar-gradient-teal);
 }
 .stat-card-faint--no-bar::before {
   display: none;

--- a/crates/intrada-web/src/components/accent_row.rs
+++ b/crates/intrada-web/src/components/accent_row.rs
@@ -8,6 +8,10 @@ pub enum AccentBar {
     Gold,
     /// Blue gradient — maps to "exercise" content.
     Blue,
+    /// Teal gradient — maps to "set" content (compositions of pieces +
+    /// exercises). Distinct from gold/blue so a Set row sits visibly
+    /// alongside atomic-item rows in a heterogeneous library list.
+    Teal,
     /// No bar — for uniform-type lists where the bar would add noise.
     None,
 }
@@ -17,6 +21,7 @@ impl AccentBar {
         match self {
             Self::Gold => "",
             Self::Blue => " accent-row--blue",
+            Self::Teal => " accent-row--teal",
             Self::None => " accent-row--no-bar",
         }
     }

--- a/crates/intrada-web/src/components/detail_group.rs
+++ b/crates/intrada-web/src/components/detail_group.rs
@@ -25,6 +25,7 @@ pub fn DetailGroup(
         match bar {
             AccentBar::Gold => "",
             AccentBar::Blue => " detail-group--blue",
+            AccentBar::Teal => " detail-group--teal",
             AccentBar::None => " detail-group--no-bar",
         }
     );

--- a/crates/intrada-web/src/components/stat_card.rs
+++ b/crates/intrada-web/src/components/stat_card.rs
@@ -42,6 +42,7 @@ pub fn StatCard(
             match bar {
                 AccentBar::Gold => "",
                 AccentBar::Blue => " stat-card-faint--blue",
+                AccentBar::Teal => " stat-card-faint--teal",
                 AccentBar::None => " stat-card-faint--no-bar",
             }
         );

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -417,6 +417,29 @@ pub fn DesignCatalogue() -> impl IntoView {
                     </div>
                 </div>
 
+                // Bar-gradient swatches — used by AccentRow / DetailGroup /
+                // StatCard to signal type (Piece / Exercise / Set) at a glance.
+                <div class="mt-6">
+                    <p class="text-xs font-medium text-muted uppercase mb-2">"Bar Gradients"</p>
+                    <div class="grid grid-cols-3 gap-3">
+                        <div class="space-y-1">
+                            <div class="h-12 rounded-lg" style="background: var(--bar-gradient-gold)"></div>
+                            <p class="text-xs text-faint">"bar-gradient-gold"</p>
+                            <p class="text-xs text-faint">"Pieces"</p>
+                        </div>
+                        <div class="space-y-1">
+                            <div class="h-12 rounded-lg" style="background: var(--bar-gradient-blue)"></div>
+                            <p class="text-xs text-faint">"bar-gradient-blue"</p>
+                            <p class="text-xs text-faint">"Exercises"</p>
+                        </div>
+                        <div class="space-y-1">
+                            <div class="h-12 rounded-lg" style="background: var(--bar-gradient-teal)"></div>
+                            <p class="text-xs text-faint">"bar-gradient-teal"</p>
+                            <p class="text-xs text-faint">"Sets"</p>
+                        </div>
+                    </div>
+                </div>
+
                 // Text colour samples
                 <div class="mt-6 space-y-1">
                     <p class="text-xs font-medium text-muted uppercase mb-2">"Text Colours"</p>
@@ -624,6 +647,12 @@ pub fn DesignCatalogue() -> impl IntoView {
                         </div>
                         <InlineTypeIndicator item_type=ItemType::Exercise />
                     </AccentRow>
+                    <AccentRow bar=AccentBar::Teal>
+                        <div class="flex flex-col flex-1 gap-0.5">
+                            <span class="text-sm font-semibold text-primary">"Morning Warm-up"</span>
+                            <span class="text-xs text-muted">"5 items"</span>
+                        </div>
+                    </AccentRow>
                     <AccentRow bar=AccentBar::None>
                         <div class="flex flex-col flex-1 gap-0.5">
                             <span class="text-sm font-semibold text-primary">"No-bar variant"</span>
@@ -646,6 +675,11 @@ pub fn DesignCatalogue() -> impl IntoView {
                     </DetailGroup>
                     <DetailGroup label="Notes" bar=AccentBar::Blue>
                         <p class="text-sm text-secondary leading-relaxed">"Focus on the arpeggiated left hand in the opening section. Keep dynamics very soft, pp throughout the first page."</p>
+                    </DetailGroup>
+                    <DetailGroup label="Set Entries" bar=AccentBar::Teal>
+                        <DetailRow label="1.">"Hanon Exercise No.1"</DetailRow>
+                        <DetailRow label="2.">"Clair de Lune"</DetailRow>
+                        <DetailRow label="3.">"Bach Prelude in C"</DetailRow>
                     </DetailGroup>
                 </div>
             </section>
@@ -692,6 +726,12 @@ pub fn DesignCatalogue() -> impl IntoView {
                     <StatCard title="Day Streak" value="12".to_string() bar=AccentBar::Gold tone=StatTone::Accent />
                     <StatCard title="Hrs This Week" value="8.5".to_string() bar=AccentBar::Blue tone=StatTone::WarmAccent />
                     <StatCard title="Pieces Learned" value="23".to_string() bar=AccentBar::Gold />
+                </div>
+                <p class="text-xs text-faint mt-3 mb-2">"Teal bar — for Set-flavoured stats."</p>
+                <div class="grid grid-cols-3 gap-3">
+                    <StatCard title="Saved Sets" value="7".to_string() bar=AccentBar::Teal />
+                    <StatCard title="Sets This Week" value="3".to_string() bar=AccentBar::Teal subtitle="Up from 1" />
+                    <StatCard title="Set Streak" value="4 days".to_string() bar=AccentBar::Teal />
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary

Foundation for the upcoming Library refactor — adds **teal** as the third \`AccentBar\` variant so Set rows can sit visibly alongside atomic-item rows in a heterogeneous library list.

The 2026 design language uses two accent bars today: gold (Pieces) / blue (Exercises). Sets are mixed compositions, so neither fits cleanly. Teal is distinct from both, cooler than \`--color-success\` (hue ~190 vs 158) so it doesn't read as a success-state cue.

## Changes

**Token** (\`input.css\`):
- New \`--bar-gradient-teal: linear-gradient(180deg, #5EBFB6 0%, #388A86 100%)\` alongside existing gold/blue
- Three matching CSS rules: \`.accent-row--teal::before\`, \`.detail-group--teal::before\`, \`.stat-card-faint--teal::before\`
- Comment block updated to document the three-variant family + colour-rationale

**Component enum** (\`accent_row.rs\`):
- \`AccentBar::Teal\` variant + match-arm in \`modifier()\`
- Match-arm additions in \`detail_group.rs\` + \`stat_card.rs\` (the other two consumers)
- Naming follows existing colour-named pattern (\`Gold\`, \`Blue\`); semantic labels live in the catalogue

**Catalogue showcase**:
- New "Bar Gradients" swatch row in Colours — gold / blue / teal side-by-side with Pieces / Exercises / Sets labels
- AccentRow: Teal variant ("Morning Warm-up · 5 items")
- DetailGroup: Teal "SET ENTRIES" sample
- StatCard: separate "Teal bar" subrow with three sample cards (Saved Sets / Sets This Week / Set Streak)

## Self-review

Ran \`superpowers:code-reviewer\` — verdict **ship it**, no critical or important findings. One cosmetic suggestion applied (S4): single-card \`grid-cols-3\` row replaced with three cards for visual parity with rows above.

Forward-looking notes (not blocking):
- If Set rows ever sit adjacent to a success-state pill on the same surface, the teal-vs-success-green proximity might want one more notch cooler (hue 195–200). No current view places them adjacent.
- If a fourth \`AccentBar\` variant ever lands, revisit semantic vs colour naming.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings\`
- [x] Build clean
- [x] Visually verified all three component showcases via preview server

## Base

Branched off \`refactor/routine-to-set\` (#407) so the new code uses the post-rename naming. Will rebase to main when #407 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)