### PR TITLE
feat(web): Account tab + Settings as a route page

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -21,7 +21,7 @@ use crate::views::DesignCatalogue;
 use crate::views::{
     AccountDeleteView, AddLibraryItemForm, AnalyticsPage, DetailView, EditLibraryItemForm,
     LibraryListView, NotFoundView, SessionActiveView, SessionNewView, SessionSummaryView,
-    SessionsAllView, SessionsListView, SetDetailView, SetEditView,
+    SessionsAllView, SessionsListView, SetDetailView, SetEditView, SettingsView,
 };
 use intrada_web::background_audio;
 use intrada_web::clerk_bindings;
@@ -263,6 +263,9 @@ fn AuthenticatedApp() -> impl IntoView {
                     } />
                     <Route path=path!("/design") view=move || view! {
                         <DesignRouteView />
+                    } />
+                    <Route path=path!("/settings") view=move || view! {
+                        <SettingsView />
                     } />
                     <Route path=path!("/settings/delete-account") view=move || view! {
                         <AccountDeleteView />

--- a/crates/intrada-web/src/components/bottom_tab_bar.rs
+++ b/crates/intrada-web/src/components/bottom_tab_bar.rs
@@ -8,12 +8,10 @@ use crate::components::{StatusDot, StatusDotState};
 
 /// Mobile bottom tab bar for primary navigation.
 ///
-/// Shows Library / Practice / Analytics tabs. Hidden on `sm:` and wider
-/// where the header nav is visible instead.
-///
-/// Sets used to live as a fourth tab pointing at `/routines`; that
-/// surface folded into Library (Sets type-tab) so the bottom tab dropped
-/// out — fewer top-level destinations, less competition for thumb reach.
+/// Shows Library / Practice / Analytics / Account route tabs. Hidden on
+/// `sm:` and wider where the header nav is visible instead — except on
+/// iOS, where the web header is hidden and this is the only entry-point
+/// to settings.
 ///
 /// Icons follow the iOS convention: outline (stroke) for the inactive
 /// tabs, solid (fill) for the active one. Sizing matches the iOS tab
@@ -39,6 +37,11 @@ pub fn BottomTabBar() -> impl IntoView {
     let is_analytics_active = move || {
         let path = location.pathname.get();
         path.starts_with("/analytics")
+    };
+
+    let is_account_active = move || {
+        let path = location.pathname.get();
+        path.starts_with("/settings")
     };
 
     // Practice-tab status dot (#272). Live takes precedence over Building
@@ -143,6 +146,27 @@ pub fn BottomTabBar() -> impl IntoView {
                         view! { <ChartIconOutline /> }.into_any()
                     }}
                     <span class="text-xs font-medium">"Analytics"</span>
+                </A>
+
+                // Account tab — settings + account actions
+                <A
+                    href="/settings"
+                    attr:class=move || {
+                        if is_account_active() {
+                            if has_tapped.get() { spring } else { active }
+                        } else {
+                            inactive
+                        }
+                    }
+                    attr:aria-current=move || if is_account_active() { Some("page") } else { None }
+                    on:click=move |_| { has_tapped.set(true); haptics::haptic_selection(); }
+                >
+                    {move || if is_account_active() {
+                        view! { <UserCircleIconSolid /> }.into_any()
+                    } else {
+                        view! { <UserCircleIconOutline /> }.into_any()
+                    }}
+                    <span class="text-xs font-medium">"Account"</span>
                 </A>
             </div>
         </nav>
@@ -249,6 +273,38 @@ fn ChartIconSolid() -> impl IntoView {
             aria-hidden="true"
         >
             <path d="M18.375 2.25c-1.035 0-1.875.84-1.875 1.875v15.75c0 1.035.84 1.875 1.875 1.875h.75c1.035 0 1.875-.84 1.875-1.875V4.125c0-1.036-.84-1.875-1.875-1.875h-.75zM9.75 8.625c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-.75a1.875 1.875 0 01-1.875-1.875V8.625zM3 13.125c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v6.75c0 1.035-.84 1.875-1.875 1.875h-.75A1.875 1.875 0 013 19.875v-6.75z" />
+        </svg>
+    }
+}
+
+#[component]
+fn UserCircleIconOutline() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            aria-hidden="true"
+        >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+    }
+}
+
+#[component]
+fn UserCircleIconSolid() -> impl IntoView {
+    view! {
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-6 w-6"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+        >
+            <path fill-rule="evenodd" d="M18.685 19.097A9.723 9.723 0 0021.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 003.065 7.097A9.716 9.716 0 0012 21.75a9.716 9.716 0 006.685-2.653zm-12.54-1.285A7.486 7.486 0 0112 15a7.486 7.486 0 015.855 2.812A8.224 8.224 0 0112 20.25a8.224 8.224 0 01-5.855-2.438zM15.75 9a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" clip-rule="evenodd" />
         </svg>
     }
 }

