### PR TITLE
fix(web): clean up window listeners + setTimeouts to stop disposed-signal panics

### DIFF
--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -1,5 +1,6 @@
 use leptos::portal::Portal;
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
@@ -78,20 +79,37 @@ pub fn BottomSheet(
     });
 
     // Attach Escape-to-close at the document level when the sheet opens.
+    // Pairs add_event_listener with on_cleanup so the listener is removed
+    // when `open` flips false AND when the component unmounts — without
+    // cleanup, listener accumulates across open/close cycles and panics
+    // ("reactive value already disposed") on Escape after the sheet's
+    // owner is gone.
     Effect::new(move || {
         if !open.get() {
             return;
         }
+        let Some(window) = web_sys::window() else {
+            return;
+        };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
             if ev.key() == "Escape" {
                 close.run(());
             }
         });
-        if let Some(window) = web_sys::window() {
-            let _ = window
-                .add_event_listener_with_callback("keydown", on_keydown.as_ref().unchecked_ref());
-        }
-        on_keydown.forget();
+        let _ =
+            window.add_event_listener_with_callback("keydown", on_keydown.as_ref().unchecked_ref());
+        // SendWrapper: leptos's on_cleanup requires Send+Sync, but the
+        // wasm-bindgen Closure body is `dyn Fn` without those bounds. Safe
+        // on wasm32 (single-threaded by construction); SendWrapper would
+        // only panic if accessed from a different thread.
+        let on_keydown = SendWrapper::new(on_keydown);
+        let window = SendWrapper::new(window);
+        on_cleanup(move || {
+            let _ = window.remove_event_listener_with_callback(
+                "keydown",
+                on_keydown.as_ref().unchecked_ref(),
+            );
+        });
     });
 
     // Wire touch handlers for swipe-down-to-dismiss. Attached to the handle

--- a/crates/intrada-web/src/components/context_menu.rs
+++ b/crates/intrada-web/src/components/context_menu.rs
@@ -1,5 +1,6 @@
 use leptos::portal::Portal;
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
@@ -61,47 +62,65 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
     });
 
     // Escape key dismisses the menu when open.
+    // Pairs add_event_listener with on_cleanup so the listener is removed
+    // when `is_open` flips false AND when the component unmounts — without
+    // cleanup, listener accumulates and panics ("reactive value already
+    // disposed") on Escape after the menu's owner is gone.
     Effect::new(move || {
         if !is_open.get() {
             return;
         }
+        let Some(window) = web_sys::window() else {
+            return;
+        };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
             if ev.key() == "Escape" {
                 close.run(());
             }
         });
-        if let Some(window) = web_sys::window() {
-            let _ = window
-                .add_event_listener_with_callback("keydown", on_keydown.as_ref().unchecked_ref());
-        }
-        on_keydown.forget();
+        let _ =
+            window.add_event_listener_with_callback("keydown", on_keydown.as_ref().unchecked_ref());
+        // SendWrapper: leptos's on_cleanup requires Send+Sync; Closure's
+        // dyn Fn body and web_sys::Window aren't both. Safe on wasm32 —
+        // single-threaded by construction.
+        let on_keydown = SendWrapper::new(on_keydown);
+        let window = SendWrapper::new(window);
+        on_cleanup(move || {
+            let _ = window.remove_event_listener_with_callback(
+                "keydown",
+                on_keydown.as_ref().unchecked_ref(),
+            );
+        });
     });
 
     // Long-press detection on the trigger. Uses touchstart + setTimeout to
     // schedule activation; touchmove past tolerance or touchend before the
