### PR TITLE
feat(observability): session.discard breadcrumb (#489)

### DIFF
--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -357,6 +357,7 @@ pub fn SessionSummary() -> impl IntoView {
                                 <Button
                                     variant=ButtonVariant::DangerOutline
                                     on_click=Callback::new(move |_| {
+                                        clerk_bindings::sentry_breadcrumb("session", "session.discard", "info");
                                         let event = Event::Session(SessionEvent::DiscardSession);
                                         let core_ref = core_discard.borrow();
                                         let effects = core_ref.process_event(event);


### PR DESCRIPTION
## Summary

Symmetric with the existing `session.save` breadcrumb. Discarding a session is a legitimate exit path — capturing it completes the session lifecycle trail in Sentry, so a bug shortly after discard (stale analytics view, new session won't start, etc.) has the trail it needs.

One-line addition at the existing `DiscardSession` dispatch site in `session_summary.rs`. `clerk_bindings` is already imported there from PR 3.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\` clean

## Closes

#489

🤖 Generated with [Claude Code](https://claude.com/claude-code)