### PR TITLE
feat(observability): Sentry release lifecycle + distributed tracing + breadcrumbs (re-stack)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   RUST_VERSION: "1.89.0"
+  SENTRY_ORG: jon-yardley
 
 jobs:
   # Detects which paths changed in the PR — used to skip jobs whose inputs
@@ -234,11 +235,32 @@ jobs:
         with:
           name: web-dist
           path: crates/intrada-web/dist
+      # Inject the release id into the prebuilt index.html before publishing.
+      # The placeholder is set in the source — this swap only happens in the
+      # main-branch deploy path, so PR builds keep `release: undefined`.
+      - name: Inject Sentry release into index.html
+        run: |
+          sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|${{ github.sha }}|g" crates/intrada-web/dist/index.html
+          grep -q "${{ github.sha }}" crates/intrada-web/dist/index.html
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Tag the release in Sentry once Cloudflare has the build. Failure
+      # here shouldn't block a successful deploy, so continue-on-error.
+      - name: Create Sentry release (intrada-web)
+        if: env.SENTRY_AUTH_TOKEN != ''
+        continue-on-error: true
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_PROJECT: intrada-web
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          set_commits: auto
+          finalize: true
 
   deploy-api:
     name: Deploy API to Fly.io
@@ -248,6 +270,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --remote-only --build-arg GIT_SHA=${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Create Sentry release (intrada-api)
+        if: env.SENTRY_AUTH_TOKEN != ''
+        continue-on-error: true
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_PROJECT: intrada-api
+        with:
+          environment: production
+          version: ${{ github.sha }}
+          set_commits: auto
+          finalize: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,15 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json --bin intrada-api
 # Build application
 COPY . .
+# Baked into the binary at compile time via `option_env!("GIT_SHA")` and
+# reported to Sentry as the `release` so events tie to deploys. Defaulted
+# empty so local `docker build` without --build-arg still works.
+# Placed AFTER cargo-chef cook so changes to GIT_SHA per deploy don't bust
+# the dependency-build cache (the most expensive layer); only the final
+# application-build layer re-runs, gated by build.rs's
+# `cargo:rerun-if-env-changed=GIT_SHA`.
+ARG GIT_SHA=""
+ENV GIT_SHA=$GIT_SHA
 RUN cargo build --release --bin intrada-api
 
 # Runtime image — no Rust toolchain needed.

--- a/crates/intrada-api/build.rs
+++ b/crates/intrada-api/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Pair with `option_env!("GIT_SHA")` in src/main.rs so changing the env
+    // (e.g. across CI deploys) invalidates the cached compile and the right
+    // value is baked into the binary. Without this, cargo can serve a stale
+    // const from a previous build.
+    println!("cargo:rerun-if-env-changed=GIT_SHA");
+}

