### PR TITLE
feat(api): MCP PAT issuance + auth (Phase 2a of #477)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,6 +3004,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -31,6 +31,11 @@ jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "multipart"] }
 rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustls-tls"] }
 
+# MCP Personal Access Tokens: cryptographically secure RNG for token bytes,
+# SHA-256 for at-rest hashing.
+rand = "0.8"
+sha2 = "0.10"
+
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
@@ -42,4 +47,3 @@ sentry = { version = "0.48", default-features = false, features = ["backtrace", 
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 rsa = "0.9"
-rand = "0.8"

--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::db;
 use crate::error::ApiError;
 use crate::state::AppState;
 
@@ -20,11 +21,19 @@ struct Claims {
     sub: String,
 }
 
+/// PAT bearer token prefix. Tokens not matching this fall through to JWT
+/// validation.
+const PAT_PREFIX: &str = "intrada_pat_";
+
 /// Extractor that yields the authenticated user's ID.
 ///
-/// When `AppState.auth_config` is `None` (no `CLERK_ISSUER_URL` set),
-/// returns `AuthUser("")` — matching the migration default and preserving
-/// existing test behavior.
+/// Resolution order:
+/// 1. `Authorization: Bearer intrada_pat_…` → MCP PAT lookup. Works whether
+///    or not Clerk is configured, so MCP can authenticate against an API
+///    instance running without `CLERK_ISSUER_URL` (dev / local).
+/// 2. No `auth_config` (Clerk disabled) → `AuthUser("")` — matches existing
+///    test behaviour.
+/// 3. JWT validation against the configured Clerk issuer.
 pub struct AuthUser(pub String);
 
 impl FromRequestParts<AppState> for AuthUser {
@@ -34,6 +43,17 @@ impl FromRequestParts<AppState> for AuthUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
+        let bearer = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|h| h.strip_prefix("Bearer "));
+
+        // PAT path runs first so it works in auth-disabled mode too.
+        if let Some(token) = bearer.filter(|t| t.starts_with(PAT_PREFIX)) {
+            return resolve_pat(state, token).await;
+        }
+
         let auth_config = match &state.auth_config {
             Some(config) => config,
             None => {
@@ -45,15 +65,7 @@ impl FromRequestParts<AppState> for AuthUser {
             }
         };
 
-        let header = parts
-            .headers
-            .get("authorization")
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| ApiError::Unauthorized("Unauthorized".to_string()))?;
-
-        let token = header
-            .strip_prefix("Bearer ")
-            .ok_or_else(|| ApiError::Unauthorized("Unauthorized".to_string()))?;
+        let token = bearer.ok_or_else(|| ApiError::Unauthorized("Unauthorized".to_string()))?;
 
         let mut validation = Validation::new(jsonwebtoken::Algorithm::RS256);
         validation.set_issuer(&[&auth_config.issuer]);
@@ -67,15 +79,7 @@ impl FromRequestParts<AppState> for AuthUser {
             match decode::<Claims>(token, key, &validation) {
                 Ok(data) => {
                     let user_id = data.claims.sub;
-                    // Per-request hub isolation comes from the
-                    // NewSentryLayer in routes/mod.rs — configuring the
-                    // current scope here cannot bleed into other requests.
-                    sentry::configure_scope(|scope| {
-                        scope.set_user(Some(sentry::User {
-                            id: Some(user_id.clone()),
-                            ..Default::default()
-                        }));
-                    });
+                    set_sentry_user(&user_id);
                     return Ok(AuthUser(user_id));
                 }
                 Err(e) => {
@@ -87,6 +91,49 @@ impl FromRequestParts<AppState> for AuthUser {
 
         Err(ApiError::Unauthorized("Unauthorized".to_string()))
     }
+}
+
+async fn resolve_pat(state: &AppState, token: &str) -> Result<AuthUser, ApiError> {
+    let conn = state.conn();
+    let hash = db::tokens::hash_token(token);
+
+    match db::tokens::lookup_by_hash(&conn, &hash).await {
+        Ok(Some((user_id, None))) => {
+            // Best-effort `last_used_at` update — auth has already succeeded,
+            // so a write failure here shouldn't deny access.
+            if let Err(e) = db::tokens::mark_used(&conn, &hash).await {
+                tracing::warn!(?e, "PAT mark_used update failed");
+            }
+            set_sentry_user(&user_id);
+            Ok(AuthUser(user_id))
+        }
+        Ok(Some((_, Some(_)))) => {
+            // Revoked. Distinct log line so revoked-token use is grep-able
+            // separately from "unknown PAT".
+            tracing::info!("PAT auth rejected: token revoked");
+            Err(ApiError::Unauthorized("Unauthorized".to_string()))
+        }
+        Ok(None) => {
+            tracing::debug!("PAT auth rejected: token not found");
+            Err(ApiError::Unauthorized("Unauthorized".to_string()))
+        }
+        Err(e) => {
+            tracing::warn!(?e, "PAT lookup DB error");
+            Err(ApiError::Internal("Auth DB error".into()))
+        }
+    }
+}
+
+fn set_sentry_user(user_id: &str) {
+    // Per-request hub isolation comes from the NewSentryLayer in
+    // routes/mod.rs — configuring the current scope here cannot bleed into
+    // other requests.
+    sentry::configure_scope(|scope| {
+        scope.set_user(Some(sentry::User {
+            id: Some(user_id.to_string()),
+            ..Default::default()
+        }));
+    });
 }
 
 impl AuthConfig {

--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::db;
+use crate::db::tokens::TOKEN_PREFIX as PAT_PREFIX;
 use crate::error::ApiError;
 use crate::state::AppState;
 
@@ -20,10 +21,6 @@ pub struct AuthConfig {
 struct Claims {
     sub: String,
 }
-
-/// PAT bearer token prefix. Tokens not matching this fall through to JWT
-/// validation.
-const PAT_PREFIX: &str = "intrada_pat_";
 
 /// Extractor that yields the authenticated user's ID.
 ///

--- a/crates/intrada-api/src/db/mod.rs
+++ b/crates/intrada-api/src/db/mod.rs
@@ -3,6 +3,7 @@ pub mod items;
 pub mod lessons;
 pub mod sessions;
 pub mod sets;
+pub mod tokens;
 
 use intrada_core::domain::item::ItemKind;
 

--- a/crates/intrada-api/src/db/tokens.rs
+++ b/crates/intrada-api/src/db/tokens.rs
@@ -1,0 +1,164 @@
+use chrono::{DateTime, Utc};
+use libsql::Connection;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::col;
+use crate::error::ApiError;
+
+/// Request payload for `POST /api/account/tokens`.
+#[derive(Debug, Deserialize)]
+pub struct CreateTokenRequest {
+    pub name: String,
+}
+
+/// Response from `POST /api/account/tokens`. The `token` field is the only
+/// place the full PAT is ever returned — list/get endpoints expose only the
+/// prefix.
+#[derive(Debug, Serialize)]
+pub struct CreatedTokenResponse {
+    pub id: String,
+    pub name: String,
+    pub token: String,
+    pub prefix: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Public list view of an MCP PAT. Never includes the full token or the
+/// hash — only the prefix (for visual identification) and metadata.
+#[derive(Debug, Serialize)]
+pub struct TokenListItem {
+    pub id: String,
+    pub name: String,
+    pub prefix: String,
+    pub last_used_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Hex-encoded SHA-256 of the full bearer token. PAT bytes have ~256 bits of
+/// entropy, so a fast unsalted hash is appropriate (bcrypt/argon2 are for
+/// low-entropy passwords).
+pub fn hash_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    digest.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+pub async fn insert(
+    conn: &Connection,
+    id: &str,
+    user_id: &str,
+    name: &str,
+    hash: &str,
+    prefix: &str,
+    created_at: DateTime<Utc>,
+) -> Result<(), ApiError> {
+    conn.execute(
+        "INSERT INTO mcp_tokens (id, user_id, name, hash, prefix, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params![id, user_id, name, hash, prefix, created_at.to_rfc3339()],
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn list(conn: &Connection, user_id: &str) -> Result<Vec<TokenListItem>, ApiError> {
+    let mut rows = conn
+        .query(
+            "SELECT id, name, prefix, last_used_at, created_at, revoked_at
+             FROM mcp_tokens WHERE user_id = ?1 ORDER BY created_at DESC",
+            libsql::params![user_id],
+        )
+        .await?;
+
+    let mut items = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        let id: String = col!(row, 0)?;
+        let name: String = col!(row, 1)?;
+        let prefix: String = col!(row, 2)?;
+        let last_used_at: Option<String> = col!(row, 3)?;
+        let created_at_str: String = col!(row, 4)?;
+        let revoked_at: Option<String> = col!(row, 5)?;
+
+        items.push(TokenListItem {
+            id,
+            name,
+            prefix,
+            last_used_at: parse_dt_opt(last_used_at)?,
+            created_at: parse_dt(&created_at_str)?,
+            revoked_at: parse_dt_opt(revoked_at)?,
+        });
+    }
+    Ok(items)
+}
+
+/// Mark the token as revoked. Returns `true` if a non-revoked row was
+/// updated, `false` if no matching row exists or it was already revoked.
+pub async fn revoke(conn: &Connection, user_id: &str, token_id: &str) -> Result<bool, ApiError> {
+    let now = Utc::now().to_rfc3339();
+    let rows = conn
+        .execute(
+            "UPDATE mcp_tokens SET revoked_at = ?1
+             WHERE id = ?2 AND user_id = ?3 AND revoked_at IS NULL",
+            libsql::params![now, token_id, user_id],
+        )
+        .await?;
+    Ok(rows > 0)
+}
+
+/// Resolve a hashed PAT to `(user_id, revoked_at)`. Caller decides what to
+/// do with the revoked-at value — we return it raw rather than baking the
+/// revocation check into this function so the auth extractor can log
+/// revoked-token use distinctly from missing-token use.
+pub async fn lookup_by_hash(
+    conn: &Connection,
+    hash: &str,
+) -> Result<Option<(String, Option<DateTime<Utc>>)>, ApiError> {
+    let mut rows = conn
+        .query(
+            "SELECT user_id, revoked_at FROM mcp_tokens WHERE hash = ?1",
+            libsql::params![hash],
+        )
+        .await?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| ApiError::Internal(e.to_string()))?
+    {
+        Some(row) => {
+            let user_id: String = col!(row, 0)?;
+            let revoked_at: Option<String> = col!(row, 1)?;
+            Ok(Some((user_id, parse_dt_opt(revoked_at)?)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Update `last_used_at` to now. Best-effort; auth extractor calls this
+/// after a successful PAT resolution but ignores errors.
+pub async fn mark_used(conn: &Connection, hash: &str) -> Result<(), ApiError> {
+    let now = Utc::now().to_rfc3339();
+    conn.execute(
+        "UPDATE mcp_tokens SET last_used_at = ?1 WHERE hash = ?2",
+        libsql::params![now, hash],
+    )
+    .await?;
+    Ok(())
+}
+
+fn parse_dt(s: &str) -> Result<DateTime<Utc>, ApiError> {
+    s.parse()
+        .map_err(|e| ApiError::Internal(format!("Invalid timestamp {s:?}: {e}")))
+}
+
+fn parse_dt_opt(s: Option<String>) -> Result<Option<DateTime<Utc>>, ApiError> {
+    s.map(|s| parse_dt(&s)).transpose()
+}

--- a/crates/intrada-api/src/db/tokens.rs
+++ b/crates/intrada-api/src/db/tokens.rs
@@ -6,6 +6,11 @@ use sha2::{Digest, Sha256};
 use super::col;
 use crate::error::ApiError;
 
+/// PAT bearer-token prefix. Single source of truth: the auth extractor
+/// filters incoming bearers by this prefix, and the service uses it when
+/// generating new tokens.
+pub const TOKEN_PREFIX: &str = "intrada_pat_";
+
 /// Request payload for `POST /api/account/tokens`.
 #[derive(Debug, Deserialize)]
 pub struct CreateTokenRequest {

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -374,6 +374,23 @@ const MIGRATIONS: &[(&str, &str)] = &[
             updated_at TEXT NOT NULL
         );",
     ),
+    (
+        "0055_create_mcp_tokens",
+        "CREATE TABLE IF NOT EXISTS mcp_tokens (
+            id TEXT PRIMARY KEY NOT NULL,
+            user_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            hash TEXT NOT NULL UNIQUE,
+            prefix TEXT NOT NULL,
+            last_used_at TEXT,
+            created_at TEXT NOT NULL,
+            revoked_at TEXT
+        );",
+    ),
+    (
+        "0056_index_mcp_tokens_user_id",
+        "CREATE INDEX IF NOT EXISTS idx_mcp_tokens_user_id ON mcp_tokens(user_id);",
+    ),
 ];
 
 /// Run migrations via libsql_migration (production path — tracks applied state).

--- a/crates/intrada-api/src/routes/account.rs
+++ b/crates/intrada-api/src/routes/account.rs
@@ -6,6 +6,7 @@ use axum::{Json, Router};
 use crate::auth::AuthUser;
 use crate::db::account::AccountPreferences;
 use crate::error::ApiError;
+use crate::routes::tokens;
 use crate::services;
 use crate::state::AppState;
 
@@ -13,6 +14,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", delete(delete_account))
         .route("/preferences", get(get_preferences).put(put_preferences))
+        .nest("/tokens", tokens::router())
 }
 
 async fn get_preferences(

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -4,6 +4,7 @@ mod items;
 mod lessons;
 mod sessions;
 mod sets;
+mod tokens;
 
 use axum::http::{header, HeaderValue, Method};
 use axum::Router;

--- a/crates/intrada-api/src/routes/tokens.rs
+++ b/crates/intrada-api/src/routes/tokens.rs
@@ -1,0 +1,45 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+
+use crate::auth::AuthUser;
+use crate::db::tokens::{CreateTokenRequest, CreatedTokenResponse, TokenListItem};
+use crate::error::ApiError;
+use crate::services;
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(list_tokens).post(create_token))
+        .route("/{id}", axum::routing::delete(revoke_token))
+}
+
+async fn list_tokens(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+) -> Result<Json<Vec<TokenListItem>>, ApiError> {
+    let conn = state.conn();
+    let tokens = services::tokens::list_tokens(&conn, &user_id).await?;
+    Ok(Json(tokens))
+}
+
+async fn create_token(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Json(input): Json<CreateTokenRequest>,
+) -> Result<(StatusCode, Json<CreatedTokenResponse>), ApiError> {
+    let conn = state.conn();
+    let response = services::tokens::create_token(&conn, &user_id, &input.name).await?;
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+async fn revoke_token(
+    State(state): State<AppState>,
+    AuthUser(user_id): AuthUser,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let conn = state.conn();
+    services::tokens::revoke_token(&conn, &user_id, &id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/intrada-api/src/services/mod.rs
+++ b/crates/intrada-api/src/services/mod.rs
@@ -3,3 +3,4 @@ pub mod items;
 pub mod lessons;
 pub mod sessions;
 pub mod sets;
+pub mod tokens;

--- a/crates/intrada-api/src/services/tokens.rs
+++ b/crates/intrada-api/src/services/tokens.rs
@@ -1,0 +1,122 @@
+use chrono::Utc;
+use libsql::Connection;
+use rand::RngCore;
+
+use crate::db;
+use crate::db::tokens::{CreatedTokenResponse, TokenListItem};
+use crate::error::ApiError;
+
+const TOKEN_PREFIX: &str = "intrada_pat_";
+
+/// Length of the user-visible prefix shown in the list endpoint:
+/// `intrada_pat_` + first 4 hex chars of the body. Long enough to identify
+/// the token in account settings, short enough to not be guessable.
+const PREFIX_DISPLAY_LEN: usize = TOKEN_PREFIX.len() + 4;
+
+const NAME_MAX_LEN: usize = 100;
+
+fn validate_name(name: &str) -> Result<&str, ApiError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(ApiError::Validation("Token name cannot be empty".into()));
+    }
+    if trimmed.chars().count() > NAME_MAX_LEN {
+        return Err(ApiError::Validation(format!(
+            "Token name cannot exceed {NAME_MAX_LEN} characters"
+        )));
+    }
+    Ok(trimmed)
+}
+
+/// Generate a fresh PAT. Returns the full token (shown to the user once),
+/// its hex SHA-256 hash (stored at rest), and the visible prefix.
+fn generate_pat() -> (String, String, String) {
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let body: String = bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    });
+    let token = format!("{TOKEN_PREFIX}{body}");
+    let hash = db::tokens::hash_token(&token);
+    let prefix = token[..PREFIX_DISPLAY_LEN].to_string();
+    (token, hash, prefix)
+}
+
+pub async fn create_token(
+    conn: &Connection,
+    user_id: &str,
+    name: &str,
+) -> Result<CreatedTokenResponse, ApiError> {
+    let trimmed = validate_name(name)?.to_string();
+    let (token, hash, prefix) = generate_pat();
+    let id = ulid::Ulid::new().to_string();
+    let created_at = Utc::now();
+
+    db::tokens::insert(conn, &id, user_id, &trimmed, &hash, &prefix, created_at).await?;
+
+    Ok(CreatedTokenResponse {
+        id,
+        name: trimmed,
+        token,
+        prefix,
+        created_at,
+    })
+}
+
+pub async fn list_tokens(conn: &Connection, user_id: &str) -> Result<Vec<TokenListItem>, ApiError> {
+    db::tokens::list(conn, user_id).await
+}
+
+pub async fn revoke_token(
+    conn: &Connection,
+    user_id: &str,
+    token_id: &str,
+) -> Result<(), ApiError> {
+    let revoked = db::tokens::revoke(conn, user_id, token_id).await?;
+    if !revoked {
+        return Err(ApiError::NotFound(format!("Token not found: {token_id}")));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_pat_format_and_uniqueness() {
+        // 32 bytes of entropy → 64 hex chars, plus the prefix.
+        const TOKEN_BODY_LEN: usize = 64;
+
+        let (t1, h1, p1) = generate_pat();
+        let (t2, h2, _) = generate_pat();
+        assert!(t1.starts_with(TOKEN_PREFIX));
+        assert_eq!(t1.len(), TOKEN_PREFIX.len() + TOKEN_BODY_LEN);
+        assert_eq!(h1.len(), 64); // hex SHA-256
+        assert_eq!(p1.len(), PREFIX_DISPLAY_LEN);
+        assert!(t1.starts_with(&p1));
+        // Two consecutive tokens must not collide. Probabilistic but
+        // 256-bit entropy → collision astronomically unlikely.
+        assert_ne!(t1, t2);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_name("").is_err());
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn validate_name_trims() {
+        assert_eq!(validate_name("  hi  ").unwrap(), "hi");
+    }
+
+    #[test]
+    fn validate_name_rejects_too_long() {
+        let long = "x".repeat(NAME_MAX_LEN + 1);
+        assert!(validate_name(&long).is_err());
+    }
+}

--- a/crates/intrada-api/src/services/tokens.rs
+++ b/crates/intrada-api/src/services/tokens.rs
@@ -3,10 +3,8 @@ use libsql::Connection;
 use rand::RngCore;
 
 use crate::db;
-use crate::db::tokens::{CreatedTokenResponse, TokenListItem};
+use crate::db::tokens::{CreatedTokenResponse, TokenListItem, TOKEN_PREFIX};
 use crate::error::ApiError;
-
-const TOKEN_PREFIX: &str = "intrada_pat_";
 
 /// Length of the user-visible prefix shown in the list endpoint:
 /// `intrada_pat_` + first 4 hex chars of the body. Long enough to identify

--- a/crates/intrada-api/tests/tokens_test.rs
+++ b/crates/intrada-api/tests/tokens_test.rs
@@ -1,0 +1,163 @@
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn create_token_returns_full_pat_once() {
+    let app = common::setup_test_app().await;
+    let (status, body) =
+        common::post_json(app, "/api/account/tokens", json!({ "name": "My laptop" })).await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let v: Value = common::json(&body);
+    let token = v["token"].as_str().expect("token field present");
+    assert!(token.starts_with("intrada_pat_"), "got: {token}");
+    assert!(
+        token.len() > 60,
+        "token should be ~76 chars (12 prefix + 64 hex), got {}",
+        token.len()
+    );
+    assert_eq!(v["name"], "My laptop");
+    assert!(v["prefix"].as_str().unwrap().starts_with("intrada_pat_"));
+    assert!(!v["id"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn create_token_trims_name_and_rejects_empty() {
+    let app = common::setup_test_app().await;
+    let (status, body) =
+        common::post_json(app, "/api/account/tokens", json!({ "name": "  " })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let v: Value = common::json(&body);
+    assert!(v["error"]
+        .as_str()
+        .unwrap()
+        .contains("Token name cannot be empty"));
+}
+
+#[tokio::test]
+async fn list_tokens_excludes_full_token_and_includes_prefix() {
+    let app = common::setup_test_app().await;
+    let (status, _) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({ "name": "Token A" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = common::get(app, "/api/account/tokens").await;
+    assert_eq!(status, StatusCode::OK);
+    let tokens: Vec<Value> = common::json(&body);
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0]["name"], "Token A");
+    assert!(tokens[0]["prefix"]
+        .as_str()
+        .unwrap()
+        .starts_with("intrada_pat_"));
+    // Critical: the full token must never be exposed by the list endpoint.
+    assert!(tokens[0].get("token").is_none());
+    // Hash must not leak either.
+    assert!(tokens[0].get("hash").is_none());
+}
+
+#[tokio::test]
+async fn revoke_token_marks_revoked_at() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({ "name": "Revoke me" }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let id = v["id"].as_str().unwrap().to_string();
+
+    let (status, _) = common::delete(app.clone(), &format!("/api/account/tokens/{id}")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = common::get(app, "/api/account/tokens").await;
+    let tokens: Vec<Value> = common::json(&body);
+    assert_eq!(tokens.len(), 1);
+    assert!(
+        tokens[0]["revoked_at"].is_string(),
+        "revoked_at should be set after DELETE; got {:?}",
+        tokens[0]["revoked_at"]
+    );
+}
+
+#[tokio::test]
+async fn revoke_unknown_token_returns_404() {
+    let app = common::setup_test_app().await;
+    let (status, _) = common::delete(app, "/api/account/tokens/01HXYZUNKNOWN0000000000000").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn revoke_already_revoked_token_returns_404() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({ "name": "double-revoke" }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let id = v["id"].as_str().unwrap().to_string();
+
+    let url = format!("/api/account/tokens/{id}");
+    let (s1, _) = common::delete(app.clone(), &url).await;
+    assert_eq!(s1, StatusCode::NO_CONTENT);
+    let (s2, _) = common::delete(app, &url).await;
+    assert_eq!(s2, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn pat_authenticates_subsequent_requests() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({ "name": "auth me" }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let token = v["token"].as_str().unwrap().to_string();
+
+    // Use the PAT to hit a protected endpoint.
+    let (status, _) = common::get_with_auth(app, "/api/items", &token).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn revoked_pat_is_rejected() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({ "name": "revoke-then-use" }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let id = v["id"].as_str().unwrap().to_string();
+    let token = v["token"].as_str().unwrap().to_string();
+
+    let (status, _) = common::delete(app.clone(), &format!("/api/account/tokens/{id}")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // Revoked PATs must be rejected even when the API runs in
+    // auth-disabled mode (no CLERK_ISSUER_URL). The PAT path takes
+    // precedence over the disabled-auth fallback.
+    let (status, _) = common::get_with_auth(app, "/api/items", &token).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn unknown_pat_is_rejected() {
+    let app = common::setup_test_app().await;
+    // Random PAT-looking string, not in the DB.
+    let bogus = "intrada_pat_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    let (status, _) = common::get_with_auth(app, "/api/items", bogus).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary

Phase 2a of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477). Adds Personal Access Tokens — the v1 auth path for MCP clients ([per spec decision 2](specs/mcp-server.md): PAT-first, OAuth later).

After this PR you can curl the API with a real PAT:

```bash
# 1. Create a PAT (auth disabled in dev → user_id "")
TOKEN=$(curl -sX POST localhost:3001/api/account/tokens \
  -H 'content-type: application/json' \
  -d '{"name":"My laptop"}' | jq -r .token)

# 2. Use it
curl -H "Authorization: Bearer $TOKEN" localhost:3001/api/items
```

This is the auth foundation for Phase 3 (the actual MCP server).

## What's in here

- **Schema**: `mcp_tokens` table (migrations 0055-0056), with `UNIQUE` hash and a `user_id` index for the list query.
- **API**: `/api/account/tokens` — `POST` creates (returns full token once), `GET` lists (prefix only), `DELETE` soft-revokes (sets `revoked_at`).
- **Auth extractor**: bearer tokens starting with `intrada_pat_` route to a PAT lookup before the existing JWT path. Works whether or not Clerk is configured — so MCP can authenticate against a dev API without `CLERK_ISSUER_URL` set.
- **Token format**: `intrada_pat_` + 64 hex chars (32 bytes random from `rand::thread_rng()`). Stored as hex SHA-256 of the full bearer string. Only the prefix (`intrada_pat_xxxx`) is ever exposed in list responses.
- **Revoked tokens are rejected immediately** (no caching), even in auth-disabled mode. The PAT path takes precedence over the disabled-auth fallback.
- **Best-effort `last_used_at` update** on every successful PAT auth.

Adds `rand = "0.8"` and `sha2 = "0.10"` to `[dependencies]` (rand was previously dev-deps only).

## Security notes for the reviewer

- **Hashing**: SHA-256 unsalted is correct here — PAT bytes have ~256 bits of entropy, so brute-force is astronomical and bcrypt/argon2 (designed for low-entropy passwords) would just slow down the auth path with no security gain.
- **Constant-time comparison**: not needed — we hash the bearer and look up by hash equality in the DB. The DB index lookup is functionally constant-time and doesn't leak per-byte timing.
- **Hash isn't returned by any endpoint**, only the prefix.
- **Revoked + no-cache**: token revocation propagates immediately via DB write; auth extractor reads fresh on every request. Per #482.

## Test plan

- [x] 9 integration tests in `tokens_test.rs` (create, list, revoke, PAT auth happy path, revoked, unknown, double-revoke, validation)
- [x] 4 unit tests in `services/tokens.rs` (generate format/uniqueness, name validation edge cases)
- [x] Existing 76 tests unchanged → 89 passing total
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings` clean (matches CI)

## Out of scope (tracked separately)

- #480 — PAT expiry / rotation policy (need to decide before this ships to prod)
- #481 — CORS for browser-based MCP clients (Phase 3 concern)
- #482 — Token-revocation propagation policy (resolved here as no-cache)
- Phase 2b — account-settings UI (web + iOS) for token management. Follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)