### PR TITLE
feat(web): "Save as Set" button → disabled "Saved" after save

### DIFF
--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -1,11 +1,13 @@
 use leptos::prelude::*;
 
-use crate::components::{Button, ButtonVariant, Card};
+use crate::components::{Button, ButtonVariant, Card, Icon, IconName};
 
 /// Inline form for saving a setlist or summary as a named set.
 ///
 /// When collapsed, shows a "Save as Set" button. When expanded, shows a
 /// name input, Save, and Cancel buttons. Calls `on_save` with the entered name.
+/// After a successful save the button switches to a disabled "Saved" state to
+/// prevent duplicate Set creation. The state resets when the form unmounts.
 #[component]
 pub fn SetSaveForm(
     /// Callback invoked with the set name when the user taps Save.
@@ -14,6 +16,7 @@ pub fn SetSaveForm(
     let expanded = RwSignal::new(false);
     let name = RwSignal::new(String::new());
     let error = RwSignal::new(Option::<String>::None);
+    let saved = RwSignal::new(false);
 
     let try_save = move || {
         let trimmed = name.get_untracked().trim().to_string();
@@ -24,6 +27,7 @@ pub fn SetSaveForm(
             on_save.run(trimmed);
             name.set(String::new());
             expanded.set(false);
+            saved.set(true);
         }
     };
 
@@ -76,6 +80,16 @@ pub fn SetSaveForm(
                             </div>
                         </div>
                     </Card>
+                }.into_any()
+            } else if saved.get() {
+                view! {
+                    <button
+                        class="w-full rounded-lg border border-success/40 bg-success/10 px-4 py-3 text-sm font-medium text-success-text inline-flex items-center justify-center gap-2 cursor-default"
+                        disabled
+                    >
+                        <Icon name=IconName::Check class="w-4 h-4" />
+                        "Saved"
+                    </button>
                 }.into_any()
             } else {
                 view! {


### PR DESCRIPTION
## Summary

Closes [intrada#424](https://github.com/jonyardley/intrada/issues/424).

After tapping **Save as Set** → entering a name → **Save**, the collapsed-state button now switches to a disabled **"Saved"** + check-icon variant so the user can't double-tap into duplicate Sets.

- New local `saved` `RwSignal<bool>` flips on the success branch of `try_save` (after `on_save.run`).
- Three-way render in the collapsed state: expanded form / saved button / default button.
- Saved styling uses `border-success/40 bg-success/10 text-success-text` + `IconName::Check` to match the existing completed-entry pattern in `session_summary.rs`.
- State resets on unmount — re-opening the review sheet starts fresh. Editing-after-save is intentionally out of scope per the issue.

## Trade-off

**Optimistic flip** — `saved` flips on dispatch, not on save success confirmation. If the request fails, the existing error toast surfaces but the button stays "Saved". The user would need to close + reopen the sheet to retry. Defensible for a Tier-1 fix because the no-feedback / duplicate-save problem was actively painful, while save failures are rare and recoverable. A success-event-driven version would need a Crux core change (#426 covers that broader pattern).

## Test plan

- [x] `cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `cargo test -p intrada-core` (253 pass)
- [x] `trunk build --release` succeeds
- [ ] Manual: build a session, hit Review → "Save as Set" → enter name → Save → button shows "Saved" with check icon, disabled; tapping no longer does anything
- [ ] Manual: close and reopen the review sheet → "Save as Set" button is back to default state
- [ ] iOS Tauri shell: same flow, success-token contrast reads correctly under `[data-platform="ios"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)