### PR TITLE
feat(mobile): Phase D — cleanup audit + Sentry for background-audio (#309)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6823,7 +6823,9 @@ dependencies = [
 name = "tauri-plugin-background-audio"
 version = "0.0.1"
 dependencies = [
+ "sentry",
  "serde",
+ "serde_json",
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",

--- a/crates/intrada-mobile/plugins/background-audio/Cargo.toml
+++ b/crates/intrada-mobile/plugins/background-audio/Cargo.toml
@@ -3,7 +3,7 @@ name = "tauri-plugin-background-audio"
 version = "0.0.1"
 edition = "2021"
 rust-version.workspace = true
-description = "Intrada-internal Tauri plugin: keeps the practice timer running while the app is backgrounded / the device is locked. Phase B scaffold — commands return Ok with no native side-effects yet."
+description = "Intrada-internal Tauri plugin: keeps the practice timer running while the app is backgrounded / the device is locked. Bridges to Swift on iOS for AVAudioSession + lock-screen Now Playing."
 # Required by tauri-plugin's build script (must match package.name).
 links = "tauri-plugin-background-audio"
 
@@ -11,6 +11,15 @@ links = "tauri-plugin-background-audio"
 tauri = { version = "2" }
 serde = { workspace = true }
 thiserror = { workspace = true }
+
+# iOS-only: sentry + serde_json. Used inside `#[cfg(target_os = "ios")]`
+# helpers to drop breadcrumbs / capture bridge errors against the host's
+# already-initialised Sentry hub (intrada-mobile/src-tauri/src/lib.rs).
+# Default sentry features off — the host owns transport (reqwest/rustls);
+# we only need the core API surface.
+[target.'cfg(target_os = "ios")'.dependencies]
+serde_json = { workspace = true }
+sentry = { version = "0.48", default-features = false }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/crates/intrada-mobile/plugins/background-audio/src/lib.rs
+++ b/crates/intrada-mobile/plugins/background-audio/src/lib.rs
@@ -58,12 +58,62 @@ pub struct NowPlayingArgs {
     pub started_at: String,
 }
 
+/// Drop a Sentry breadcrumb tagged `background-audio` so any subsequent
+/// failure (here or elsewhere in the session) carries the lifecycle
+/// context. No-op when Sentry isn't initialised (simulator / dev /
+/// non-iOS), so cheap to call unconditionally.
+#[cfg(target_os = "ios")]
+fn breadcrumb(command: &str, data: serde_json::Value) {
+    sentry::add_breadcrumb(sentry::Breadcrumb {
+        category: Some("background-audio".to_string()),
+        message: Some(command.to_string()),
+        level: sentry::Level::Info,
+        data: data
+            .as_object()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    });
+}
+
+/// Capture a plugin-bridge failure as a Sentry message tagged with the
+/// command name. Errors here mean the iOS audio session is likely not
+/// active (timer will keep running web-side via the wall-clock derive,
+/// but the lock-screen + background timer behaviour is broken) — we want
+/// telemetry on the rate so we can prioritise fixes against real-device
+/// data. No-op when Sentry isn't initialised.
+#[cfg(target_os = "ios")]
+fn capture_bridge_error(command: &str, err: &Error) {
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("plugin", "background-audio");
+            scope.set_tag("command", command);
+        },
+        || {
+            sentry::capture_message(&format!("{err}"), sentry::Level::Error);
+        },
+    );
+}
+
 #[tauri::command]
 async fn begin_session<R: Runtime>(app: AppHandle<R>, args: BeginSessionArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        breadcrumb(
+            "begin_session",
+            serde_json::json!({
+                "title": &args.title,
+                "started_at": &args.started_at,
+            }),
+        );
         let state = app.state::<mobile::BackgroundAudio<R>>();
-        return state.run("begin_session", args);
+        let result = state.run("begin_session", args);
+        if let Err(err) = &result {
+            capture_bridge_error("begin_session", err);
+        }
+        result
     }
     #[cfg(not(target_os = "ios"))]
     {
@@ -76,8 +126,20 @@ async fn begin_session<R: Runtime>(app: AppHandle<R>, args: BeginSessionArgs) ->
 async fn set_now_playing<R: Runtime>(app: AppHandle<R>, args: NowPlayingArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        breadcrumb(
+            "set_now_playing",
+            serde_json::json!({
+                "title": &args.title,
+                "position_label": &args.position_label,
+                "started_at": &args.started_at,
+            }),
+        );
         let state = app.state::<mobile::BackgroundAudio<R>>();
-        return state.run("set_now_playing", args);
+        let result = state.run("set_now_playing", args);
+        if let Err(err) = &result {
+            capture_bridge_error("set_now_playing", err);
+        }
+        result
     }
     #[cfg(not(target_os = "ios"))]
     {
@@ -90,8 +152,13 @@ async fn set_now_playing<R: Runtime>(app: AppHandle<R>, args: NowPlayingArgs) ->
 async fn end_session<R: Runtime>(app: AppHandle<R>) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        breadcrumb("end_session", serde_json::json!({}));
         let state = app.state::<mobile::BackgroundAudio<R>>();
-        return state.run("end_session", ());
+        let result = state.run("end_session", ());
+        if let Err(err) = &result {
+            capture_bridge_error("end_session", err);
+        }
+        result
     }
     #[cfg(not(target_os = "ios"))]
     {

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -22,6 +22,7 @@ use crate::views::{
     LibraryListView, NotFoundView, SessionActiveView, SessionNewView, SessionSummaryView,
     SessionsAllView, SessionsListView, SetDetailView, SetEditView,
 };
+use intrada_web::background_audio;
 use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::{init_core, load_session_in_progress, process_effects};
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -152,6 +153,15 @@ fn AuthenticatedApp() -> impl IntoView {
             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
         }
     }
+
+    // Background-audio plugin lifecycle (#309 Phase D). Mounted at the
+    // app level so the Some → None transition fires `end_session()` even
+    // when the user navigates away from /sessions/active before
+    // finishing — e.g. backing to home, switching tabs, or hitting
+    // "Discard Session" from /sessions/new. Mounting inside <SessionTimer>
+    // would unmount the Effect alongside the route and leak the iOS
+    // AVAudioSession + silent loop until the OS reclaims it.
+    background_audio::mount_background_audio_lifecycle(view_model);
 
     view! {
         <div class="relative z-0 min-h-screen text-primary">

--- a/crates/intrada-web/src/background_audio.rs
+++ b/crates/intrada-web/src/background_audio.rs
@@ -1,14 +1,14 @@
+use leptos::prelude::*;
 use wasm_bindgen::prelude::*;
+
+use intrada_core::ViewModel;
 
 // Calls Tauri plugin-background-audio commands via the Tauri IPC invoke
 // bridge. All functions are no-ops outside a Tauri context (web browser,
 // E2E tests). The try/catch in JS ensures plugin failures never surface
 // as Rust errors — the timer continues working even if the audio session
-// can't be activated.
-//
-// Phase B: the plugin's Rust commands return Ok without side-effects.
-// Phase C swaps in the Swift impl behind the same command names; no
-// change needed on this side.
+// can't be activated. The Rust plugin captures failures into Sentry so
+// we still get telemetry without surfacing UI banners users can't act on.
 #[wasm_bindgen(inline_js = "
     function bg_audio_invoke(cmd, args) {
         try {
@@ -30,12 +30,63 @@ use wasm_bindgen::prelude::*;
 ")]
 extern "C" {
     /// Activate the iOS audio session + seed lock-screen Now Playing
-    /// when a practice session starts. Phase B: plugin command returns
-    /// Ok with no native effect; Phase C wires AVAudioSession.
+    /// when a practice session starts. No-op outside Tauri.
     pub fn begin_session(title: &str, started_at: &str);
-    /// Update lock-screen Now Playing on item advance. Phase B: no-op.
+    /// Update lock-screen Now Playing on item advance. No-op outside Tauri.
     pub fn set_now_playing(title: &str, position_label: &str, started_at: &str);
     /// Release the audio session + clear Now Playing on session end.
-    /// Phase B: no-op.
+    /// No-op outside Tauri.
     pub fn end_session();
+}
+
+/// Mount the background-audio lifecycle Effect on the global `ViewModel`
+/// signal. Tracks `current_item_started_at` across renders so we can tell
+/// session start (None → Some), item advance (anchor change), and session
+/// end (Some → None) apart with a single Effect.
+///
+/// Must be called from a Leptos owner scope that lives for the duration of
+/// the user's authenticated app session — i.e. `AuthenticatedApp`, not a
+/// per-route component. Mounting this inside `<SessionTimer>` would leak
+/// the audio session: when the user navigates away from `/sessions/active`
+/// without finishing (e.g. taps a tab, hits Discard from `/sessions/new`)
+/// the timer unmounts before the Effect can observe `Some → None`, so
+/// `end_session()` never fires and the AVAudioSession stays active until
+/// the OS reclaims it.
+///
+/// The Effect re-fires on every ViewModel push (coarser than ideal — any
+/// unrelated VM mutation triggers it) but the anchor-equality guard makes
+/// that idempotent.
+pub fn mount_background_audio_lifecycle(view_model: RwSignal<ViewModel>) {
+    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
+    Effect::new(move |_| {
+        let next = view_model.with(|vm| {
+            vm.active_session.as_ref().map(|a| {
+                (
+                    a.current_item_title.clone(),
+                    a.current_position,
+                    a.total_items,
+                    a.current_item_started_at.clone(),
+                )
+            })
+        });
+        let prev = prev_anchor.get_untracked();
+        match (prev, next) {
+            (None, Some((title, _pos, _total, started_at))) => {
+                begin_session(&title, &started_at);
+                prev_anchor.set(Some(started_at));
+            }
+            (Some(prev_anchor_val), Some((title, pos, total, started_at)))
+                if prev_anchor_val != started_at =>
+            {
+                let position_label = format!("Item {} of {}", pos + 1, total);
+                set_now_playing(&title, &position_label, &started_at);
+                prev_anchor.set(Some(started_at));
+            }
+            (Some(_), None) => {
+                end_session();
+                prev_anchor.set(None);
+            }
+            _ => {}
+        }
+    });
 }

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -10,7 +10,6 @@ use crate::components::{
     Button, ButtonSize, ButtonVariant, Icon, IconName, InlineTypeIndicator, ItemReflectionSheet,
     ItemReflectionTarget, ProgressRing, SectionLabel, SetlistEntryRow, TransitionPrompt,
 };
-use intrada_web::background_audio;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, ItemType, SharedCore};
 
@@ -98,51 +97,11 @@ pub fn SessionTimer() -> impl IntoView {
         recompute();
     });
 
-    // Background-audio plugin lifecycle (Phase B of #309 — plugin
-    // commands return Ok with no native side-effects yet, JS bindings
-    // are no-ops outside Tauri, so this is safe to land before any iOS
-    // work). Tracks the `current_item_started_at` anchor across renders
-    // so we can tell session start (None → Some), item advance (anchor
-    // change), and session end (Some → None) apart with a single
-    // Effect.
-    //
-    // The Effect re-fires on every ViewModel push (coarser than ideal —
-    // any unrelated VM mutation triggers it) but the anchor-equality
-    // guard makes that idempotent. If we ever care about the wasted
-    // work, a Memo<Option<String>> over current_item_started_at would
-    // isolate the dependency.
-    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
-    Effect::new(move |_| {
-        let next = view_model.with(|vm| {
-            vm.active_session.as_ref().map(|a| {
-                (
-                    a.current_item_title.clone(),
-                    a.current_position,
-                    a.total_items,
-                    a.current_item_started_at.clone(),
-                )
-            })
-        });
-        let prev = prev_anchor.get_untracked();
-        match (prev, next) {
-            (None, Some((title, _pos, _total, started_at))) => {
-                background_audio::begin_session(&title, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(prev_anchor_val), Some((title, pos, total, started_at)))
-                if prev_anchor_val != started_at =>
-            {
-                let position_label = format!("Item {} of {}", pos + 1, total);
-                background_audio::set_now_playing(&title, &position_label, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(_), None) => {
-                background_audio::end_session();
-                prev_anchor.set(None);
-            }
-            _ => {}
-        }
-    });
+    // Background-audio plugin lifecycle is mounted in `AuthenticatedApp`
+    // (see `background_audio::mount_background_audio_lifecycle`) so that
+    // session-end transitions fire `end_session()` regardless of whether
+    // the user is currently on /sessions/active. Mounting it here would
+    // leak the AVAudioSession on tab switches / Discard from new-session.
 
     // Coarse 1Hz tick for the second-resolution display. The closure just
     // calls recompute(); skipping a fire (backgrounded tab) is harmless


### PR DESCRIPTION
## Summary

- Move background-audio lifecycle Effect from \`<SessionTimer>\` up to \`<AuthenticatedApp>\` so \`end_session()\` fires on every session-end transition, regardless of which route is mounted
- Add Sentry breadcrumbs + error capture to the Rust plugin commands so we get real-device telemetry on bridge failures
- Defer in-app vm.error UI surfacing until we have failure data to cluster against (#458)

## Why this matters

Phase C (#450, just merged) shipped the Swift implementation, but the lifecycle Effect was still mounted inside \`<SessionTimer>\`. That meant the iOS AVAudioSession + silent loop would leak in two real-world flows:

1. User starts a session, taps a tab bar item or backs to home (without finishing) → \`<SessionTimer>\` unmounts → Effect disposed → audio session keeps running until the OS reclaims it.
2. User starts a session, navigates to \`/sessions/new\`, taps "Discard Session" → \`<SessionTimer>\` is not mounted at this route → Effect doesn't observe the \`Some → None\` transition → \`end_session()\` never fires.

Both leaks would have shipped to TestFlight without this fix. Mounting the Effect at \`<AuthenticatedApp>\` level fixes both because that owner outlives any route change while the user is signed in.

## What's intentionally not done

- **vm.error UI surfacing** — deferred to #458. We don't yet know which failure modes are user-actionable; telemetry-first.
- **Sign-out mid-session cleanup** — deferred to #459. Edge case; OS reclaims the session on app foreground.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --workspace --exclude tauri-plugin-background-audio -- -D warnings\` passes
- [x] \`cargo clippy -p tauri-plugin-background-audio --target aarch64-apple-ios -- -D warnings\` passes (covers the iOS-gated breadcrumb/capture code that Linux CI doesn't see)
- [x] \`cargo test --workspace --exclude tauri-plugin-background-audio\` passes (418 tests)
- [x] \`cargo build -p intrada-mobile --target aarch64-apple-ios\` succeeds (host links plugin cleanly with new sentry dep)
- [ ] Device: 30-min session, lock + unlock, verify Now Playing still updates and timer is correct after unlock — folds into the Phase C device-test pass; not regressing what Phase C did.
- [ ] Device: start session → tap tab → wait → verify Now Playing card disappears and Control Center has no stale Intrada entry.
- [ ] Device: start session → navigate to /sessions/new → tap Discard → verify Now Playing card disappears within ~1s.

## Self-review

- ✅ Effect ownership: \`AuthenticatedApp\` lives as long as the user is signed in, strictly longer than any session.
- ✅ Crash recovery interaction: \`RecoverSession\` runs at line 148-153 of app.rs, Effect mounts on line ~163. Effect's first observation sees \`(None, Some(recovered))\` → fires \`begin_session()\` to seed lock-screen on relaunch with an in-progress session. Correct behaviour.
- ✅ Sentry version match: plugin (0.48) matches host (0.48), so \`Hub::current()\` lookup works across the FFI boundary.
- ✅ Breadcrumb on every command, capture only on Err — exactly what telemetry needs ("see context when something fails"), no noise on success path.
- ⚠️ Sign-out mid-session leaks the audio session — filed as #459, not blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)