### PR TITLE
fix(web): real spacing utilities on Settings + Delete-account pages

### DIFF
--- a/crates/intrada-web/src/views/account_delete.rs
+++ b/crates/intrada-web/src/views/account_delete.rs
@@ -80,7 +80,7 @@ pub fn AccountDeleteView() -> impl IntoView {
     };
 
     view! {
-        <div class="max-w-md mx-auto py-comfortable space-y-comfortable pb-[env(safe-area-inset-bottom)]">
+        <div class="max-w-md mx-auto py-card-comfortable space-y-card-comfortable pb-[env(safe-area-inset-bottom)]">
             <h1 class="page-title">"Delete your account?"</h1>
 
             <p class="text-sm text-secondary">

--- a/crates/intrada-web/src/views/settings.rs
+++ b/crates/intrada-web/src/views/settings.rs
@@ -109,7 +109,7 @@ pub fn SettingsView() -> impl IntoView {
     });
 
     view! {
-        <div class="max-w-md mx-auto py-comfortable space-y-comfortable pb-[env(safe-area-inset-bottom)]">
+        <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
             <h1 class="page-title">"Settings"</h1>
 
             // Account header


### PR DESCRIPTION
## Summary

Follow-up to #495. The squash-merged commit shipped `py-comfortable` / `space-y-comfortable` on the SettingsView and AccountDeleteView containers — those aren't real utilities. The token defined in input.css is `--spacing-card-comfortable` (not `--spacing-comfortable`), so without the prefix the classes were silent no-ops and both pages rendered with zero padding/gap. The Settings title, signed-in card, Defaults form, and Account actions all touched each other; same on the destructive Delete-account flow.

This PR:

- **Settings**: `py-card-comfortable space-y-section` — 48px between major sections, matches the Apple Settings.app feel for an iOS-first surface.
- **Delete account**: `py-card-comfortable space-y-card-comfortable` — 24px (the originally intended value); the page is shorter and doesn't need the bigger section gap.

The text-element padding (heading mb, hint mb, avatar size, field-row spacing) is unchanged from #495 — only the outer container's two utilities are corrected.

## Test plan

- [ ] `/settings` on web mobile / desktop / iOS Tauri: visible 48px gap between Settings title, Signed-in card, Defaults section, Account section.
- [ ] `/settings/delete-account`: visible 24px gap between heading, list, confirmation field, button stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)