-    // timeout cancels.
+    // timeout cancels. on_cleanup also clears any pending timeout on
+    // component unmount — without it, the activate Closure can fire after
+    // the component is gone and panic accessing disposed signals.
     Effect::new(move || {
         let Some(el) = trigger_ref.get() else {
             return;
         };
 
         // setTimeout handle so we can cancel on early release / scroll.
-        let timeout_handle = std::rc::Rc::new(std::cell::Cell::new(None::<i32>));
+        // RwSignal (instead of Rc<Cell>) so on_cleanup's Send+Sync bound
+        // is satisfied and the closure stays Copy across the touch handlers.
+        let timeout_handle: RwSignal<Option<i32>> = RwSignal::new(None);
 
-        let cancel_pending = {
-            let timeout_handle = std::rc::Rc::clone(&timeout_handle);
-            move || {
-                if let Some(handle) = timeout_handle.take() {
-                    if let Some(window) = web_sys::window() {
-                        window.clear_timeout_with_handle(handle);
-                    }
+        let cancel_pending = move || {
+            let prev = timeout_handle.get_untracked();
+            timeout_handle.set(None);
+            if let Some(handle) = prev {
+                if let Some(window) = web_sys::window() {
+                    window.clear_timeout_with_handle(handle);
                 }
             }
         };
 
+        on_cleanup(cancel_pending);
+
         let touchstart: Closure<dyn Fn(TouchEvent)> = {
-            let timeout_handle = std::rc::Rc::clone(&timeout_handle);
-            let cancel_pending = cancel_pending.clone();
             Closure::new(move |ev: TouchEvent| {
                 cancel_pending();
                 if let Some(touch) = ev.touches().get(0) {
@@ -147,7 +166,6 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
         };
 
         let touchmove: Closure<dyn Fn(TouchEvent)> = {
-            let cancel_pending = cancel_pending.clone();
             Closure::new(move |ev: TouchEvent| {
                 let (Some(start_x), Some(start_y)) =
                     (touch_start_x.get_untracked(), touch_start_y.get_untracked())
@@ -168,7 +186,6 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
         };
 
         let touchend: Closure<dyn Fn(TouchEvent)> = {
-            let cancel_pending = cancel_pending.clone();
             Closure::new(move |_: TouchEvent| {
                 cancel_pending();
                 touch_start_x.set(None);
@@ -177,7 +194,6 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
         };
 
         let touchcancel: Closure<dyn Fn(TouchEvent)> = {
-            let cancel_pending = cancel_pending.clone();
             Closure::new(move |_: TouchEvent| {
                 cancel_pending();
                 touch_start_x.set(None);

--- a/crates/intrada-web/src/components/week_strip.rs
+++ b/crates/intrada-web/src/components/week_strip.rs
@@ -158,6 +158,22 @@ pub fn WeekStrip(
     // selected date as a side-effect of swiping.
     let suppress_next_click = RwSignal::new(false);
 
+    // Snap-back setTimeout handle. Stored at component scope (RwSignal
+    // because the outer pointer-up closure must be Fn, and on_cleanup
+    // requires Send+Sync) so on_cleanup can cancel it on unmount — without
+    // that, the timeout's callback (which sets signals like
+    // transition_disabled / snap_target) fires after the parent owner is
+    // disposed and panics with "reactive value already disposed".
+    let snap_timeout_handle: RwSignal<Option<i32>> = RwSignal::new(None);
+
+    on_cleanup(move || {
+        if let Some(id) = snap_timeout_handle.get_untracked() {
+            if let Some(window) = web_sys::window() {
+                window.clear_timeout_with_handle(id);
+            }
+        }
+    });
+
     let frame_ref = NodeRef::<leptos::html::Div>::new();
 
     // Day-cell click goes through this wrapper so the strip can swallow
@@ -346,10 +362,12 @@ pub fn WeekStrip(
                 cb_re_enable.forget();
             });
             if let Some(window) = web_sys::window() {
-                let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+                if let Ok(id) = window.set_timeout_with_callback_and_timeout_and_arguments_0(
                     cb.as_ref().unchecked_ref(),
                     SNAP_DURATION_MS,
-                );
+                ) {
+                    snap_timeout_handle.set(Some(id));
+                }
             }
             cb.forget();
         } else {

--- a/crates/intrada-web/src/hooks/use_drag_reorder.rs
+++ b/crates/intrada-web/src/hooks/use_drag_reorder.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlElement, PointerEvent};
@@ -104,6 +105,18 @@ impl DragReorderReturn {
 /// Movement threshold in pixels before drag is committed.
 const DRAG_THRESHOLD_PX: f64 = 5.0;
 
+/// Owned trio of (pointermove, pointerup, pointercancel) closures kept alive
+/// for the component's lifetime so they can be removed on unmount.
+type PointerListenerTrio = (
+    Closure<dyn Fn(PointerEvent)>,
+    Closure<dyn Fn(PointerEvent)>,
+    Closure<dyn Fn(PointerEvent)>,
+);
+
+/// Wrapped so it satisfies `on_cleanup`'s Send+Sync bound on wasm32.
+type PointerListenersHandle =
+    SendWrapper<std::rc::Rc<std::cell::RefCell<Option<PointerListenerTrio>>>>;
+
 /// Creates a reusable drag-and-drop reorder hook.
 ///
 /// # Arguments
@@ -166,8 +179,17 @@ pub fn use_drag_reorder(
     });
 
     // --- Register window-level pointer event listeners ---
-    // We use Closure::forget() to leak the closures (same pattern as session_timer.rs).
-    // These listeners live for the component's lifetime. In a WASM SPA this is acceptable.
+    // Pair add_event_listener with on_cleanup so the listeners are removed
+    // when the component unmounts. Without cleanup, pointermove fires on
+    // every mouse movement after unmount and panics ("reactive value already
+    // disposed") accessing drag_state.
+    //
+    // SendWrapper wraps the !Send Rc<RefCell<Closure>> so it can pass through
+    // leptos's `on_cleanup` (which requires Send + Sync). Safe on wasm32 —
+    // single-threaded by construction; SendWrapper would only panic if
+    // accessed from a different thread, which can't happen here.
+    let pointer_listeners: PointerListenersHandle =
+        SendWrapper::new(std::rc::Rc::new(std::cell::RefCell::new(None)));
     {
         let pointer_move_handler: Closure<dyn Fn(PointerEvent)> =
             Closure::new(move |ev: PointerEvent| {
@@ -280,14 +302,31 @@ pub fn use_drag_reorder(
             );
         }
 
-        // Leak closures so they stay alive (same pattern as session_timer.rs)
-        pointer_move_handler.forget();
-        pointer_up_handler.forget();
-        pointer_cancel_handler.forget();
+        // Hold closures so they stay alive while the component is mounted.
+        // on_cleanup below removes the listeners and drops the closures.
+        *pointer_listeners.borrow_mut() = Some((
+            pointer_move_handler,
+            pointer_up_handler,
+            pointer_cancel_handler,
+        ));
     }
 
-    // Clean up drag state when component unmounts
+    // Remove window listeners and clear drag state on component unmount.
     on_cleanup(move || {
+        if let Some((mv, up, cancel)) = pointer_listeners.borrow_mut().take() {
+            if let Some(window) = web_sys::window() {
+                let _ = window.remove_event_listener_with_callback(
+                    "pointermove",
+                    mv.as_ref().unchecked_ref(),
+                );
+                let _ = window
+                    .remove_event_listener_with_callback("pointerup", up.as_ref().unchecked_ref());
+                let _ = window.remove_event_listener_with_callback(
+                    "pointercancel",
+                    cancel.as_ref().unchecked_ref(),
+                );
+            }
+        }
         drag_state.set(None);
     });
 


### PR DESCRIPTION
## Summary

Fixes the repeating `panicked at reactive_graph::traits:361 — Tried to access a reactive value that has already been disposed` panic that's been hitting the deployed web app during normal use.

Five sites attached `add_event_listener` callbacks to `window` (or scheduled `setTimeout`s) whose closures captured `RwSignal`s owned by the component scope, but never tore them down. After the component unmounted, the next firing of the leaked callback panicked. Listeners also accumulated across re-runs of Effects whose deps toggled (open/close cycles), so a single Escape press could fire N stale listeners and produce N panics — matching the symptom in the user's console paste.

Pattern applied: every window-level `add_event_listener` paired with `on_cleanup` + `remove_event_listener`; every signal-touching `setTimeout` paired with cleanup that calls `clear_timeout_with_handle`.

## Sites fixed

| File | Site | Fix |
|------|------|-----|
| [bottom_sheet.rs](crates/intrada-web/src/components/bottom_sheet.rs) | `keydown` (Escape-to-close) on window | `on_cleanup` removes listener on close/unmount |
| [context_menu.rs](crates/intrada-web/src/components/context_menu.rs) | `keydown` (Escape-to-close) on window | Same |
| [context_menu.rs](crates/intrada-web/src/components/context_menu.rs) | Long-press `activate` setTimeout | Handle moved to `RwSignal<Option<i32>>`; cleanup cancels pending timeout |
| [use_drag_reorder.rs](crates/intrada-web/src/hooks/use_drag_reorder.rs) | `pointermove` / `pointerup` / `pointercancel` on window | Trio stored in `SendWrapper<Rc<RefCell<...>>>`; cleanup removes all three |
| [week_strip.rs](crates/intrada-web/src/components/week_strip.rs) | Snap-back setTimeout | Handle in component-scope `RwSignal`; cleanup cancels |

Element-attached touch listeners (touch handlers on local `el` refs in `pull_to_refresh`, `swipe_actions`, the touch part of `bottom_sheet`, the long-press trigger of `context_menu`) were intentionally left alone — they GC with the DOM element so don't leak past unmount.

## Implementation notes

- `leptos::on_cleanup` requires `FnOnce + Send + Sync + 'static`. On wasm32 most `web_sys` types are Send+Sync, but `wasm_bindgen::closure::Closure<dyn Fn(...)>` is not (the inner `dyn Fn` lacks the bound).
  - For the !Send `Closure`s and the listener trio in `use_drag_reorder`: wrapped in `send_wrapper::SendWrapper` (already a project dep — `crates/intrada-web/src/types.rs` uses it for `SharedCore`). Safe on wasm32 (single-threaded by construction).
  - For the i32 `setTimeout` handles: `RwSignal<Option<i32>>` (i32 is Send+Sync). Matches the existing pattern in [session_timer.rs:122](crates/intrada-web/src/components/session_timer.rs:122).
- `use_drag_reorder` got `PointerListenerTrio` and `PointerListenersHandle` type aliases to satisfy clippy's `type_complexity` lint.
- In `context_menu`, switching `timeout_handle` from `Rc<Cell<i32>>` to `RwSignal<Option<i32>>` made `cancel_pending` a `Copy` closure, so several redundant `let cancel_pending = cancel_pending.clone();` shadow-bindings inside the touch handler scopes were dropped.

## Self-review

Ran `superpowers:code-reviewer` against the commit before pushing. No blockers; review summary will be posted as a PR comment. Two deferred audit items tracked in #479 (autocomplete focusout setTimeout + week_strip rAF inside snap callback — same shape, lower risk).

## Test plan

- [x] `cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings` (matches CI)
- [x] `cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings`
- [x] `cargo test --workspace --exclude tauri-plugin-background-audio` → 432 passed
- [x] `cargo fmt --check`
- [ ] Deploy and exercise the app: open/close BottomSheets, open ContextMenus, drag-reorder, swipe through WeekStrip pages, then press Escape / move mouse — no panics in browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)