### PR TITLE
fix(web): reset SetSaveForm "Saved" state when sheet closes

### DIFF
--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -49,7 +49,7 @@ pub fn SessionReviewSheet(open: Signal<bool>, on_close: Callback<()>) -> impl In
             on_nav_action=on_start
             nav_action_disabled=setlist_empty
         >
-            <ReviewSheetBody />
+            <ReviewSheetBody sheet_open=open />
         </BottomSheet>
     }
 }
@@ -58,8 +58,11 @@ pub fn SessionReviewSheet(open: Signal<bool>, on_close: Callback<()>) -> impl In
 /// Lives in its own component so per-entry move-closures don't have to
 /// satisfy `Fn` for the BottomSheet's children prop — the Leptos component
 /// boundary breaks the closure-trait dependency chain.
+///
+/// `sheet_open` is forwarded to [`SetSaveForm`] so it can reset its
+/// "Saved" state when the sheet closes.
 #[component]
-fn ReviewSheetBody() -> impl IntoView {
+fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
     let is_loading = expect_context::<IsLoading>();
@@ -207,12 +210,15 @@ fn ReviewSheetBody() -> impl IntoView {
                 {
                     let core_save = core_save_set.clone();
                     view! {
-                        <SetSaveForm on_save=Callback::new(move |name: String| {
-                            let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
-                            let core_ref = core_save.borrow();
-                            let effects = core_ref.process_event(event);
-                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                        }) />
+                        <SetSaveForm
+                            sheet_open=sheet_open
+                            on_save=Callback::new(move |name: String| {
+                                let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
+                                let core_ref = core_save.borrow();
+                                let effects = core_ref.process_event(event);
+                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                            })
+                        />
                     }
                 }
             </Show>

--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -7,16 +7,35 @@ use crate::components::{Button, ButtonVariant, Card, Icon, IconName};
 /// When collapsed, shows a "Save as Set" button. When expanded, shows a
 /// name input, Save, and Cancel buttons. Calls `on_save` with the entered name.
 /// After a successful save the button switches to a disabled "Saved" state to
-/// prevent duplicate Set creation. The state resets when the form unmounts.
+/// prevent duplicate Set creation.
+///
+/// When mounted inside a [`BottomSheet`], pass the sheet's `open` signal as
+/// `sheet_open` — the "Saved" state will reset when the sheet closes, so a
+/// close→reopen cycle starts fresh. Bottom sheets keep their children
+/// mounted (translated off-screen), so without this the button would stay
+/// stuck in the "Saved" state forever. Full-screen mounts (e.g. session
+/// summary) can omit it.
 #[component]
 pub fn SetSaveForm(
     /// Callback invoked with the set name when the user taps Save.
     on_save: Callback<String>,
+    /// Optional parent-sheet open signal. If provided, the "Saved" state
+    /// resets when this transitions to false.
+    #[prop(optional, into)]
+    sheet_open: Option<Signal<bool>>,
 ) -> impl IntoView {
     let expanded = RwSignal::new(false);
     let name = RwSignal::new(String::new());
     let error = RwSignal::new(Option::<String>::None);
     let saved = RwSignal::new(false);
+
+    if let Some(open) = sheet_open {
+        Effect::new(move |_| {
+            if !open.get() {
+                saved.set(false);
+            }
+        });
+    }
 
     let try_save = move || {
         let trimmed = name.get_untracked().trim().to_string();


### PR DESCRIPTION
## Summary

Follow-up fix to [#430](https://github.com/jonyardley/intrada/pull/430) ([#424](https://github.com/jonyardley/intrada/issues/424)).

The "Saved" disabled state added in #430 was claimed to reset on unmount, but `BottomSheet` keeps its children mounted (just translates them off-screen — see [`bottom_sheet.rs:267-272`](https://github.com/jonyardley/intrada/blob/main/crates/intrada-web/src/components/bottom_sheet.rs#L267-L272)). So the actual behaviour was:

> open sheet → save → close → reopen → button still says **"Saved"**, disabled

Leaving the user with no way to initiate another save without removing every setlist item to remount the form. Caught in self-review of #430 post-merge.

## Fix

`SetSaveForm` gains an optional `sheet_open: Signal<bool>` prop. When provided, an `Effect::new` resets `saved` to false whenever the signal transitions to false (sheet closing). Plumbed through:

```
SessionReviewSheet (open prop)
  → ReviewSheetBody (new sheet_open prop)
    → SetSaveForm (sheet_open prop)
```

The prop is **optional** (`#[prop(optional, into)]`) so non-sheet callers — `session_summary.rs:316` (post-session full-screen) and `design_catalogue.rs:1539` (showcase) — need no change. Full-screen mounts naturally remount on revisit.

## Test plan

- [x] `cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings`
- [x] `cargo test -p intrada-core` (253 pass)
- [x] `trunk build` succeeds
- [x] **Self-review (code-reviewer subagent) — approved.** Walked through Effect step-by-step (mount/open/save/close/reopen), confirmed no spurious resets and no in-flight-save consumption. Optional-prop pattern + prop-not-context choice both confirmed idiomatic.
- [ ] Manual: open Review sheet → Save as Set → name → Save → button shows "Saved" disabled
- [ ] Manual: **close Review sheet → reopen → button is back to default "Save as Set"** (this is the bug)
- [ ] Manual: post-session summary save flow still works (`session_summary.rs` path) — no behaviour change expected

## Follow-up (not in this PR)

The reviewer flagged a pre-existing UX wart from #430: the **optimistic flip** sets `saved=true` even if the save HTTP request fails — the user briefly sees "Saved" for a Set that wasn't created. Recoverable (close→reopen frees them), and superseded by the broader [#426](https://github.com/jonyardley/intrada/issues/426) save-feedback pattern. Filing as a sub-task there if it isn't already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)