### PR TITLE
refactor(api): extract service layer for HTTP + MCP shared use (Phase 1 of #477)

### DIFF
--- a/crates/intrada-api/src/lib.rs
+++ b/crates/intrada-api/src/lib.rs
@@ -4,5 +4,6 @@ pub mod db;
 pub mod error;
 pub mod migrations;
 pub mod routes;
+pub mod services;
 pub mod state;
 pub mod storage;

--- a/crates/intrada-api/src/routes/account.rs
+++ b/crates/intrada-api/src/routes/account.rs
@@ -4,9 +4,9 @@ use axum::routing::{delete, get};
 use axum::{Json, Router};
 
 use crate::auth::AuthUser;
-use crate::db;
 use crate::db::account::AccountPreferences;
 use crate::error::ApiError;
+use crate::services;
 use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -20,7 +20,7 @@ async fn get_preferences(
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<AccountPreferences>, ApiError> {
     let conn = state.conn();
-    let prefs = db::account::get_preferences(&conn, &user_id).await?;
+    let prefs = services::account::get_preferences(&conn, &user_id).await?;
     Ok(Json(prefs))
 }
 
@@ -29,18 +29,8 @@ async fn put_preferences(
     AuthUser(user_id): AuthUser,
     Json(input): Json<AccountPreferences>,
 ) -> Result<Json<AccountPreferences>, ApiError> {
-    if input.default_focus_minutes == 0 || input.default_focus_minutes > 600 {
-        return Err(ApiError::Validation(
-            "default_focus_minutes must be 1..=600".to_string(),
-        ));
-    }
-    if input.default_rep_count == 0 || input.default_rep_count > 999 {
-        return Err(ApiError::Validation(
-            "default_rep_count must be 1..=999".to_string(),
-        ));
-    }
     let conn = state.conn();
-    let prefs = db::account::upsert_preferences(&conn, &user_id, &input).await?;
+    let prefs = services::account::put_preferences(&conn, &user_id, &input).await?;
     Ok(Json(prefs))
 }
 
@@ -48,36 +38,8 @@ async fn delete_account(
     State(state): State<AppState>,
     AuthUser(user_id): AuthUser,
 ) -> Result<StatusCode, ApiError> {
-    // Refuse empty user_id outright — auth-disabled mode (no
-    // CLERK_ISSUER_URL) yields `AuthUser("")`, which would otherwise
-    // turn into an R2 prefix `/` and a Clerk DELETE /v1/users/ —
-    // both blast-radius hazards.
-    if user_id.is_empty() {
-        return Err(ApiError::Unauthorized("Unauthorized".to_string()));
-    }
-
-    // 1. DB rows. Hard fail — if data delete doesn't succeed, the user
-    //    can re-run.
     let conn = state.conn();
-    db::account::delete_all_user_data(&conn, &user_id).await?;
-
-    // 2. R2 photo blobs. Best-effort: log but don't fail. The DB
-    //    `lesson_photos` rows are already gone, so the blobs are
-    //    orphaned-but-private (keys include user_id; bucket has no public
-    //    listing).
-    if let Some(r2) = &state.r2 {
-        if let Err(err) = r2.delete_user_photos(&user_id).await {
-            tracing::warn!(?err, %user_id, "R2 photo cleanup failed during account delete");
-        }
-    }
-
-    // 3. Clerk user record. Best-effort: log but don't fail. 404 from
-    //    Clerk is treated as success (idempotent retry).
-    if let Some(clerk) = &state.clerk {
-        if let Err(err) = clerk.delete_user(&user_id).await {
-            tracing::warn!(?err, %user_id, "Clerk user delete failed during account delete");
-        }
-    }
-
+    services::account::delete_account(&conn, state.r2.as_ref(), state.clerk.as_ref(), &user_id)
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/intrada-api/src/routes/items.rs
+++ b/crates/intrada-api/src/routes/items.rs
@@ -5,11 +5,10 @@ use axum::{Json, Router};
 
 use intrada_core::domain::item::Item;
 use intrada_core::domain::types::{CreateItem, UpdateItem};
-use intrada_core::validation;
 
 use crate::auth::AuthUser;
-use crate::db;
 use crate::error::ApiError;
+use crate::services;
 use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -23,7 +22,7 @@ async fn list_items(
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<Item>>, ApiError> {
     let conn = state.conn();
-    let items = db::items::list_items(&conn, &user_id).await?;
+    let items = services::items::list_items(&conn, &user_id).await?;
     Ok(Json(items))
 }
 
@@ -33,9 +32,7 @@ async fn get_item(
     Path(id): Path<String>,
 ) -> Result<Json<Item>, ApiError> {
     let conn = state.conn();
-    let item = db::items::get_item(&conn, &id, &user_id)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))?;
+    let item = services::items::get_item(&conn, &id, &user_id).await?;
     Ok(Json(item))
 }
 
@@ -44,9 +41,8 @@ async fn create_item(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateItem>,
 ) -> Result<(StatusCode, Json<Item>), ApiError> {
-    validation::validate_create_item(&input)?;
     let conn = state.conn();
-    let item = db::items::insert_item(&conn, &user_id, &input).await?;
+    let item = services::items::create_item(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(item)))
 }
 
@@ -56,11 +52,8 @@ async fn update_item(
     Path(id): Path<String>,
     Json(input): Json<UpdateItem>,
 ) -> Result<Json<Item>, ApiError> {
-    validation::validate_update_item(&input)?;
     let conn = state.conn();
-    let item = db::items::update_item(&conn, &id, &user_id, &input)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))?;
+    let item = services::items::update_item(&conn, &id, &user_id, &input).await?;
     Ok(Json(item))
 }
 
