### PR TITLE
fix(ios): patch project.yml to resolve libapp.a duplicate output (#476)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,15 @@ First-time iOS setup (run once after cloning or pulling this branch):
 ```bash
 cargo install tauri-cli --version "^2" --locked   # Tauri CLI
 brew install cocoapods                             # CocoaPods (required by Tauri iOS)
+brew install xcodegen                              # xcodegen (required by Tauri iOS)
 # Also requires: iOS Simulator runtime (Xcode → Settings → Platforms → iOS Simulator)
 cd crates/intrada-mobile/src-tauri
 cargo tauri ios init       # generates the Xcode project under src-tauri/gen/apple/
+
+# Patch the generated project.yml to fix the libapp.a duplicate-output
+# bug (#476) — run after every `cargo tauri ios init`. Idempotent.
+cd ..
+ruby scripts/fix-ios-build-config.rb
 ```
 
 If you're forking this repo, update `bundle.iOS.developmentTeam` in

--- a/crates/intrada-mobile/scripts/fix-ios-build-config.rb
+++ b/crates/intrada-mobile/scripts/fix-ios-build-config.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# fix-ios-build-config.rb
+#
+# Patches the Tauri-generated `gen/apple/project.yml` to work around a
+# real iOS build failure (#476): xcodegen treats Tauri's `Externals/`
+# directory as a Sources path, which causes Xcode to generate
+# `CpResource` build phases for both `Externals/arm64/debug/libapp.a`
+# and `Externals/arm64/release/libapp.a` — both targeting the same
+# destination `Intrada.app/libapp.a`. xcodebuild errors out with:
+#
+#   error: Multiple commands produce '...Intrada.app/libapp.a'
+#   warning: duplicate output file '...Intrada.app/libapp.a' on task: CpResource
+#
+# `Externals/` is meant to hold the staged Rust core library for linking
+# (referenced via `LIBRARY_SEARCH_PATHS` in the same project.yml). It's
+# not supposed to be in any build phase — the linker finds libapp.a via
+# search paths, and the resulting binary is embedded as a `framework:`
+# dependency on the main target. xcodegen's default of putting source
+# paths into the Sources phase is wrong for this directory.
+#
+# Fix: set `buildPhase: none` on the `Externals` source entry so
+# xcodegen excludes it from all build phases. The directory still
+# appears in the project tree (Xcode needs to know it exists), but
+# nothing inside is added to a copy / compile / resource step.
+#
+# When to run: once after `cargo tauri ios init` (and again any time you
+# regenerate gen/apple/). Idempotent — safe to re-run.
+#
+# Upstream: this should ideally land in cargo-mobile2's project.yml.hbs
+# template. Until then we patch locally.
+#
+# Tracks: #476.
+
+require 'pathname'
+require 'yaml'
+
+# ── Paths ─────────────────────────────────────────────────────────────
+MOBILE_ROOT = Pathname.new(__dir__).parent.expand_path
+GEN_DIR     = MOBILE_ROOT.join('src-tauri/gen/apple')
+PROJECT_YML = GEN_DIR.join('project.yml')
+
+# ── Pre-flight ────────────────────────────────────────────────────────
+unless PROJECT_YML.exist?
+  abort <<~ERR
+    ERROR: #{PROJECT_YML} not found.
+    Run `cargo tauri ios init` from #{MOBILE_ROOT.join('src-tauri')} first.
+  ERR
+end
+
+unless system('which', 'xcodegen', out: File::NULL, err: File::NULL)
+  abort <<~ERR
+    ERROR: xcodegen not found on PATH.
+    Tauri's iOS workflow depends on xcodegen — install with:
+      brew install xcodegen
+  ERR
+end
+
+# ── Mutate ────────────────────────────────────────────────────────────
+project = YAML.load_file(PROJECT_YML)
+
+mutated = false
+(project['targets'] || {}).each do |name, target|
+  sources = target['sources']
+  next unless sources.is_a?(Array)
+
+  sources.each do |src|
+    next unless src.is_a?(Hash) && src['path'] == 'Externals'
+    next if src['buildPhase'] == 'none'
+
+    src['buildPhase'] = 'none'
+    mutated = true
+    puts "Patched Externals -> buildPhase: none in target: #{name}"
+  end
+end
+
+if !mutated
+  puts 'OK: Externals paths already use buildPhase: none (or no Externals path found). Nothing to do.'
+  exit 0
+end
+
+PROJECT_YML.write(project.to_yaml)
+puts "Wrote #{PROJECT_YML.relative_path_from(MOBILE_ROOT)}"
+
+# ── Re-run xcodegen ───────────────────────────────────────────────────
+puts 'Re-running xcodegen to regenerate .xcodeproj...'
+ok = Dir.chdir(GEN_DIR) do
+  system('xcodegen', 'generate', '--no-env', '--spec', 'project.yml')
+end
+
+abort 'ERROR: xcodegen generate failed. Check the output above.' unless ok
+
+puts ''
+puts 'Done. Try the iOS build again:'
+puts "  cd #{MOBILE_ROOT.join('src-tauri')} && cargo tauri ios build --target aarch64"


### PR DESCRIPTION
## Summary

- Adds \`crates/intrada-mobile/scripts/fix-ios-build-config.rb\` — post-\`init\` script that patches \`gen/apple/project.yml\` to fix the libapp.a duplicate-output build failure
- Updates CLAUDE.md "first-time iOS setup" with the script invocation
- Closes #476

## The bug

\`cargo tauri ios build\` was failing with:

\`\`\`
error: Multiple commands produce '...Intrada.app/libapp.a'
    note: copy command from 'Externals/arm64/debug/libapp.a' → '...Intrada.app/libapp.a'
    note: copy command from 'Externals/arm64/release/libapp.a' → '...Intrada.app/libapp.a'
warning: duplicate output file on task: CpResource
** BUILD FAILED **
\`\`\`

Reproducible from a pristine \`cargo tauri ios init\`. Both Debug and Release configurations.

## Root cause

xcodegen's default behaviour treats \`sources:\` paths as inputs to the Sources / Resources build phases. Tauri's template puts \`Externals/\` (where the Rust core's libapp.a is staged for linking) into \`sources:\`. xcodegen then generates \`CpResource\` build phases for *every* file in that path — including both the debug and release variants of libapp.a — all targeting the same destination.

\`Externals/\` is meant to be a linker search path only (referenced via \`LIBRARY_SEARCH_PATHS\` in the same project.yml). The framework dependency \`framework: libapp.a\` handles the actual link step. There's no need for any build phase to copy the .a files.

## The fix

Set \`buildPhase: none\` on the Externals source entry. xcodegen still tracks the directory in the project tree (so Xcode can navigate it) but doesn't add anything inside to a build phase.

Implemented as a post-\`init\` script because \`gen/apple/project.yml\` is regenerated by Tauri on every \`cargo tauri ios init\`. The script mutates the YAML and re-runs xcodegen. Idempotent.

Long-term, this should land upstream in cargo-mobile2's \`project.yml.hbs\` template. Until then, every developer runs the script after init.

## Test plan

- [x] Fresh \`cargo tauri ios init\` → run script → \`cargo tauri ios build --target aarch64\` → \`Intrada.ipa\` produced cleanly
- [x] Re-running script on already-patched state reports "OK: nothing to do" and exits 0 (idempotent)
- [x] Script pre-flight checks: project.yml exists, xcodegen on PATH

## Self-review

- ✅ Mutation is minimal — only the Externals \`sources\` entries get \`buildPhase: none\`. All other settings untouched.
- ✅ Idempotent: detects existing \`buildPhase: none\` and exits without re-running xcodegen.
- ✅ Same author / placement convention as \`add-live-activity-target.rb\` (sitting unmerged on a different branch — Phase A of #474). When that lands, both scripts share the \`crates/intrada-mobile/scripts/\` home.
- ⚠️ This is a workaround for an upstream Tauri/cargo-mobile2 issue. Filing the upstream report is follow-up work — see #476 for that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)