### PR TITLE
feat(mobile): Phase C — ActivityKit + SwiftUI Live Activity (#474)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
       # intrada-mobile + its plugins (Tauri 2) require GTK/glib system libs
       # not present on Ubuntu runners — iOS-only crates with no meaningful
       # unit tests on Linux.
-      - run: cargo nextest run --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio
+      - run: cargo nextest run --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity
       - name: Doc tests
-        run: cargo test --doc --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio
+        run: cargo test --doc --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity
 
   clippy:
     name: Clippy
@@ -89,7 +89,7 @@ jobs:
           prefix-key: "native"
           save-if: "false"
       # intrada-mobile + its plugins excluded: Tauri 2 needs GTK/glib system libs on Linux.
-      - run: cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings
+      - run: cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity -- -D warnings
       - name: Clippy (WASM target)
         run: cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "tauri-plugin-background-audio",
  "tauri-plugin-deep-link",
  "tauri-plugin-haptics",
+ "tauri-plugin-live-activity",
 ]
 
 [[package]]
@@ -6859,6 +6860,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b167d598ada05c599f4460595108c8d1aa636030a97d19796c1bcda97d881d"
 dependencies = [
  "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-live-activity"
+version = "0.0.1"
+dependencies = [
+ "sentry",
  "serde",
  "serde_json",
  "tauri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/intrada-web",
   "crates/intrada-mobile/src-tauri",
   "crates/intrada-mobile/plugins/background-audio",
+  "crates/intrada-mobile/plugins/live-activity",
 ]
 resolver = "2"
 package.rust-version = "1.75"

--- a/crates/intrada-mobile/plugins/background-audio/src/lib.rs
+++ b/crates/intrada-mobile/plugins/background-audio/src/lib.rs
@@ -101,10 +101,12 @@ fn capture_bridge_error(command: &str, err: &Error) {
 async fn begin_session<R: Runtime>(app: AppHandle<R>, args: BeginSessionArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        // Item title is user content (piece / exercise name); strip it
+        // from the breadcrumb so it doesn't bypass `send_default_pii:
+        // false`. Sentry can still triage by command + started_at.
         breadcrumb(
             "begin_session",
             serde_json::json!({
-                "title": &args.title,
                 "started_at": &args.started_at,
             }),
         );
@@ -126,10 +128,11 @@ async fn begin_session<R: Runtime>(app: AppHandle<R>, args: BeginSessionArgs) ->
 async fn set_now_playing<R: Runtime>(app: AppHandle<R>, args: NowPlayingArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        // See `begin_session` — `title` is user content; only generic
+        // metadata in the breadcrumb.
         breadcrumb(
             "set_now_playing",
             serde_json::json!({
-                "title": &args.title,
                 "position_label": &args.position_label,
                 "started_at": &args.started_at,
             }),

--- a/crates/intrada-mobile/plugins/live-activity/Cargo.toml
+++ b/crates/intrada-mobile/plugins/live-activity/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tauri-plugin-live-activity"
+version = "0.0.1"
+edition = "2021"
+rust-version.workspace = true
+description = "Intrada-internal Tauri plugin: ActivityKit Live Activity for the active practice session — Lock Screen card + Dynamic Island compact / expanded views. iOS-only; layered alongside the background-audio plugin."
+# Required by tauri-plugin's build script (must match package.name).
+links = "tauri-plugin-live-activity"
+
+[dependencies]
+tauri = { version = "2" }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+# iOS-only: sentry + serde_json. Used inside `#[cfg(target_os = "ios")]`
+# helpers to drop breadcrumbs / capture bridge errors against the host's
+# already-initialised Sentry hub (intrada-mobile/src-tauri/src/lib.rs).
+# Mirrors the same pattern as the background-audio plugin.
+[target.'cfg(target_os = "ios")'.dependencies]
+serde_json = { workspace = true }
+sentry = { version = "0.48", default-features = false }
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/crates/intrada-mobile/plugins/live-activity/build.rs
+++ b/crates/intrada-mobile/plugins/live-activity/build.rs
@@ -1,0 +1,9 @@
+// Tauri plugin build script: generates the permission JSON schema and
+// the allowlist of commands the plugin exposes, and points Tauri at the
+// iOS Swift package so the host Xcode project picks it up at
+// `cargo tauri ios init` / build time.
+const COMMANDS: &[&str] = &["begin", "update", "end"];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS).ios_path("ios").build();
+}

--- a/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+  name: "tauri-plugin-live-activity",
+  platforms: [
+    .iOS(.v13)
+  ],
+  products: [
+    .library(
+      name: "tauri-plugin-live-activity",
+      type: .static,
+      targets: ["tauri-plugin-live-activity"])
+  ],
+  dependencies: [
+    // The Tauri SwiftPM umbrella package is generated under the host
+    // Xcode project's `gen/apple/.tauri/tauri-api/` when `cargo tauri ios
+    // init` runs. Path is relative to this Package.swift after the host
+    // app's local plugin path declaration.
+    .package(name: "Tauri", path: "../.tauri/tauri-api")
+  ],
+  targets: [
+    .target(
+      name: "tauri-plugin-live-activity",
+      dependencies: [
+        .byName(name: "Tauri")
+      ],
+      path: "Sources/LiveActivityPlugin")
+  ]
+)

--- a/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Package.swift
@@ -1,9 +1,12 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
   name: "tauri-plugin-live-activity",
   platforms: [
+    // Plugin target compiles down to iOS 13 so it can ship alongside
+    // the rest of the app (which targets 14.0). ActivityKit calls are
+    // gated with @available(iOS 16.1, *) at the call sites.
     .iOS(.v13)
   ],
   products: [
@@ -13,17 +16,20 @@ let package = Package(
       targets: ["tauri-plugin-live-activity"])
   ],
   dependencies: [
-    // The Tauri SwiftPM umbrella package is generated under the host
-    // Xcode project's `gen/apple/.tauri/tauri-api/` when `cargo tauri ios
-    // init` runs. Path is relative to this Package.swift after the host
-    // app's local plugin path declaration.
-    .package(name: "Tauri", path: "../.tauri/tauri-api")
+    // Tauri SwiftPM umbrella — generated under the host Xcode project's
+    // `gen/apple/.tauri/tauri-api/` when `cargo tauri ios init` runs.
+    .package(name: "Tauri", path: "../.tauri/tauri-api"),
+    // Shared ActivityAttributes type — same identity must appear here
+    // and on the widget extension. See
+    // crates/intrada-mobile/shared/IntradaActivityShared/.
+    .package(name: "IntradaActivityShared", path: "../../../shared/IntradaActivityShared"),
   ],
   targets: [
     .target(
       name: "tauri-plugin-live-activity",
       dependencies: [
-        .byName(name: "Tauri")
+        .byName(name: "Tauri"),
+        .byName(name: "IntradaActivityShared"),
       ],
       path: "Sources/LiveActivityPlugin")
   ]

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -1,0 +1,50 @@
+// Phase B of intrada#474 — placeholder Swift plugin. Resolves all three
+// commands (begin / update / end) without touching ActivityKit yet, so
+// the IPC roundtrip from JS → Rust → Swift can be exercised end-to-end.
+// Phase C swaps these stubs for the real Activity<...>.request /
+// activity.update / activity.end calls.
+//
+// Spec: specs/live-activity-plugin.md
+
+import SwiftRs
+import Tauri
+import UIKit
+import WebKit
+
+struct BeginArgs: Decodable {
+  let item_title: String
+  let position_label: String
+  let started_at: String  // RFC3339 UTC
+  let planned_duration_secs: UInt32?
+}
+
+struct UpdateArgs: Decodable {
+  let item_title: String
+  let position_label: String
+  let started_at: String
+  let planned_duration_secs: UInt32?
+}
+
+class LiveActivityPlugin: Plugin {
+  // Phase B: parse args to confirm shape, then resolve. Phase C
+  // replaces each stub body with the corresponding ActivityKit call.
+
+  @objc public func begin(_ invoke: Invoke) throws {
+    let _ = try invoke.parseArgs(BeginArgs.self)
+    invoke.resolve()
+  }
+
+  @objc public func update(_ invoke: Invoke) throws {
+    let _ = try invoke.parseArgs(UpdateArgs.self)
+    invoke.resolve()
+  }
+
+  @objc public func end(_ invoke: Invoke) {
+    invoke.resolve()
+  }
+}
+
+@_cdecl("init_plugin_live_activity")
+func initPlugin() -> Plugin {
+  return LiveActivityPlugin()
+}

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -1,11 +1,27 @@
-// Phase B of intrada#474 — placeholder Swift plugin. Resolves all three
-// commands (begin / update / end) without touching ActivityKit yet, so
-// the IPC roundtrip from JS → Rust → Swift can be exercised end-to-end.
-// Phase C swaps these stubs for the real Activity<...>.request /
-// activity.update / activity.end calls.
+// Phase C of intrada#474 — drives an ActivityKit Live Activity for the
+// active practice session. Layers on top of the background-audio
+// plugin (#309): same lifecycle, different surface.
 //
-// Spec: specs/live-activity-plugin.md
+// Design (per specs/live-activity-plugin.md):
+// - Single in-flight activity at a time. Stored on the plugin instance
+//   so `update` and `end` can target the right activity reference.
+// - Wall-clock anchor in ContentState — the widget extension's SwiftUI
+//   views use `Text(timerInterval:)` / `ProgressView(timerInterval:)` so
+//   iOS handles the per-second update without IPC traffic. We push only
+//   on item advance.
+// - `dismissalPolicy: .immediate` on end — once the user puts the
+//   instrument down, the activity disappears within ~1s. Apple's
+//   default `.default` keeps it for ~8h which feels wrong for practice.
+// - All ActivityKit calls gated with `@available(iOS 16.1, *)`.
+//   Older devices let the plugin commands resolve; the activity is
+//   just silently absent.
 
+#if canImport(ActivityKit)
+  import ActivityKit
+#endif
+
+import Foundation
+import IntradaActivityShared
 import SwiftRs
 import Tauri
 import UIKit
@@ -26,21 +42,142 @@ struct UpdateArgs: Decodable {
 }
 
 class LiveActivityPlugin: Plugin {
-  // Phase B: parse args to confirm shape, then resolve. Phase C
-  // replaces each stub body with the corresponding ActivityKit call.
+  // Currently-active activity reference. Held for the lifetime of a
+  // session so `update` and `end` can target it. `Any?` (rather than
+  // typed) so this stored property compiles on iOS < 16.1; the actual
+  // type is `Activity<IntradaActivityAttributes>?` enforced via casts
+  // at use sites.
+  private var currentActivity: Any?
+
+  // Cached because ISO8601DateFormatter is expensive to instantiate and
+  // we re-parse on every `begin` / `update`.
+  private static let rfc3339WithFractional: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+  }()
+  private static let rfc3339Plain: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime]
+    return f
+  }()
+
+  // Tauri dispatches `Invoke` calls on a serial per-plugin queue, but
+  // ActivityKit's API is documented as main-thread-safe. We dispatch
+  // every state mutation to the main queue to mirror background-audio's
+  // pattern and avoid surprises.
 
   @objc public func begin(_ invoke: Invoke) throws {
-    let _ = try invoke.parseArgs(BeginArgs.self)
-    invoke.resolve()
+    let args = try invoke.parseArgs(BeginArgs.self)
+    let started = parseRfc3339(args.started_at) ?? Date()
+
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+
+      if #available(iOS 16.1, *) {
+        // If a previous session left an activity hanging (app crash
+        // mid-session, ActivityKit error path), end it before starting
+        // the new one. iOS allows only one activity per attribute type
+        // before throwing `.tooManyActivitiesForApplication`.
+        self.endCurrentActivityIfAny()
+
+        let state = IntradaActivityAttributes.ContentState(
+          itemTitle: args.item_title,
+          positionLabel: args.position_label,
+          startedAt: started,
+          plannedDurationSecs: args.planned_duration_secs
+        )
+
+        do {
+          let activity = try Activity<IntradaActivityAttributes>.request(
+            attributes: IntradaActivityAttributes(),
+            contentState: state,
+            pushType: nil
+          )
+          self.currentActivity = activity
+          invoke.resolve()
+        } catch {
+          // Common failure modes:
+          // - User disabled Live Activities in Settings
+          // - Missing NSSupportsLiveActivities in Info.plist
+          // - .tooManyActivitiesForApplication if cleanup above raced
+          // The wall-clock timer + background-audio still work; only
+          // the lock-screen card is missing. Surface to the bridge so
+          // Sentry catches it (per the plugin's Rust-side capture).
+          invoke.reject(
+            "live-activity: Activity.request failed: \(error.localizedDescription)")
+        }
+      } else {
+        // Older iOS: no Live Activities — resolve silently. Background
+        // audio still gives the user a lock-screen Now Playing card.
+        invoke.resolve()
+      }
+    }
   }
 
   @objc public func update(_ invoke: Invoke) throws {
-    let _ = try invoke.parseArgs(UpdateArgs.self)
-    invoke.resolve()
+    let args = try invoke.parseArgs(UpdateArgs.self)
+    let started = parseRfc3339(args.started_at) ?? Date()
+
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+
+      if #available(iOS 16.1, *) {
+        guard let activity = self.currentActivity as? Activity<IntradaActivityAttributes>
+        else {
+          // No activity in flight — `update` arrived without a matching
+          // `begin`, or the activity already ended (e.g. user revoked
+          // Live Activities mid-session). No-op rather than error: the
+          // shell-side lifecycle Effect can race ahead of iOS state.
+          invoke.resolve()
+          return
+        }
+
+        let state = IntradaActivityAttributes.ContentState(
+          itemTitle: args.item_title,
+          positionLabel: args.position_label,
+          startedAt: started,
+          plannedDurationSecs: args.planned_duration_secs
+        )
+
+        Task {
+          await activity.update(using: state)
+          invoke.resolve()
+        }
+      } else {
+        invoke.resolve()
+      }
+    }
   }
 
   @objc public func end(_ invoke: Invoke) {
-    invoke.resolve()
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+
+      if #available(iOS 16.1, *) {
+        self.endCurrentActivityIfAny()
+      }
+      invoke.resolve()
+    }
+  }
+
+  // MARK: - Helpers
+
+  @available(iOS 16.1, *)
+  private func endCurrentActivityIfAny() {
+    guard let activity = currentActivity as? Activity<IntradaActivityAttributes> else { return }
+    // `Activity.end` requires a final ContentState even though the
+    // activity dismisses immediately — reuse the last known state.
+    let final = activity.contentState
+    Task {
+      await activity.end(using: final, dismissalPolicy: .immediate)
+    }
+    currentActivity = nil
+  }
+
+  private func parseRfc3339(_ s: String) -> Date? {
+    if let d = Self.rfc3339WithFractional.date(from: s) { return d }
+    return Self.rfc3339Plain.date(from: s)
   }
 }
 

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -63,9 +63,18 @@ class LiveActivityPlugin: Plugin {
   }()
 
   // Tauri dispatches `Invoke` calls on a serial per-plugin queue, but
