### PR TITLE
refactor(api): AuthUser carries source (Jwt/Pat/Disabled) (#501)

### DIFF
--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -31,8 +31,11 @@ pub enum AuthSource {
     Jwt,
     /// MCP Personal Access Token resolved.
     Pat { token_id: String },
-    /// `CLERK_ISSUER_URL` is unset and no PAT was provided. Local dev only;
-    /// MCP write tools will refuse to record audit rows for this source.
+    /// `CLERK_ISSUER_URL` is unset and no PAT was provided. Local dev only.
+    // TODO(#477 phase 4): MCP write tools must refuse to record audit-log
+    // rows when source is Disabled (otherwise the audit table will record
+    // anonymous-but-attributed-to-empty-user_id rows in dev). The contract
+    // is captured here; enforcement lives with the audit-log impl.
     Disabled,
 }
 
@@ -215,4 +218,90 @@ pub async fn fetch_jwks(
     }
 
     Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Db;
+
+    async fn make_state() -> AppState {
+        let db_path = std::env::temp_dir().join(format!("auth_test_{}.db", ulid::Ulid::new()));
+        let db = libsql::Builder::new_local(&db_path)
+            .build()
+            .await
+            .expect("test db build");
+        let conn = db.connect().expect("test db connect");
+        crate::migrations::run_migrations_direct(&conn)
+            .await
+            .expect("test migrations");
+        AppState::new(
+            Db::new(db, conn),
+            "http://localhost".to_string(),
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn pat_resolves_to_pat_source_with_correct_token_id() {
+        // Locks in the contract: a successfully-resolved PAT must produce
+        // AuthSource::Pat carrying the inserted token_id (not the user_id,
+        // not the hash). Phase 4's audit log depends on this.
+        let state = make_state().await;
+        let conn = state.conn();
+
+        let token = "intrada_pat_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+        let hash = db::tokens::hash_token(token);
+        let token_id = "01HTEST00000000000000000PAT".to_string();
+        let prefix = token[..16].to_string();
+        db::tokens::insert(
+            &conn,
+            &token_id,
+            "user_42",
+            "auth-test",
+            &hash,
+            &prefix,
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("insert PAT");
+
+        let auth_user = resolve_pat(&state, token)
+            .await
+            .expect("PAT should resolve");
+        assert_eq!(auth_user.user_id, "user_42");
+        match auth_user.source {
+            AuthSource::Pat { token_id: t } => assert_eq!(t, token_id),
+            other => panic!("Expected AuthSource::Pat, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn revoked_pat_resolves_to_unauthorized() {
+        let state = make_state().await;
+        let conn = state.conn();
+
+        let token = "intrada_pat_b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2";
+        let hash = db::tokens::hash_token(token);
+        let token_id = "01HTEST_REVOKED_PAT".to_string();
+        db::tokens::insert(
+            &conn,
+            &token_id,
+            "user_42",
+            "auth-test",
+            &hash,
+            "intrada_pat_b1c2",
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("insert PAT");
+        db::tokens::revoke(&conn, "user_42", &token_id)
+            .await
+            .expect("revoke PAT");
+
+        let result = resolve_pat(&state, token).await;
+        assert!(matches!(result, Err(ApiError::Unauthorized(_))));
+    }
 }

--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::db;
-use crate::db::tokens::TOKEN_PREFIX as PAT_PREFIX;
+use crate::db::tokens::{PatLookup, TOKEN_PREFIX as PAT_PREFIX};
 use crate::error::ApiError;
 use crate::state::AppState;
 
@@ -22,16 +22,33 @@ struct Claims {
     sub: String,
 }
 
-/// Extractor that yields the authenticated user's ID.
+/// How an `AuthUser` was produced. Phase 4's `mcp_audit_log` will record the
+/// `token_id` for every MCP write — surfacing it through the extractor here
+/// avoids a redundant DB lookup per write handler.
+#[derive(Debug, Clone)]
+pub enum AuthSource {
+    /// Clerk JWT validation passed.
+    Jwt,
+    /// MCP Personal Access Token resolved.
+    Pat { token_id: String },
+    /// `CLERK_ISSUER_URL` is unset and no PAT was provided. Local dev only;
+    /// MCP write tools will refuse to record audit rows for this source.
+    Disabled,
+}
+
+/// Extractor that yields the authenticated user's ID and how the request
+/// authenticated.
 ///
 /// Resolution order:
 /// 1. `Authorization: Bearer intrada_pat_…` → MCP PAT lookup. Works whether
 ///    or not Clerk is configured, so MCP can authenticate against an API
 ///    instance running without `CLERK_ISSUER_URL` (dev / local).
-/// 2. No `auth_config` (Clerk disabled) → `AuthUser("")` — matches existing
-///    test behaviour.
+/// 2. No `auth_config` (Clerk disabled) → empty `user_id` + `AuthSource::Disabled`.
 /// 3. JWT validation against the configured Clerk issuer.
-pub struct AuthUser(pub String);
+pub struct AuthUser {
+    pub user_id: String,
+    pub source: AuthSource,
+}
 
 impl FromRequestParts<AppState> for AuthUser {
     type Rejection = ApiError;
@@ -58,7 +75,10 @@ impl FromRequestParts<AppState> for AuthUser {
                 // attaches a user to this per-request hub, make sure the
                 // auth-disabled path doesn't inherit it.
                 sentry::configure_scope(|scope| scope.set_user(None));
-                return Ok(AuthUser(String::new()));
+                return Ok(AuthUser {
+                    user_id: String::new(),
+                    source: AuthSource::Disabled,
+                });
             }
         };
 
@@ -77,7 +97,10 @@ impl FromRequestParts<AppState> for AuthUser {
                 Ok(data) => {
                     let user_id = data.claims.sub;
                     set_sentry_user(&user_id);
-                    return Ok(AuthUser(user_id));
+                    return Ok(AuthUser {
+                        user_id,
+                        source: AuthSource::Jwt,
+                    });
                 }
                 Err(e) => {
                     tracing::debug!("JWT decode error: {e}");
@@ -95,16 +118,26 @@ async fn resolve_pat(state: &AppState, token: &str) -> Result<AuthUser, ApiError
     let hash = db::tokens::hash_token(token);
 
     match db::tokens::lookup_by_hash(&conn, &hash).await {
-        Ok(Some((user_id, None))) => {
+        Ok(Some(PatLookup {
+            token_id,
+            user_id,
+            revoked_at: None,
+        })) => {
             // Best-effort `last_used_at` update — auth has already succeeded,
             // so a write failure here shouldn't deny access.
             if let Err(e) = db::tokens::mark_used(&conn, &hash).await {
                 tracing::warn!(?e, "PAT mark_used update failed");
             }
             set_sentry_user(&user_id);
-            Ok(AuthUser(user_id))
+            Ok(AuthUser {
+                user_id,
+                source: AuthSource::Pat { token_id },
+            })
         }
-        Ok(Some((_, Some(_)))) => {
+        Ok(Some(PatLookup {
+            revoked_at: Some(_),
+            ..
+        })) => {
             // Revoked. Distinct log line so revoked-token use is grep-able
             // separately from "unknown PAT".
             tracing::info!("PAT auth rejected: token revoked");

--- a/crates/intrada-api/src/db/tokens.rs
+++ b/crates/intrada-api/src/db/tokens.rs
@@ -119,17 +119,21 @@ pub async fn revoke(conn: &Connection, user_id: &str, token_id: &str) -> Result<
     Ok(rows > 0)
 }
 
-/// Resolve a hashed PAT to `(user_id, revoked_at)`. Caller decides what to
-/// do with the revoked-at value — we return it raw rather than baking the
-/// revocation check into this function so the auth extractor can log
-/// revoked-token use distinctly from missing-token use.
-pub async fn lookup_by_hash(
-    conn: &Connection,
-    hash: &str,
-) -> Result<Option<(String, Option<DateTime<Utc>>)>, ApiError> {
+/// Result of a `lookup_by_hash` call. `revoked_at` is returned raw rather
+/// than baking the revocation check into the lookup so the auth extractor
+/// can log revoked-token use distinctly from missing-token use; and the
+/// Phase 4 audit log will need `token_id` to record which token initiated
+/// each MCP write.
+pub struct PatLookup {
+    pub token_id: String,
+    pub user_id: String,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+pub async fn lookup_by_hash(conn: &Connection, hash: &str) -> Result<Option<PatLookup>, ApiError> {
     let mut rows = conn
         .query(
-            "SELECT user_id, revoked_at FROM mcp_tokens WHERE hash = ?1",
+            "SELECT id, user_id, revoked_at FROM mcp_tokens WHERE hash = ?1",
             libsql::params![hash],
         )
         .await?;
@@ -139,9 +143,14 @@ pub async fn lookup_by_hash(
         .map_err(|e| ApiError::Internal(e.to_string()))?
     {
         Some(row) => {
-            let user_id: String = col!(row, 0)?;
-            let revoked_at: Option<String> = col!(row, 1)?;
-            Ok(Some((user_id, parse_dt_opt(revoked_at)?)))
+            let token_id: String = col!(row, 0)?;
+            let user_id: String = col!(row, 1)?;
+            let revoked_at: Option<String> = col!(row, 2)?;
+            Ok(Some(PatLookup {
+                token_id,
+                user_id,
+                revoked_at: parse_dt_opt(revoked_at)?,
+            }))
         }
         None => Ok(None),
     }

--- a/crates/intrada-api/src/routes/account.rs
+++ b/crates/intrada-api/src/routes/account.rs
@@ -19,7 +19,7 @@ pub fn router() -> Router<AppState> {
 
 async fn get_preferences(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<AccountPreferences>, ApiError> {
     let conn = state.conn();
     let prefs = services::account::get_preferences(&conn, &user_id).await?;
@@ -28,7 +28,7 @@ async fn get_preferences(
 
 async fn put_preferences(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<AccountPreferences>,
 ) -> Result<Json<AccountPreferences>, ApiError> {
     let conn = state.conn();
@@ -38,7 +38,7 @@ async fn put_preferences(
 
 async fn delete_account(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();
     services::account::delete_account(&conn, state.r2.as_ref(), state.clerk.as_ref(), &user_id)

--- a/crates/intrada-api/src/routes/items.rs
+++ b/crates/intrada-api/src/routes/items.rs
@@ -19,7 +19,7 @@ pub fn router() -> Router<AppState> {
 
 async fn list_items(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Item>>, ApiError> {
     let conn = state.conn();
     let items = services::items::list_items(&conn, &user_id).await?;
@@ -28,7 +28,7 @@ async fn list_items(
 
 async fn get_item(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Item>, ApiError> {
     let conn = state.conn();
@@ -38,7 +38,7 @@ async fn get_item(
 
 async fn create_item(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<CreateItem>,
 ) -> Result<(StatusCode, Json<Item>), ApiError> {
     let conn = state.conn();
@@ -48,7 +48,7 @@ async fn create_item(
 
 async fn update_item(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
     Json(input): Json<UpdateItem>,
 ) -> Result<Json<Item>, ApiError> {
@@ -59,7 +59,7 @@ async fn update_item(
 
 async fn delete_item(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -36,7 +36,7 @@ pub fn router() -> Router<AppState> {
 
 async fn list_lessons(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Lesson>>, ApiError> {
     let conn = state.conn();
     let r2 = state.r2()?;
@@ -46,7 +46,7 @@ async fn list_lessons(
 
 async fn get_lesson(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Lesson>, ApiError> {
     let conn = state.conn();
@@ -57,7 +57,7 @@ async fn get_lesson(
 
 async fn create_lesson(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<CreateLesson>,
 ) -> Result<(StatusCode, Json<Lesson>), ApiError> {
     let conn = state.conn();
@@ -68,7 +68,7 @@ async fn create_lesson(
 
 async fn update_lesson(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
     Json(input): Json<UpdateLesson>,
 ) -> Result<Json<Lesson>, ApiError> {
@@ -80,7 +80,7 @@ async fn update_lesson(
 
 async fn delete_lesson(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();
@@ -92,7 +92,7 @@ async fn delete_lesson(
 
 async fn upload_photo(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
     mut multipart: Multipart,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
@@ -135,7 +135,7 @@ async fn upload_photo(
 
 async fn delete_photo(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path((id, photo_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();

--- a/crates/intrada-api/src/routes/sessions.rs
+++ b/crates/intrada-api/src/routes/sessions.rs
@@ -19,7 +19,7 @@ pub fn router() -> Router<AppState> {
 
 async fn list_sessions(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<PracticeSession>>, ApiError> {
     let conn = state.conn();
     let sessions = services::sessions::list_sessions(&conn, &user_id).await?;
@@ -28,7 +28,7 @@ async fn list_sessions(
 
 async fn get_session(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<PracticeSession>, ApiError> {
     let conn = state.conn();
@@ -38,7 +38,7 @@ async fn get_session(
 
 async fn save_session(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<SaveSessionRequest>,
 ) -> Result<(StatusCode, Json<PracticeSession>), ApiError> {
     let conn = state.conn();
@@ -48,7 +48,7 @@ async fn save_session(
 
 async fn delete_session(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();

--- a/crates/intrada-api/src/routes/sets.rs
+++ b/crates/intrada-api/src/routes/sets.rs
@@ -19,7 +19,7 @@ pub fn router() -> Router<AppState> {
 
 async fn list_sets(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Set>>, ApiError> {
     let conn = state.conn();
     let sets = services::sets::list_sets(&conn, &user_id).await?;
@@ -28,7 +28,7 @@ async fn list_sets(
 
 async fn get_set(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Set>, ApiError> {
     let conn = state.conn();
@@ -38,7 +38,7 @@ async fn get_set(
 
 async fn create_set(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<CreateSetRequest>,
 ) -> Result<(StatusCode, Json<Set>), ApiError> {
     let conn = state.conn();
@@ -48,7 +48,7 @@ async fn create_set(
 
 async fn update_set(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
     Json(input): Json<UpdateSetRequest>,
 ) -> Result<Json<Set>, ApiError> {
@@ -59,7 +59,7 @@ async fn update_set(
 
 async fn delete_set(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let conn = state.conn();

--- a/crates/intrada-api/src/routes/tokens.rs
+++ b/crates/intrada-api/src/routes/tokens.rs
@@ -17,7 +17,7 @@ pub fn router() -> Router<AppState> {
 
 async fn list_tokens(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<TokenListItem>>, ApiError> {
     let conn = state.conn();
     let tokens = services::tokens::list_tokens(&conn, &user_id).await?;
@@ -26,7 +26,7 @@ async fn list_tokens(
 
 async fn create_token(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Json(input): Json<CreateTokenRequest>,
 ) -> Result<(StatusCode, Json<CreatedTokenResponse>), ApiError> {
     let conn = state.conn();
@@ -36,7 +36,7 @@ async fn create_token(
 
 async fn revoke_token(
     State(state): State<AppState>,
-    AuthUser(user_id): AuthUser,
+    AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
     let conn = state.conn();

--- a/crates/intrada-api/src/services/account.rs
+++ b/crates/intrada-api/src/services/account.rs
@@ -38,9 +38,9 @@ pub async fn delete_account(
     user_id: &str,
 ) -> Result<(), ApiError> {
     // Refuse empty user_id outright — auth-disabled mode (no
-    // CLERK_ISSUER_URL) yields `AuthUser("")`, which would otherwise
-    // turn into an R2 prefix `/` and a Clerk DELETE /v1/users/ —
-    // both blast-radius hazards.
+    // CLERK_ISSUER_URL) yields `user_id == ""` (with `AuthSource::Disabled`),
+    // which would otherwise turn into an R2 prefix `/` and a Clerk
+    // DELETE /v1/users/ — both blast-radius hazards.
     if user_id.is_empty() {
         return Err(ApiError::Unauthorized("Unauthorized".to_string()));
     }


### PR DESCRIPTION
## Summary

Closes [#501](https://github.com/jonyardley/intrada/issues/501). Stacked on [#500](https://github.com/jonyardley/intrada/pull/500); base will auto-flip to main once that merges.

Phase 4 of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477) adds an \`mcp_audit_log\` table that records which **token** initiated each MCP write. Doing the \`AuthUser\` shape change *now* — before Phase 3 — means the new \`intrada-mcp\` crate inherits the right shape from day one rather than needing a refactor in Phase 4.

## What's in here

- \`AuthUser\` is now \`{ user_id: String, source: AuthSource }\`.
- \`AuthSource::{Jwt, Pat { token_id }, Disabled}\` records how the request authenticated:
  - \`Jwt\` — Clerk JWT validation passed.
  - \`Pat { token_id }\` — MCP PAT resolved. Phase 4's audit log reads \`token_id\` here.
  - \`Disabled\` — \`CLERK_ISSUER_URL\` is unset, no PAT provided. Local dev only; MCP write tools will refuse to record audit rows for this source.
- \`db::tokens::lookup_by_hash\` now returns a named \`PatLookup\` struct (was a 3-tuple — adds \`token_id\` field).
- All 27 route handler destructures updated: \`AuthUser(user_id): AuthUser\` → \`AuthUser { user_id, .. }: AuthUser\`.

The \`..\` in the destructure means existing handlers don't read \`source\` — Phase 4 will replace \`..\` with \`source\` at the specific write handlers that need to record audit rows.

## No behaviour change

- 89 tests pass unchanged (76 baseline + 13 from Phase 2a).
- Same wire format on all endpoints.
- Same auth precedence (PAT → disabled-fallback → JWT).
- \`fmt --check\` clean.
- \`cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings\` clean (matches CI).

## Why now (not in Phase 4)

The \`intrada-mcp\` crate (Phase 3) takes \`AuthUser\` and threads it through every tool handler. If we ship Phase 3 with the flat shape, Phase 4 has to refactor a brand-new crate. Doing it before Phase 3 means tool handlers get the right shape from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)