### PR TITLE
feat(observability): Sentry foundation — user identity + release lifecycle

### DIFF
--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -36,7 +36,13 @@ impl FromRequestParts<AppState> for AuthUser {
     ) -> Result<Self, Self::Rejection> {
         let auth_config = match &state.auth_config {
             Some(config) => config,
-            None => return Ok(AuthUser(String::new())),
+            None => {
+                // Defensive: if anything earlier in the middleware chain ever
+                // attaches a user to this per-request hub, make sure the
+                // auth-disabled path doesn't inherit it.
+                sentry::configure_scope(|scope| scope.set_user(None));
+                return Ok(AuthUser(String::new()));
+            }
         };
 
         let header = parts
@@ -59,7 +65,19 @@ impl FromRequestParts<AppState> for AuthUser {
         let keys = auth_config.decoding_keys.read().await;
         for key in keys.iter() {
             match decode::<Claims>(token, key, &validation) {
-                Ok(data) => return Ok(AuthUser(data.claims.sub)),
+                Ok(data) => {
+                    let user_id = data.claims.sub;
+                    // Per-request hub isolation comes from the
+                    // NewSentryLayer in routes/mod.rs — configuring the
+                    // current scope here cannot bleed into other requests.
+                    sentry::configure_scope(|scope| {
+                        scope.set_user(Some(sentry::User {
+                            id: Some(user_id.clone()),
+                            ..Default::default()
+                        }));
+                    });
+                    return Ok(AuthUser(user_id));
+                }
                 Err(e) => {
                     tracing::debug!("JWT decode error: {e}");
                     continue;

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -43,8 +43,7 @@ async fn main() {
                     for crumb in event.breadcrumbs.iter_mut() {
                         crumb.data.retain(|k, _| !is_auth_key(k));
                         for nested in ["headers", "http.headers"] {
-                            if let Some(serde_json::Value::Object(map)) =
-                                crumb.data.get_mut(nested)
+                            if let Some(serde_json::Value::Object(map)) = crumb.data.get_mut(nested)
                             {
                                 map.retain(|k, _| !is_auth_key(k));
                             }

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -28,6 +28,30 @@ async fn main() {
                 // real traffic arrives — every transaction counts against quota.
                 traces_sample_rate: 1.0,
                 send_default_pii: false,
+                // Defensive scrubber alongside send_default_pii: false. Strip
+                // auth-bearing headers from both request data and any
+                // breadcrumbs (tower-http's TraceLayer + sentry's tracing
+                // integration can record request headers as breadcrumb data).
+                before_send: Some(std::sync::Arc::new(|mut event| {
+                    fn is_auth_key(k: &str) -> bool {
+                        let k = k.to_ascii_lowercase();
+                        k == "authorization" || k == "proxy-authorization" || k == "cookie"
+                    }
+                    if let Some(req) = event.request.as_mut() {
+                        req.headers.retain(|k, _| !is_auth_key(k));
+                    }
+                    for crumb in event.breadcrumbs.iter_mut() {
+                        crumb.data.retain(|k, _| !is_auth_key(k));
+                        for nested in ["headers", "http.headers"] {
+                            if let Some(serde_json::Value::Object(map)) =
+                                crumb.data.get_mut(nested)
+                            {
+                                map.retain(|k, _| !is_auth_key(k));
+                            }
+                        }
+                    }
+                    Some(event)
+                })),
                 ..Default::default()
             },
         ))

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -32,6 +32,49 @@
           tracesSampleRate: 1.0,
           sendDefaultPii: false,
           integrations: [Sentry.browserTracingIntegration()],
+          // Defensive scrubber alongside sendDefaultPii: false. Any throw
+          // here would drop the event entirely — keep wrapped in try/catch
+          // and return the event unchanged on any failure.
+          beforeSend: function (event) {
+            try {
+              var EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+              var redactEmails = function (s) {
+                return typeof s === 'string' ? s.replace(EMAIL_RE, '[email]') : s;
+              };
+              var stripAuthHeaders = function (headers) {
+                if (!headers) return;
+                if (Array.isArray(headers)) {
+                  for (var i = headers.length - 1; i >= 0; i--) {
+                    var pair = headers[i];
+                    if (pair && typeof pair[0] === 'string' &&
+                        pair[0].toLowerCase() === 'authorization') {
+                      headers.splice(i, 1);
+                    }
+                  }
+                } else if (typeof headers === 'object') {
+                  Object.keys(headers).forEach(function (k) {
+                    if (k.toLowerCase() === 'authorization') delete headers[k];
+                  });
+                }
+              };
+              if (event.request) stripAuthHeaders(event.request.headers);
+              if (Array.isArray(event.breadcrumbs)) {
+                event.breadcrumbs.forEach(function (b) {
+                  if (b && b.data) stripAuthHeaders(b.data.headers || b.data);
+                  if (b && typeof b.message === 'string') b.message = redactEmails(b.message);
+                });
+              }
+              if (event.message) event.message = redactEmails(event.message);
+              if (event.exception && Array.isArray(event.exception.values)) {
+                event.exception.values.forEach(function (v) {
+                  if (v && typeof v.value === 'string') v.value = redactEmails(v.value);
+                });
+              }
+            } catch (e) {
+              // Swallow — never drop events because of scrubber failure.
+            }
+            return event;
+          },
         });
       })();
     </script>

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -69,6 +69,9 @@ pub fn App() -> impl IntoView {
             for _ in 0..50 {
                 gloo_timers::future::TimeoutFuture::new(100).await;
                 if clerk_bindings::is_signed_in() {
+                    if let Some(id) = clerk_bindings::get_user_id() {
+                        clerk_bindings::sentry_set_user(&id);
+                    }
                     is_authenticated.set(true);
                     auth_loading.set(false);
                     return;
@@ -90,6 +93,13 @@ pub fn App() -> impl IntoView {
     {
         let closure = Closure::new(move || {
             let signed_in = clerk_bindings::is_signed_in();
+            if signed_in {
+                if let Some(id) = clerk_bindings::get_user_id() {
+                    clerk_bindings::sentry_set_user(&id);
+                }
+            } else {
+                clerk_bindings::sentry_clear_user();
+            }
             is_authenticated.set(signed_in);
             auth_loading.set(false);
         });

--- a/crates/intrada-web/src/clerk_bindings.rs
+++ b/crates/intrada-web/src/clerk_bindings.rs
@@ -58,6 +58,16 @@ use wasm_bindgen::prelude::*;
             });
         }
     }
+    export function js_sentry_set_user(id) {
+        if (window.Sentry && id) {
+            window.Sentry.setUser({ id: id });
+        }
+    }
+    export function js_sentry_clear_user() {
+        if (window.Sentry) {
+            window.Sentry.setUser(null);
+        }
+    }
 ")]
 extern "C" {
     fn js_init_clerk(key: &str);
@@ -69,6 +79,8 @@ extern "C" {
     async fn js_sign_out();
     async fn js_sign_in_with_google();
     fn js_add_auth_listener(callback: &Closure<dyn Fn()>);
+    fn js_sentry_set_user(id: &str);
+    fn js_sentry_clear_user();
 }
 
 /// Initialize Clerk with the publishable key.
@@ -122,4 +134,18 @@ pub async fn sign_in_with_google() {
 /// Register a listener for auth state changes (sign-in/sign-out).
 pub fn add_auth_listener(callback: &Closure<dyn Fn()>) {
     js_add_auth_listener(callback);
+}
+
+/// Attach the Clerk user id to Sentry's current scope. No-op if Sentry is
+/// not loaded (web dev) or `id` is empty. Safe to call from non-Leptos-owner
+/// contexts (raw event listeners, Closures) — only touches window globals.
+pub fn sentry_set_user(id: &str) {
+    if !id.is_empty() {
+        js_sentry_set_user(id);
+    }
+}
+
+/// Clear the Sentry user scope. Call on sign-out.
+pub fn sentry_clear_user() {
+    js_sentry_clear_user();
 }


### PR DESCRIPTION
## Summary

Two of three Sentry foundation PRs combined (originally planned as separate but landed on the same branch — combined scope is still tight, ~120 lines).

Until now Sentry events were anonymous *and* had no real release object behind the `release = $GIT_SHA` tag — so triage couldn't filter by user, regression detection didn't work, and deploy markers / commits-per-release stayed dark.

This PR fixes both.

### Part 1 — User identity + PII scrubber

- **Web**: set/clear `Sentry.setUser({id})` from Clerk auth state via `clerk_bindings.rs`; `beforeSend` strips `Authorization` headers (request + breadcrumb) and redacts email-shaped strings, wrapped in try/catch so a scrubber bug never drops events.
- **API**: per-request `sentry::configure_scope` on successful JWT decode in `auth.rs` (per-request hub isolation from existing `NewSentryLayer`); `before_send` removes `Authorization` / `Proxy-Authorization` / `Cookie` from request headers and breadcrumb data (top-level + nested `headers` / `http.headers` sub-objects).
- The id we attach is the Clerk user id (`sub` claim) — non-PII public identifier, not the email.

### Part 2 — Release lifecycle on deploy

- **API**: `flyctl deploy --build-arg GIT_SHA=${{ github.sha }}` → Dockerfile `ARG GIT_SHA` → `ENV GIT_SHA` → cargo build → `option_env!("GIT_SHA")` → Sentry `release` field. New `crates/intrada-api/build.rs` with `cargo:rerun-if-env-changed=GIT_SHA` (matches mobile pattern). After `flyctl deploy`, `getsentry/action-release@v3` for project `intrada-api`.
- **Web**: `window.__SENTRY_RELEASE__ = "__SENTRY_RELEASE_PLACEHOLDER__"` set before the Sentry SDK loads. CI's deploy job sed-swaps the placeholder for `${{ github.sha }}` between artifact download and `wrangler deploy`, with a `grep -q` guard so a missing swap fails loudly. After Cloudflare publish, `getsentry/action-release@v3` for project `intrada-web`.
- Sentry release steps gated on `SENTRY_AUTH_TOKEN != ''` and `continue-on-error: true` so a Sentry blip never blocks a successful Cloudflare/Fly deploy.

### Out of scope (deliberately)

- Mobile host user identity ([#473](https://github.com/jonyardley/intrada/issues/473)) — needs IPC plumbing for low payoff.
- Mobile release tagging via `just ios-*` — small follow-up, will track.
- WASM debug symbol upload — heavy lift, separate PR.
- JS source map upload — Trunk doesn't currently emit them, low payoff alone.
- Distributed tracing + domain breadcrumbs — PR 3 of the rollout.
- User-feedback widget evaluation ([#464](https://github.com/jonyardley/intrada/issues/464)).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 432 passed
- [x] `cargo check --target wasm32-unknown-unknown` for `intrada-web` clean
- [x] Self-review with `superpowers:code-reviewer` subagent (twice — once per scope). Findings applied inline:
  - Identity: case-insensitive header strip + `Proxy-Authorization`/`Cookie` + breadcrumb walk on API; defensive `set_user(None)` on auth-disabled path.
  - Release: filter empty GIT_SHA in `option_env!` (blocker — `Some("")` is not `None`); reorder Dockerfile `ARG GIT_SHA` to *after* `cargo chef cook` so per-deploy GIT_SHA changes don't bust the dependency-build cache.
- [ ] Manual verify post-merge: confirm `user.id` present on events, `Authorization` absent on captured request data, release object created in both `intrada-api` and `intrada-web` Sentry projects.

## Prerequisites for the release-lifecycle half to actually work

User has confirmed:
- `SENTRY_AUTH_TOKEN` GitHub Actions secret set with `org:read` + `project:releases` scopes.
- Sentry org slug: `jon-yardley` (extracted to workflow-level `env:` for reuse).
- Project slugs: `intrada-api`, `intrada-web` (assumed `intrada-web` follows the same pattern as `intrada-api` — confirm post-merge).

## Continues on

PR 3: distributed tracing (`tracePropagationTargets` on web SDK so `sentry-trace` propagates to the API's existing `SentryHttpLayer`) + domain breadcrumbs (`session.started`, `score.submitted`, `sync.failed`, `auth.retry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)