### PR TITLE
feat(web): re-introduce Load Set affordance in session builder

### DIFF
--- a/crates/intrada-web/src/components/mod.rs
+++ b/crates/intrada-web/src/components/mod.rs
@@ -84,12 +84,11 @@ pub use page_heading::PageHeading;
 pub use progress_ring::ProgressRing;
 pub use pull_to_refresh::PullToRefresh;
 pub use rating_chips::RatingChips;
-// SetLoader is currently unused — kept around for the planned set
-// flows revisit (see PR conversation). Re-export when something needs it.
 pub use section_label::SectionLabel;
 pub use session_review_sheet::SessionReviewSheet;
 pub use session_summary::SessionSummary;
 pub use session_timer::SessionTimer;
+pub use set_loader::SetLoader;
 pub use set_save_form::SetSaveForm;
 pub use setlist_builder::SetlistBuilder;
 pub use setlist_entry::SetlistEntryRow;

--- a/crates/intrada-web/src/components/set_loader.rs
+++ b/crates/intrada-web/src/components/set_loader.rs
@@ -2,14 +2,21 @@ use leptos::prelude::*;
 
 use intrada_core::{Event, SetEvent, ViewModel};
 
-use crate::components::Card;
+use crate::components::{AccentBar, AccentRow, Button, ButtonVariant};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-/// Shows saved sets and lets the user load one into the current setlist.
+/// Lists the user's saved Sets and lets them load one into the current
+/// (empty) building setlist. Renders nothing when there are no saved Sets.
 ///