@@ -70,10 +63,6 @@ async fn delete_item(
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();
-    let deleted = db::items::delete_item(&conn, &id, &user_id).await?;
-    if deleted {
-        Ok(Json(serde_json::json!({ "message": "Item deleted" })))
-    } else {
-        Err(ApiError::NotFound(format!("Item not found: {id}")))
-    }
+    services::items::delete_item(&conn, &id, &user_id).await?;
+    Ok(Json(serde_json::json!({ "message": "Item deleted" })))
 }

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -61,8 +61,8 @@ async fn create_lesson(
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
     let conn = state.conn();
-    let r2 = state.r2()?;
-    let lesson = services::lessons::create_lesson(&conn, r2, &user_id, &input).await?;
+    let lesson =
+        services::lessons::create_lesson(&conn, state.r2.as_ref(), &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(lesson)))
 }
 
@@ -73,8 +73,8 @@ async fn update_lesson(
     Json(input): Json<UpdateLesson>,
 ) -> Result<Json<Lesson>, ApiError> {
     let conn = state.conn();
-    let r2 = state.r2()?;
-    let lesson = services::lessons::update_lesson(&conn, r2, &id, &user_id, &input).await?;
+    let lesson =
+        services::lessons::update_lesson(&conn, state.r2.as_ref(), &id, &user_id, &input).await?;
     Ok(Json(lesson))
 }
 

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -6,16 +6,12 @@ use tower_http::limit::RequestBodyLimitLayer;
 
 use intrada_core::domain::lesson::Lesson;
 use intrada_core::domain::types::{CreateLesson, UpdateLesson};
-use intrada_core::validation;
 
 use crate::auth::AuthUser;
-use crate::db;
 use crate::error::ApiError;
+use crate::services;
+use crate::services::lessons::MAX_PHOTO_SIZE;
 use crate::state::AppState;
-use crate::storage::R2Client;
-
-/// Max photo upload size: 5 MB
-const MAX_PHOTO_SIZE: usize = 5 * 1024 * 1024;
 
 /// HTTP body limit for photo uploads: 5 MB photo + multipart overhead.
 const PHOTO_BODY_LIMIT: usize = 6 * 1024 * 1024;
@@ -44,7 +40,7 @@ async fn list_lessons(
 ) -> Result<Json<Vec<Lesson>>, ApiError> {
     let conn = state.conn();
     let r2 = state.r2()?;
-    let lessons = db::lessons::list_lessons(&conn, &user_id, r2).await?;
+    let lessons = services::lessons::list_lessons(&conn, r2, &user_id).await?;
     Ok(Json(lessons))
 }
 
@@ -55,9 +51,7 @@ async fn get_lesson(
 ) -> Result<Json<Lesson>, ApiError> {
     let conn = state.conn();
     let r2 = state.r2()?;
-    let lesson = db::lessons::get_lesson(&conn, &id, &user_id, r2)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
+    let lesson = services::lessons::get_lesson(&conn, r2, &id, &user_id).await?;
     Ok(Json(lesson))
 }
 
@@ -66,10 +60,9 @@ async fn create_lesson(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
-    validation::validate_create_lesson(&input)?;
     let conn = state.conn();
     let r2 = state.r2()?;
-    let lesson = db::lessons::insert_lesson(&conn, &user_id, &input, r2).await?;
+    let lesson = services::lessons::create_lesson(&conn, r2, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(lesson)))
 }
 
@@ -79,12 +72,9 @@ async fn update_lesson(
     Path(id): Path<String>,
     Json(input): Json<UpdateLesson>,
 ) -> Result<Json<Lesson>, ApiError> {
-    validation::validate_update_lesson(&input)?;
     let conn = state.conn();
     let r2 = state.r2()?;
-    let lesson = db::lessons::update_lesson(&conn, &id, &user_id, &input, r2)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))?;
+    let lesson = services::lessons::update_lesson(&conn, r2, &id, &user_id, &input).await?;
     Ok(Json(lesson))
 }
 
