### PR TITLE
feat(web): "Start over" with confirmation in session builder

### DIFF
--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -213,40 +213,55 @@ pub fn SetlistBuilder() -> impl IntoView {
                 }}
             </div>
 
-            // Start over — destructive reset of the in-progress setlist.
-            // Hidden when the setlist is empty (nothing to clear).
-            // First tap reveals a Yes/No confirmation pair; second tap
-            // dispatches CancelBuilding.
-            <Show when=move || !setlist_empty.get()>
-                <div class="flex justify-center pt-2">
-                    <Show
-                        when=move || confirming_clear.get()
-                        fallback=move || view! {
-                            <Button
-                                variant=ButtonVariant::DangerOutline
-                                on_click=on_clear_request
-                            >
-                                "Start over"
-                            </Button>
-                        }
+            // Cancel / Start over — both fire CancelBuilding (same
+            // downstream effect: clears building state and the
+            // in-progress localStorage blob, returning the user to the
+            // sessions list). Different UX:
+            // - Empty setlist: single-tap "Cancel" — there's nothing to
+            //   lose, so navigation is the only intent.
+            // - Non-empty setlist: two-step "Start over" → "Yes, clear
+            //   it" / "Keep it" so the user can't accidentally discard
+            //   their work.
+            <div class="flex justify-center pt-2">
+                <Show
+                    when=move || setlist_empty.get()
+                    fallback=move || view! {
+                        <Show
+                            when=move || confirming_clear.get()
+                            fallback=move || view! {
+                                <Button
+                                    variant=ButtonVariant::DangerOutline
+                                    on_click=on_clear_request
+                                >
+                                    "Start over"
+                                </Button>
+                            }
+                        >
+                            <div class="flex gap-2">
+                                <Button
+                                    variant=ButtonVariant::Danger
+                                    on_click=on_clear_confirm
+                                >
+                                    "Yes, clear it"
+                                </Button>
+                                <Button
+                                    variant=ButtonVariant::Secondary
+                                    on_click=on_clear_cancel
+                                >
+                                    "Keep it"
+                                </Button>
+                            </div>
+                        </Show>
+                    }
+                >
+                    <Button
+                        variant=ButtonVariant::Secondary
+                        on_click=on_clear_confirm
                     >
-                        <div class="flex gap-2">
-                            <Button
-                                variant=ButtonVariant::Danger
-                                on_click=on_clear_confirm
-                            >
-                                "Yes, clear it"
-                            </Button>
-                            <Button
-                                variant=ButtonVariant::Secondary
-                                on_click=on_clear_cancel
-                            >
-                                "Keep it"
-                            </Button>
-                        </div>
-                    </Show>
-                </div>
-            </Show>
+                        "Cancel"
+                    </Button>
+                </Show>
+            </div>
         </div>
 
         // Sticky bottom toolbar — count + duration + Review CTA.

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -37,6 +37,22 @@ pub fn SetlistBuilder() -> impl IntoView {
     let core_toggle = core.clone();
     let core_cancel = core.clone();
 
+    // "Start over" two-step confirmation. First tap shows the
+    // confirmation pair; second tap on "Yes, clear it" dispatches
+    // CancelBuilding (which already wipes the in-progress localStorage
+    // blob via AppEffect::ClearSessionInProgress).
+    let confirming_clear = RwSignal::new(false);
+
+    let on_clear_request = Callback::new(move |_| confirming_clear.set(true));
+    let on_clear_cancel = Callback::new(move |_| confirming_clear.set(false));
+    let on_clear_confirm = Callback::new(move |_| {
+        let event = Event::Session(SessionEvent::CancelBuilding);
+        let core_ref = core_cancel.borrow();
+        let effects = core_ref.process_event(event);
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        confirming_clear.set(false);
+    });
+
     // Library list filter state.
     let active_filter: RwSignal<Option<ItemKind>> = RwSignal::new(None);
     let query = RwSignal::new(String::new());
@@ -197,19 +213,40 @@ pub fn SetlistBuilder() -> impl IntoView {
                 }}
             </div>
 
-            // Cancel — kept here so the user can back out without leaving
-            // the page; primary navigation away is "Start Session" inside
-            // the sheet.
-            <div class="flex justify-center pt-2">
-                <Button variant=ButtonVariant::Secondary on_click=Callback::new(move |_| {
-                    let event = Event::Session(SessionEvent::CancelBuilding);
-                    let core_ref = core_cancel.borrow();
-                    let effects = core_ref.process_event(event);
-                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                })>
-                    "Cancel"
-                </Button>
-            </div>
+            // Start over — destructive reset of the in-progress setlist.
+            // Hidden when the setlist is empty (nothing to clear).
+            // First tap reveals a Yes/No confirmation pair; second tap
+            // dispatches CancelBuilding.
+            <Show when=move || !setlist_empty.get()>
+                <div class="flex justify-center pt-2">
+                    <Show
+                        when=move || confirming_clear.get()
+                        fallback=move || view! {
+                            <Button
+                                variant=ButtonVariant::DangerOutline
+                                on_click=on_clear_request
+                            >
+                                "Start over"
+                            </Button>
+                        }
+                    >
+                        <div class="flex gap-2">
+                            <Button
+                                variant=ButtonVariant::Danger
+                                on_click=on_clear_confirm
+                            >
+                                "Yes, clear it"
+                            </Button>
+                            <Button
+                                variant=ButtonVariant::Secondary
+                                on_click=on_clear_cancel
+                            >
+                                "Keep it"
+                            </Button>
+                        </div>
+                    </Show>
+                </div>
+            </Show>
         </div>
 
         // Sticky bottom toolbar — count + duration + Review CTA.

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -111,7 +111,9 @@ test.describe("sessions page", () => {
     await expect(page.getByText("Items Practiced")).toBeVisible();
   });
 