--- a/crates/intrada-web/src/components/profile_button.rs
+++ b/crates/intrada-web/src/components/profile_button.rs
@@ -1,10 +1,9 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 
 use intrada_web::clerk_bindings;
 
-use crate::views::SettingsSheet;
-
-/// Avatar button that opens the Settings bottom sheet.
+/// Avatar button that links to the Settings route.
 ///
 /// Shows the first letter of the signed-in user's email (initial fallback
 /// when Clerk doesn't expose a name). Hidden when not signed in — the
@@ -12,9 +11,6 @@ use crate::views::SettingsSheet;
 /// `Show` keeps the chrome stable during early init.
 #[component]
 pub fn ProfileButton() -> impl IntoView {
-    let open = RwSignal::new(false);
-    let close = Callback::new(move |_: ()| open.set(false));
-
     let initial = move || {
         clerk_bindings::email()
             .as_deref()
@@ -25,21 +21,13 @@ pub fn ProfileButton() -> impl IntoView {
 
     view! {
         <Show when=move || clerk_bindings::is_signed_in()>
-            <button
-                type="button"
-                class="ml-2 flex items-center justify-center h-8 w-8 rounded-full bg-surface-primary border border-border-default text-sm font-medium text-primary hover:bg-surface-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-focus motion-safe:transition-colors"
-                aria-label="Account and settings"
-                on:click=move |_| open.set(true)
+            <A
+                href="/settings"
+                attr:class="ml-2 flex items-center justify-center h-8 w-8 rounded-full bg-surface-primary border border-border-default text-sm font-medium text-primary hover:bg-surface-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-focus motion-safe:transition-colors no-underline"
+                attr:aria-label="Account and settings"
             >
                 {initial}
-            </button>
-            // Lazy-mount the sheet so its (Cancel, Delete account, …)
-            // buttons aren't in the DOM tree when closed — otherwise
-            // role-based selectors elsewhere on the page get strict-mode
-            // collisions.
-            <Show when=move || open.get()>
-                <SettingsSheet open=open on_close=close />
-            </Show>
+            </A>
         </Show>
     }
 }

--- a/crates/intrada-web/src/views/mod.rs
+++ b/crates/intrada-web/src/views/mod.rs
@@ -32,4 +32,4 @@ pub use sessions::SessionsListView;
 pub use sessions_all::SessionsAllView;
 pub use set_detail::SetDetailView;
 pub use set_edit::SetEditView;
-pub use settings::SettingsSheet;
+pub use settings::SettingsView;

--- a/crates/intrada-web/src/views/settings.rs
+++ b/crates/intrada-web/src/views/settings.rs
@@ -9,51 +9,57 @@ use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-use crate::components::{BottomSheet, GroupedList, GroupedListRow, Icon, IconName, TextField};
+use crate::components::{
+    Button, ButtonVariant, GroupedList, GroupedListRow, Icon, IconName, TextField,
+};
 
-/// Bottom-sheet Settings surface — account info, practice defaults, sign-out,
-/// account deletion entry-point.
+/// Settings route — account info, practice defaults, sign-out, and the
+/// entry-point to account deletion. Reached via the Account tab on mobile
+/// (bottom tab bar) and the profile button in the header at `sm:` and wider.
 #[component]
-pub fn SettingsSheet(open: RwSignal<bool>, on_close: Callback<()>) -> impl IntoView {
+pub fn SettingsView() -> impl IntoView {
     let core = expect_context::<SharedCore>();
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
 
-    // Trigger preferences load each time the sheet opens so the displayed
-    // values match the server (a sign-in or another device may have changed
-    // them since the last open).
-    Effect::new({
+    // Refresh preferences on mount — server may have newer values from
+    // another device.
+    {
         let core = core.clone();
-        move |_| {
-            if !open.get() {
-                return;
-            }
+        Effect::new(move |_| {
             let core_ref = core.borrow();
             let effects = core_ref.process_event(Event::Account(AccountEvent::LoadPreferences));
             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-        }
-    });
+        });
+    }
 
     let email = move || clerk_bindings::email().unwrap_or_else(|| "Signed in".to_string());
 
-    // Local form state for the duration / rep editors. Initialised from the
-    // ViewModel (or the local default) on every open.
-    let focus_minutes = RwSignal::new(String::new());
-    let rep_count = RwSignal::new(String::new());
+    // Seed with defaults so the form is never blank — falls through to
+    // these values whenever the API hasn't returned yet, including the
+    // dev shell with the API offline.
+    let defaults = AccountPreferences::default();
+    let focus_minutes = RwSignal::new(defaults.default_focus_minutes.to_string());
+    let rep_count = RwSignal::new(defaults.default_rep_count.to_string());
     let errors = RwSignal::new(HashMap::<String, String>::new());
 
+    // Replace defaults with real values once preferences load. The
+    // `primed` guard locks the form after that — subsequent view_model
+    // updates (e.g. our own save round-tripping back) must not clobber
+    // the user's edits.
+    let primed = RwSignal::new(false);
     Effect::new(move |_| {
-        if !open.get() {
+        if primed.get_untracked() {
             return;
         }
-        let prefs = view_model.get().account_preferences.unwrap_or_default();
-        focus_minutes.set(prefs.default_focus_minutes.to_string());
-        rep_count.set(prefs.default_rep_count.to_string());
-        errors.set(HashMap::new());
+        if let Some(prefs) = view_model.get().account_preferences {
+            focus_minutes.set(prefs.default_focus_minutes.to_string());
+            rep_count.set(prefs.default_rep_count.to_string());
+            primed.set(true);
+        }
     });
 
-    // "Done" trailing nav action saves preferences if changed, else closes.
     let dirty = Signal::derive(move || {
         let saved = view_model.get().account_preferences.unwrap_or_default();
         focus_minutes.get().parse::<u32>().ok() != Some(saved.default_focus_minutes)
@@ -61,7 +67,7 @@ pub fn SettingsSheet(open: RwSignal<bool>, on_close: Callback<()>) -> impl IntoV
     });
 
     let core_for_save = core.clone();
-    let save = Callback::new(move |_: ()| {
+    let save = Callback::new(move |_: leptos::ev::MouseEvent| {
         let mut errs = HashMap::new();
         let focus = focus_minutes.get().trim().parse::<u32>().ok();
         let reps = rep_count.get().trim().parse::<u32>().ok();
@@ -89,114 +95,101 @@ pub fn SettingsSheet(open: RwSignal<bool>, on_close: Callback<()>) -> impl IntoV
         let core_ref = core_for_save.borrow();
         let effects = core_ref.process_event(Event::Account(AccountEvent::SavePreferences(prefs)));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-        on_close.run(());
     });
-
-    let nav_action = Callback::new(move |_: ()| {
-        if dirty.get_untracked() {
-            save.run(());
-        } else {
-            on_close.run(());
-        }
-    });
-    let nav_action_disabled = Signal::derive(move || !errors.get().is_empty());
 
     let sign_out_click = move |_| {
-        let close = on_close;
         leptos::task::spawn_local(async move {
-            close.run(());
             clerk_bindings::sign_out().await;
         });
     };
 
     let navigate = use_navigate();
     let go_delete = Callback::new(move |_: leptos::ev::MouseEvent| {
-        on_close.run(());
         navigate("/settings/delete-account", NavigateOptions::default());
     });
 
     view! {
-        <BottomSheet
-            open=open
-            on_close=on_close
-            nav_title="Settings".to_string()
-            nav_action_label="Done".to_string()
-            on_nav_action=nav_action
-            nav_action_disabled=nav_action_disabled
-        >
-            <div class="space-y-comfortable">
-                // Account header
-                <div class="flex items-center gap-card">
-                    <div class="flex items-center justify-center h-10 w-10 rounded-full bg-surface-primary border border-border-default text-base font-medium text-primary">
-                        {move || {
-                            email()
-                                .chars()
-                                .next()
-                                .map(|c| c.to_ascii_uppercase().to_string())
-                                .unwrap_or_default()
-                        }}
-                    </div>
-                    <div class="flex flex-col">
-                        <span class="text-sm font-medium text-primary">"Signed in as"</span>
-                        <span class="text-sm text-secondary">{email}</span>
-                    </div>
-                </div>
+        <div class="max-w-md mx-auto py-comfortable space-y-comfortable pb-[env(safe-area-inset-bottom)]">
+            <h1 class="page-title">"Settings"</h1>
 
-                // Practice defaults section
-                <div>
-                    <h3 class="section-title mb-card-compact">"Defaults"</h3>
-                    <p class="hint-text">
-                        "Used to pre-fill new custom practice sessions."
-                    </p>
-                    <div class="space-y-card mt-card-compact">
-                        <TextField
-                            id="settings-focus-minutes"
-                            label="Default focus duration (minutes)"
-                            value=focus_minutes
-                            field_name="focus"
-                            errors=errors
-                            input_type="text"
-                            input_mode="numeric"
-                        />
-                        <TextField
-                            id="settings-rep-count"
-                            label="Default rep count"
-                            value=rep_count
-                            field_name="reps"
-                            errors=errors
-                            input_type="text"
-                            input_mode="numeric"
-                        />
-                    </div>
+            // Account header
+            <div class="flex items-center gap-card">
+                <div class="flex items-center justify-center h-10 w-10 rounded-full bg-surface-primary border border-border-default text-base font-medium text-primary">
+                    {move || {
+                        email()
+                            .chars()
+                            .next()
+                            .map(|c| c.to_ascii_uppercase().to_string())
+                            .unwrap_or_default()
+                    }}
                 </div>
-
-                // Account section
-                <div>
-                    <h3 class="section-title mb-card-compact">"Account"</h3>
-                    <GroupedList aria_label="Account actions".to_string()>
-                        <GroupedListRow>
-                            <button
-                                type="button"
-                                class="w-full flex items-center justify-between px-card-compact py-card-compact text-left text-sm font-medium text-primary hover:bg-surface-hover motion-safe:transition-colors min-h-[44px]"
-                                on:click=sign_out_click
-                            >
-                                <span>"Sign out"</span>
-                                <Icon name=IconName::ChevronRight class="w-4 h-4 text-muted" />
-                            </button>
-                        </GroupedListRow>
-                        <GroupedListRow>
-                            <button
-                                type="button"
-                                class="w-full flex items-center justify-between px-card-compact py-card-compact text-left text-sm font-medium text-danger-text hover:bg-surface-hover motion-safe:transition-colors min-h-[44px]"
-                                on:click=move |ev| go_delete.run(ev)
-                            >
-                                <span>"Delete account"</span>
-                                <Icon name=IconName::ChevronRight class="w-4 h-4 text-danger-text" />
-                            </button>
-                        </GroupedListRow>
-                    </GroupedList>
+                <div class="flex flex-col">
+                    <span class="text-sm font-medium text-primary">"Signed in as"</span>
+                    <span class="text-sm text-secondary">{email}</span>
                 </div>
             </div>
-        </BottomSheet>
+
+            // Practice defaults section
+            <div>
+                <h3 class="section-title mb-card-compact">"Defaults"</h3>
+                <p class="hint-text">
+                    "Used to pre-fill new custom practice sessions."
+                </p>
+                <div class="space-y-card mt-card-compact">
+                    <TextField
+                        id="settings-focus-minutes"
+                        label="Default focus duration (minutes)"
+                        value=focus_minutes
+                        field_name="focus"
+                        errors=errors
+                        input_type="text"
+                        input_mode="numeric"
+                    />
+                    <TextField
+                        id="settings-rep-count"
+                        label="Default rep count"
+                        value=rep_count
+                        field_name="reps"
+                        errors=errors
+                        input_type="text"
+                        input_mode="numeric"
+                    />
+                </div>
+                <Show when=move || dirty.get()>
+                    <div class="mt-card">
+                        <Button variant=ButtonVariant::Primary on_click=save full_width=true>
+                            "Save changes"
+                        </Button>
+                    </div>
+                </Show>
+            </div>
+
+            // Account section
+            <div>
+                <h3 class="section-title mb-card-compact">"Account"</h3>
+                <GroupedList aria_label="Account actions".to_string()>
+                    <GroupedListRow>
+                        <button
+                            type="button"
+                            class="w-full flex items-center justify-between px-card-compact py-card-compact text-left text-sm font-medium text-primary hover:bg-surface-hover motion-safe:transition-colors min-h-[44px]"
+                            on:click=sign_out_click
+                        >
+                            <span>"Sign out"</span>
+                            <Icon name=IconName::ChevronRight class="w-4 h-4 text-muted" />
+                        </button>
+                    </GroupedListRow>
+                    <GroupedListRow>
+                        <button
+                            type="button"
+                            class="w-full flex items-center justify-between px-card-compact py-card-compact text-left text-sm font-medium text-danger-text hover:bg-surface-hover motion-safe:transition-colors min-h-[44px]"
+                            on:click=move |ev| go_delete.run(ev)
+                        >
+                            <span>"Delete account"</span>
+                            <Icon name=IconName::ChevronRight class="w-4 h-4 text-danger-text" />
+                        </button>
+                    </GroupedListRow>
+                </GroupedList>
+            </div>
+        </div>
     }
 }


### PR DESCRIPTION
## Summary

- Adds an **Account tab** (4th item, rightmost) to the mobile `BottomTabBar` so settings are reachable on iOS — previously the only entry-point (`ProfileButton` in the web header) was hidden by `[data-platform="ios"] header[role="banner"] { display: none; }`, leaving the Settings UI unreachable inside the Tauri shell after #443.
- Converts the **`SettingsSheet`** (BottomSheet wrapper) into a **`SettingsView`** route page at `/settings`. The header `ProfileButton` (web ≥sm) now also navigates there instead of opening a sheet.
- Form seeds with `AccountPreferences::default()` so it never renders blank, then primes once when real prefs arrive (a `primed` guard prevents clobbering edits on later view_model updates). The "Done" save button becomes an inline "Save changes" button that only appears while the form is dirty.

## Test plan

- [ ] iOS (Tauri sim or device): bottom tab bar shows 4 tabs — Library / Practice / Analytics / Account. Tapping Account opens the Settings page.
- [ ] iOS: tapping a different tab from /settings switches cleanly; coming back to Account preserves the page state.
- [ ] Web mobile (≤sm): same flow as iOS via the Account tab.
- [ ] Web desktop (≥sm): header avatar (when signed in) navigates to /settings.
- [ ] Settings page: defaults pre-fill the focus minutes / rep count fields immediately. When the API responds, real saved values replace the defaults. Editing a field shows the "Save changes" button; saving clears it.
- [ ] Sign out / Delete account rows still link out correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)