### PR TITLE
feat(web): Set Detail page at /library/sets/:id

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -18,7 +18,7 @@ use crate::views::DesignCatalogue;
 use crate::views::{
     AddLibraryItemForm, AnalyticsPage, DetailView, EditLibraryItemForm, LibraryListView,
     NotFoundView, SessionActiveView, SessionNewView, SessionSummaryView, SessionsAllView,
-    SessionsListView, SetEditView, SetsListView,
+    SessionsListView, SetDetailView, SetEditView, SetsListView,
 };
 use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::{init_core, load_session_in_progress, process_effects};
@@ -176,6 +176,12 @@ fn AuthenticatedApp() -> impl IntoView {
                     // /library/new MUST come before /library/:id to avoid "new" matching :id
                     <Route path=path!("/library/new") view=move || view! {
                         <AddLibraryItemForm />
+                    } />
+                    // /library/sets/:id — Set Detail page. Literal "sets"
+                    // segment in the middle so this doesn't collide with
+                    // /library/:id (piece/exercise detail).
+                    <Route path=path!("/library/sets/:id") view=move || view! {
+                        <SetDetailView />
                     } />
                     <Route path=path!("/library/:id") view=move || view! {
                         <DetailView />

--- a/crates/intrada-web/src/components/library_set_card.rs
+++ b/crates/intrada-web/src/components/library_set_card.rs
@@ -17,10 +17,10 @@ use crate::components::{
 /// "X items" (no time estimate — Sets are recipes; durations come from
 /// session-time defaults).
 ///
-/// Tapping navigates to the Set Detail surface for review-then-start.
-/// While the dedicated `/library/sets/:id` route is being built, this
-/// links to the existing `/routines/:id/edit` page so the row stays
-/// functional in the interim.
+/// Tapping navigates to the Set Detail surface (`/library/sets/:id`)
+/// for review-then-start. The context-menu Edit action goes to the
+/// edit form (`/routines/:id/edit`) — that route stays as-is until the
+/// fold-into-Library URL migration ships in a later PR.
 #[component]
 pub fn LibrarySetCard(
     set: SetView,
@@ -39,11 +39,10 @@ pub fn LibrarySetCard(
         format!("{entry_count} items")
     };
 
-    // TODO: switch to `/library/sets/:id` when Set Detail lands.
-    let href = format!("/routines/{id}/edit");
+    let href = format!("/library/sets/{id}");
     let id_for_swipe = id.clone();
     let id_for_menu_delete = id.clone();
-    let edit_href = href.clone();
+    let edit_href = format!("/routines/{id}/edit");
 
     let row = view! {
         <A href=href attr:class="block no-underline">

--- a/crates/intrada-web/src/views/mod.rs
+++ b/crates/intrada-web/src/views/mod.rs
@@ -11,6 +11,7 @@ pub mod session_new;
 pub mod session_summary;
 pub mod sessions;
 pub mod sessions_all;
+pub mod set_detail;
 pub mod set_edit;
 pub mod sets;
 
@@ -27,5 +28,6 @@ pub use session_new::SessionNewView;
 pub use session_summary::SessionSummaryView;
 pub use sessions::SessionsListView;
 pub use sessions_all::SessionsAllView;
+pub use set_detail::SetDetailView;
 pub use set_edit::SetEditView;
 pub use sets::SetsListView;

--- a/crates/intrada-web/src/views/set_detail.rs
+++ b/crates/intrada-web/src/views/set_detail.rs
@@ -1,0 +1,224 @@
+use leptos::prelude::*;
+use leptos_router::components::A;
+use leptos_router::hooks::{use_navigate, use_params_map};
+use leptos_router::NavigateOptions;
+
+use intrada_core::{Event, ItemKind, SessionEvent, SetEvent, SetView, ViewModel};
+
+use crate::components::{
+    AccentBar, AccentRow, BackLink, Button, ButtonSize, ButtonVariant, Icon, IconName,
+    InlineTypeIndicator, SkeletonBlock, SkeletonLine,
+};
+use intrada_web::core_bridge::process_effects;
+use intrada_web::types::{IsLoading, IsSubmitting, ItemType, SharedCore};
+
+/// Map an `ItemKind` from core into the `ItemType` enum used by
+/// `<InlineTypeIndicator>`.
+fn item_kind_to_type(kind: ItemKind) -> ItemType {
+    match kind {
+        ItemKind::Piece => ItemType::Piece,
+        ItemKind::Exercise => ItemType::Exercise,
+    }
+}
+
+/// Set Detail page — read-only review of a saved set with the entries
+/// inline, plus a hero **Start Practice** CTA, an **Edit** trailing
+/// action in the nav row, and a **Delete** at the bottom.
+///
+/// Pencil reference: the proposal frames placed at `dCQvy` / `K7RMu`
+/// (set as a 4th tab in Library, set detail mirroring piece detail).
+///
+/// Route: `/library/sets/:id`. Tap a Set row in the Library list → here.
+/// Start Practice dispatches `SessionEvent::StartBuilding` followed by
+/// `SetEvent::LoadSetIntoSetlist`, then navigates to `/sessions/new`
+/// where the populated builder takes over.
+#[component]
+pub fn SetDetailView() -> impl IntoView {
+    let view_model = expect_context::<RwSignal<ViewModel>>();
+    let core = expect_context::<SharedCore>();
+    let is_loading = expect_context::<IsLoading>();
+    let is_submitting = expect_context::<IsSubmitting>();
+    let params = use_params_map();
+    let id = params.read().get("id").unwrap_or_default();
+
+    let core_start = core.clone();
+    let core_delete = core;
+
+    let id_for_start = id.clone();
+    let id_for_delete = id.clone();
+    let id_for_edit = id.clone();
+    let id_for_lookup = id;
+
+    let on_start_practice = Callback::new(move |_| {
+        // Two-step dispatch: StartBuilding (Idle → Building) then
+        // LoadSetIntoSetlist (push entries onto the new building
+        // setlist). If a session is already in progress, StartBuilding
+        // surfaces an error via the global ErrorBanner — the user sees
+        // it and resolves manually (resume / abandon).
+        let core_ref = core_start.borrow();
+        let mut effects = core_ref.process_event(Event::Session(SessionEvent::StartBuilding));
+        effects.extend(
+            core_ref.process_event(Event::Set(SetEvent::LoadSetIntoSetlist {
+                set_id: id_for_start.clone(),
+            })),
+        );
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        drop(core_ref);
+        let nav = use_navigate();
+        nav(
+            "/sessions/new",
+            NavigateOptions {
+                replace: false,
+                ..Default::default()
+            },
+        );
+    });
+
+    let on_delete = Callback::new(move |_| {
+        let event = Event::Set(SetEvent::DeleteSet {
+            id: id_for_delete.clone(),
+        });
+        let core_ref = core_delete.borrow();
+        let effects = core_ref.process_event(event);
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        drop(core_ref);
+        let nav = use_navigate();
+        nav(
+            "/",
+            NavigateOptions {
+                replace: true,
+                ..Default::default()
+            },
+        );
+    });
+
+    view! {
+        <div class="space-y-5">
+            // Nav row — back link + trailing Edit action (iOS
+            // UINavigationBar idiom; matches piece detail).
+            <div class="flex items-center justify-between -mb-2">
+                <BackLink label="Library" href="/".to_string() />
+                <A
+                    href=format!("/routines/{id_for_edit}/edit")
+                    attr:class="text-sm font-medium text-accent-text hover:text-accent-hover"
+                >
+                    "Edit"
+                </A>
+            </div>
+
+            {move || {
+                let id = id_for_lookup.clone();
+                let set = view_model.with(|vm| vm.sets.iter().find(|s| s.id == id).cloned());
+                match (set, is_loading.get()) {
+                    (Some(set), _) => render_loaded(set, on_start_practice, on_delete, is_submitting),
+                    (None, true) => view! {
+                        <div class="space-y-4 animate-pulse">
+                            <SkeletonLine width="w-2/3" height="h-8" />
+                            <SkeletonLine width="w-1/3" height="h-4" />
+                            <SkeletonBlock height="h-32" />
+                        </div>
+                    }
+                    .into_any(),
+                    (None, false) => view! {
+                        <div class="text-center py-8">
+                            <p class="text-secondary mb-4">"Set not found."</p>
+                            <A
+                                href="/"
+                                attr:class="text-accent-text hover:text-accent-hover font-medium"
+                            >
+                                "\u{2190} Back to Library"
+                            </A>
+                        </div>
+                    }
+                    .into_any(),
+                }
+            }}
+        </div>
+    }
+}
+
+fn render_loaded(
+    set: SetView,
+    on_start_practice: Callback<leptos::ev::MouseEvent>,
+    on_delete: Callback<leptos::ev::MouseEvent>,
+    is_submitting: IsSubmitting,
+) -> leptos::prelude::AnyView {
+    let entry_count = set.entry_count;
+    let count_label = if entry_count == 1 {
+        "1 item".to_string()
+    } else {
+        format!("{entry_count} items")
+    };
+    let entries = set.entries.clone();
+    let name = set.name.clone();
+
+    view! {
+        // Inline heading (PageHeading takes static strings; set names
+        // are dynamic). Mirrors DetailView's piece-detail header shape.
+        <div class="space-y-1">
+            <h2 class="page-title">{name}</h2>
+            <p class="text-sm text-muted">{count_label}</p>
+        </div>
+
+        // Entries — read-only AccentRows (no drag handle, no remove).
+        // Each entry shows the item title + InlineTypeIndicator dot/label
+        // — the same shape used in the Library list, just inert here.
+        <div class="space-y-3">
+            <h3 class="section-title">"Entries"</h3>
+            {if entries.is_empty() {
+                view! {
+                    <p class="text-sm text-muted">"This set has no entries yet."</p>
+                }.into_any()
+            } else {
+                view! {
+                    <div class="space-y-2">
+                        {entries.into_iter().map(|entry| {
+                            let bar = match entry.item_type {
+                                ItemKind::Piece => AccentBar::Gold,
+                                ItemKind::Exercise => AccentBar::Blue,
+                            };
+                            let inline_type = item_kind_to_type(entry.item_type);
+                            view! {
+                                <AccentRow bar=bar>
+                                    <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                                        <span class="text-sm font-semibold text-primary truncate">
+                                            {entry.item_title}
+                                        </span>
+                                    </div>
+                                    <InlineTypeIndicator item_type=inline_type />
+                                </AccentRow>
+                            }
+                        }).collect::<Vec<_>>()}
+                    </div>
+                }.into_any()
+            }}
+        </div>
+
+        // Hero CTA — Start Practice with this set. Dispatches the two-step
+        // StartBuilding + LoadSet flow then navigates to the builder.
+        <Button
+            variant=ButtonVariant::Primary
+            size=ButtonSize::Hero
+            full_width=true
+            on_click=on_start_practice
+        >
+            <span class="inline-flex items-center gap-1.5">
+                <Icon name=IconName::Play class="w-4 h-4" />
+                "Start Practice"
+            </span>
+        </Button>
+
+        // Delete — destructive, de-emphasised. No confirm sheet for v1
+        // because Sets are recipes (re-creating from any setlist is
+        // cheap); revisit if accidental deletes turn out to be a real
+        // pain point.
+        <Button
+            variant=ButtonVariant::DangerOutline
+            disabled=Signal::derive(move || is_submitting.get())
+            on_click=on_delete
+        >
+            "Delete Set"
+        </Button>
+    }
+    .into_any()
+}


### PR DESCRIPTION
## Summary
- Adds a read-only review surface for saved Sets at `/library/sets/:id` — tap a Set row in Library to see title, item count, and the entries inline (gold/blue AccentBar by item type).
- Hero **Start Practice** CTA dispatches the two-step `SessionEvent::StartBuilding` + `SetEvent::LoadSetIntoSetlist` flow, then routes to `/sessions/new` where the populated builder takes over. Trailing **Edit** action in the nav row, destructive **Delete** at the bottom.
- Skeleton state while loading; "Set not found" + back link if the id doesn't resolve.

Route is registered **before** `/library/:id` so the literal `sets` segment doesn't collide with piece/exercise detail. `LibrarySetCard` now points its row href at the new route; the context-menu **Edit** action still goes to `/routines/:id/edit` until the URL migration ships in a later PR (per the staged plan in #390).

Pencil reference: proposal frames at `dCQvy` / `K7RMu`.

Builds on the merged Sets-in-Library work (#407 rename, #408 Teal accent, #411 Library tab + card).

## Test plan
- [ ] `cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings` clean
- [ ] `cargo test -p intrada-core` green (no core changes; sanity)
- [ ] Manual: navigate to a Set in the Library Sets tab → tap row → review page renders with entries
- [ ] Manual: tap **Start Practice** → lands on `/sessions/new` with the builder pre-filled
- [ ] Manual: tap **Edit** → routes to existing `/routines/:id/edit` form
- [ ] Manual: tap **Delete Set** → returns to Library, set gone
- [ ] Manual: visit `/library/sets/<bogus-id>` → "Set not found" empty state with back link

🤖 Generated with [Claude Code](https://claude.com/claude-code)