-  test("cancel building returns to sessions list", async ({ page }) => {
+  test("cancel building from empty setlist returns to sessions list", async ({
+    page,
+  }) => {
     await page.goto("/sessions/new");
 
     // Click "Custom Session" to enter the setlist builder
@@ -122,14 +124,61 @@ test.describe("sessions page", () => {
       page.getByRole("heading", { name: "New Session" })
     ).toBeVisible();
 
-    // Click Cancel — scoped to <main> to avoid matching the (closed but
-    // still mounted) bottom sheet's own Cancel button.
+    // Empty-setlist branch: single-tap Cancel (no confirmation, since
+    // there's nothing to lose). Scoped to <main> to avoid matching the
+    // (closed but still mounted) bottom sheet's own Cancel button.
     await page
       .getByRole("main")
       .getByRole("button", { name: "Cancel" })
       .click();
 
     // Should redirect to sessions list
+    await expect(
+      page.getByRole("heading", { name: "Practice" })
+    ).toBeVisible();
+  });
+
+  test("Start over with confirmation clears non-empty setlist", async ({
+    page,
+  }) => {
+    await page.goto("/sessions/new");
+    await page.getByRole("button", { name: "Custom Session" }).click();
+    await expect(
+      page.getByRole("heading", { name: "New Session" })
+    ).toBeVisible();
+
+    // Add an item — Start over only appears when the setlist is non-empty.
+    await page.getByText("Clair de Lune").click();
+
+    // First tap: Start over → confirmation pair appears.
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Start over" })
+      .click();
+    await expect(
+      page.getByRole("main").getByRole("button", { name: "Yes, clear it" })
+    ).toBeVisible();
+
+    // Tap "Keep it" to abort — single Start over button returns.
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Keep it" })
+      .click();
+    await expect(
+      page.getByRole("main").getByRole("button", { name: "Start over" })
+    ).toBeVisible();
+
+    // Tap Start over again, then confirm.
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Start over" })
+      .click();
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Yes, clear it" })
+      .click();
+
+    // CancelBuilding clears the in-progress setlist and redirects.
     await expect(
       page.getByRole("heading", { name: "Practice" })
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Closes [intrada#427](https://github.com/jonyardley/intrada/issues/427).

The previous **Cancel** button was easily missed (passive label, Secondary variant, centred below the library list) and had no confirmation — so the user couldn't reliably reset an in-progress setlist.

This PR replaces it with a **Start over** affordance that:

- **Hides when the setlist is empty** (nothing to clear)
- Uses **`DangerOutline`** variant so the destructive intent reads at a glance
- **Two-step inline confirmation**: first tap reveals a `"Yes, clear it"` (Danger) + `"Keep it"` (Secondary) pair; second tap dispatches `SessionEvent::CancelBuilding`

`CancelBuilding` already wipes the `intrada:session-in-progress` localStorage blob via `AppEffect::ClearSessionInProgress`, so no persistence change was needed.

## Implementation note

Callbacks (`on_clear_request`, `on_clear_cancel`, `on_clear_confirm`) are extracted to function scope to lean on Leptos's `Copy` semantics for `Callback<T>`. Inlining them inside the reactive `<Show>` children produced `FnOnce` captures of `core_cancel`. Pattern matches the existing `on_toggle` / `close_review` callbacks in the same file.

The two-step pattern fits the iOS Tauri shell — `Button` already wires a **warning haptic** to `Danger`/`DangerOutline` variants, so taps emit the right destructive-confirm feedback automatically.

## Test plan

- [x] `cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `cargo test -p intrada-core` (253 pass)
- [x] `trunk build` succeeds
- [x] Self-review (code-reviewer subagent) — approved with non-blocking notes
- [ ] Manual: build a session → "Start over" visible (DangerOutline); tap → Yes/Keep pair appears; "Yes, clear it" → setlist cleared, button hides
- [ ] Manual: empty setlist → no Start over button
- [ ] Manual: tap "Start over" → "Keep it" → state returns to single button (no clear)
- [ ] Manual: navigate away mid-confirmation → return → builder still showing in-progress items, confirmation reset to default
- [ ] iOS: warning haptic fires on first tap and on "Yes, clear it"

## Follow-ups (not in this PR)

- **Keyboard Esc dismissal** — pressing Esc mid-confirmation should revert to the single button (web-only concern; iOS shell is the primary target).
- **`aria-live` on the swap** — screen-reader users aren't announced when the Yes/Keep pair appears. Both small a11y improvements, worth a separate issue if web a11y becomes a focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)