--- a/crates/intrada-api/src/main.rs
+++ b/crates/intrada-api/src/main.rs
@@ -14,7 +14,14 @@ async fn main() {
         sentry::init((
             dsn,
             sentry::ClientOptions {
-                release: option_env!("GIT_SHA").map(Into::into),
+                // Filter the empty string explicitly: `option_env!` returns
+                // `Some("")` (not `None`) when the env var is set to "" at
+                // build time — which would tag every event with an empty
+                // release rather than no release. Mirrors the same guard in
+                // `intrada-mobile/src-tauri/src/lib.rs`.
+                release: option_env!("GIT_SHA")
+                    .filter(|s| !s.is_empty())
+                    .map(Into::into),
                 environment: Some(
                     if cfg!(debug_assertions) {
                         "development"

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -45,6 +45,13 @@
           // traffic arrives — every transaction counts against quota.
           tracesSampleRate: 1.0,
           sendDefaultPii: false,
+          // Continue traces across the web → API boundary so one waterfall
+          // shows route render → fetch → handler → DB. The Rust server's
+          // SentryHttpLayer (intrada-api/src/routes/mod.rs) reads the
+          // `sentry-trace` + `baggage` headers this propagation injects.
+          // Strings: production hostname. Regex: dev path (Trunk proxies
+          // /api/* to the local API server).
+          tracePropagationTargets: ["intrada-api.fly.dev", /\/api\//],
           integrations: [Sentry.browserTracingIntegration()],
           // Defensive scrubber alongside sendDefaultPii: false. Any throw
           // here would drop the event entirely — keep wrapped in try/catch

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Intrada</title>
 
+    <!-- Release tag for Sentry. Defaults to null (PR builds, local dev) and
+         is replaced by CI's deploy step with `sed` before publishing to
+         Cloudflare — the literal string `__SENTRY_RELEASE_PLACEHOLDER__`
+         is the swap target. Keep this script BEFORE the Sentry SDK so the
+         init below can read it. -->
+    <script>window.__SENTRY_RELEASE__ = "__SENTRY_RELEASE_PLACEHOLDER__";</script>
+
     <!-- Sentry browser SDK. Loaded synchronously in <head> so it's ready
          before any other script runs — catches errors from the inline
          scripts below (data-platform setup, press feedback, Clerk bridge)
@@ -23,8 +30,15 @@
         var isWebDev = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
           && location.protocol !== 'tauri:';
         if (isWebDev) return;
+        var release = window.__SENTRY_RELEASE__;
+        // Treat the unsubstituted placeholder (PR builds, local dev) as no
+        // release — undefined disables release tagging cleanly.
+        if (typeof release !== 'string' || release.indexOf('PLACEHOLDER') !== -1) {
+          release = undefined;
+        }
         Sentry.init({
           dsn: "https://2a33748d4de845f26e3711629e47b38f@o4511313186979840.ingest.de.sentry.io/4511313298980944",
+          release: release,
           environment: location.protocol === 'tauri:' ? 'ios' : 'production',
           // Bumped from 0.1 → 1.0 while traffic is single-digit-user (just
           // @jonyardley testing). Dial back to 0.1 (or 0.01) once real

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -74,6 +74,11 @@ pub fn App() -> impl IntoView {
                     if let Some(id) = clerk_bindings::get_user_id() {
                         clerk_bindings::sentry_set_user(&id);
                     }
+                    // No breadcrumb here — Clerk's `addListener` fires
+                    // immediately on subscribe with the current state, so the
+                    // listener path below catches both fresh and warm sign-ins
+                    // and emits the breadcrumb there. Emitting here too would
+                    // double-fire on every load.
                     is_authenticated.set(true);
                     auth_loading.set(false);
                     return;
@@ -99,8 +104,10 @@ pub fn App() -> impl IntoView {
                 if let Some(id) = clerk_bindings::get_user_id() {
                     clerk_bindings::sentry_set_user(&id);
                 }
+                clerk_bindings::sentry_breadcrumb("auth", "signed-in", "info");
             } else {
                 clerk_bindings::sentry_clear_user();
+                clerk_bindings::sentry_breadcrumb("auth", "signed-out", "info");
             }
             is_authenticated.set(signed_in);
             auth_loading.set(false);

--- a/crates/intrada-web/src/clerk_bindings.rs
+++ b/crates/intrada-web/src/clerk_bindings.rs
@@ -68,6 +68,15 @@ use wasm_bindgen::prelude::*;
             window.Sentry.setUser(null);
         }
     }
+    export function js_sentry_breadcrumb(category, message, level) {
+        if (window.Sentry) {
+            window.Sentry.addBreadcrumb({
+                category: category,
+                message: message,
+                level: level || 'info',
+            });
+        }
+    }
 ")]
 extern "C" {
     fn js_init_clerk(key: &str);
@@ -81,6 +90,7 @@ extern "C" {
     fn js_add_auth_listener(callback: &Closure<dyn Fn()>);
     fn js_sentry_set_user(id: &str);
     fn js_sentry_clear_user();
+    fn js_sentry_breadcrumb(category: &str, message: &str, level: &str);
 }
 
 /// Initialize Clerk with the publishable key.
@@ -148,4 +158,13 @@ pub fn sentry_set_user(id: &str) {
 /// Clear the Sentry user scope. Call on sign-out.
 pub fn sentry_clear_user() {
     js_sentry_clear_user();
+}
+
+/// Add a Sentry breadcrumb attached to subsequent events. Use at key UX
+/// moments (auth lifecycle, session lifecycle, sync failures) so that the
+/// "what was the user doing 5s before this crash" question has answers.
+/// `level` should be one of: "fatal", "error", "warning", "info", "debug".
+/// No-op if Sentry isn't loaded.
+pub fn sentry_breadcrumb(category: &str, message: &str, level: &str) {
+    js_sentry_breadcrumb(category, message, level);
 }

--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -3,6 +3,7 @@ use leptos::prelude::*;
 use intrada_core::{Event, SessionEvent, SetEvent, ViewModel};
 
 use crate::components::{BottomSheet, EditorEntry, EntryListEditor, SetSaveForm};
+use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::{process_effects, process_effects_with_core};
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
@@ -34,6 +35,7 @@ pub fn SessionReviewSheet(open: Signal<bool>, on_close: Callback<()>) -> impl In
 
     let on_start = Callback::new(move |_| {
         let now = chrono::Utc::now();
+        clerk_bindings::sentry_breadcrumb("session", "session.start", "info");
         let event = Event::Session(SessionEvent::StartSession { now });
         let core_ref = core_start.borrow();
         let effects = core_ref.process_event(event);

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -6,6 +6,7 @@ use intrada_web::validation::validate_achieved_tempo_input;
 use crate::components::{
     AccentBar, Button, ButtonVariant, Icon, IconName, RatingChips, SetSaveForm, StatCard, StatTone,
 };
+use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
@@ -343,6 +344,7 @@ pub fn SessionSummary() -> impl IntoView {
                                         full_width=true
                                         on_click=Callback::new(move |_| {
                                             let now = chrono::Utc::now();
+                                            clerk_bindings::sentry_breadcrumb("session", "session.save", "info");
                                             let event = Event::Session(SessionEvent::SaveSession { now });
                                             let core_ref = core_save.borrow();
                                             let effects = core_ref.process_event(event);

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -10,6 +10,7 @@ use crate::components::{
     Button, ButtonSize, ButtonVariant, Icon, IconName, InlineTypeIndicator, ItemReflectionSheet,
     ItemReflectionTarget, ProgressRing, SectionLabel, SetlistEntryRow, TransitionPrompt,
 };
+use intrada_web::clerk_bindings;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, ItemType, SharedCore};
 
@@ -501,6 +502,11 @@ pub fn SessionTimer() -> impl IntoView {
                                         a.current_position == a.total_items.saturating_sub(1)
                                     });
                                     let event = if is_last_now {
+                                        clerk_bindings::sentry_breadcrumb(
+                                            "session",
+                                            "session.finish",
+                                            "info",
+                                        );
                                         Event::Session(SessionEvent::FinishSession { now })
                                     } else {
                                         Event::Session(SessionEvent::NextItem { now })


### PR DESCRIPTION
## Summary

Re-stack of [#488](https://github.com/jonyardley/intrada/pull/488) onto current main. The original PR was unable to merge cleanly because:

1. [#472](https://github.com/jonyardley/intrada/pull/472) was merged with only PR-1's content (the user-identity + PII scrubber half) — PR-2's release-lifecycle changes (Dockerfile, build.rs, CI workflow, `option_env!` filter, `__SENTRY_RELEASE__` placeholder) didn't make it into main.
2. PR #488 itself was marked MERGED by GitHub when its base branch was deleted, but the squash landed on the orphaned intermediate branch — not main.

This PR cherry-picks the missing commits (`dd2e6df` + `ccf5887`) cleanly onto current main, including resolving the one merge conflict (`session_timer.rs` — main removed an unused `background_audio` import).

## What's actually in this PR

### Release lifecycle (was PR 2)
- `crates/intrada-api/build.rs` (new) — `cargo:rerun-if-env-changed=GIT_SHA`
- `Dockerfile` — `ARG GIT_SHA` after `cargo chef cook` so per-deploy SHA changes don't bust the dependency cache
- `crates/intrada-api/src/main.rs` — `option_env!("GIT_SHA").filter(|s| !s.is_empty())` so empty env doesn't tag events with empty release
- `crates/intrada-web/index.html` — `window.__SENTRY_RELEASE__` placeholder (replaced by CI's `sed` step before Cloudflare publish)
- `.github/workflows/ci.yml` — `flyctl deploy --build-arg GIT_SHA=...`, `getsentry/action-release@v3` for both projects, `sed` injection for web release tag

### Distributed tracing + domain breadcrumbs (was PR 3)
- `Sentry.init` adds `tracePropagationTargets: ["intrada-api.fly.dev", /\/api\//]` so `sentry-trace` + `baggage` headers flow web → API. The Rust `SentryHttpLayer` already reads them.
- New `js_sentry_breadcrumb` FFI helper in `clerk_bindings.rs`.
- 5 breadcrumb call sites: `auth.signed-in`, `auth.signed-out`, `session.start`, `session.save`, `session.finish`.

## What's deliberately NOT in this PR

- The cache-bust-snippets.sh fix (`8c99f70` on the old branch). The script was reverted from main in [#461](https://github.com/jonyardley/intrada/pull/461) before this PR re-stacks, so the bug it fixed isn't reachable on main any more. If the script ever comes back, the fixed version is preserved on the old branch (`claude/sentry-pr3-tracing-breadcrumbs`) for reference.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` clean (no test changes; existing 432 pass)
- [x] `trunk build --release` clean
- [x] Full Playwright suite locally — **32/32 pass in 17s**
- [ ] Manual verify post-merge: confirm release object created in Sentry on next deploy, single trace links web fetch span to API handler span, breadcrumb chain shows up on a real error.

## Continues

- [#464](https://github.com/jonyardley/intrada/issues/464) feedback widget evaluation
- [#473](https://github.com/jonyardley/intrada/issues/473) mobile host user identity
- [#484](https://github.com/jonyardley/intrada/issues/484) `just ios-*` GIT_SHA pass-through
- [#485](https://github.com/jonyardley/intrada/issues/485) WASM debug symbols + JS source maps
- [#489](https://github.com/jonyardley/intrada/issues/489) `session.discard` breadcrumb
- [#490](https://github.com/jonyardley/intrada/issues/490) rename `clerk_bindings.rs` → `js_bridge.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)