-  // ActivityKit's API is documented as main-thread-safe. We dispatch
-  // every state mutation to the main queue to mirror background-audio's
-  // pattern and avoid surprises.
+  // we still wrap the synchronous parts in `DispatchQueue.main.async`
+  // because reads/writes of `currentActivity` need a single home queue
+  // to avoid races with future timer / notification callbacks (mirrors
+  // background-audio's pattern). The `await activity.update(...)` and
+  // `await activity.end(...)` calls themselves are documented as safe
+  // from any context — they hop off main via `Task { @MainActor in }`
+  // so that any post-await state mutation lands back on main.
+  //
+  // iPad: ActivityKit doesn't support Live Activities on iPad. We
+  // short-circuit here rather than letting `Activity.request` throw,
+  // which would otherwise produce one Sentry "rejected" event per
+  // session start on every iPad install.
 
   @objc public func begin(_ invoke: Invoke) throws {
     let args = try invoke.parseArgs(BeginArgs.self)
@@ -73,6 +82,11 @@ class LiveActivityPlugin: Plugin {
 
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
+
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        invoke.resolve()
+        return
+      }
 
       if #available(iOS 16.1, *) {
         // If a previous session left an activity hanging (app crash
@@ -89,11 +103,23 @@ class LiveActivityPlugin: Plugin {
         )
 
         do {
-          let activity = try Activity<IntradaActivityAttributes>.request(
-            attributes: IntradaActivityAttributes(),
-            contentState: state,
-            pushType: nil
-          )
+          let activity: Activity<IntradaActivityAttributes>
+          if #available(iOS 16.2, *) {
+            // 16.2+: ActivityContent wrapper (preferred; iOS 16.1's
+            // contentState: API was deprecated in favour of this).
+            activity = try Activity<IntradaActivityAttributes>.request(
+              attributes: IntradaActivityAttributes(),
+              content: ActivityContent(state: state, staleDate: nil),
+              pushType: nil
+            )
+          } else {
+            // 16.1 baseline: contentState: parameter.
+            activity = try Activity<IntradaActivityAttributes>.request(
+              attributes: IntradaActivityAttributes(),
+              contentState: state,
+              pushType: nil
+            )
+          }
           self.currentActivity = activity
           invoke.resolve()
         } catch {
@@ -122,6 +148,11 @@ class LiveActivityPlugin: Plugin {
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
 
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        invoke.resolve()
+        return
+      }
+
       if #available(iOS 16.1, *) {
         guard let activity = self.currentActivity as? Activity<IntradaActivityAttributes>
         else {
@@ -140,8 +171,17 @@ class LiveActivityPlugin: Plugin {
           plannedDurationSecs: args.planned_duration_secs
         )
 
-        Task {
-          await activity.update(using: state)
+        // `Activity.update` is `async` but not `throws` per Apple's API:
+        // it silently no-ops if the activity has been revoked / replaced.
+        // The lifecycle Effect's next item-advance fires another update,
+        // so transient failures self-heal. If `.activityState` checks
+        // become necessary we can add them here in Phase D.
+        Task { @MainActor in
+          if #available(iOS 16.2, *) {
+            await activity.update(ActivityContent(state: state, staleDate: nil))
+          } else {
+            await activity.update(using: state)
+          }
           invoke.resolve()
         }
       } else {
@@ -153,6 +193,11 @@ class LiveActivityPlugin: Plugin {
   @objc public func end(_ invoke: Invoke) {
     DispatchQueue.main.async { [weak self] in
       guard let self = self else { return }
+
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        invoke.resolve()
+        return
+      }
 
       if #available(iOS 16.1, *) {
         self.endCurrentActivityIfAny()
@@ -168,11 +213,23 @@ class LiveActivityPlugin: Plugin {
     guard let activity = currentActivity as? Activity<IntradaActivityAttributes> else { return }
     // `Activity.end` requires a final ContentState even though the
     // activity dismisses immediately — reuse the last known state.
-    let final = activity.contentState
-    Task {
-      await activity.end(using: final, dismissalPolicy: .immediate)
+    // iOS 16.2 deprecated `contentState` in favour of `content.state`.
+    let final: IntradaActivityAttributes.ContentState
+    if #available(iOS 16.2, *) {
+      final = activity.content.state
+    } else {
+      final = activity.contentState
     }
     currentActivity = nil
+    Task { @MainActor in
+      if #available(iOS 16.2, *) {
+        await activity.end(
+          ActivityContent(state: final, staleDate: nil),
+          dismissalPolicy: .immediate)
+      } else {
+        await activity.end(using: final, dismissalPolicy: .immediate)
+      }
+    }
   }
 
   private func parseRfc3339(_ s: String) -> Date? {

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/begin.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/begin.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-begin"
+description = "Enables the begin command without any pre-configured scope."
+commands.allow = ["begin"]
+
+[[permission]]
+identifier = "deny-begin"
+description = "Denies the begin command without any pre-configured scope."
+commands.deny = ["begin"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/end.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/end.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-end"
+description = "Enables the end command without any pre-configured scope."
+commands.allow = ["end"]
+
+[[permission]]
+identifier = "deny-end"
+description = "Denies the end command without any pre-configured scope."
+commands.deny = ["end"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/update.toml
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/commands/update.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-update"
+description = "Enables the update command without any pre-configured scope."
+commands.allow = ["update"]
+
+[[permission]]
+identifier = "deny-update"
+description = "Denies the update command without any pre-configured scope."
+commands.deny = ["update"]

--- a/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/reference.md
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/reference.md
@@ -1,0 +1,97 @@
+## Default Permission
+
+Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.
+
+#### This default permission set includes the following:
+
+- `allow-begin`
+- `allow-update`
+- `allow-end`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`live-activity:allow-begin`
+
+</td>
+<td>
+
+Enables the begin command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-begin`
+
+</td>
+<td>
+
+Denies the begin command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:allow-end`
+
+</td>
+<td>
+
+Enables the end command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-end`
+
+</td>
+<td>
+
+Denies the end command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:allow-update`
+
+</td>
+<td>
+
+Enables the update command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`live-activity:deny-update`
+
+</td>
+<td>
+
+Denies the update command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/crates/intrada-mobile/plugins/live-activity/permissions/default.json
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/default.json
@@ -1,0 +1,10 @@
+{
+  "default": {
+    "description": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.",
+    "permissions": [
+      "allow-begin",
+      "allow-update",
+      "allow-end"
+    ]
+  }
+}

--- a/crates/intrada-mobile/plugins/live-activity/permissions/schemas/schema.json
+++ b/crates/intrada-mobile/plugins/live-activity/permissions/schemas/schema.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the begin command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-begin",
+          "markdownDescription": "Enables the begin command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the begin command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-begin",
+          "markdownDescription": "Denies the begin command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the end command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-end",
+          "markdownDescription": "Enables the end command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the end command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-end",
+          "markdownDescription": "Denies the end command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the update command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-update",
+          "markdownDescription": "Enables the update command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the update command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-update",
+          "markdownDescription": "Denies the update command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.\n#### This default permission set includes:\n\n- `allow-begin`\n- `allow-update`\n- `allow-end`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Default permissions for the live-activity plugin: allow the WebView to begin, update, and end a Live Activity for the current practice session.\n#### This default permission set includes:\n\n- `allow-begin`\n- `allow-update`\n- `allow-end`"
+        }
+      ]
+    }
+  }
+}

--- a/crates/intrada-mobile/plugins/live-activity/src/lib.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/lib.rs
@@ -107,10 +107,15 @@ fn capture_bridge_error(command: &str, err: &Error) {
 async fn begin<R: Runtime>(app: AppHandle<R>, args: BeginArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        // Strip `item_title` from breadcrumb data — piece/exercise titles
+        // are user content that bypass `send_default_pii: false` if
+        // attached explicitly. `position_label` ("Item N of M") is
+        // generic; `planned_duration_secs` is metadata. Both are
+        // sufficient for Sentry to triage failures by item position
+        // without exposing what the user is practising.
         breadcrumb(
             "begin",
             serde_json::json!({
-                "item_title": &args.item_title,
                 "position_label": &args.position_label,
                 "started_at": &args.started_at,
                 "planned_duration_secs": args.planned_duration_secs,
@@ -134,10 +139,11 @@ async fn begin<R: Runtime>(app: AppHandle<R>, args: BeginArgs) -> Result<()> {
 async fn update<R: Runtime>(app: AppHandle<R>, args: UpdateArgs) -> Result<()> {
     #[cfg(target_os = "ios")]
     {
+        // See `begin` — `item_title` deliberately omitted from
+        // breadcrumb data to avoid leaking user content into Sentry.
         breadcrumb(
             "update",
             serde_json::json!({
-                "item_title": &args.item_title,
                 "position_label": &args.position_label,
                 "started_at": &args.started_at,
                 "planned_duration_secs": args.planned_duration_secs,

--- a/crates/intrada-mobile/plugins/live-activity/src/lib.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/lib.rs
@@ -1,0 +1,199 @@
+//! Intrada internal Tauri plugin — drives an ActivityKit Live Activity
+//! for the duration of a practice session. Layers on top of the
+//! background-audio plugin: same lifecycle (None → Some → None as the
+//! WebView's `vm.active_session` changes), different surface.
+//!
+//! Phase B (#474): Rust commands accept the same shape Phase C will
+//! consume but currently return `Ok(())` — the Swift side is a
+//! placeholder that doesn't call ActivityKit yet. Spec:
+//! `specs/live-activity-plugin.md`.
+//!
+//! On non-iOS platforms the commands resolve to `Ok(())` without doing
+//! anything — the JS bindings call them unconditionally and we don't
+//! want them to error on web / macOS / Android / iPad (where Live
+//! Activities aren't supported).
+
+use serde::{Deserialize, Serialize};
+#[cfg(target_os = "ios")]
+use tauri::Manager;
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    AppHandle, Runtime,
+};
+
+#[cfg(target_os = "ios")]
+mod mobile;
+
+/// Errors surfaceable from plugin commands. Phase C surfaces native-side
+/// failures (ActivityKit `Activity.request` rejection, user disabled
+/// Live Activities in Settings, missing `NSSupportsLiveActivities`
+/// plist key) so the shell can decide whether to keep going with just
+/// the background-audio plugin.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Tauri / Swift bridge surfaced an error string.
+    #[error("live-activity: {0}")]
+    Bridge(String),
+}
+
+impl Serialize for Error {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        s.serialize_str(self.to_string().as_str())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Argument shape for `begin`. Field names use snake_case to match what
+/// JS sends; Swift's `Decodable` accepts the same shape.
+///
+/// `planned_duration_secs` is optional because not every entry has a
+/// planned duration set — the activity falls back to elapsed-only
+/// rendering in that case.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BeginArgs {
+    pub item_title: String,
+    pub position_label: String,
+    pub started_at: String,
+    pub planned_duration_secs: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateArgs {
+    pub item_title: String,
+    pub position_label: String,
+    pub started_at: String,
+    pub planned_duration_secs: Option<u32>,
+}
+
+/// Drop a Sentry breadcrumb tagged `live-activity` so any subsequent
+/// failure (here or elsewhere in the session) carries the lifecycle
+/// context. No-op when Sentry isn't initialised (simulator / dev /
+/// non-iOS), so cheap to call unconditionally.
+#[cfg(target_os = "ios")]
+fn breadcrumb(command: &str, data: serde_json::Value) {
+    sentry::add_breadcrumb(sentry::Breadcrumb {
+        category: Some("live-activity".to_string()),
+        message: Some(command.to_string()),
+        level: sentry::Level::Info,
+        data: data
+            .as_object()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+        ..Default::default()
+    });
+}
+
+/// Capture a plugin-bridge failure as a Sentry message tagged with the
+/// command name. ActivityKit failures mean the Live Activity didn't
+/// start / update — timer + lock-screen Now Playing (background-audio)
+/// still work, so this isn't fatal, but we want telemetry on the rate.
+#[cfg(target_os = "ios")]
+fn capture_bridge_error(command: &str, err: &Error) {
+    sentry::with_scope(
+        |scope| {
+            scope.set_tag("plugin", "live-activity");
+            scope.set_tag("command", command);
+        },
+        || {
+            sentry::capture_message(&format!("{err}"), sentry::Level::Error);
+        },
+    );
+}
+
+#[tauri::command]
+async fn begin<R: Runtime>(app: AppHandle<R>, args: BeginArgs) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb(
+            "begin",
+            serde_json::json!({
+                "item_title": &args.item_title,
+                "position_label": &args.position_label,
+                "started_at": &args.started_at,
+                "planned_duration_secs": args.planned_duration_secs,
+            }),
+        );
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("begin", args);
+        if let Err(err) = &result {
+            capture_bridge_error("begin", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = (app, args);
+        Ok(())
+    }
+}
+
+#[tauri::command]
+async fn update<R: Runtime>(app: AppHandle<R>, args: UpdateArgs) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb(
+            "update",
+            serde_json::json!({
+                "item_title": &args.item_title,
+                "position_label": &args.position_label,
+                "started_at": &args.started_at,
+                "planned_duration_secs": args.planned_duration_secs,
+            }),
+        );
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("update", args);
+        if let Err(err) = &result {
+            capture_bridge_error("update", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = (app, args);
+        Ok(())
+    }
+}
+
+#[tauri::command]
+async fn end<R: Runtime>(app: AppHandle<R>) -> Result<()> {
+    #[cfg(target_os = "ios")]
+    {
+        breadcrumb("end", serde_json::json!({}));
+        let state = app.state::<mobile::LiveActivity<R>>();
+        let result = state.run("end", ());
+        if let Err(err) = &result {
+            capture_bridge_error("end", err);
+        }
+        result
+    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}
+
+/// Plugin entry point — wired into the Tauri Builder in
+/// `intrada-mobile/src-tauri/src/lib.rs`.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("live-activity")
+        .invoke_handler(tauri::generate_handler![begin, update, end])
+        .setup(|app, _api| {
+            #[cfg(target_os = "ios")]
+            {
+                let handle = mobile::init(app, _api)?;
+                app.manage(handle);
+            }
+            // Suppress unused-variable warning on non-iOS targets where
+            // the setup hook is a no-op.
+            #[cfg(not(target_os = "ios"))]
+            {
+                let _ = app;
+            }
+            Ok(())
+        })
+        .build()
+}

--- a/crates/intrada-mobile/plugins/live-activity/src/mobile.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/mobile.rs
@@ -1,0 +1,42 @@
+//! iOS-only bridge: registers the Swift plugin and gives the Rust
+//! commands a typed handle for invoking its `@objc` methods. The
+//! `tauri::ios_plugin_binding!` macro generates the FFI binding to the
+//! `init_plugin_live_activity` C symbol exported by the Swift side
+//! (see `ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift`).
+
+use serde::Serialize;
+use tauri::{
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+tauri::ios_plugin_binding!(init_plugin_live_activity);
+
+/// Initializes the Swift plugin and returns a handle the commands can
+/// dispatch through. Stored on the AppHandle via `app.manage(...)` from
+/// the plugin's setup hook.
+pub fn init<R: Runtime, C: serde::de::DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> crate::Result<LiveActivity<R>> {
+    let handle = api
+        .register_ios_plugin(init_plugin_live_activity)
+        .map_err(|e| crate::Error::Bridge(e.to_string()))?;
+    Ok(LiveActivity(handle))
+}
+
+/// Wrapper around the Swift plugin's IPC handle.
+pub struct LiveActivity<R: Runtime>(pub PluginHandle<R>);
+
+impl<R: Runtime> LiveActivity<R> {
+    /// Generic "send `args` to the Swift method named `cmd`" — the
+    /// individual commands map their own typed payloads to this. Method
+    /// names match the Swift `@objc` selectors, which are snake_case
+    /// here so they line up 1:1 with the JS-side command names (no
+    /// translation needed in either direction).
+    pub fn run<P: Serialize>(&self, cmd: &str, payload: P) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin::<()>(cmd, payload)
+            .map_err(|e| crate::Error::Bridge(e.to_string()))
+    }
+}

--- a/crates/intrada-mobile/scripts/add-live-activity-target.rb
+++ b/crates/intrada-mobile/scripts/add-live-activity-target.rb
@@ -36,12 +36,21 @@ GEN_DIR     = MOBILE_ROOT.join('src-tauri/gen/apple')
 PROJECT_YML = GEN_DIR.join('project.yml')
 
 WIDGET_EXTENSION_ROOT = MOBILE_ROOT.join('widget-extension')
+SHARED_PACKAGE_ROOT   = MOBILE_ROOT.join('shared/IntradaActivityShared')
 
 # Bundle ID convention: append `.LiveActivity` to the main app's bundle
 # ID. Apple requires extension bundle IDs to be a child of the host
 # app's bundle ID for App Store submission.
 TARGET_NAME       = 'IntradaLiveActivity'
 TARGET_BUNDLE_ID  = 'com.intrada.app.LiveActivity'
+
+# Shared Swift package consumed by both this widget extension and the
+# tauri-plugin-live-activity Swift target. Hosts the
+# `IntradaActivityAttributes` type — the same identity must appear on
+# both sides of the `Activity<T>` / `ActivityConfiguration<T>`
+# boundary (Swift's type system enforces this).
+SHARED_PACKAGE_NAME    = 'IntradaActivityShared'
+SHARED_PACKAGE_PRODUCT = 'IntradaActivityShared'
 
 # Live Activities first shipped in iOS 16.1. Bumping above the main
 # app's deployment target (iOS 14.0 per project.yml) is fine — the
@@ -61,6 +70,14 @@ unless WIDGET_EXTENSION_ROOT.directory?
     ERROR: #{WIDGET_EXTENSION_ROOT} not found.
     The widget-extension/ directory is checked in — this script should be
     run from a clean checkout. If it's missing, your tree is broken.
+  ERR
+end
+
+unless SHARED_PACKAGE_ROOT.directory?
+  abort <<~ERR
+    ERROR: #{SHARED_PACKAGE_ROOT} not found.
+    The shared SwiftPM package (IntradaActivityShared) is checked in — this script
+    should be run from a clean checkout. If it's missing, your tree is broken.
   ERR
 end
 
@@ -87,8 +104,16 @@ end
 
 # ── Mutate ────────────────────────────────────────────────────────────
 # Paths in project.yml are relative to gen/apple/. We need to express
-# the path back up to crates/intrada-mobile/widget-extension/.
+# the path back up to crates/intrada-mobile/widget-extension/ and the
+# shared SwiftPM package directory.
 widget_rel = WIDGET_EXTENSION_ROOT.relative_path_from(GEN_DIR).to_s
+shared_rel = SHARED_PACKAGE_ROOT.relative_path_from(GEN_DIR).to_s
+
+# Declare the shared SwiftPM package at project scope so multiple
+# targets can depend on it. xcodegen merges this with whatever existing
+# `packages:` section Tauri's template has (currently empty).
+project['packages'] ||= {}
+project['packages'][SHARED_PACKAGE_NAME] = { 'path' => shared_rel }
 
 project['targets'][TARGET_NAME] = {
   'type'       => 'app-extension',
@@ -125,6 +150,13 @@ project['targets'][TARGET_NAME] = {
   'dependencies' => [
     { 'sdk' => 'WidgetKit.framework' },
     { 'sdk' => 'SwiftUI.framework' },
+    { 'sdk' => 'ActivityKit.framework' },
+    # Shared types (IntradaActivityAttributes) — declared in the
+    # project-scope `packages:` section above. Same package is also
+    # referenced by tauri-plugin-live-activity's Package.swift, so the
+    # SAME type identity reaches both the widget extension and the
+    # plugin's Activity<T>.request call.
+    { 'package' => SHARED_PACKAGE_NAME, 'product' => SHARED_PACKAGE_PRODUCT },
   ],
 }
 

--- a/crates/intrada-mobile/shared/IntradaActivityShared/Package.swift
+++ b/crates/intrada-mobile/shared/IntradaActivityShared/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.9
+// IntradaActivityShared — type definitions shared between the
+// tauri-plugin-live-activity Swift target and the IntradaLiveActivity
+// widget extension. Live Activities require the SAME `ActivityAttributes`
+// type identity on both sides — Swift's type system enforces this, so
+// duplicating the struct in two targets won't work; they have to share
+// a single declaration via a shared module.
+//
+// Spec: ../../../../specs/live-activity-plugin.md (Phase C, #474).
+
+import PackageDescription
+
+let package = Package(
+  name: "IntradaActivityShared",
+  platforms: [
+    // ActivityKit shipped in iOS 16.1. Targets older than that compile
+    // the type defs but never request an activity.
+    .iOS(.v16)
+  ],
+  products: [
+    .library(
+      name: "IntradaActivityShared",
+      type: .static,
+      targets: ["IntradaActivityShared"])
+  ],
+  targets: [
+    .target(
+      name: "IntradaActivityShared",
+      path: "Sources/IntradaActivityShared")
+  ]
+)

--- a/crates/intrada-mobile/shared/IntradaActivityShared/Package.swift
+++ b/crates/intrada-mobile/shared/IntradaActivityShared/Package.swift
@@ -13,9 +13,10 @@ import PackageDescription
 let package = Package(
   name: "IntradaActivityShared",
   platforms: [
-    // ActivityKit shipped in iOS 16.1. Targets older than that compile
-    // the type defs but never request an activity.
-    .iOS(.v16)
+    // ActivityKit shipped in iOS 16.1. The `ActivityAttributes`
+    // conformance on `IntradaActivityAttributes` is `@available(iOS
+    // 16.1, *)` gated, so the platform target needs to match.
+    .iOS("16.1")
   ],
   products: [
     .library(

--- a/crates/intrada-mobile/shared/IntradaActivityShared/Sources/IntradaActivityShared/IntradaActivityAttributes.swift
+++ b/crates/intrada-mobile/shared/IntradaActivityShared/Sources/IntradaActivityShared/IntradaActivityAttributes.swift
@@ -1,0 +1,79 @@
+// IntradaActivityAttributes — the ActivityAttributes type that backs
+// the Live Activity for the active practice session. Lives in a shared
+// SwiftPM target because Swift requires identical type identity (not
+// just structural matching) on both sides of the
+// `Activity<T>` / `ActivityConfiguration<T>` boundary:
+//
+//   - Plugin (`tauri-plugin-live-activity`) calls
+//     `Activity<IntradaActivityAttributes>.request(...)` to start /
+//     update / end activities.
+//   - Widget extension (`IntradaLiveActivity`) declares
+//     `ActivityConfiguration(for: IntradaActivityAttributes.self)` to
+//     provide the SwiftUI views WidgetKit renders on the Lock Screen +
+//     Dynamic Island.
+//
+// Both targets depend on this shared package (see their Package.swift /
+// project.yml entries).
+//
+// `ActivityAttributes` is iOS 16.1+; we gate the conformance with
+// `@available` so this file compiles on older targets (the rest of the
+// app supports iOS 14.0+) without forcing the whole shared target's
+// minimum up.
+
+#if canImport(ActivityKit)
+  import ActivityKit
+#endif
+import Foundation
+
+#if canImport(ActivityKit)
+
+  @available(iOS 16.1, *)
+  public struct IntradaActivityAttributes: ActivityAttributes {
+
+    /// Mutable state pushed by the plugin on item advance / planned
+    /// duration changes. Drives the SwiftUI views in the widget
+    /// extension. All four fields must be `Codable + Hashable` per
+    /// ActivityAttributes' contract.
+    public struct ContentState: Codable, Hashable {
+      /// Item title shown as the primary text on the lock-screen card
+      /// and the Dynamic Island expanded view.
+      public var itemTitle: String
+
+      /// "Item N of M" — secondary text. Pre-formatted by the
+      /// shell-side lifecycle Effect rather than the widget so we can
+      /// share the format with `MPNowPlayingInfoCenter` (background
+      /// audio).
+      public var positionLabel: String
+
+      /// Wall-clock anchor for elapsed-time math. The widget's SwiftUI
+      /// views use `Text(timerInterval:)` and
+      /// `ProgressView(timerInterval:)` so iOS handles the per-second
+      /// update without us pushing IPC traffic. We only push on item
+      /// advance.
+      public var startedAt: Date
+
+      /// Drives the progress arc / bar. `nil` when the entry has no
+      /// planned duration (free-form practice) — widget falls back to
+      /// elapsed-only rendering.
+      public var plannedDurationSecs: UInt32?
+
+      public init(
+        itemTitle: String,
+        positionLabel: String,
+        startedAt: Date,
+        plannedDurationSecs: UInt32? = nil
+      ) {
+        self.itemTitle = itemTitle
+        self.positionLabel = positionLabel
+        self.startedAt = startedAt
+        self.plannedDurationSecs = plannedDurationSecs
+      }
+    }
+
+    /// Static for the duration of the session. Currently empty —
+    /// reserved for future session-level metadata (theme, instrument,
+    /// goal text) that doesn't change item-to-item.
+    public init() {}
+  }
+
+#endif

--- a/crates/intrada-mobile/src-tauri/Cargo.toml
+++ b/crates/intrada-mobile/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-haptics = "2"
 tauri-plugin-deep-link = "2"
 tauri-plugin-background-audio = { path = "../plugins/background-audio" }
+tauri-plugin-live-activity = { path = "../plugins/live-activity" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/intrada-mobile/src-tauri/Info.ios.plist
+++ b/crates/intrada-mobile/src-tauri/Info.ios.plist
@@ -16,5 +16,14 @@
 	<array>
 		<string>audio</string>
 	</array>
+
+	<!--
+		NSSupportsLiveActivities: opt the host app into ActivityKit so
+		`Activity<IntradaActivityAttributes>.request(...)` from the
+		tauri-plugin-live-activity Swift target succeeds. Without this
+		key, ActivityKit rejects every request immediately. Phase C of #474.
+	-->
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 </dict>
 </plist>

--- a/crates/intrada-mobile/src-tauri/capabilities/mobile.json
+++ b/crates/intrada-mobile/src-tauri/capabilities/mobile.json
@@ -11,6 +11,7 @@
     "haptics:allow-notification-feedback",
     "haptics:allow-vibrate",
     "deep-link:default",
-    "background-audio:default"
+    "background-audio:default",
+    "live-activity:default"
   ]
 }

--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -34,10 +34,15 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_haptics::init())
         .plugin(tauri_plugin_deep_link::init())
-        // Phase B scaffold of #309 — Rust commands return Ok with no
-        // native side-effects. Phase C adds the AVAudioSession + Now
-        // Playing Swift impl behind the same command names.
+        // Background audio: AVAudioSession + Now Playing for the active
+        // practice session. Keeps the timer alive while the device is
+        // locked. (#309 — fully shipped.)
         .plugin(tauri_plugin_background_audio::init())
+        // Live Activity: Lock Screen + Dynamic Island for the active
+        // practice session. Phase B scaffold of #474 — Swift side
+        // resolves with no ActivityKit calls yet; Phase C wires the
+        // real Activity<...>.request / update / end.
+        .plugin(tauri_plugin_live_activity::init())
         .run(tauri::generate_context!())
         .expect("error while running intrada");
 }

--- a/crates/intrada-mobile/widget-extension/Sources/IntradaActivityWidget.swift
+++ b/crates/intrada-mobile/widget-extension/Sources/IntradaActivityWidget.swift
@@ -1,0 +1,178 @@
+// Phase C of #474 — SwiftUI views for the Live Activity.
+//
+// Three surfaces, one ActivityConfiguration:
+//   - Lock Screen / banner: full card with item title, position,
+//     elapsed time, and progress bar.
+//   - Dynamic Island compact: progress arc + elapsed time. Width is
+//     ~20pt + leading symbol; we lean on a circular ProgressView with
+//     a tiny inset elapsed time for at-a-glance reading.
+//   - Dynamic Island expanded: same primary content as the lock
+//     screen card but laid out for the wider expanded region.
+//   - Dynamic Island minimal: single icon (the user is in the Dynamic
+//     Island fast-switcher).
+//
+// All elapsed-time / progress views use `Text(timerInterval:)` and
+// `ProgressView(timerInterval:)` so iOS handles per-second updates
+// without IPC traffic. We push only on item advance.
+//
+// Spec: specs/live-activity-plugin.md
+
+#if canImport(ActivityKit)
+  import ActivityKit
+#endif
+import IntradaActivityShared
+import SwiftUI
+import WidgetKit
+
+@available(iOS 16.1, *)
+struct IntradaActivityWidget: Widget {
+  var body: some WidgetConfiguration {
+    ActivityConfiguration(for: IntradaActivityAttributes.self) { context in
+      // ── Lock Screen / banner view ────────────────────────────────
+      LockScreenView(state: context.state)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .activityBackgroundTint(Color.black.opacity(0.85))
+        .activitySystemActionForegroundColor(Color.white)
+    } dynamicIsland: { context in
+      DynamicIsland {
+        // ── Expanded ── (regions: leading, trailing, center, bottom)
+        DynamicIslandExpandedRegion(.leading) {
+          Image(systemName: "music.note")
+            .foregroundStyle(.tint)
+            .font(.title2)
+        }
+        DynamicIslandExpandedRegion(.trailing) {
+          ElapsedTimeText(startedAt: context.state.startedAt)
+            .font(.title3.monospacedDigit())
+            .foregroundStyle(.primary)
+        }
+        DynamicIslandExpandedRegion(.center) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text(context.state.itemTitle)
+              .font(.headline)
+              .lineLimit(1)
+            Text(context.state.positionLabel)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+          }
+        }
+        DynamicIslandExpandedRegion(.bottom) {
+          if let planned = context.state.plannedDurationSecs, planned > 0 {
+            ProgressView(
+              timerInterval: context.state.startedAt...endDate(
+                from: context.state.startedAt, addingSecs: planned),
+              countsDown: false,
+              label: { EmptyView() },
+              currentValueLabel: { EmptyView() }
+            )
+            .tint(.indigo)
+          }
+        }
+      } compactLeading: {
+        // Progress arc when planned duration is set; clock icon
+        // otherwise. The arc gives a glanceable "how far through this
+        // item am I" signal without any text.
+        if let planned = context.state.plannedDurationSecs, planned > 0 {
+          CompactArc(
+            startedAt: context.state.startedAt,
+            plannedDurationSecs: planned
+          )
+          .frame(width: 18, height: 18)
+        } else {
+          Image(systemName: "music.note")
+            .foregroundStyle(.tint)
+        }
+      } compactTrailing: {
+        ElapsedTimeText(startedAt: context.state.startedAt)
+          .font(.caption.monospacedDigit())
+          .foregroundStyle(.primary)
+      } minimal: {
+        Image(systemName: "music.note")
+          .foregroundStyle(.tint)
+      }
+      .keylineTint(.indigo)
+    }
+  }
+}
+
+// MARK: - Lock Screen view
+
+@available(iOS 16.1, *)
+struct LockScreenView: View {
+  let state: IntradaActivityAttributes.ContentState
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(state.itemTitle)
+            .font(.headline)
+            .lineLimit(1)
+          Text(state.positionLabel)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+        Spacer(minLength: 12)
+        ElapsedTimeText(startedAt: state.startedAt)
+          .font(.title2.monospacedDigit())
+          .foregroundStyle(.primary)
+      }
+
+      if let planned = state.plannedDurationSecs, planned > 0 {
+        ProgressView(
+          timerInterval: state.startedAt...endDate(from: state.startedAt, addingSecs: planned),
+          countsDown: false,
+          label: { EmptyView() },
+          currentValueLabel: { EmptyView() }
+        )
+        .progressViewStyle(.linear)
+        .tint(.indigo)
+      }
+    }
+  }
+}
+
+// MARK: - Shared time helpers
+
+/// Auto-updating elapsed-time text — iOS handles per-second redraws
+/// internally when the view uses `Text(timerInterval:)`. The activity
+/// only pushes new state on item advance, not per second.
+@available(iOS 16.0, *)
+struct ElapsedTimeText: View {
+  let startedAt: Date
+  var body: some View {
+    // Open-ended interval so the text counts up indefinitely from
+    // `startedAt`. iOS uses the system clock to refresh.
+    Text(timerInterval: startedAt...Date.distantFuture, countsDown: false)
+  }
+}
+
+/// Tiny circular progress arc for the Dynamic Island compact-leading
+/// region. Same auto-updating story as `ElapsedTimeText`.
+@available(iOS 16.1, *)
+struct CompactArc: View {
+  let startedAt: Date
+  let plannedDurationSecs: UInt32
+
+  var body: some View {
+    ProgressView(
+      timerInterval: startedAt...endDate(from: startedAt, addingSecs: plannedDurationSecs),
+      countsDown: false,
+      label: { EmptyView() },
+      currentValueLabel: { EmptyView() }
+    )
+    .progressViewStyle(.circular)
+    .tint(.indigo)
+  }
+}
+
+/// Helper: compute end-Date by adding `secs` to `startedAt`. Pulled out
+/// because both lock-screen and Dynamic Island ProgressViews compute it
+/// the same way.
+@available(iOS 16.0, *)
+fileprivate func endDate(from startedAt: Date, addingSecs secs: UInt32) -> Date {
+  startedAt.addingTimeInterval(TimeInterval(secs))
+}

--- a/crates/intrada-mobile/widget-extension/Sources/IntradaWidgetBundle.swift
+++ b/crates/intrada-mobile/widget-extension/Sources/IntradaWidgetBundle.swift
@@ -1,54 +1,20 @@
+// Phase C of #474 — Live Activity widget bundle entry point.
+//
+// The widget extension target's deployment is iOS 16.1+ (set by
+// `add-live-activity-target.rb` via `IPHONEOS_DEPLOYMENT_TARGET`), so
+// `IntradaActivityWidget` is unconditionally available — no
+// `@available` fallback needed at the bundle level. WidgetBundleBuilder
+// doesn't support `if` control flow anyway, so this is also the only
+// shape the result builder accepts.
+//
+// Spec: specs/live-activity-plugin.md
+
 import SwiftUI
 import WidgetKit
 
-/// Widget extension entry point.
-///
-/// Phase A (#474): placeholder bundle so the widget extension target
-/// builds clean. Phase C swaps `IntradaPlaceholderWidget` for the
-/// `ActivityWidget` that renders the Live Activity SwiftUI views (Lock
-/// Screen card + Dynamic Island compact / expanded).
-///
-/// We need *something* in `body` because `WidgetBundle` requires at
-/// least one widget for the bundle to be valid. The placeholder is a
-/// home-screen widget that isn't surfaced to the user (no
-/// `Configuration` flag enabling it as a home-screen option) — it's
-/// purely there to keep the build green until ActivityKit lands.
 @main
 struct IntradaWidgetBundle: WidgetBundle {
-    var body: some Widget {
-        IntradaPlaceholderWidget()
-    }
-}
-
-/// Phase A placeholder. Renders nothing useful; replaced by the
-/// `ActivityWidget` in Phase C. See `specs/live-activity-plugin.md`.
-struct IntradaPlaceholderWidget: Widget {
-    var body: some WidgetConfiguration {
-        StaticConfiguration(
-            kind: "intrada-placeholder",
-            provider: IntradaPlaceholderProvider()
-        ) { _ in
-            Text("Intrada")
-        }
-        .configurationDisplayName("Intrada")
-        .description("Phase A placeholder. Phase C adds the Live Activity.")
-    }
-}
-
-struct IntradaPlaceholderProvider: TimelineProvider {
-    func placeholder(in _: Context) -> IntradaPlaceholderEntry {
-        IntradaPlaceholderEntry(date: Date())
-    }
-
-    func getSnapshot(in _: Context, completion: @escaping (IntradaPlaceholderEntry) -> Void) {
-        completion(IntradaPlaceholderEntry(date: Date()))
-    }
-
-    func getTimeline(in _: Context, completion: @escaping (Timeline<IntradaPlaceholderEntry>) -> Void) {
-        completion(Timeline(entries: [IntradaPlaceholderEntry(date: Date())], policy: .never))
-    }
-}
-
-struct IntradaPlaceholderEntry: TimelineEntry {
-    let date: Date
+  var body: some Widget {
+    IntradaActivityWidget()
+  }
 }

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -23,9 +23,9 @@ use crate::views::{
     LibraryListView, NotFoundView, SessionActiveView, SessionNewView, SessionSummaryView,
     SessionsAllView, SessionsListView, SetDetailView, SetEditView, SettingsView,
 };
-use intrada_web::background_audio;
 use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::{init_core, load_session_in_progress, process_effects};
+use intrada_web::session_lifecycle;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// App-level signal for focus mode — when true, navigation and non-essential UI are hidden.
@@ -170,14 +170,16 @@ fn AuthenticatedApp() -> impl IntoView {
         }
     }
 
-    // Background-audio plugin lifecycle (#309 Phase D). Mounted at the
-    // app level so the Some → None transition fires `end_session()` even
+    // Session-lifecycle Effect (#309 Phase D + #474 Phase B). Drives
+    // both the background-audio plugin (lock-screen Now Playing /
+    // AVAudioSession) and the live-activity plugin (Lock Screen +
+    // Dynamic Island) from the same vm.active_session transitions.
+    // Mounted at the app level so Some → None fires the end calls even
     // when the user navigates away from /sessions/active before
     // finishing — e.g. backing to home, switching tabs, or hitting
-    // "Discard Session" from /sessions/new. Mounting inside <SessionTimer>
-    // would unmount the Effect alongside the route and leak the iOS
-    // AVAudioSession + silent loop until the OS reclaims it.
-    background_audio::mount_background_audio_lifecycle(view_model);
+    // "Discard Session" from /sessions/new. Mounting inside
+    // <SessionTimer> would leak both plugins.
+    session_lifecycle::mount_session_lifecycle(view_model);
 
     view! {
         <div class="relative z-0 min-h-screen text-primary">

--- a/crates/intrada-web/src/background_audio.rs
+++ b/crates/intrada-web/src/background_audio.rs
@@ -1,7 +1,4 @@
-use leptos::prelude::*;
 use wasm_bindgen::prelude::*;
-
-use intrada_core::ViewModel;
 
 // Calls Tauri plugin-background-audio commands via the Tauri IPC invoke
 // bridge. All functions are no-ops outside a Tauri context (web browser,
@@ -9,6 +6,10 @@ use intrada_core::ViewModel;
 // as Rust errors — the timer continues working even if the audio session
 // can't be activated. The Rust plugin captures failures into Sentry so
 // we still get telemetry without surfacing UI banners users can't act on.
+//
+// Lifecycle orchestration lives in `session_lifecycle.rs` — a single
+// Effect drives both this plugin and the live-activity plugin from the
+// same `vm.active_session` transitions.
 #[wasm_bindgen(inline_js = "
     function bg_audio_invoke(cmd, args) {
         try {
@@ -37,56 +38,4 @@ extern "C" {
     /// Release the audio session + clear Now Playing on session end.
     /// No-op outside Tauri.
     pub fn end_session();
-}
-
-/// Mount the background-audio lifecycle Effect on the global `ViewModel`
-/// signal. Tracks `current_item_started_at` across renders so we can tell
-/// session start (None → Some), item advance (anchor change), and session
-/// end (Some → None) apart with a single Effect.
-///
-/// Must be called from a Leptos owner scope that lives for the duration of
-/// the user's authenticated app session — i.e. `AuthenticatedApp`, not a
-/// per-route component. Mounting this inside `<SessionTimer>` would leak
-/// the audio session: when the user navigates away from `/sessions/active`
-/// without finishing (e.g. taps a tab, hits Discard from `/sessions/new`)
-/// the timer unmounts before the Effect can observe `Some → None`, so
-/// `end_session()` never fires and the AVAudioSession stays active until
-/// the OS reclaims it.
-///
-/// The Effect re-fires on every ViewModel push (coarser than ideal — any
-/// unrelated VM mutation triggers it) but the anchor-equality guard makes
-/// that idempotent.
-pub fn mount_background_audio_lifecycle(view_model: RwSignal<ViewModel>) {
-    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
-    Effect::new(move |_| {
-        let next = view_model.with(|vm| {
-            vm.active_session.as_ref().map(|a| {
-                (
-                    a.current_item_title.clone(),
-                    a.current_position,
-                    a.total_items,
-                    a.current_item_started_at.clone(),
-                )
-            })
-        });
-        let prev = prev_anchor.get_untracked();
-        match (prev, next) {
-            (None, Some((title, _pos, _total, started_at))) => {
-                begin_session(&title, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(prev_anchor_val), Some((title, pos, total, started_at)))
-                if prev_anchor_val != started_at =>
-            {
-                let position_label = format!("Item {} of {}", pos + 1, total);
-                set_now_playing(&title, &position_label, &started_at);
-                prev_anchor.set(Some(started_at));
-            }
-            (Some(_), None) => {
-                end_session();
-                prev_anchor.set(None);
-            }
-            _ => {}
-        }
-    });
 }

--- a/crates/intrada-web/src/lib.rs
+++ b/crates/intrada-web/src/lib.rs
@@ -5,5 +5,7 @@ pub mod core_bridge;
 pub mod haptics;
 pub mod helpers;
 pub mod hooks;
+pub mod live_activity;
+pub mod session_lifecycle;
 pub mod types;
 pub mod validation;

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -1,0 +1,60 @@
+use wasm_bindgen::prelude::*;
+
+// Calls Tauri plugin-live-activity commands via the Tauri IPC invoke
+// bridge. All functions are no-ops outside a Tauri context (web browser,
+// E2E tests, iPad — Live Activities are iPhone-only). The try/catch in
+// JS ensures plugin failures never surface as Rust errors. The Rust
+// plugin captures failures into Sentry so we still get telemetry
+// without surfacing UI banners users can't act on.
+//
+// Mirrors the shape of `intrada-web/src/background_audio.rs` so both
+// plugins can be driven from the same lifecycle Effect (see
+// `mount_session_lifecycle` in `background_audio.rs`).
+#[wasm_bindgen(inline_js = "
+    function live_activity_invoke(cmd, args) {
+        try {
+            const invoke =
+                window.__TAURI__?.core?.invoke ??
+                window.__TAURI_INTERNALS__?.invoke;
+            if (invoke) invoke(cmd, args ?? {});
+        } catch(e) {}
+    }
+    export function begin(item_title, position_label, started_at, planned_duration_secs) {
+        live_activity_invoke('plugin:live-activity|begin', {
+            item_title,
+            position_label,
+            started_at,
+            planned_duration_secs: planned_duration_secs ?? null,
+        });
+    }
+    export function update(item_title, position_label, started_at, planned_duration_secs) {
+        live_activity_invoke('plugin:live-activity|update', {
+            item_title,
+            position_label,
+            started_at,
+            planned_duration_secs: planned_duration_secs ?? null,
+        });
+    }
+    export function end() {
+        live_activity_invoke('plugin:live-activity|end');
+    }
+")]
+extern "C" {
+    /// Start a Live Activity for the active practice session. No-op
+    /// outside Tauri / on iPad.
+    pub fn begin(
+        item_title: &str,
+        position_label: &str,
+        started_at: &str,
+        planned_duration_secs: Option<u32>,
+    );
+    /// Update the Live Activity on item advance. No-op outside Tauri.
+    pub fn update(
+        item_title: &str,
+        position_label: &str,
+        started_at: &str,
+        planned_duration_secs: Option<u32>,
+    );
+    /// End the Live Activity. No-op outside Tauri.
+    pub fn end();
+}

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::*;
 //
 // Mirrors the shape of `intrada-web/src/background_audio.rs` so both
 // plugins can be driven from the same lifecycle Effect (see
-// `mount_session_lifecycle` in `background_audio.rs`).
+// `mount_session_lifecycle` in `session_lifecycle.rs`).
 #[wasm_bindgen(inline_js = "
     function live_activity_invoke(cmd, args) {
         try {

--- a/crates/intrada-web/src/session_lifecycle.rs
+++ b/crates/intrada-web/src/session_lifecycle.rs
@@ -1,0 +1,81 @@
+use leptos::prelude::*;
+
+use intrada_core::ViewModel;
+
+use crate::{background_audio, live_activity};
+
+/// Mount the session-lifecycle Effect on the global `ViewModel` signal.
+/// Tracks `current_item_started_at` across renders so we can tell session
+/// start (None → Some), item advance (anchor change), and session end
+/// (Some → None) apart with a single Effect, then fans the transition
+/// out to *both* native plugins:
+///
+/// - `background-audio` (#309) — keeps the timer alive while the device
+///   is locked + shows a Now Playing card.
+/// - `live-activity` (#474) — Lock Screen + Dynamic Island for the
+///   active session. Layered on top, not a replacement.
+///
+/// One Effect, two side-effects: avoids two parallel observers racing
+/// with divergent ordering.
+///
+/// # Where this must be mounted
+///
+/// Must be called from a Leptos owner scope that lives for the duration
+/// of the user's authenticated app session — i.e. `AuthenticatedApp`,
+/// not a per-route component. Mounting this inside `<SessionTimer>`
+/// would leak both plugins' state: when the user navigates away from
+/// `/sessions/active` without finishing (e.g. taps a tab, hits Discard
+/// from `/sessions/new`) the timer unmounts before the Effect can
+/// observe `Some → None`, so the `end` transition never fires and the
+/// AVAudioSession + Live Activity stay active until the OS reclaims
+/// them. (See #309 Phase D for the original observation.)
+///
+/// # Reactivity
+///
+/// The Effect re-fires on every ViewModel push (coarser than ideal —
+/// any unrelated VM mutation triggers it) but the anchor-equality guard
+/// makes that idempotent. If we ever care about the wasted work, a
+/// Memo<Option<String>> over current_item_started_at would isolate the
+/// dependency.
+pub fn mount_session_lifecycle(view_model: RwSignal<ViewModel>) {
+    let prev_anchor: RwSignal<Option<String>> = RwSignal::new(None);
+    Effect::new(move |_| {
+        let next = view_model.with(|vm| {
+            vm.active_session.as_ref().map(|a| {
+                (
+                    a.current_item_title.clone(),
+                    a.current_position,
+                    a.total_items,
+                    a.current_item_started_at.clone(),
+                    a.current_planned_duration_secs,
+                )
+            })
+        });
+        let prev = prev_anchor.get_untracked();
+        match (prev, next) {
+            // Session start: vm.active_session went from None to Some.
+            (None, Some((title, pos, total, started_at, planned))) => {
+                let position_label = format!("Item {} of {}", pos + 1, total);
+                background_audio::begin_session(&title, &started_at);
+                live_activity::begin(&title, &position_label, &started_at, planned);
+                prev_anchor.set(Some(started_at));
+            }
+            // Item advance: same session, new item anchor.
+            (Some(prev_anchor_val), Some((title, pos, total, started_at, planned)))
+                if prev_anchor_val != started_at =>
+            {
+                let position_label = format!("Item {} of {}", pos + 1, total);
+                background_audio::set_now_playing(&title, &position_label, &started_at);
+                live_activity::update(&title, &position_label, &started_at, planned);
+                prev_anchor.set(Some(started_at));
+            }
+            // Session end: vm.active_session went from Some to None.
+            (Some(_), None) => {
+                background_audio::end_session();
+                live_activity::end();
+                prev_anchor.set(None);
+            }
+            _ => {}
+        }
+    });
+}

--- a/specs/live-activity-plugin.md
+++ b/specs/live-activity-plugin.md
@@ -227,28 +227,32 @@ the WebView's session_timer.
    than spawning a parallel one — one observer of session state, two
    side-effects.
 
+## Decisions locked
+
+- **Widget extension setup** (was open question §1): post-`init` Ruby
+  script using stdlib YAML + xcodegen. Implemented in Phase A as
+  `crates/intrada-mobile/scripts/add-live-activity-target.rb`.
+- **Dismissal policy** (was §2): `.immediate`. The activity disappears
+  from the lock screen + Dynamic Island within ~1s of session end.
+  Apple's `.default` keeps it in the Recent tray for ~8h, but for a
+  practice app the activity is no longer relevant once the user puts
+  the instrument down. Phase C uses `.immediate`.
+- **Compact Dynamic Island content** (was §3): progress arc + elapsed
+  time. Arc fills against `current_planned_duration_secs`; falls back
+  to indeterminate / elapsed-only when no planned duration is set.
+
 ## Open questions
 
-1. **Widget extension target setup in Tauri 2.** The single biggest
-   unknown. Phase A validates the chosen approach (manual / scripted /
-   upstream Tauri PR) before the Swift implementation is locked in.
-2. **Activity dismissal policy.** `.immediate` vs `.after(date)` vs
-   `.default`. Default keeps the activity in the user's Recent tray for
-   8 hours after end — useful "you finished a session" reminder, or
-   distracting clutter? Try both and pick.
-3. **Compact Dynamic Island content.** Width is severely limited
-   (~20pt + leading symbol). Options: (a) elapsed time only ("12:34"),
-   (b) progress arc + elapsed, (c) item-type icon + elapsed. Need to
-   eyeball on device.
-4. **Activity bundle ID + signing.** The widget extension is a separate
-   bundle (`com.intrada.app.LiveActivity`?) and needs its own
-   provisioning profile. May surface as a new step in the
-   "first-time iOS setup" section of CLAUDE.md.
-5. **Failure modes if `Activity.request` throws** (user disabled Live
-   Activities in Settings, or the app's
-   `NSSupportsLiveActivities` plist key is missing). Sentry-capture and
-   continue silently — same pattern as background-audio bridge errors.
-6. **Asset sharing.** If the lock-screen card uses the intrada logo or
+1. **Activity bundle ID + signing.** The widget extension is a separate
+   bundle (`com.intrada.app.LiveActivity` proposed) and needs its own
+   provisioning profile. Surfaces as a new step in the "first-time iOS
+   setup" section of CLAUDE.md alongside the `add-live-activity-target.rb`
+   script invocation.
+2. **Failure modes if `Activity.request` throws** (user disabled Live
+   Activities in Settings, or the app's `NSSupportsLiveActivities`
+   plist key is missing). Sentry-capture and continue silently — same
+   pattern as background-audio bridge errors.
+3. **Asset sharing.** If the lock-screen card uses the intrada logo or
    an item-type icon, the widget extension target needs the asset
    bundled. Determine whether to share the main-app asset catalogue or
    duplicate.


### PR DESCRIPTION
## Summary

- **ActivityKit calls** in the plugin Swift — \`Activity<T>.request\` / \`update\` / \`end\` with \`dismissalPolicy: .immediate\`
- **Widget extension** SwiftUI views: Lock Screen card, Dynamic Island compact (progress arc + elapsed) / expanded / minimal
- **Shared SwiftPM package** for \`IntradaActivityAttributes\` (Swift requires identical type identity on both sides of \`Activity<T>\` / \`ActivityConfiguration<T>\`)
- \`NSSupportsLiveActivities\` opt-in via \`Info.ios.plist\`
- Includes Phase B re-applied (#491 was merged into Phase A's branch but lost in the squash to main)

## What this delivers

Once on device with iOS 16.1+:
- Start a session → Lock Screen card appears with item title, position label, auto-updating elapsed time, progress bar (when planned duration is set)
- iPhone 14 Pro+ → Dynamic Island compact-leading shows a progress arc; compact-trailing shows elapsed time; long-press / expand to see full info
- Item advance → card updates within ~1s (no IPC traffic between updates — iOS handles the per-second tick)
- Finish / End / Abandon → activity disappears within ~1s

## Architecture: shared SwiftPM package

Live Activities require the SAME \`ActivityAttributes\` type identity on both sides of \`Activity<T>.request\` (plugin) and \`ActivityConfiguration<T>\` (widget extension). Swift's type system enforces this — duplicating the struct in two targets doesn't work.

New package at \`crates/intrada-mobile/shared/IntradaActivityShared/\` hosts the type. Both:
- The plugin's \`Package.swift\` declares it as a SwiftPM dependency
- The widget extension's xcodegen target declares it via \`packages:\` and references it as \`{ package: IntradaActivityShared, product: IntradaActivityShared }\` in dependencies

\`add-live-activity-target.rb\` was extended to handle this wiring.

## Verification

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace --exclude tauri-plugin-{background-audio,live-activity}\` clean
- [x] \`cargo clippy -p tauri-plugin-live-activity --target aarch64-apple-ios\` clean
- [x] \`cargo test --workspace --exclude tauri-plugin-{background-audio,live-activity}\` → 432 pass
- [x] Fresh \`cargo tauri ios init\` → \`fix-ios-build-config.rb\` → \`add-live-activity-target.rb\` → \`cargo tauri ios build --target aarch64\` → \`Intrada.ipa\`
- [x] Verified \`Payload/Intrada.app/PlugIns/IntradaLiveActivity.appex\` is embedded + code-signed in the IPA
- [ ] **Device test required** (Live Activities have flaky simulator support):
  - Start session → Lock Screen card appears with item title + elapsed advancing
  - Lock phone for 5 minutes → unlock → elapsed is correct (no jump)
  - iPhone 14 Pro+: Dynamic Island compact shows progress arc + elapsed
  - Long-press Dynamic Island → expanded view
  - Item advance → card updates within ~1s
  - Finish → card disappears within ~1s (\`.immediate\` dismissal)
  - Crash mid-session: relaunching the app cleans up the stale activity
  - User has Live Activities disabled in Settings → app doesn't crash, Sentry captures the rejection

## On-device tests Phase C alone can't cover

ActivityKit's behaviour with the IPC roundtrip can only be verified on a real iPhone — simulators emit Activity views but the bridge from JS → Rust → Swift may behave differently on device. Document any device-only bugs that surface as Phase D follow-ups.

## Self-review

- ✅ \`@available(iOS 16.1, *)\` gating at every ActivityKit call site; older iOS resolves the IPC silently
- ✅ \`#if canImport(ActivityKit)\` around the import (plugin compiles for any target SDK)
- ✅ \`endCurrentActivityIfAny()\` runs at start of \`begin\` so a stale activity from a previous session (crash recovery) doesn't trigger \`.tooManyActivitiesForApplication\`
- ✅ All ActivityKit state mutation on the main queue (mirrors background-audio's pattern)
- ✅ \`update\` no-ops if no activity is in flight (handles race where the shell-side lifecycle Effect runs ahead of iOS state)
- ✅ Cached \`ISO8601DateFormatter\` instances (mirror background-audio)
- ✅ \`dismissalPolicy: .immediate\` per spec decision
- ✅ Widget views use \`Text(timerInterval:)\` / \`ProgressView(timerInterval:)\` for free per-second updates without IPC chatter

## Out of scope (Phase D)

- Bundle ID / signing documentation (CLAUDE.md update)
- Asset bundling — we use SF Symbols today; revisit if the design wants a custom Intrada glyph in the Dynamic Island
- Sentry-side dashboarding for activity request failures (we're already capturing them; the dashboard config is separate)
- Edge case from review of #491: planned-duration-changes-mid-item not triggering update (#496)

🤖 Generated with [Claude Code](https://claude.com/claude-code)