### PR TITLE
feat(web): add Start/Resume Session CTA on Practice list

### DIFF
--- a/crates/intrada-web/src/views/sessions.rs
+++ b/crates/intrada-web/src/views/sessions.rs
@@ -5,12 +5,14 @@ use leptos::prelude::*;
 use leptos_router::components::A;
 
 use intrada_core::{
-    CompletionStatus, EntryStatus, Event, PracticeSessionView, SessionEvent, ViewModel,
+    CompletionStatus, EntryStatus, Event, PracticeSessionView, SessionEvent, SessionStatusView,
+    ViewModel,
 };
 
 use crate::components::{
-    ContextMenu, ContextMenuAction, EmptyState, GroupedList, GroupedListRow, Icon, IconName,
-    PageAddButton, PageHeading, SkeletonCardList, SwipeActions, WeekStrip,
+    ButtonSize, ButtonVariant, ContextMenu, ContextMenuAction, EmptyState, GroupedList,
+    GroupedListRow, Icon, IconName, LinkButton, PageAddButton, PageHeading, SkeletonCardList,
+    SwipeActions, WeekStrip,
 };
 use intrada_web::core_bridge::process_effects_with_core;
 use intrada_web::helpers::{
@@ -143,6 +145,37 @@ pub fn SessionsListView() -> impl IntoView {
                     on_today=on_today
                     is_current_week=Signal::derive(move || week_offset.get() == 0)
                 />
+            </div>
+
+            // Body CTA — Resume the running session if there is one,
+            // otherwise Start a new one. Discard lives inside the active
+            // session view; we deliberately don't surface it here.
+            <div class="mb-6">
+                {move || {
+                    if view_model.get().session_status == SessionStatusView::Active {
+                        view! {
+                            <LinkButton
+                                variant=ButtonVariant::Primary
+                                size=ButtonSize::Hero
+                                full_width=true
+                                href="/sessions/active"
+                            >
+                                "Resume Session"
+                            </LinkButton>
+                        }.into_any()
+                    } else {
+                        view! {
+                            <LinkButton
+                                variant=ButtonVariant::Primary
+                                size=ButtonSize::Hero
+                                full_width=true
+                                href="/sessions/new"
+                            >
+                                "Start Session"
+                            </LinkButton>
+                        }.into_any()
+                    }
+                }}
             </div>
 
             // Session cards for selected day


### PR DESCRIPTION
## Summary
- Adds a full-width primary CTA below the week strip on the Practice page. Reads as "Start Session" when idle and "Resume Session" → `/sessions/active` when a session is in progress (`session_status == Active`).
- Keeps the existing top-right `+` (`PageAddButton`) as a secondary affordance — both stay so the empty-state "New Session" link and the body CTA remain consistent across busy and quiet days.
- Deliberately no Cancel/Discard on this list page — destructive ending lives inside the active session view (`End Early` in `session_timer.rs`) where a fat-finger tap is far less likely to nuke an in-flight session.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-web -- -D warnings`
- [x] `cargo check -p intrada-web`
- [x] Visual: trunk dev server, Practice page renders the new "Start Session" CTA in the right slot (between strip and cards / empty state)
- [ ] Visual: confirm Resume Session label + `/sessions/active` href appears once a real session is in flight (couldn't drive end-to-end in dev env without API creds; conditional is a simple equality check on `SessionStatusView::Active` and the build is clean — low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)