@@ -94,41 +84,11 @@ async fn delete_lesson(
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();
-
-    // Delete photos from R2 if storage is configured. Log but don't fail
-    // the request on R2 errors — DB is the source of truth.
-    if let Ok(r2) = state.r2() {
-        let keys = db::lessons::list_photo_storage_keys(&conn, &id, &user_id).await?;
-        for key in keys {
-            if let Err(e) = r2.delete(&key).await {
-                tracing::warn!(lesson_id = %id, storage_key = %key, error = ?e, "R2 photo delete failed; orphaning object");
-            }
-        }
-    }
-
-    let deleted = db::lessons::delete_lesson(&conn, &id, &user_id).await?;
-    if deleted {
-        Ok(StatusCode::NO_CONTENT)
-    } else {
-        Err(ApiError::NotFound(format!("Lesson not found: {id}")))
-    }
+    services::lessons::delete_lesson(&conn, state.r2.as_ref(), &id, &user_id).await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ── Photo endpoints ────────────────────────────────────────────────────
-
-/// Inspect the leading bytes and return the canonical image content-type,
-/// or `None` if the bytes don't match a supported format. This is the only
-/// source of truth for a photo's content-type — the client-supplied
-/// multipart header is never trusted.
-fn sniff_image_content_type(bytes: &[u8]) -> Option<&'static str> {
-    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
-        Some("image/jpeg")
-    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
-        Some("image/png")
-    } else {
-        None
-    }
-}
 
 async fn upload_photo(
     State(state): State<AppState>,
@@ -151,6 +111,9 @@ async fn upload_photo(
         .await
         .map_err(|e| ApiError::Validation(format!("Failed to read photo data: {e}")))?;
 
+    // Early body-size guard before handing off to the service. The service
+    // checks again (so non-HTTP callers like MCP get the same behaviour),
+    // but rejecting here avoids a wasted clone of the bytes into the service.
     if data.len() > MAX_PHOTO_SIZE {
         return Err(ApiError::Validation(format!(
             "Photo exceeds maximum size of {} MB",
@@ -158,19 +121,7 @@ async fn upload_photo(
         )));
     }
 
-    // Determine content-type from the bytes themselves — never trust the
-    // client's multipart header. Prevents XSS via spoofed Content-Type on
-    // the public R2 URL.
-    let content_type = sniff_image_content_type(&data)
-        .ok_or_else(|| ApiError::Validation("Photo must be JPEG or PNG".into()))?;
-
-    // Upload to R2
-    let photo_id = ulid::Ulid::new().to_string();
-    let storage_key = R2Client::photo_key(&user_id, &id, &photo_id);
-    r2.upload(&storage_key, &data, content_type).await?;
-
-    // Record in DB
-    let photo = db::lessons::insert_lesson_photo(&conn, &id, &user_id, &storage_key, r2).await?;
+    let photo = services::lessons::upload_lesson_photo(&conn, r2, &user_id, &id, &data).await?;
 
     Ok((
         StatusCode::CREATED,
@@ -188,23 +139,7 @@ async fn delete_photo(
     Path((id, photo_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();
-
-    // Get storage key before deleting from DB
-    let storage_key = db::lessons::get_lesson_photo_storage_key(&conn, &photo_id, &id, &user_id)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Photo not found: {photo_id}")))?;
-
-    // Delete from R2. Log but don't fail the request on R2 errors — the
-    // DB row below is the authoritative pointer; orphaned R2 objects are
-    // recoverable via prefix sweep but a stuck DB row is not.
-    if let Ok(r2) = state.r2() {
-        if let Err(e) = r2.delete(&storage_key).await {
-            tracing::warn!(photo_id = %photo_id, storage_key = %storage_key, error = ?e, "R2 photo delete failed; orphaning object");
-        }
-    }
-
-    // Delete from DB
-    db::lessons::delete_lesson_photo(&conn, &photo_id, &id, &user_id).await?;
-
+    services::lessons::delete_lesson_photo(&conn, state.r2.as_ref(), &user_id, &id, &photo_id)
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/intrada-api/src/routes/sessions.rs
+++ b/crates/intrada-api/src/routes/sessions.rs
@@ -4,12 +4,11 @@ use axum::routing::get;
 use axum::{Json, Router};
 
 use intrada_core::domain::session::PracticeSession;
-use intrada_core::validation;
 
 use crate::auth::AuthUser;
-use crate::db;
 use crate::db::sessions::SaveSessionRequest;
 use crate::error::ApiError;
+use crate::services;
 use crate::state::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -23,7 +22,7 @@ async fn list_sessions(
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<PracticeSession>>, ApiError> {
     let conn = state.conn();
-    let sessions = db::sessions::list_sessions(&conn, &user_id).await?;
+    let sessions = services::sessions::list_sessions(&conn, &user_id).await?;
     Ok(Json(sessions))
 }
 
@@ -33,9 +32,7 @@ async fn get_session(
     Path(id): Path<String>,
 ) -> Result<Json<PracticeSession>, ApiError> {
     let conn = state.conn();
-    let session = db::sessions::get_session(&conn, &id, &user_id)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Session not found: {id}")))?;
+    let session = services::sessions::get_session(&conn, &id, &user_id).await?;
     Ok(Json(session))
 }
 
@@ -44,32 +41,8 @@ async fn save_session(
     AuthUser(user_id): AuthUser,
     Json(input): Json<SaveSessionRequest>,
 ) -> Result<(StatusCode, Json<PracticeSession>), ApiError> {
-    // Validate session-level fields
-    validation::validate_session_notes(&input.session_notes)?;
-    validation::validate_intention(&input.session_intention)?;
-
-    // Validate entries not empty
-    validation::validate_entries_not_empty(&input.entries, "Practice")?;
-
-    // Validate each entry's fields
-    for entry in &input.entries {
-        validation::validate_set_entry_fields(&entry.item_id, &entry.item_title)?;
-        validation::validate_entry_notes(&entry.notes)?;
-        validation::validate_score(&entry.score)?;
-        validation::validate_intention(&entry.intention)?;
-        validation::validate_rep_target(&entry.rep_target)?;
-        validation::validate_planned_duration(&entry.planned_duration_secs)?;
-        validation::validate_achieved_tempo(&entry.achieved_tempo)?;
-        validation::validate_rep_consistency(
-            entry.rep_target,
-            entry.rep_count,
-            entry.rep_target_reached,
-            entry.rep_history.is_some(),
-        )?;
-    }
-
     let conn = state.conn();
-    let session = db::sessions::insert_session(&conn, &user_id, &input).await?;
+    let session = services::sessions::save_session(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(session)))
 }
 
@@ -79,10 +52,6 @@ async fn delete_session(
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();
-    let deleted = db::sessions::delete_session(&conn, &id, &user_id).await?;
-    if deleted {
-        Ok(Json(serde_json::json!({ "message": "Session deleted" })))
-    } else {
-        Err(ApiError::NotFound(format!("Session not found: {id}")))
-    }
+    services::sessions::delete_session(&conn, &id, &user_id).await?;
+    Ok(Json(serde_json::json!({ "message": "Session deleted" })))
 }

--- a/crates/intrada-api/src/routes/sets.rs
+++ b/crates/intrada-api/src/routes/sets.rs
@@ -4,20 +4,12 @@ use axum::routing::get;
 use axum::{Json, Router};
 
 use intrada_core::domain::set::Set;
-use intrada_core::validation;
 
 use crate::auth::AuthUser;
-use crate::db;
-use crate::db::sets::{CreateSetEntry, CreateSetRequest, UpdateSetRequest};
+use crate::db::sets::{CreateSetRequest, UpdateSetRequest};
 use crate::error::ApiError;
+use crate::services;
 use crate::state::AppState;
-
-fn validate_entries(entries: &[CreateSetEntry]) -> Result<(), ApiError> {
-    for entry in entries {
-        validation::validate_set_entry_fields(&entry.item_id, &entry.item_title)?;
-    }
-    Ok(())
-}
 
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -30,7 +22,7 @@ async fn list_sets(
     AuthUser(user_id): AuthUser,
 ) -> Result<Json<Vec<Set>>, ApiError> {
     let conn = state.conn();
-    let sets = db::sets::list_sets(&conn, &user_id).await?;
+    let sets = services::sets::list_sets(&conn, &user_id).await?;
     Ok(Json(sets))
 }
 
@@ -40,9 +32,7 @@ async fn get_set(
     Path(id): Path<String>,
 ) -> Result<Json<Set>, ApiError> {
     let conn = state.conn();
-    let set = db::sets::get_set(&conn, &id, &user_id)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Set not found: {id}")))?;
+    let set = services::sets::get_set(&conn, &id, &user_id).await?;
     Ok(Json(set))
 }
 
@@ -51,17 +41,8 @@ async fn create_set(
     AuthUser(user_id): AuthUser,
     Json(input): Json<CreateSetRequest>,
 ) -> Result<(StatusCode, Json<Set>), ApiError> {
-    // Validate set name
-    validation::validate_set_name(&input.name)?;
-
-    // Validate entries not empty
-    validation::validate_entries_not_empty(&input.entries, "Set")?;
-
-    // Validate each entry has required fields and valid item_type
-    validate_entries(&input.entries)?;
-
     let conn = state.conn();
-    let set = db::sets::insert_set(&conn, &user_id, &input).await?;
+    let set = services::sets::create_set(&conn, &user_id, &input).await?;
     Ok((StatusCode::CREATED, Json(set)))
 }
 
@@ -71,19 +52,8 @@ async fn update_set(
     Path(id): Path<String>,
     Json(input): Json<UpdateSetRequest>,
 ) -> Result<Json<Set>, ApiError> {
-    // Validate set name
-    validation::validate_set_name(&input.name)?;
-
-    // Validate entries not empty
-    validation::validate_entries_not_empty(&input.entries, "Set")?;
-
-    // Validate each entry has required fields and valid item_type
-    validate_entries(&input.entries)?;
-
     let conn = state.conn();
-    let set = db::sets::update_set(&conn, &id, &user_id, &input)
-        .await?
-        .ok_or_else(|| ApiError::NotFound(format!("Set not found: {id}")))?;
+    let set = services::sets::update_set(&conn, &id, &user_id, &input).await?;
     Ok(Json(set))
 }
 
@@ -93,10 +63,6 @@ async fn delete_set(
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();
-    let deleted = db::sets::delete_set(&conn, &id, &user_id).await?;
-    if deleted {
-        Ok(Json(serde_json::json!({ "message": "Set deleted" })))
-    } else {
-        Err(ApiError::NotFound(format!("Set not found: {id}")))
-    }
+    services::sets::delete_set(&conn, &id, &user_id).await?;
+    Ok(Json(serde_json::json!({ "message": "Set deleted" })))
 }

--- a/crates/intrada-api/src/services/account.rs
+++ b/crates/intrada-api/src/services/account.rs
@@ -1,0 +1,71 @@
+use libsql::Connection;
+
+use crate::clerk::ClerkClient;
+use crate::db;
+use crate::db::account::AccountPreferences;
+use crate::error::ApiError;
+use crate::storage::R2Client;
+
+pub async fn get_preferences(
+    conn: &Connection,
+    user_id: &str,
+) -> Result<AccountPreferences, ApiError> {
+    db::account::get_preferences(conn, user_id).await
+}
+
+pub async fn put_preferences(
+    conn: &Connection,
+    user_id: &str,
+    input: &AccountPreferences,
+) -> Result<AccountPreferences, ApiError> {
+    if input.default_focus_minutes == 0 || input.default_focus_minutes > 600 {
+        return Err(ApiError::Validation(
+            "default_focus_minutes must be 1..=600".to_string(),
+        ));
+    }
+    if input.default_rep_count == 0 || input.default_rep_count > 999 {
+        return Err(ApiError::Validation(
+            "default_rep_count must be 1..=999".to_string(),
+        ));
+    }
+    db::account::upsert_preferences(conn, user_id, input).await
+}
+
+pub async fn delete_account(
+    conn: &Connection,
+    r2: Option<&R2Client>,
+    clerk: Option<&ClerkClient>,
+    user_id: &str,
+) -> Result<(), ApiError> {
+    // Refuse empty user_id outright — auth-disabled mode (no
+    // CLERK_ISSUER_URL) yields `AuthUser("")`, which would otherwise
+    // turn into an R2 prefix `/` and a Clerk DELETE /v1/users/ —
+    // both blast-radius hazards.
+    if user_id.is_empty() {
+        return Err(ApiError::Unauthorized("Unauthorized".to_string()));
+    }
+
+    // 1. DB rows. Hard fail — if data delete doesn't succeed, the user
+    //    can re-run.
+    db::account::delete_all_user_data(conn, user_id).await?;
+
+    // 2. R2 photo blobs. Best-effort: log but don't fail. The DB
+    //    `lesson_photos` rows are already gone, so the blobs are
+    //    orphaned-but-private (keys include user_id; bucket has no public
+    //    listing).
+    if let Some(r2) = r2 {
+        if let Err(err) = r2.delete_user_photos(user_id).await {
+            tracing::warn!(?err, %user_id, "R2 photo cleanup failed during account delete");
+        }
+    }
+
+    // 3. Clerk user record. Best-effort: log but don't fail. 404 from
+    //    Clerk is treated as success (idempotent retry).
+    if let Some(clerk) = clerk {
+        if let Err(err) = clerk.delete_user(user_id).await {
+            tracing::warn!(?err, %user_id, "Clerk user delete failed during account delete");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/intrada-api/src/services/items.rs
+++ b/crates/intrada-api/src/services/items.rs
@@ -1,0 +1,47 @@
+use libsql::Connection;
+
+use intrada_core::domain::item::Item;
+use intrada_core::domain::types::{CreateItem, UpdateItem};
+use intrada_core::validation;
+
+use crate::db;
+use crate::error::ApiError;
+
+pub async fn list_items(conn: &Connection, user_id: &str) -> Result<Vec<Item>, ApiError> {
+    db::items::list_items(conn, user_id).await
+}
+
+pub async fn get_item(conn: &Connection, id: &str, user_id: &str) -> Result<Item, ApiError> {
+    db::items::get_item(conn, id, user_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))
+}
+
+pub async fn create_item(
+    conn: &Connection,
+    user_id: &str,
+    input: &CreateItem,
+) -> Result<Item, ApiError> {
+    validation::validate_create_item(input)?;
+    db::items::insert_item(conn, user_id, input).await
+}
+
+pub async fn update_item(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+    input: &UpdateItem,
+) -> Result<Item, ApiError> {
+    validation::validate_update_item(input)?;
+    db::items::update_item(conn, id, user_id, input)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Item not found: {id}")))
+}
+
+pub async fn delete_item(conn: &Connection, id: &str, user_id: &str) -> Result<(), ApiError> {
+    let deleted = db::items::delete_item(conn, id, user_id).await?;
+    if !deleted {
+        return Err(ApiError::NotFound(format!("Item not found: {id}")));
+    }
+    Ok(())
+}

--- a/crates/intrada-api/src/services/lessons.rs
+++ b/crates/intrada-api/src/services/lessons.rs
@@ -46,22 +46,26 @@ pub async fn get_lesson(
 
 pub async fn create_lesson(
     conn: &Connection,
-    r2: &R2Client,
+    r2: Option<&R2Client>,
     user_id: &str,
     input: &CreateLesson,
 ) -> Result<Lesson, ApiError> {
+    // Validate first so an invalid payload returns 422 even when R2 is
+    // unconfigured. Unwrap r2 only after validation passes.
     validation::validate_create_lesson(input)?;
+    let r2 = r2.ok_or_else(|| ApiError::Internal("Photo storage (R2) is not configured".into()))?;
     db::lessons::insert_lesson(conn, user_id, input, r2).await
 }
 
 pub async fn update_lesson(
     conn: &Connection,
-    r2: &R2Client,
+    r2: Option<&R2Client>,
     id: &str,
     user_id: &str,
     input: &UpdateLesson,
 ) -> Result<Lesson, ApiError> {
     validation::validate_update_lesson(input)?;
+    let r2 = r2.ok_or_else(|| ApiError::Internal("Photo storage (R2) is not configured".into()))?;
     db::lessons::update_lesson(conn, id, user_id, input, r2)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))

--- a/crates/intrada-api/src/services/lessons.rs
+++ b/crates/intrada-api/src/services/lessons.rs
@@ -1,0 +1,143 @@
+use libsql::Connection;
+
+use intrada_core::domain::lesson::{Lesson, LessonPhoto};
+use intrada_core::domain::types::{CreateLesson, UpdateLesson};
+use intrada_core::validation;
+
+use crate::db;
+use crate::error::ApiError;
+use crate::storage::R2Client;
+
+/// Max photo upload size: 5 MB
+pub const MAX_PHOTO_SIZE: usize = 5 * 1024 * 1024;
+
+/// Inspect the leading bytes and return the canonical image content-type,
+/// or `None` if the bytes don't match a supported format. This is the only
+/// source of truth for a photo's content-type — the client-supplied
+/// multipart header is never trusted.
+fn sniff_image_content_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        Some("image/jpeg")
+    } else if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        Some("image/png")
+    } else {
+        None
+    }
+}
+
+pub async fn list_lessons(
+    conn: &Connection,
+    r2: &R2Client,
+    user_id: &str,
+) -> Result<Vec<Lesson>, ApiError> {
+    db::lessons::list_lessons(conn, user_id, r2).await
+}
+
+pub async fn get_lesson(
+    conn: &Connection,
+    r2: &R2Client,
+    id: &str,
+    user_id: &str,
+) -> Result<Lesson, ApiError> {
+    db::lessons::get_lesson(conn, id, user_id, r2)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))
+}
+
+pub async fn create_lesson(
+    conn: &Connection,
+    r2: &R2Client,
+    user_id: &str,
+    input: &CreateLesson,
+) -> Result<Lesson, ApiError> {
+    validation::validate_create_lesson(input)?;
+    db::lessons::insert_lesson(conn, user_id, input, r2).await
+}
+
+pub async fn update_lesson(
+    conn: &Connection,
+    r2: &R2Client,
+    id: &str,
+    user_id: &str,
+    input: &UpdateLesson,
+) -> Result<Lesson, ApiError> {
+    validation::validate_update_lesson(input)?;
+    db::lessons::update_lesson(conn, id, user_id, input, r2)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Lesson not found: {id}")))
+}
+
+pub async fn delete_lesson(
+    conn: &Connection,
+    r2: Option<&R2Client>,
+    id: &str,
+    user_id: &str,
+) -> Result<(), ApiError> {
+    // Delete photos from R2 if storage is configured. Log but don't fail
+    // the request on R2 errors — DB is the source of truth.
+    if let Some(r2) = r2 {
+        let keys = db::lessons::list_photo_storage_keys(conn, id, user_id).await?;
+        for key in keys {
+            if let Err(e) = r2.delete(&key).await {
+                tracing::warn!(lesson_id = %id, storage_key = %key, error = ?e, "R2 photo delete failed; orphaning object");
+            }
+        }
+    }
+
+    let deleted = db::lessons::delete_lesson(conn, id, user_id).await?;
+    if !deleted {
+        return Err(ApiError::NotFound(format!("Lesson not found: {id}")));
+    }
+    Ok(())
+}
+
+pub async fn upload_lesson_photo(
+    conn: &Connection,
+    r2: &R2Client,
+    user_id: &str,
+    lesson_id: &str,
+    bytes: &[u8],
+) -> Result<LessonPhoto, ApiError> {
+    if bytes.len() > MAX_PHOTO_SIZE {
+        return Err(ApiError::Validation(format!(
+            "Photo exceeds maximum size of {} MB",
+            MAX_PHOTO_SIZE / (1024 * 1024)
+        )));
+    }
+
+    // Determine content-type from the bytes themselves — never trust the
+    // client's multipart header. Prevents XSS via spoofed Content-Type on
+    // the public R2 URL.
+    let content_type = sniff_image_content_type(bytes)
+        .ok_or_else(|| ApiError::Validation("Photo must be JPEG or PNG".into()))?;
+
+    let photo_id = ulid::Ulid::new().to_string();
+    let storage_key = R2Client::photo_key(user_id, lesson_id, &photo_id);
+    r2.upload(&storage_key, bytes, content_type).await?;
+
+    db::lessons::insert_lesson_photo(conn, lesson_id, user_id, &storage_key, r2).await
+}
+
+pub async fn delete_lesson_photo(
+    conn: &Connection,
+    r2: Option<&R2Client>,
+    user_id: &str,
+    lesson_id: &str,
+    photo_id: &str,
+) -> Result<(), ApiError> {
+    let storage_key = db::lessons::get_lesson_photo_storage_key(conn, photo_id, lesson_id, user_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Photo not found: {photo_id}")))?;
+
+    // Delete from R2. Log but don't fail the request on R2 errors — the
+    // DB row below is the authoritative pointer; orphaned R2 objects are
+    // recoverable via prefix sweep but a stuck DB row is not.
+    if let Some(r2) = r2 {
+        if let Err(e) = r2.delete(&storage_key).await {
+            tracing::warn!(photo_id = %photo_id, storage_key = %storage_key, error = ?e, "R2 photo delete failed; orphaning object");
+        }
+    }
+
+    db::lessons::delete_lesson_photo(conn, photo_id, lesson_id, user_id).await?;
+    Ok(())
+}

--- a/crates/intrada-api/src/services/mod.rs
+++ b/crates/intrada-api/src/services/mod.rs
@@ -1,0 +1,5 @@
+pub mod account;
+pub mod items;
+pub mod lessons;
+pub mod sessions;
+pub mod sets;

--- a/crates/intrada-api/src/services/sessions.rs
+++ b/crates/intrada-api/src/services/sessions.rs
@@ -1,0 +1,61 @@
+use libsql::Connection;
+
+use intrada_core::domain::session::PracticeSession;
+use intrada_core::validation;
+
+use crate::db;
+use crate::db::sessions::SaveSessionRequest;
+use crate::error::ApiError;
+
+pub async fn list_sessions(
+    conn: &Connection,
+    user_id: &str,
+) -> Result<Vec<PracticeSession>, ApiError> {
+    db::sessions::list_sessions(conn, user_id).await
+}
+
+pub async fn get_session(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+) -> Result<PracticeSession, ApiError> {
+    db::sessions::get_session(conn, id, user_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Session not found: {id}")))
+}
+
+pub async fn save_session(
+    conn: &Connection,
+    user_id: &str,
+    input: &SaveSessionRequest,
+) -> Result<PracticeSession, ApiError> {
+    validation::validate_session_notes(&input.session_notes)?;
+    validation::validate_intention(&input.session_intention)?;
+    validation::validate_entries_not_empty(&input.entries, "Practice")?;
+
+    for entry in &input.entries {
+        validation::validate_set_entry_fields(&entry.item_id, &entry.item_title)?;
+        validation::validate_entry_notes(&entry.notes)?;
+        validation::validate_score(&entry.score)?;
+        validation::validate_intention(&entry.intention)?;
+        validation::validate_rep_target(&entry.rep_target)?;
+        validation::validate_planned_duration(&entry.planned_duration_secs)?;
+        validation::validate_achieved_tempo(&entry.achieved_tempo)?;
+        validation::validate_rep_consistency(
+            entry.rep_target,
+            entry.rep_count,
+            entry.rep_target_reached,
+            entry.rep_history.is_some(),
+        )?;
+    }
+
+    db::sessions::insert_session(conn, user_id, input).await
+}
+
+pub async fn delete_session(conn: &Connection, id: &str, user_id: &str) -> Result<(), ApiError> {
+    let deleted = db::sessions::delete_session(conn, id, user_id).await?;
+    if !deleted {
+        return Err(ApiError::NotFound(format!("Session not found: {id}")));
+    }
+    Ok(())
+}

--- a/crates/intrada-api/src/services/sets.rs
+++ b/crates/intrada-api/src/services/sets.rs
@@ -1,0 +1,58 @@
+use libsql::Connection;
+
+use intrada_core::domain::set::Set;
+use intrada_core::validation;
+
+use crate::db;
+use crate::db::sets::{CreateSetEntry, CreateSetRequest, UpdateSetRequest};
+use crate::error::ApiError;
+
+fn validate_entries(entries: &[CreateSetEntry]) -> Result<(), ApiError> {
+    for entry in entries {
+        validation::validate_set_entry_fields(&entry.item_id, &entry.item_title)?;
+    }
+    Ok(())
+}
+
+pub async fn list_sets(conn: &Connection, user_id: &str) -> Result<Vec<Set>, ApiError> {
+    db::sets::list_sets(conn, user_id).await
+}
+
+pub async fn get_set(conn: &Connection, id: &str, user_id: &str) -> Result<Set, ApiError> {
+    db::sets::get_set(conn, id, user_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Set not found: {id}")))
+}
+
+pub async fn create_set(
+    conn: &Connection,
+    user_id: &str,
+    input: &CreateSetRequest,
+) -> Result<Set, ApiError> {
+    validation::validate_set_name(&input.name)?;
+    validation::validate_entries_not_empty(&input.entries, "Set")?;
+    validate_entries(&input.entries)?;
+    db::sets::insert_set(conn, user_id, input).await
+}
+
+pub async fn update_set(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+    input: &UpdateSetRequest,
+) -> Result<Set, ApiError> {
+    validation::validate_set_name(&input.name)?;
+    validation::validate_entries_not_empty(&input.entries, "Set")?;
+    validate_entries(&input.entries)?;
+    db::sets::update_set(conn, id, user_id, input)
+        .await?
+        .ok_or_else(|| ApiError::NotFound(format!("Set not found: {id}")))
+}
+
+pub async fn delete_set(conn: &Connection, id: &str, user_id: &str) -> Result<(), ApiError> {
+    let deleted = db::sets::delete_set(conn, id, user_id).await?;
+    if !deleted {
+        return Err(ApiError::NotFound(format!("Set not found: {id}")));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Phase 1 of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477) per [`specs/mcp-server.md`](specs/mcp-server.md) (merged in #478).

Validation + db calls + NotFound mapping move from route handlers into a new `intrada-api/src/services/` module. Future MCP tool handlers will call into these same services so MCP and HTTP can't drift on validation or error semantics.

**No behaviour change.** Existing 76 integration tests pass unchanged. Lessons photo upload keeps multipart parsing in the handler (HTTP-specific) and hands bytes to the service.

## What moved

| From | To |
|------|----|
| `validation::*` calls in handlers | `services::<resource>::*` |
| `Option<T>` → `NotFound` mapping in handlers | `services::<resource>::get/update/delete` |
| `delete_account` empty-user_id check + R2 + Clerk best-effort | `services::account::delete_account` |
| Photo size check, content-type sniff, R2 upload, DB insert | `services::lessons::upload_lesson_photo` (handler keeps multipart parsing + early body-size guard) |
| Photo delete (R2 best-effort + DB) | `services::lessons::delete_lesson_photo` |

Routes shrink ~220 lines; services add ~400. Net is more code but with clear separation of concerns.

## Service signatures

Take `&Connection` (and `&R2Client` / `Option<&ClerkClient>` where relevant) plus `user_id: &str` directly — no Axum extractors. Return domain types in `Result<T, ApiError>`. Easy for MCP tool handlers to call.

## Test plan

- [x] `cargo test -p intrada-api` — 76 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings` (matches CI invocation) — clean
- [ ] CI on this PR (workspace tests + clippy + wasm build + e2e)

## Notes for the reviewer

- One subtle decision: the photo body-size check is **duplicated** — once in the route handler (early reject after multipart parse) and once in the service (so non-HTTP callers like future MCP tools also get the limit). Worth flagging because it's the only bit of logic that intentionally lives in both places. The service is the source of truth; the handler check is a perf optimisation to avoid wasted work.
- `MAX_PHOTO_SIZE` moved from route to service (now `pub const` so the route can still reference it for the early guard).
- `sniff_image_content_type` moved from route to service as a private fn (only used by `upload_lesson_photo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)