### PR TITLE
feat(mobile): Phase B — Live Activity plugin scaffold + unified session lifecycle (#474)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
       # intrada-mobile + its plugins (Tauri 2) require GTK/glib system libs
       # not present on Ubuntu runners — iOS-only crates with no meaningful
       # unit tests on Linux.
-      - run: cargo nextest run --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio
+      - run: cargo nextest run --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity
       - name: Doc tests
-        run: cargo test --doc --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio
+        run: cargo test --doc --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity
 
   clippy:
     name: Clippy
@@ -89,7 +89,7 @@ jobs:
           prefix-key: "native"
           save-if: "false"
       # intrada-mobile + its plugins excluded: Tauri 2 needs GTK/glib system libs on Linux.
-      - run: cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings
+      - run: cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity -- -D warnings
       - name: Clippy (WASM target)
         run: cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "tauri-plugin-background-audio",
  "tauri-plugin-deep-link",
  "tauri-plugin-haptics",
+ "tauri-plugin-live-activity",
 ]
 
 [[package]]
@@ -6859,6 +6860,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b167d598ada05c599f4460595108c8d1aa636030a97d19796c1bcda97d881d"
 dependencies = [
  "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-live-activity"
+version = "0.0.1"
+dependencies = [
+ "sentry",
  "serde",
  "serde_json",
  "tauri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/intrada-web",
   "crates/intrada-mobile/src-tauri",
   "crates/intrada-mobile/plugins/background-audio",
+  "crates/intrada-mobile/plugins/live-activity",
 ]
 resolver = "2"
 package.rust-version = "1.75"

--- a/crates/intrada-mobile/plugins/live-activity/Cargo.toml
+++ b/crates/intrada-mobile/plugins/live-activity/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tauri-plugin-live-activity"
+version = "0.0.1"
+edition = "2021"
+rust-version.workspace = true
+description = "Intrada-internal Tauri plugin: ActivityKit Live Activity for the active practice session — Lock Screen card + Dynamic Island compact / expanded views. iOS-only; layered alongside the background-audio plugin."
+# Required by tauri-plugin's build script (must match package.name).
+links = "tauri-plugin-live-activity"
+
+[dependencies]
+tauri = { version = "2" }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+# iOS-only: sentry + serde_json. Used inside `#[cfg(target_os = "ios")]`
+# helpers to drop breadcrumbs / capture bridge errors against the host's
+# already-initialised Sentry hub (intrada-mobile/src-tauri/src/lib.rs).
+# Mirrors the same pattern as the background-audio plugin.
+[target.'cfg(target_os = "ios")'.dependencies]
+serde_json = { workspace = true }
+sentry = { version = "0.48", default-features = false }
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/crates/intrada-mobile/plugins/live-activity/build.rs
+++ b/crates/intrada-mobile/plugins/live-activity/build.rs
@@ -1,0 +1,9 @@
+// Tauri plugin build script: generates the permission JSON schema and
+// the allowlist of commands the plugin exposes, and points Tauri at the
+// iOS Swift package so the host Xcode project picks it up at
+// `cargo tauri ios init` / build time.
+const COMMANDS: &[&str] = &["begin", "update", "end"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();
+}

--- a/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+  name: "tauri-plugin-live-activity",
+  platforms: [
+    .iOS(.v13)
+  ],
+  products: [
+    .library(
+      name: "tauri-plugin-live-activity",
+      type: .static,
+      targets: ["tauri-plugin-live-activity"])
+  ],
+  dependencies: [
+    // The Tauri SwiftPM umbrella package is generated under the host
+    // Xcode project's `gen/apple/.tauri/tauri-api/` when `cargo tauri ios
+    // init` runs. Path is relative to this Package.swift after the host
+    // app's local plugin path declaration.
+    .package(name: "Tauri", path: "../.tauri/tauri-api")
+  ],
+  targets: [
+    .target(
+      name: "tauri-plugin-live-activity",
+      dependencies: [
+        .byName(name: "Tauri")
+      ],
+      path: "Sources/LiveActivityPlugin")
+  ]
+)

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -1,0 +1,50 @@
+// Phase B of intrada#474 — placeholder Swift plugin. Resolves all three
+// commands (begin / update / end) without touching ActivityKit yet, so
+// the IPC roundtrip from JS → Rust → Swift can be exercised end-to-end.
+// Phase C swaps these stubs for the real Activity<...>.request /
+// activity.update / activity.end calls.
+//
+// Spec: specs/live-activity-plugin.md
+
+import SwiftRs
+import Tauri
+import UIKit
+import WebKit
+
+struct BeginArgs: Decodable {
+  let item_title: String
+  let position_label: String
+  let started_at: String  // RFC3339 UTC
+  let planned_duration_secs: UInt32?
+}
+
+struct UpdateArgs: Decodable {
+  let item_title: String
+  let position_label: String
+  let started_at: String
+  let planned_duration_secs: UInt32?
+}
+
+class LiveActivityPlugin: Plugin {
+  // Phase B: parse args to confirm shape, then resolve. Phase C
+  // replaces each stub body with the corresponding ActivityKit call.
+
+  @objc public func begin(_ invoke: Invoke) throws {
+    let _ = try invoke.parseArgs(BeginArgs.self)
+    invoke.resolve()
+  }
+
+  @objc public func update(_ invoke: Invoke) throws {
+    let _ = try invoke.parseArgs(UpdateArgs.self)
+    invoke.resolve()
+  }
+
+  @objc public func end(_ invoke: Invoke) {
+    invoke.resolve()
+  }
+}
+
+@_cdecl("init_plugin_live_activity")
+func initPlugin() -> Plugin {
+  return LiveActivityPlugin()
+}

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/begin.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/begin.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-begin"
+description = "Enables the begin command without any pre-configured scope."
+commands.allow = ["begin"]
+
+[[permission]]
+identifier = "deny-begin"
+description = "Denies the begin command without any pre-configured scope."
+commands.deny = ["begin"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/end.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/end.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-end"
+description = "Enables the end command without any pre-configured scope."
+commands.allow = ["end"]
+
+[[permission]]
+identifier = "deny-end"
+description = "Denies the end command without any pre-configured scope."
+commands.deny = ["end"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/update.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/update.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-update"
+description = "Enables the update command without any pre-configured scope."
+commands.allow = ["update"]
+
+[[permission]]
+identifier = "deny-update"
+description = "Denies the update command without any pre-configured scope."
+commands.deny = ["update"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/reference.md
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/reference.md
@@ -1,0 +1,97 @@
+## Default Permission
+
+Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.
+
+#### This default permission set includes the following:
+
+- `allow-begin`
+- `allow-update`
+- `allow-end`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`live-activity:allow-begin`
+
+</td>
+<td>
+
+Enables the begin command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-begin`
+
+</td>
+<td>
+
+Denies the begin command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:allow-end`
+
+</td>
+<td>
+
+Enables the end command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-end`
+
+</td>
+<td>
+
+Denies the end command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:allow-update`
+
+</td>
+<td>
+
+Enables the update command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-update`
+
+</td>
+<td>
+
+Denies the update command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/crates/intrada-mobile/plugins/live-activity/permissions/default.json
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/default.json
@@ -1,0 +1,10 @@
+{
+  "default": {
+    "description": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.",
+    "permissions": [
+      "allow-begin",
+      "allow-update",
+      "allow-end"
+    ]
+  }
+}

--- a/crates/intrada-mobile/plugins/live-activity/permissions/schemas/schema.json
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/schemas/schema.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the begin command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-begin",
+          "markdownDescription": "Enables the begin command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the begin command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-begin",
+          "markdownDescription": "Denies the begin command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the end command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-end",
+          "markdownDescription": "Enables the end command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the end command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-end",
+          "markdownDescription": "Denies the end command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the update command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-update",
+          "markdownDescription": "Enables the update command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the update command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-update",
+          "markdownDescription": "Denies the update command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.\n#### This default permission set includes:\n\n- `allow-begin`\n- `allow-update`\n- `allow-end`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.\n#### This default permission set includes:\n\n- `allow-begin`\n- `allow-update`\n- `allow-end`"
+        }
+      ]
+    }
+  }
+}

--- a/crates/intrada-mobile/plugins/live-activity/src/lib.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/lib.rs
@@ -1,0 +1,199 @@
+//! Intrada internal Tauri plugin — drives an ActivityKit Live Activity
+//! for the duration of a practice session. Layers on top of the
+//! background-audio plugin: same lifecycle (None → Some → None as the
+//! WebView's `vm.active_session` changes), different surface.
+//!
+//! Phase B (#474): Rust commands accept the same shape Phase C will
+//! consume but currently return `Ok(())` — the Swift side is a
+//! placeholder that doesn't call ActivityKit yet. Spec:
+//! `specs/live-activity-plugin.md`.
+//!
+//! On non-iOS platforms the commands resolve to `Ok(())` without doing
+//! anything — the JS bindings call them unconditionally and we don't
+//! want them to error on web / macOS / Android / iPad (where Live
+//! Activities aren't supported).
+
+use serde::{Deserialize, Serialize};
+#[cfg(target_os = "ios")]
+use tauri::Manager;
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    AppHandle, Runtime,
+};
+
+#[cfg(target_os = "ios")]
+mod mobile;
+
+/// Errors surfaceable from plugin commands. Phase C surfaces native-side
+/// failures (ActivityKit `Activity.request` rejection, user disabled
+/// Live Activities in Settings, missing `NSSupportsLiveActivities`
+/// plist key) so the shell can decide whether to keep going with just
+/// the background-audio plugin.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Tauri / Swift bridge surfaced an error string.
+    #[error("live-activity: {0}")]
+    Bridge(String),
+}
+
+impl Serialize for Error {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        s.serialize_str(self.to_string().as_str())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Argument shape for `begin`. Field names use snake_case to match what
+/// JS sends; Swift's `Decodable` accepts the same shape.
+///
+/// `planned_duration_secs` is optional because not every entry has a
+/// planned duration set — the activity falls back to elapsed-only
+/// rendering in that case.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BeginArgs {
+    pub item_title: String,
+    pub position_label: String,
+    pub started_at: String,
+    pub planned_duration_secs: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateArgs {
+    pub item_title: String,
+    pub position_label: String,
+    pub started_at: String,
+    pub planned_duration_secs: Option<u32>,
+}
+
+/// Drop a Sentry breadcrumb tagged `live-activity` so any subsequent
+/// failure (here or elsewhere in the session) carries the lifecycle
+/// context. No-op when Sentry isn't initialised (simulator / dev /
+/// non-iOS), so cheap to call unconditionally.
+#[cfg(target_os = "ios")]
+fn breadcrumb(command: &str, data: serde_json::Value) {
+    sentry::add_breadcrumb(sentry::Breadcrumb {
+        category: Some("live-activity".to_string()),
+        message: Some(command.to_string()),
+        level: sentry::Level::Info,
+        data: data
+            .as_object()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    });
+}
+
+/// Capture a plugin-bridge failure as a Sentry message tagged with the
+/// command name. ActivityKit failures mean the Live Activity didn't
+/// start / update — timer + lock-screen Now Playing (background-audio)
+/// still work, so this isn't fatal, but we want telemetry on the rate.
+#[cfg(target_os = "ios")]
+fn capture_bridge_error(command: &str, err: &Error) {
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("plugin", "live-activity");
+            scope.set_tag("command", command);
+        },
+        || {
+            sentry::capture_message(&format!("{err}"), sentry::Level::Error);
+        },
+    );
+}
+
+#[tauri::command]
+async fn begin<R: Runtime>(app: AppHandle<R>, args: BeginArgs) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb(
+            "begin",
+            serde_json::json!({
+                "item_title": &args.item_title,
+                "position_label": &args.position_label,
+                "started_at": &args.started_at,
+                "planned_duration_secs": args.planned_duration_secs,
+            }),
+        );
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("begin", args);
+        if let Err(err) = &result {
+            capture_bridge_error("begin", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = (app, args);
+        Ok(())
+    }
+}
+
+#[tauri::command]
+async fn update<R: Runtime>(app: AppHandle<R>, args: UpdateArgs) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb(
+            "update",
+            serde_json::json!({
+                "item_title": &args.item_title,
+                "position_label": &args.position_label,
+                "started_at": &args.started_at,
+                "planned_duration_secs": args.planned_duration_secs,
+            }),
+        );
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("update", args);
+        if let Err(err) = &result {
+            capture_bridge_error("update", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = (app, args);
+        Ok(())
+    }
+}
+
+#[tauri::command]
+async fn end<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb("end", serde_json::json!({}));
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("end", ());
+        if let Err(err) = &result {
+            capture_bridge_error("end", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}
+
+/// Plugin entry point — wired into the Tauri Builder in
+/// `intrada-mobile/src-tauri/src/lib.rs`.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("live-activity")
+        .invoke_handler(tauri::generate_handler![begin, update, end])
+        .setup(|app, _api| {
+            #[cfg(target_os = "ios")]
+            {
+                let handle = mobile::init(app, _api)?;
+                app.manage(handle);
+            }
+            // Suppress unused-variable warning on non-iOS targets where
+            // the setup hook is a no-op.
+            #[cfg(not(target_os = "ios"))]
+            {
+                let _ = app;
+            }
+            Ok(())
+        })
+        .build()
+}

--- a/crates/intrada-mobile/plugins/live-activity/src/mobile.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/mobile.rs
@@ -1,0 +1,42 @@
+//! iOS-only bridge: registers the Swift plugin and gives the Rust
+//! commands a typed handle for invoking its `@objc` methods. The
+//! `tauri::ios_plugin_binding!` macro generates the FFI binding to the
+//! `init_plugin_live_activity` C symbol exported by the Swift side
+//! (see `ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift`).
+
+use serde::Serialize;
+use tauri::{
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+tauri::ios_plugin_binding!(init_plugin_live_activity);
+
+/// Initializes the Swift plugin and returns a handle the commands can
+/// dispatch through. Stored on the AppHandle via `app.manage(...)` from
+/// the plugin's setup hook.
+pub fn init<R: Runtime, C: serde::de::DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> crate::Result<LiveActivity<R>> {
+    let handle = api
+        .register_ios_plugin(init_plugin_live_activity)
+        .map_err(|e| crate::Error::Bridge(e.to_string()))?;
+    Ok(LiveActivity(handle))
+}
+
+/// Wrapper around the Swift plugin's IPC handle.
+pub struct LiveActivity<R: Runtime>(pub PluginHandle<R>);
+
+impl<R: Runtime> LiveActivity<R> {
+    /// Generic "send `args` to the Swift method named `cmd`" — the
+    /// individual commands map their own typed payloads to this. Method
+    /// names match the Swift `@objc` selectors, which are snake_case
+    /// here so they line up 1:1 with the JS-side command names (no
+    /// translation needed in either direction).
+    pub fn run<P: Serialize>(&self, cmd: &str, payload: P) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin::<()>(cmd, payload)
+            .map_err(|e| crate::Error::Bridge(e.to_string()))
+    }
+}

--- a/crates/intrada-mobile/src-tauri/Cargo.toml
+++ b/crates/intrada-mobile/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-haptics = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-background-audio = { path = "../plugins/background-audio" }
+tauri-plugin-live-activity = { path = "../plugins/live-activity" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/intrada-mobile/src-tauri/capabilities/mobile.json
+++ b/crates/intrada-mobile/src-tauri/capabilities/mobile.json
@@ -11,6 +11,7 @@
     "haptics:allow-notification-feedback",
     "haptics:allow-vibrate",
     "deep-link:default",
-    "background-audio:default"
+    "background-audio:default",
+    "live-activity:default"
   ]
 }

--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -34,10 +34,15 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_deep_link::init())
-        // Phase B scaffold of #309 — Rust commands return Ok with no
-        // native side-effects. Phase C adds the AVAudioSession + Now
-        // Playing Swift impl behind the same command names.
+        // Background audio: AVAudioSession + Now Playing for the active
+        // practice session. Keeps the timer alive while the device is
+        // locked. (#309 — fully shipped.)
         .plugin(tauri_plugin_background_audio::init())
+        // Live Activity: Lock Screen + Dynamic Island for the active
+        // practice session. Phase B scaffold of #474 — Swift side
+        // resolves with no ActivityKit calls yet; Phase C wires the
+        // real Activity<...>.request / update / end.
+        .plugin(tauri_plugin_live_activity::init())
         .run(tauri::generate_context!())
         .expect("error while running intrada");
 }

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -23,9 +23,9 @@ use crate::views::{
     LibraryListView, NotFoundView, SessionActiveView, SessionNewView, SessionSummaryView,
     SessionsAllView, SessionsListView, SetDetailView, SetEditView,
 };
-use intrada_web::background_audio;
 use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::{init_core, load_session_in_progress, process_effects};
+use intrada_web::session_lifecycle;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// App-level signal for focus mode — when true, navigation and non-essential UI are hidden.
@@ -170,14 +170,16 @@ fn AuthenticatedApp() -> impl IntoView {
         }
     }
 
-    // Background-audio plugin lifecycle (#309 Phase D). Mounted at the
-    // app level so the Some → None transition fires `end_session()` even
+    // Session-lifecycle Effect (#309 Phase D + #474 Phase B). Drives
+    // both the background-audio plugin (lock-screen Now Playing /
+    // AVAudioSession) and the live-activity plugin (Lock Screen +
+    // Dynamic Island) from the same vm.active_session transitions.
+    // Mounted at the app level so Some → None fires the end calls even
     // when the user navigates away from /sessions/active before
     // finishing — e.g. backing to home, switching tabs, or hitting
-    // "Discard Session" from /sessions/new. Mounting inside <SessionTimer>
-    // would unmount the Effect alongside the route and leak the iOS
-    // AVAudioSession + silent loop until the OS reclaims it.
-    background_audio::mount_background_audio_lifecycle(view_model);
+    // "Discard Session" from /sessions/new. Mounting inside
+    // <SessionTimer> would leak both plugins.
+    session_lifecycle::mount_session_lifecycle(view_model);
 
     view! {
         <div class="relative z-0 min-h-screen text-primary">

--- a/crates/intrada-web/src/background_audio.rs
+++ b/crates/intrada-web/src/background_audio.rs
@@ -1,7 +1,4 @@
-use leptos::prelude::*;
 use wasm_bindgen::prelude::*;
-
-use intrada_core::ViewModel;
 
 // Calls Tauri plugin-background-audio commands via the Tauri IPC invoke
 // bridge. All functions are no-ops outside a Tauri context (web browser,
@@ -9,6 +6,10 @@ use intrada_core::ViewModel;
 // as Rust errors — the timer continues working even if the audio session
 // can't be activated. The Rust plugin captures failures into Sentry so
 // we still get telemetry without surfacing UI banners users can't act on.
+//
+// Lifecycle orchestration lives in `session_lifecycle.rs` — a single
+// Effect drives both this plugin and the live-activity plugin from the
+// same `vm.active_session` transitions.
 #[wasm_bindgen(inline_js = "
     function bg_audio_invoke(cmd, args) {
         try {
@@ -37,56 +38,4 @@ extern "C" {
     /// Release the audio session + clear Now Playing on session end.
     /// No-op outside Tauri.
     pub fn end_session();
-}
-
-/// Mount the background-audio lifecycle Effect on the global `ViewModel`
-/// signal. Tracks `current_item_started_at` across renders so we can tell
-/// session start (None → Some), item advance (anchor change), and session
-/// end (Some → None) apart with a single Effect.
-///
-/// Must be called from a Leptos owner scope that lives for the duration of
-/// the user's authenticated app session — i.e. `AuthenticatedApp`, not a
-/// per-route component. Mounting this inside `<SessionTimer>` would leak
-/// the audio session: when the user navigates away from `/sessions/active`
-/// without finishing (e.g. taps a tab, hits Discard from `/sessions/new`)
-/// the timer unmounts before the Effect can observe `Some → None`, so
-/// `end_session()` never fires and the AVAudioSession stays active until
-/// the OS reclaims it.
-///
-/// The Effect re-fires on every ViewModel push (coarser than ideal — any
-/// unrelated VM mutation triggers it) but the anchor-equality guard makes
-/// that idempotent.
-pub fn mount_background_audio_lifecycle(view_model: RwSignal<ViewModel>) {
-    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
-    Effect::new(move |_| {
-        let next = view_model.with(|vm| {
-            vm.active_session.as_ref().map(|a| {
-                (
-                    a.current_item_title.clone(),
-                    a.current_position,
-                    a.total_items,
-                    a.current_item_started_at.clone(),
-                )
-            })
-        });
-        let prev = prev_anchor.get_untracked();
-        match (prev, next) {
-            (None, Some((title, _pos, _total, started_at))) => {
-                begin_session(&title, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(prev_anchor_val), Some((title, pos, total, started_at)))
-                if prev_anchor_val != started_at =>
-            {
-                let position_label = format!("Item {} of {}", pos + 1, total);
-                set_now_playing(&title, &position_label, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(_), None) => {
-                end_session();
-                prev_anchor.set(None);
-            }
-            _ => {}
-        }
-    });
 }

--- a/crates/intrada-web/src/lib.rs
+++ b/crates/intrada-web/src/lib.rs
@@ -5,5 +5,7 @@ pub mod core_bridge;
 pub mod haptics;
 pub mod helpers;
 pub mod hooks;
+pub mod live_activity;
+pub mod session_lifecycle;
 pub mod types;
 pub mod validation;

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -1,0 +1,60 @@
+use wasm_bindgen::prelude::*;
+
+// Calls Tauri plugin-live-activity commands via the Tauri IPC invoke
+// bridge. All functions are no-ops outside a Tauri context (web browser,
+// E2E tests, iPad — Live Activities are iPhone-only). The try/catch in
+// JS ensures plugin failures never surface as Rust errors. The Rust
+// plugin captures failures into Sentry so we still get telemetry
+// without surfacing UI banners users can't act on.
+//
+// Mirrors the shape of `intrada-web/src/background_audio.rs` so both
+// plugins can be driven from the same lifecycle Effect (see
+// `mount_session_lifecycle` in `background_audio.rs`).
+#[wasm_bindgen(inline_js = "
+    function live_activity_invoke(cmd, args) {
+        try {
+            const invoke =
+                window.__TAURI__?.core?.invoke ??
+                window.__TAURI_INTERNALS__?.invoke;
+            if (invoke) invoke(cmd, args ?? {});
+        } catch(e) {}
+    }
+    export function begin(item_title, position_label, started_at, planned_duration_secs) {
+        live_activity_invoke('plugin:live-activity|begin', {
+            item_title,
+            position_label,
+            started_at,
+            planned_duration_secs: planned_duration_secs ?? null,
+        });
+    }
+    export function update(item_title, position_label, started_at, planned_duration_secs) {
+        live_activity_invoke('plugin:live-activity|update', {
+            item_title,
+            position_label,
+            started_at,
+            planned_duration_secs: planned_duration_secs ?? null,
+        });
+    }
+    export function end() {
+        live_activity_invoke('plugin:live-activity|end');
+    }
+")]
+extern "C" {
+    /// Start a Live Activity for the active practice session. No-op
+    /// outside Tauri / on iPad.
+    pub fn begin(
+        item_title: &str,
+        position_label: &str,
+        started_at: &str,
+        planned_duration_secs: Option<u32>,
+    );
+    /// Update the Live Activity on item advance. No-op outside Tauri.
+    pub fn update(
+        item_title: &str,
+        position_label: &str,
+        started_at: &str,
+        planned_duration_secs: Option<u32>,
+    );
+    /// End the Live Activity. No-op outside Tauri.
+    pub fn end();
+}

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::*;
 //
 // Mirrors the shape of `intrada-web/src/background_audio.rs` so both
 // plugins can be driven from the same lifecycle Effect (see
-// `mount_session_lifecycle` in `background_audio.rs`).
+// `mount_session_lifecycle` in `session_lifecycle.rs`).
 #[wasm_bindgen(inline_js = "
     function live_activity_invoke(cmd, args) {
         try {

--- a/crates/intrada-web/src/session_lifecycle.rs
+++ b/crates/intrada-web/src/session_lifecycle.rs
@@ -1,0 +1,81 @@
+use leptos::prelude::*;
+
+use intrada_core::ViewModel;
+
+use crate::{background_audio, live_activity};
+
+/// Mount the session-lifecycle Effect on the global `ViewModel` signal.
+/// Tracks `current_item_started_at` across renders so we can tell session
+/// start (None → Some), item advance (anchor change), and session end
+/// (Some → None) apart with a single Effect, then fans the transition
+/// out to *both* native plugins:
+///
+/// - `background-audio` (#309) — keeps the timer alive while the device
+///   is locked + shows a Now Playing card.
+/// - `live-activity` (#474) — Lock Screen + Dynamic Island for the
+///   active session. Layered on top, not a replacement.
+///
+/// One Effect, two side-effects: avoids two parallel observers racing
+/// with divergent ordering.
+///
+/// # Where this must be mounted
+///
+/// Must be called from a Leptos owner scope that lives for the duration
+/// of the user's authenticated app session — i.e. `AuthenticatedApp`,
+/// not a per-route component. Mounting this inside `<SessionTimer>`
+/// would leak both plugins' state: when the user navigates away from
+/// `/sessions/active` without finishing (e.g. taps a tab, hits Discard
+/// from `/sessions/new`) the timer unmounts before the Effect can
+/// observe `Some → None`, so the `end` transition never fires and the
+/// AVAudioSession + Live Activity stay active until the OS reclaims
+/// them. (See #309 Phase D for the original observation.)
+///
+/// # Reactivity
+///
+/// The Effect re-fires on every ViewModel push (coarser than ideal —
+/// any unrelated VM mutation triggers it) but the anchor-equality guard
+/// makes that idempotent. If we ever care about the wasted work, a
+/// Memo<Option<String>> over current_item_started_at would isolate the
+/// dependency.
+pub fn mount_session_lifecycle(view_model: RwSignal<ViewModel>) {
+    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
+    Effect::new(move |_| {
+        let next = view_model.with(|vm| {
+            vm.active_session.as_ref().map(|a| {
+                (
+                    a.current_item_title.clone(),
+                    a.current_position,
+                    a.total_items,
+                    a.current_item_started_at.clone(),
+                    a.current_planned_duration_secs,
+                )
+            })
+        });
+        let prev = prev_anchor.get_untracked();
+        match (prev, next) {
+            // Session start: vm.active_session went from None to Some.
+            (None, Some((title, pos, total, started_at, planned))) => {
+                let position_label = format!("Item {} of {}", pos + 1, total);
+                background_audio::begin_session(&title, &started_at);
+                live_activity::begin(&title, &position_label, &started_at, planned);
+                prev_anchor.set(Some(started_at));
+            }
+            // Item advance: same session, new item anchor.
+            (Some(prev_anchor_val), Some((title, pos, total, started_at, planned)))
+                if prev_anchor_val != started_at =>
+            {
+                let position_label = format!("Item {} of {}", pos + 1, total);
+                background_audio::set_now_playing(&title, &position_label, &started_at);
+                live_activity::update(&title, &position_label, &started_at, planned);
+                prev_anchor.set(Some(started_at));
+            }
+            // Session end: vm.active_session went from Some to None.
+            (Some(_), None) => {
+                background_audio::end_session();
+                live_activity::end();
+                prev_anchor.set(None);
+            }
+            _ => {}
+        }
+    });
+}


### PR DESCRIPTION
## Summary

- New \`tauri-plugin-live-activity\` plugin under \`crates/intrada-mobile/plugins/live-activity/\` mirroring the background-audio plugin's shape
- Three commands (\`begin\`, \`update\`, \`end\`) wired through to a placeholder Swift plugin — no ActivityKit yet
- **Unified session lifecycle**: extracts the lifecycle Effect into \`session_lifecycle.rs\`, renames it \`mount_session_lifecycle\`, drives both plugins from one observer
- Sentry breadcrumbs + bridge-error capture (mirrors background-audio Phase D pattern)
- CI exclude added; iOS-target clippy clean

Stacks on **#487** (Phase A — widget extension target). Merge that first.

## What this delivers (and what it doesn't)

**Delivers**: The IPC roundtrip from JS → Rust → Swift is exercised end-to-end. Each session start / item advance / session end fires both plugins from the same Effect. Swift side resolves the IPC without doing anything yet.

**Does not deliver**: Actual Live Activities. Phase C swaps the Swift placeholder for the real \`Activity<...>.request\` / \`activity.update\` / \`activity.end\` calls + the SwiftUI views in the widget extension.

## Architecture decision: one Effect, two side-effects

Rather than spawning a parallel \`mount_live_activity_lifecycle\` Effect alongside \`mount_background_audio_lifecycle\`, I unified them into \`session_lifecycle::mount_session_lifecycle\`. Two reasons:

1. **No ordering races.** Both plugins react to the same \`vm.active_session\` transition (None → Some, anchor change, Some → None). Two parallel Effects might observe the transition at slightly different times, leading to "Live Activity started before audio session" or vice versa.
2. **Single source of truth for the \"is the user in a session?\" derive.** If we ever add a third plugin (Apple Watch companion, Siri Intent), it slots into the same Effect rather than a third parallel observer.

Tracked tuple gained \`current_planned_duration_secs\` (already in the ViewModel) so the live-activity's progress arc has the data it needs. background-audio doesn't use it but the cost is one extra Option<u32> per push — negligible.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --workspace --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity\` passes
- [x] \`cargo clippy -p tauri-plugin-live-activity --target aarch64-apple-ios\` passes (catches the cfg-gated iOS branches Linux CI silently skips — per CLAUDE.md gotcha)
- [x] \`cargo test --workspace --exclude tauri-plugin-{background-audio,live-activity}\` → 432 pass
- [x] End-to-end iOS build: \`cargo tauri ios init\` → \`ruby scripts/fix-ios-build-config.rb\` → \`ruby scripts/add-live-activity-target.rb\` → \`cargo tauri ios build --target aarch64\` → \`Intrada.ipa\` produced cleanly
- [ ] Device install: start a session → verify nothing visible changes (Phase B is a no-op behaviourally) and Sentry shows \`live-activity\` breadcrumbs in the session trace

## Self-review

- ✅ Plugin name + bundle ID + Swift binding name (\`init_plugin_live_activity\`) consistent across Cargo.toml, mobile.rs, Package.swift, and the Swift \`@_cdecl\` export
- ✅ Sentry config matches background-audio's plugin (default features off, only the core API surface)
- ✅ JS shim's \`planned_duration_secs ?? null\` — Swift's \`UInt32?\` decodes \`null\` as \`nil\` correctly
- ✅ Capability declared in \`mobile.json\` (\`live-activity:default\`) — without it the WebView can't invoke the commands
- ✅ \`session_lifecycle.rs\` carries thorough doc-comment explaining where it must be mounted (#309 Phase D's "leak the session" lesson re-articulated)
- ✅ \`background_audio.rs\` shrunk to just the JS bindings — lifecycle moved out cleanly

## Out of scope (Phase C / D)

- ActivityKit \`Activity<IntradaActivityAttributes>.request\` etc. → Phase C
- SwiftUI views for Lock Screen + Dynamic Island (compact/expanded) → Phase C
- \`NSSupportsLiveActivities = true\` in Info.plist → Phase C (when ActivityKit is actually used)
- Asset bundling for widget extension → Phase D

🤖 Generated with [Claude Code](https://claude.com/claude-code)