-/// Each set is displayed as a row with name, entry count, and a Load button.
-/// Only visible when at least one set exists.
+/// Mounted at the top of the SetlistBuilder, gated by the caller on
+/// `setlist_empty` — once the user has picked items, the loader hides so
+/// the "load vs current selection" decision doesn't arise. Merge/replace
+/// is deferred until that flow is needed (see #390).
+///
+/// Each row mirrors the LibrarySetCard chrome (AccentRow with the Teal
+/// bar that signals Set content) so saved Sets read consistently across
+/// the Library and the builder.
 #[component]
 pub fn SetLoader() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -25,40 +32,46 @@ pub fn SetLoader() -> impl IntoView {
             } else {
                 let core_load = core.clone();
                 Some(view! {
-                    <Card>
+                    <div class="space-y-2">
                         <h3 class="section-title">"Saved Sets"</h3>
-                        <div class="space-y-2">
+                        <ul class="space-y-2">
                             {vm.sets.iter().map(|set| {
                                 let set_id = set.id.clone();
                                 let name = set.name.clone();
                                 let entry_count = set.entry_count;
+                                let count_label = if entry_count == 1 {
+                                    "1 item".to_string()
+                                } else {
+                                    format!("{entry_count} items")
+                                };
                                 let core_l = core_load.clone();
+                                let on_load = Callback::new(move |_| {
+                                    let event = Event::Set(SetEvent::LoadSetIntoSetlist {
+                                        set_id: set_id.clone(),
+                                    });
+                                    let core_ref = core_l.borrow();
+                                    let effects = core_ref.process_event(event);
+                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                });
                                 view! {
-                                    <div class="flex items-center justify-between rounded-lg bg-surface-secondary px-3 py-2 hover:bg-surface-hover">
-                                        <div class="flex items-center gap-2">
-                                            <span class="text-sm text-primary font-medium">{name}</span>
-                                            <span class="badge badge--accent">
-                                                {format!("{} item{}", entry_count, if entry_count == 1 { "" } else { "s" })}
-                                            </span>
-                                        </div>
-                                        <button
-                                            class="text-xs font-medium text-accent-text hover:text-accent-hover px-2 py-1 rounded hover:bg-surface-secondary motion-safe:transition-colors motion-safe:duration-150"
-                                            on:click=move |_| {
-                                                let event = Event::Set(SetEvent::LoadSetIntoSetlist {
-                                                    set_id: set_id.clone(),
-                                                });
-                                                let core_ref = core_l.borrow();
-                                                let effects = core_ref.process_event(event);
-                                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                            }
-                                        >
-                                            "Load"
-                                        </button>
-                                    </div>
+                                    <li>
+                                        <AccentRow bar=AccentBar::Teal>
+                                            <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                                                <span class="text-sm font-semibold text-primary truncate">{name}</span>
+                                                <span class="text-xs text-muted truncate">{count_label}</span>
+                                            </div>
+                                            <Button
+                                                variant=ButtonVariant::Secondary
+                                                on_click=on_load
+                                            >
+                                                "Load"
+                                            </Button>
+                                        </AccentRow>
+                                    </li>
                                 }
                             }).collect::<Vec<_>>()}
-                        </div>
-                    </Card>
+                        </ul>
+                    </div>
                 })
             }
         }}

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -9,6 +9,7 @@ use intrada_core::{Event, ItemKind, LibraryItemView, SessionEvent, ViewModel};
 
 use crate::components::{
     BuilderItemRow, Button, ButtonVariant, Icon, IconName, LibraryTypeTabs, SessionReviewSheet,
+    SetLoader,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -119,6 +120,15 @@ pub fn SetlistBuilder() -> impl IntoView {
 
     view! {
         <div class="space-y-4 pb-32">
+            // Saved Sets — visible while the setlist is empty so the user
+            // can start from a saved Set rather than picking items
+            // individually. Hides once they've added their first item to
+            // keep the library list uncluttered (merge/replace flow is
+            // out of scope here — see #390).
+            <Show when=move || setlist_empty.get()>
+                <SetLoader />
+            </Show>
+
             // Search bar with built-in clear button (mirrors the library
             // list's affordance — clear the query without clearing tabs).
             <div class="search-bar">

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -1838,7 +1838,7 @@ pub fn DesignCatalogue() -> impl IntoView {
                         </div>
                         <div class="flex items-center gap-2">
                             <span class="text-accent-text">"→"</span>
-                            <span>"SetLoader — Card (set list with load buttons)"</span>
+                            <span>"SetLoader — AccentRow (Teal) + Button (saved-set picker for the builder)"</span>
                         </div>
                         <div class="flex items-center gap-2">
                             <span class="text-accent-text">"→"</span>

--- a/e2e/tests/sets.spec.ts
+++ b/e2e/tests/sets.spec.ts
@@ -63,10 +63,7 @@ test.describe("sets page", () => {
     await expect(page.getByText("My New Set")).toBeVisible();
   });
 
-  // Skipped: "Load set" UI was removed from the builder during #388
-  // and the strip-back kept it out — see #390. The SetLoader component
-  // is still in the module tree pending the sets revisit.
-  test.skip("load set into session builder", async ({ page, mockApi }) => {
+  test("load set into session builder", async ({ page, mockApi }) => {
     mockApi.sets = createSeedSetsWithStub();
 
     await page.goto("/sessions/new");
@@ -74,7 +71,13 @@ test.describe("sets page", () => {
 
     await expect(page.getByText("Saved Sets")).toBeVisible();
     await expect(page.getByText("Morning Warm-up")).toBeVisible();
-    await page.getByRole("button", { name: "Load" }).click();
+    // Scope by row so the click stays unambiguous if more saved sets are
+    // ever seeded — prevents future flakes when the loader has >1 row.
+    await page
+      .getByRole("listitem")
+      .filter({ hasText: "Morning Warm-up" })
+      .getByRole("button", { name: "Load" })
+      .click();
 
     await page.getByRole("button", { name: "Review session" }).click();
     await expect(


### PR DESCRIPTION
## Summary
- Mounts the existing `<SetLoader>` at the top of the `SetlistBuilder`, gated on the existing `setlist_empty` signal so it disappears once the user adds an item.
- Refactors `SetLoader` from raw markup (`rounded-lg bg-surface-secondary px-3 py-2 …`) to `<AccentRow bar=AccentBar::Teal>` + `<Button variant=Secondary>` — mirrors `LibrarySetCard`'s chrome so saved Sets read consistently across Library and the builder.
- Re-exports the component (was deliberately unexported during the strip-back).
- Re-enables the previously-skipped `load set into session builder` e2e test, with a tightened listitem-scoped selector.

Closes [intrada#390](https://github.com/jonyardley/intrada/issues/390) (the second half — the first half landed in [intrada#413](https://github.com/jonyardley/intrada/pull/413)).

### Why no merge/replace prompt?
The issue calls out merge/replace as TBD. Empty-only gating sidesteps the question entirely: `LoadSetIntoSetlist` already appends, and append-into-empty == replace-from-zero. Avoids a Crux core change for behaviour the user may never need (their flow at this point is "load a set OR pick items individually", not "load on top of items I already picked"). If we discover users do want this, we'd add `SetEvent::ReplaceSetlistWithSet` and an inline merge/replace choice — easy follow-up.

## Test plan
- [x] `cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `cargo test -p intrada-core` (253 pass)
- [x] Empty-state visual check: builder renders, no "Saved Sets" panel when no sets exist (local API was 500'ing so positive state not exercised locally)
- [ ] CI runs the un-skipped Playwright test end-to-end with mockApi seed
- [ ] Manual: visit `/sessions/new` → Custom Session, see "Saved Sets" panel above search bar; tap Load on a set → entries appear in the library list as selected, panel hides, Review session enabled

## Follow-ups (not in this PR)
- If saved-sets count grows large the loader needs `max-h` / scroll. Surface as an issue if it becomes a real problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)