### PR TITLE
ux: BottomSheet backdrop blur + Library subheading mentions Sets

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1555,6 +1555,12 @@ html:not([data-platform="ios"]) .pull-to-refresh-indicator {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
+  /* Soft blur so the underlying page recedes — matches the chrome
+     treatment used elsewhere (.glass-chrome, .action-bar). Without
+     this the dim looks flat and the page is still legible behind
+     the sheet. -webkit- prefix for the iOS Tauri WebView. */
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
   z-index: 1000;
   opacity: 0;
   pointer-events: none;

--- a/crates/intrada-web/src/views/library_list.rs
+++ b/crates/intrada-web/src/views/library_list.rs
@@ -194,7 +194,7 @@ pub fn LibraryListView() -> impl IntoView {
             // (circular "+") for consistency across all top-level pages.
             <PageHeading
                 text="Library"
-                subtitle="Your pieces and exercises."
+                subtitle="Your pieces, exercises, and sets."
                 trailing=Box::new(move || view! {
                     <PageAddButton
                         aria_label="Add Item"


### PR DESCRIPTION
## Summary

Two small UX tweaks bundled because both are single-line changes:

- **[#423](https://github.com/jonyardley/intrada/issues/423) — BottomSheet backdrop blur.** The backdrop was just \`rgba(0,0,0,0.5)\` with no \`backdrop-filter\` — the dim looked flat and the underlying page was still legible behind the sheet. Adds \`backdrop-filter: blur(12px)\` (with the \`-webkit-\` prefix for iOS Tauri WebView). The dim alpha is unchanged. 12px matches \`.glass-chrome\` and \`.action-bar\` so the chrome treatment is consistent across the app.

- **[#422](https://github.com/jonyardley/intrada/issues/422) — Library subheading.** Now reads \"Your pieces, exercises, and sets.\" to reflect the IA shift in [#415](https://github.com/jonyardley/intrada/pull/415) — Sets live as a third type-tab under Library now.

## Test plan

- [x] \`cargo fmt --check && cargo clippy -p intrada-web --target wasm32-unknown-unknown --no-default-features -- -D warnings\`
- [x] \`trunk build\` succeeds
- [ ] Manual: open the session review sheet — content underneath visibly softens / blurs (not just dimmed)
- [ ] Manual: \`/library\` heading reads \"Your pieces, exercises, and sets.\"
- [ ] iOS Tauri shell: backdrop blur renders (the \`-webkit-\` prefix is in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)