### PR TITLE
feat(api): MCP server (reads-only) at /api/mcp (Phase 3 of #477)

### DIFF
--- a/crates/intrada-api/src/lib.rs
+++ b/crates/intrada-api/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod clerk;
 pub mod db;
 pub mod error;
+pub mod mcp;
 pub mod migrations;
 pub mod routes;
 pub mod services;

--- a/crates/intrada-api/src/mcp/handlers.rs
+++ b/crates/intrada-api/src/mcp/handlers.rs
@@ -166,7 +166,11 @@ pub async fn get_practice_summary(
         .collect();
 
     let sessions_count = in_window.len();
-    let total_minutes: u64 = in_window.iter().map(|s| s.total_duration_secs / 60).sum();
+    // Sum seconds first, divide once at the end — dividing per-session
+    // would drop sub-minute remainders. With 10 × 90s sessions the
+    // per-session approach reads as 10min instead of the correct 15.
+    let total_secs: u64 = in_window.iter().map(|s| s.total_duration_secs).sum();
+    let total_minutes = total_secs / 60;
 
     let mut item_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut score_sum: u32 = 0;

--- a/crates/intrada-api/src/mcp/handlers.rs
+++ b/crates/intrada-api/src/mcp/handlers.rs
@@ -1,0 +1,253 @@
+//! Tool implementations.
+//!
+//! Each handler:
+//! - Takes the typed arguments parsed from the JSON-RPC `arguments` object.
+//! - Calls into `crate::services::*` (the same layer HTTP routes use).
+//! - Returns the result as `serde_json::Value` for the dispatcher to wrap
+//!   in MCP's `content: [{ type: "text", text: "<JSON>" }]` shape.
+//!
+//! Date-range filtering on `list_sessions` happens here rather than in the
+//! service layer to keep this PR scoped — pushing the filter down is a
+//! follow-up refactor.
+
+use chrono::{DateTime, Utc};
+use libsql::Connection;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use intrada_core::domain::item::ItemKind;
+
+use crate::error::ApiError;
+use crate::services;
+
+// ── list_items ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListItemsArgs {
+    #[serde(default)]
+    pub kind: Option<String>,
+}
+
+pub async fn list_items(
+    conn: &Connection,
+    user_id: &str,
+    args: ListItemsArgs,
+) -> Result<Value, ApiError> {
+    let kind_filter = match args.kind.as_deref() {
+        None => None,
+        Some("piece") => Some(ItemKind::Piece),
+        Some("exercise") => Some(ItemKind::Exercise),
+        Some(other) => {
+            return Err(ApiError::Validation(format!(
+                "Invalid kind: {other:?} (expected \"piece\" or \"exercise\")"
+            )))
+        }
+    };
+    let items = services::items::list_items(conn, user_id).await?;
+    let filtered: Vec<_> = items
+        .into_iter()
+        .filter(|i| kind_filter.is_none() || Some(i.kind.clone()) == kind_filter)
+        .collect();
+    serde_json::to_value(filtered).map_err(|e| ApiError::Internal(format!("serialize items: {e}")))
+}
+
+// ── get_item ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetItemArgs {
+    pub id: String,
+}
+
+pub async fn get_item(
+    conn: &Connection,
+    user_id: &str,
+    args: GetItemArgs,
+) -> Result<Value, ApiError> {
+    let item = services::items::get_item(conn, &args.id, user_id).await?;
+    serde_json::to_value(item).map_err(|e| ApiError::Internal(format!("serialize item: {e}")))
+}
+
+// ── list_sets ──────────────────────────────────────────────────────────
+
+pub async fn list_sets(conn: &Connection, user_id: &str) -> Result<Value, ApiError> {
+    let sets = services::sets::list_sets(conn, user_id).await?;
+    serde_json::to_value(sets).map_err(|e| ApiError::Internal(format!("serialize sets: {e}")))
+}
+
+// ── get_set ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetSetArgs {
+    pub id: String,
+}
+
+pub async fn get_set(
+    conn: &Connection,
+    user_id: &str,
+    args: GetSetArgs,
+) -> Result<Value, ApiError> {
+    let set = services::sets::get_set(conn, &args.id, user_id).await?;
+    serde_json::to_value(set).map_err(|e| ApiError::Internal(format!("serialize set: {e}")))
+}
+
+// ── list_sessions ──────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListSessionsArgs {
+    #[serde(default)]
+    pub start: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub end: Option<DateTime<Utc>>,
+}
+
+pub async fn list_sessions(
+    conn: &Connection,
+    user_id: &str,
+    args: ListSessionsArgs,
+) -> Result<Value, ApiError> {
+    let sessions = services::sessions::list_sessions(conn, user_id).await?;
+    let filtered: Vec<_> = sessions
+        .into_iter()
+        .filter(|s| in_range(s.started_at, args.start, args.end))
+        .collect();
+    serde_json::to_value(filtered)
+        .map_err(|e| ApiError::Internal(format!("serialize sessions: {e}")))
+}
+
+fn in_range(when: DateTime<Utc>, start: Option<DateTime<Utc>>, end: Option<DateTime<Utc>>) -> bool {
+    if let Some(s) = start {
+        if when < s {
+            return false;
+        }
+    }
+    if let Some(e) = end {
+        if when > e {
+            return false;
+        }
+    }
+    true
+}
+
+// ── get_session ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetSessionArgs {
+    pub id: String,
+}
+
+pub async fn get_session(
+    conn: &Connection,
+    user_id: &str,
+    args: GetSessionArgs,
+) -> Result<Value, ApiError> {
+    let session = services::sessions::get_session(conn, &args.id, user_id).await?;
+    serde_json::to_value(session).map_err(|e| ApiError::Internal(format!("serialize session: {e}")))
+}
+
+// ── get_practice_summary ───────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct GetPracticeSummaryArgs {
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+}
+
+/// Wide-view aggregation. Pre-joins sessions + entries so the agent
+/// doesn't need 10 round trips to answer "how was my week?".
+pub async fn get_practice_summary(
+    conn: &Connection,
+    user_id: &str,
+    args: GetPracticeSummaryArgs,
+) -> Result<Value, ApiError> {
+    let sessions = services::sessions::list_sessions(conn, user_id).await?;
+    let in_window: Vec<_> = sessions
+        .into_iter()
+        .filter(|s| in_range(s.started_at, Some(args.start), Some(args.end)))
+        .collect();
+
+    let sessions_count = in_window.len();
+    let total_minutes: u64 = in_window.iter().map(|s| s.total_duration_secs / 60).sum();
+
+    let mut item_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut score_sum: u32 = 0;
+    let mut score_count: u32 = 0;
+    let mut entry_count: u32 = 0;
+
+    // Per-item aggregations: total minutes + count + average score.
+    use std::collections::HashMap;
+    #[derive(Default)]
+    struct ItemAcc {
+        title: String,
+        kind: String,
+        total_secs: u64,
+        entry_count: u32,
+        score_sum: u32,
+        score_count: u32,
+    }
+    let mut per_item: HashMap<String, ItemAcc> = HashMap::new();
+
+    for session in &in_window {
+        for entry in &session.entries {
+            entry_count += 1;
+            item_ids.insert(entry.item_id.clone());
+            if let Some(score) = entry.score {
+                score_sum += u32::from(score);
+                score_count += 1;
+            }
+            let acc = per_item.entry(entry.item_id.clone()).or_default();
+            acc.title = entry.item_title.clone();
+            acc.kind = match entry.item_type {
+                ItemKind::Piece => "piece".to_string(),
+                ItemKind::Exercise => "exercise".to_string(),
+            };
+            acc.total_secs += entry.duration_secs;
+            acc.entry_count += 1;
+            if let Some(score) = entry.score {
+                acc.score_sum += u32::from(score);
+                acc.score_count += 1;
+            }
+        }
+    }
+
+    let avg_score = if score_count > 0 {
+        Some(score_sum as f32 / score_count as f32)
+    } else {
+        None
+    };
+
+    let mut items: Vec<_> = per_item
+        .into_iter()
+        .map(|(id, acc)| {
+            json!({
+                "item_id": id,
+                "title": acc.title,
+                "kind": acc.kind,
+                "total_minutes": acc.total_secs / 60,
+                "session_appearances": acc.entry_count,
+                "average_score": if acc.score_count > 0 {
+                    Some(acc.score_sum as f32 / acc.score_count as f32)
+                } else {
+                    None
+                },
+            })
+        })
+        .collect();
+    // Sort by total time descending — most-practiced first is what an
+    // agent reading this summary will want.
+    items.sort_by(|a, b| {
+        let a_min = a["total_minutes"].as_u64().unwrap_or(0);
+        let b_min = b["total_minutes"].as_u64().unwrap_or(0);
+        b_min.cmp(&a_min)
+    });
+
+    Ok(json!({
+        "start": args.start,
+        "end": args.end,
+        "sessions_count": sessions_count,
+        "total_minutes": total_minutes,
+        "items_practiced": item_ids.len(),
+        "entries_count": entry_count,
+        "average_score": avg_score,
+        "items": items,
+    }))
+}

--- a/crates/intrada-api/src/mcp/mod.rs
+++ b/crates/intrada-api/src/mcp/mod.rs
@@ -1,0 +1,19 @@
+//! MCP (Model Context Protocol) server.
+//!
+//! Per the spec at `specs/mcp-server.md`, this is Phase 3: a reads-only
+//! tool surface that lets MCP clients (Claude Desktop, Cursor, custom
+//! agents) act on the user's behalf.
+//!
+//! Lives as a module inside `intrada-api` rather than a separate crate
+//! because it needs `AppState`, `AuthUser`, and `services::*` — extracting
+//! those into a shared crate would be a much bigger refactor than the
+//! Phase 3 scope justifies. If we ever want to publish the MCP server
+//! independently, the surface here is structured so that move would be
+//! local to this module.
+
+mod handlers;
+pub mod protocol;
+mod server;
+mod tools;
+
+pub use server::router;

--- a/crates/intrada-api/src/mcp/protocol.rs
+++ b/crates/intrada-api/src/mcp/protocol.rs
@@ -1,0 +1,167 @@
+//! JSON-RPC 2.0 + minimal MCP protocol types.
+//!
+//! We hand-roll the protocol rather than depend on `rmcp` because:
+//! 1. Per-request user context is awkward to plumb through `rmcp`'s
+//!    session-factory closure.
+//! 2. Read-only tools don't need streaming/SSE/sessions.
+//! 3. Direct integration with the existing `AuthUser` extractor and
+//!    `services::*` layer is cleaner.
+//!
+//! If we later need streaming or want to drop maintenance burden, swapping
+//! to `rmcp` is a focused refactor — the on-the-wire protocol is the same.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// MCP protocol version we advertise. Bumping this requires reviewing any
+/// behaviour that changed between versions.
+pub const PROTOCOL_VERSION: &str = "2024-11-05";
+
+pub const SERVER_NAME: &str = "intrada";
+pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Standard JSON-RPC 2.0 error codes.
+pub mod error_code {
+    pub const PARSE_ERROR: i32 = -32700;
+    pub const INVALID_REQUEST: i32 = -32600;
+    pub const METHOD_NOT_FOUND: i32 = -32601;
+    pub const INVALID_PARAMS: i32 = -32602;
+    pub const INTERNAL_ERROR: i32 = -32603;
+}
+
+/// Inbound JSON-RPC request. We accept both notifications (no `id`) and
+/// regular requests.
+#[derive(Debug, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    /// `None` means the message is a notification — no response is sent.
+    #[serde(default)]
+    pub id: Option<Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    pub id: Value,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    pub fn error(id: Value, code: i32, message: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message: message.into(),
+                data: None,
+            }),
+            id,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+/// `initialize` response payload — server announces protocol version,
+/// capabilities, and identity.
+#[derive(Debug, Serialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: &'static str,
+    pub capabilities: Capabilities,
+    #[serde(rename = "serverInfo")]
+    pub server_info: ServerInfo,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Capabilities {
+    /// Empty object signals "tools are supported"; absence would mean
+    /// the client shouldn't bother calling `tools/list`.
+    pub tools: ToolsCapability,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolsCapability {
+    /// We don't push `tools/list_changed` notifications today (tools are
+    /// statically defined). `false` is the spec-compliant signal.
+    #[serde(rename = "listChanged")]
+    pub list_changed: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServerInfo {
+    pub name: &'static str,
+    pub version: &'static str,
+}
+
+/// `tools/list` response payload.
+#[derive(Debug, Serialize)]
+pub struct ToolsListResult {
+    pub tools: Vec<ToolDefinition>,
+}
+
+/// A single tool definition surfaced via `tools/list`.
+#[derive(Debug, Serialize)]
+pub struct ToolDefinition {
+    pub name: &'static str,
+    pub description: &'static str,
+    /// JSON Schema describing the tool's `arguments` shape. Hand-written
+    /// rather than derived because our argument types are small and the
+    /// `description` strings on each property are tuned for the agent.
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+/// `tools/call` request params.
+#[derive(Debug, Deserialize)]
+pub struct ToolsCallParams {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Value,
+}
+
+/// `tools/call` response. Results are wrapped in a `content` array per the
+/// MCP spec; for our reads-only tools we always return a single
+/// JSON-stringified text item.
+#[derive(Debug, Serialize)]
+pub struct ToolsCallResult {
+    pub content: Vec<ToolContent>,
+    /// `true` means the tool ran but the operation failed (validation,
+    /// not-found). Distinct from a JSON-RPC error which signals a
+    /// protocol-level problem.
+    #[serde(rename = "isError", skip_serializing_if = "is_false")]
+    pub is_error: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum ToolContent {
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
+fn is_false(v: &bool) -> bool {
+    !v
+}

--- a/crates/intrada-api/src/mcp/server.rs
+++ b/crates/intrada-api/src/mcp/server.rs
@@ -1,0 +1,259 @@
+//! Axum handler that dispatches JSON-RPC requests to MCP methods + tools.
+//!
+//! Auth: reuses the existing `AuthUser` extractor — same Bearer-PAT path
+//! that protects `/api/items` etc. PATs in auth-disabled (dev) mode resolve
+//! to the empty user_id, matching the rest of the API.
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::auth::AuthUser;
+use crate::error::ApiError;
+use crate::state::AppState;
+
+use super::handlers;
+use super::protocol::{
+    error_code, Capabilities, InitializeResult, JsonRpcRequest, JsonRpcResponse, ServerInfo,
+    ToolContent, ToolsCallParams, ToolsCallResult, ToolsCapability, ToolsListResult,
+    PROTOCOL_VERSION, SERVER_NAME, SERVER_VERSION,
+};
+use super::tools;
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/", post(handle))
+}
+
+/// Top-level JSON-RPC handler. Routes by `method` to either MCP-protocol
+/// methods (`initialize`, `tools/list`, `tools/call`) or returns a
+/// JSON-RPC `METHOD_NOT_FOUND` error. Notifications (no `id`) get a 204.
+async fn handle(
+    State(state): State<AppState>,
+    AuthUser { user_id, .. }: AuthUser,
+    Json(req): Json<JsonRpcRequest>,
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    if req.jsonrpc != "2.0" {
+        let id = req.id.unwrap_or(Value::Null);
+        return Json(JsonRpcResponse::error(
+            id,
+            error_code::INVALID_REQUEST,
+            "jsonrpc must be \"2.0\"",
+        ))
+        .into_response();
+    }
+
+    // Notifications: no `id`, no response. Common ones: `notifications/initialized`.
+    let id = match req.id {
+        Some(v) => v,
+        None => return StatusCode::NO_CONTENT.into_response(),
+    };
+
+    let response = match req.method.as_str() {
+        "initialize" => Json(JsonRpcResponse::success(
+            id,
+            serde_json::to_value(InitializeResult {
+                protocol_version: PROTOCOL_VERSION,
+                capabilities: Capabilities {
+                    tools: ToolsCapability {
+                        list_changed: false,
+                    },
+                },
+                server_info: ServerInfo {
+                    name: SERVER_NAME,
+                    version: SERVER_VERSION,
+                },
+            })
+            .expect("InitializeResult serializes"),
+        ))
+        .into_response(),
+
+        "tools/list" => Json(JsonRpcResponse::success(
+            id,
+            serde_json::to_value(ToolsListResult {
+                tools: tools::catalogue(),
+            })
+            .expect("ToolsListResult serializes"),
+        ))
+        .into_response(),
+
+        "tools/call" => {
+            let params: ToolsCallParams = match serde_json::from_value(req.params) {
+                Ok(p) => p,
+                Err(e) => {
+                    return Json(JsonRpcResponse::error(
+                        id,
+                        error_code::INVALID_PARAMS,
+                        format!("Invalid tools/call params: {e}"),
+                    ))
+                    .into_response();
+                }
+            };
+            dispatch_tool(&state, &user_id, params, id).await
+        }
+
+        // Notifications-as-requests: some clients send them with an id. Treat
+        // as no-op success rather than method-not-found.
+        method if method.starts_with("notifications/") => {
+            Json(JsonRpcResponse::success(id, Value::Null)).into_response()
+        }
+
+        other => Json(JsonRpcResponse::error(
+            id,
+            error_code::METHOD_NOT_FOUND,
+            format!("Method not found: {other}"),
+        ))
+        .into_response(),
+    };
+
+    response
+}
+
+/// Dispatch a `tools/call` to the appropriate handler. Returns a successful
+/// JSON-RPC response — tool-level errors (validation, not-found) are
+/// embedded in the result with `is_error: true` per the MCP spec, not
+/// surfaced as JSON-RPC errors (those are reserved for protocol-level
+/// problems).
+async fn dispatch_tool(
+    state: &AppState,
+    user_id: &str,
+    params: ToolsCallParams,
+    id: Value,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let conn = state.conn();
+    let result = match params.name.as_str() {
+        tools::LIST_ITEMS => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::list_items(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        tools::GET_ITEM => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::get_item(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        tools::LIST_SETS => {
+            parse_and_run::<EmptyArgs, _, _>(params.arguments, |_| async move {
+                handlers::list_sets(&conn, user_id).await
+            })
+            .await
+        }
+
+        tools::GET_SET => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::get_set(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        tools::LIST_SESSIONS => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::list_sessions(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        tools::GET_SESSION => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::get_session(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        tools::GET_PRACTICE_SUMMARY => {
+            parse_and_run(params.arguments, |args| async move {
+                handlers::get_practice_summary(&conn, user_id, args).await
+            })
+            .await
+        }
+
+        unknown => {
+            return Json(JsonRpcResponse::error(
+                id,
+                error_code::METHOD_NOT_FOUND,
+                format!("Unknown tool: {unknown}"),
+            ))
+            .into_response();
+        }
+    };
+
+    match result {
+        Ok(value) => Json(JsonRpcResponse::success(
+            id,
+            serde_json::to_value(ToolsCallResult {
+                content: vec![ToolContent::Text {
+                    text: serde_json::to_string(&value).unwrap_or_else(|e| {
+                        format!("{{\"error\":\"failed to serialize result: {e}\"}}")
+                    }),
+                }],
+                is_error: false,
+            })
+            .expect("ToolsCallResult serializes"),
+        ))
+        .into_response(),
+
+        Err(api_err) => Json(JsonRpcResponse::success(
+            id,
+            serde_json::to_value(ToolsCallResult {
+                content: vec![ToolContent::Text {
+                    text: serde_json::to_string(&serde_json::json!({
+                        "error": format_api_error(&api_err),
+                    }))
+                    .unwrap_or_else(|_| "{}".into()),
+                }],
+                is_error: true,
+            })
+            .expect("ToolsCallResult serializes"),
+        ))
+        .into_response(),
+    }
+}
+
+#[derive(Deserialize, Default)]
+struct EmptyArgs;
+
+/// Parse `arguments` into the typed `A` and pass to the async closure. Any
+/// parse failure becomes an `ApiError::Validation` so it's surfaced as a
+/// tool-level error (`isError: true`) rather than a JSON-RPC error.
+///
+/// Missing/null `arguments` is normalised to `{}` so tools whose args are
+/// all-optional don't require the agent to pass an explicit empty object;
+/// tools with required fields still error cleanly via serde.
+async fn parse_and_run<A, F, Fut>(args: Value, run: F) -> Result<Value, ApiError>
+where
+    A: serde::de::DeserializeOwned,
+    F: FnOnce(A) -> Fut,
+    Fut: std::future::Future<Output = Result<Value, ApiError>>,
+{
+    let args = if args.is_null() {
+        Value::Object(Default::default())
+    } else {
+        args
+    };
+    let parsed: A = serde_json::from_value(args)
+        .map_err(|e| ApiError::Validation(format!("Invalid arguments: {e}")))?;
+    run(parsed).await
+}
+
+fn format_api_error(err: &ApiError) -> String {
+    match err {
+        ApiError::Validation(msg) => format!("Validation error: {msg}"),
+        ApiError::NotFound(msg) => format!("Not found: {msg}"),
+        ApiError::Unauthorized(msg) => format!("Unauthorized: {msg}"),
+        ApiError::Internal(msg) => {
+            // Don't leak internal details to the agent — just say "internal error".
+            tracing::warn!(?msg, "MCP tool internal error");
+            "Internal error".to_string()
+        }
+    }
+}

--- a/crates/intrada-api/src/mcp/server.rs
+++ b/crates/intrada-api/src/mcp/server.rs
@@ -31,6 +31,10 @@ pub fn router() -> Router<AppState> {
 /// JSON-RPC `METHOD_NOT_FOUND` error. Notifications (no `id`) get a 204.
 async fn handle(
     State(state): State<AppState>,
+    // The `..` drops `AuthSource` for now. Phase 4 (#477) will read
+    // `AuthSource::Pat { token_id }` here to record audit-log rows for
+    // every MCP write — that's where the token_id plumbed through #501
+    // gets consumed.
     AuthUser { user_id, .. }: AuthUser,
     Json(req): Json<JsonRpcRequest>,
 ) -> axum::response::Response {

--- a/crates/intrada-api/src/mcp/tools.rs
+++ b/crates/intrada-api/src/mcp/tools.rs
@@ -72,19 +72,19 @@ pub fn catalogue() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: LIST_SESSIONS,
-            description: "List the user's practice sessions, optionally filtered by date range. Each session has a start time, total duration, and a setlist of items practiced with per-item scores.",
+            description: "List the user's practice sessions, optionally filtered by start time (`session.started_at`). Each session has a start time, total duration, and a setlist of items practiced with per-item scores.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "start": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Optional RFC 3339 lower bound (inclusive)."
+                        "description": "Optional RFC 3339 lower bound (inclusive); compared against session.started_at."
                     },
                     "end": {
                         "type": "string",
                         "format": "date-time",
-                        "description": "Optional RFC 3339 upper bound (inclusive)."
+                        "description": "Optional RFC 3339 upper bound (inclusive); compared against session.started_at."
                     }
                 },
                 "additionalProperties": false

--- a/crates/intrada-api/src/mcp/tools.rs
+++ b/crates/intrada-api/src/mcp/tools.rs
@@ -1,0 +1,127 @@
+//! Tool catalogue surfaced via `tools/list`.
+//!
+//! Each tool has:
+//! - `name` — what the agent calls
+//! - `description` — what the agent reads to decide *whether* to call it.
+//!   These descriptions are tuned for the agent (user-facing terminology
+//!   like "piece" / "exercise" / "routine") even though wire-protocol
+//!   names match the API (`items`, `sets`).
+//! - `input_schema` — JSON Schema for `arguments`, validated at call time.
+
+use serde_json::json;
+
+use super::protocol::ToolDefinition;
+
+pub const LIST_ITEMS: &str = "list_items";
+pub const GET_ITEM: &str = "get_item";
+pub const LIST_SETS: &str = "list_sets";
+pub const GET_SET: &str = "get_set";
+pub const LIST_SESSIONS: &str = "list_sessions";
+pub const GET_SESSION: &str = "get_session";
+pub const GET_PRACTICE_SUMMARY: &str = "get_practice_summary";
+
+pub fn catalogue() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: LIST_ITEMS,
+            description: "List the user's library items — pieces and exercises they're working on. Optionally filter by `kind` (\"piece\" or \"exercise\").",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["piece", "exercise"],
+                        "description": "Optional filter. Omit to return both pieces and exercises."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: GET_ITEM,
+            description: "Fetch a single item (piece or exercise) by its id, including title, composer, key signature, tempo, notes, and tags.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "The item's id (ULID)." }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: LIST_SETS,
+            description: "List the user's routines — ordered groups of items they practice together as a sequence.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: GET_SET,
+            description: "Fetch a single routine by its id, including its name and the ordered list of items inside it.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "The routine's id (ULID)." }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: LIST_SESSIONS,
+            description: "List the user's practice sessions, optionally filtered by date range. Each session has a start time, total duration, and a setlist of items practiced with per-item scores.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Optional RFC 3339 lower bound (inclusive)."
+                    },
+                    "end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Optional RFC 3339 upper bound (inclusive)."
+                    }
+                },
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: GET_SESSION,
+            description: "Fetch a single practice session by id with full per-item details (durations, scores, notes, intentions).",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string", "description": "The session's id (ULID)." }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: GET_PRACTICE_SUMMARY,
+            description: "Aggregate practice statistics over a date range — total minutes, session count, distinct items practiced, and average score. Use this for typical \"how was my week\" questions instead of fetching every session and aggregating client-side.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "RFC 3339 lower bound (inclusive)."
+                    },
+                    "end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "RFC 3339 upper bound (inclusive)."
+                    }
+                },
+                "required": ["start", "end"],
+                "additionalProperties": false
+            }),
+        },
+    ]
+}

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -31,9 +31,21 @@ pub fn api_router(state: AppState) -> Router {
         })
         .collect();
 
-    let cors = CorsLayer::new()
+    // Strict CORS for the user-facing API surface. Browser-based MCP
+    // clients use the separate `/api/mcp` route below with its own
+    // permissive CORS.
+    let strict_cors = CorsLayer::new()
         .allow_origin(AllowOrigin::list(origins))
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+
+    // Permissive CORS for `/api/mcp/*` only. Per #481 — MCP auth is
+    // bearer-token-only (PAT), no cookies are involved, so CORS adds zero
+    // security on this route while removing a real product capability
+    // (browser-based MCP agents). The PAT IS the auth gate.
+    let mcp_cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::any())
+        .allow_methods([Method::POST, Method::OPTIONS])
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 
     let trace = TraceLayer::new_for_http()
@@ -47,9 +59,14 @@ pub fn api_router(state: AppState) -> Router {
         // ERROR-only event capture.
         .on_failure(DefaultOnFailure::new().level(Level::WARN));
 
+    let mcp_routes = crate::mcp::router().layer(mcp_cors);
+
     Router::new()
-        .nest("/api", api_routes())
-        .layer(cors)
+        // Order matters: longest-prefix wins. `/api/mcp/*` resolves here
+        // (permissive CORS); everything else under `/api/*` goes to the
+        // strict-CORS subtree below.
+        .nest("/api/mcp", mcp_routes)
+        .nest("/api", api_routes().layer(strict_cors))
         .layer(trace)
         // Sentry layers: per-request hub + HTTP transaction (route-aware via
         // the `tower-axum-matched-path` feature). NewSentryLayer must wrap

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -62,9 +62,10 @@ pub fn api_router(state: AppState) -> Router {
     let mcp_routes = crate::mcp::router().layer(mcp_cors);
 
     Router::new()
-        // Order matters: longest-prefix wins. `/api/mcp/*` resolves here
-        // (permissive CORS); everything else under `/api/*` goes to the
-        // strict-CORS subtree below.
+        // Two sibling nests: axum routes by path specificity, so a request
+        // to `/api/mcp/*` resolves to the permissive-CORS subtree, while
+        // every other `/api/*` path resolves to the strict-CORS subtree.
+        // Each subtree carries its own CorsLayer.
         .nest("/api/mcp", mcp_routes)
         .nest("/api", api_routes().layer(strict_cors))
         .layer(trace)

--- a/crates/intrada-api/tests/mcp_test.rs
+++ b/crates/intrada-api/tests/mcp_test.rs
@@ -1,0 +1,331 @@
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn initialize_returns_protocol_version_and_server_info() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {},
+            "id": 1
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = common::json(&body);
+    assert_eq!(v["jsonrpc"], "2.0");
+    assert_eq!(v["id"], 1);
+    let result = &v["result"];
+    assert!(
+        result["protocolVersion"].as_str().is_some(),
+        "missing protocolVersion: {result:?}"
+    );
+    assert_eq!(result["serverInfo"]["name"], "intrada");
+    assert!(result["capabilities"]["tools"].is_object());
+}
+
+#[tokio::test]
+async fn tools_list_returns_full_catalogue() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 2
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = common::json(&body);
+    let tools = v["result"]["tools"].as_array().expect("tools array");
+    assert_eq!(tools.len(), 7, "expected 7 tools, got {}", tools.len());
+
+    let names: Vec<_> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"list_items"));
+    assert!(names.contains(&"get_item"));
+    assert!(names.contains(&"list_sets"));
+    assert!(names.contains(&"get_set"));
+    assert!(names.contains(&"list_sessions"));
+    assert!(names.contains(&"get_session"));
+    assert!(names.contains(&"get_practice_summary"));
+
+    // Every tool must declare an inputSchema (agents rely on this for
+    // argument validation).
+    for tool in tools {
+        assert!(
+            tool["inputSchema"].is_object(),
+            "{} missing inputSchema",
+            tool["name"]
+        );
+    }
+}
+
+#[tokio::test]
+async fn tools_call_list_items_returns_items_as_json_text() {
+    let app = common::setup_test_app().await;
+
+    // Seed an item via the regular HTTP path.
+    let (status, _) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Clair de Lune",
+            "kind": "piece",
+            "composer": "Claude Debussy",
+            "tags": []
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Now ask via MCP.
+    let (status, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "list_items",
+                "arguments": {}
+            },
+            "id": 3
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = common::json(&body);
+    let result = &v["result"];
+    assert_eq!(
+        result["isError"],
+        Value::Null,
+        "expected isError omitted (=false) on success"
+    );
+    let content = result["content"].as_array().expect("content array");
+    assert_eq!(content.len(), 1);
+    assert_eq!(content[0]["type"], "text");
+    let text = content[0]["text"].as_str().expect("text payload");
+    let inner: Value = serde_json::from_str(text).expect("text is JSON");
+    let items = inner.as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["title"], "Clair de Lune");
+}
+
+#[tokio::test]
+async fn tools_call_list_items_filters_by_kind() {
+    let app = common::setup_test_app().await;
+
+    common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({"title": "Étude", "kind": "exercise", "tags": []}),
+    )
+    .await;
+    common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({"title": "Sonata", "kind": "piece", "tags": []}),
+    )
+    .await;
+
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "list_items", "arguments": {"kind": "exercise"}},
+            "id": 4
+        }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let items: Vec<Value> = serde_json::from_str(text).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["title"], "Étude");
+}
+
+#[tokio::test]
+async fn tools_call_get_item_unknown_returns_is_error() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "get_item",
+                "arguments": {"id": "01HXNONE000000000000000000"}
+            },
+            "id": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let v: Value = common::json(&body);
+    // Tool-level errors return JSON-RPC success with isError: true on result.
+    assert!(v["error"].is_null(), "should not be a JSON-RPC error");
+    assert_eq!(v["result"]["isError"], true);
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("Not found"), "got: {text}");
+}
+
+#[tokio::test]
+async fn tools_call_unknown_tool_returns_method_not_found() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "make_coffee", "arguments": {}},
+            "id": 6
+        }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    assert_eq!(v["error"]["code"], -32601);
+    assert!(v["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("Unknown tool"));
+}
+
+#[tokio::test]
+async fn unknown_method_returns_method_not_found() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "nonexistent/method",
+            "id": 7
+        }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    assert_eq!(v["error"]["code"], -32601);
+}
+
+#[tokio::test]
+async fn invalid_jsonrpc_version_returns_invalid_request() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "1.0",
+            "method": "initialize",
+            "id": 8
+        }),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    assert_eq!(v["error"]["code"], -32600);
+}
+
+#[tokio::test]
+async fn notification_returns_no_content() {
+    // No `id` → notification → 204 No Content per JSON-RPC spec.
+    let app = common::setup_test_app().await;
+    let (status, _) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn get_practice_summary_returns_aggregates() {
+    let app = common::setup_test_app().await;
+
+    // Seed a session with two entries.
+    let session_payload = json!({
+        "session_notes": null,
+        "session_intention": null,
+        "started_at": "2026-05-01T10:00:00Z",
+        "completed_at": "2026-05-01T10:30:00Z",
+        "total_duration_secs": 1800,
+        "completion_status": "Completed",
+        "entries": [
+            {
+                "id": "entry-001",
+                "item_id": "i1",
+                "item_title": "Etude 1",
+                "item_type": "exercise",
+                "position": 0,
+                "duration_secs": 600,
+                "status": "Completed",
+                "notes": null,
+                "score": 4
+            },
+            {
+                "id": "entry-002",
+                "item_id": "i2",
+                "item_title": "Sonata",
+                "item_type": "piece",
+                "position": 1,
+                "duration_secs": 1200,
+                "status": "Completed",
+                "notes": null,
+                "score": 3
+            }
+        ]
+    });
+    let (status, _) = common::post_json(app.clone(), "/api/sessions", session_payload).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "get_practice_summary",
+                "arguments": {
+                    "start": "2026-05-01T00:00:00Z",
+                    "end": "2026-05-02T00:00:00Z"
+                }
+            },
+            "id": 9
+        }),
+    )
+    .await;
+
+    let v: Value = common::json(&body);
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let inner: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(inner["sessions_count"], 1);
+    assert_eq!(inner["total_minutes"], 30);
+    assert_eq!(inner["items_practiced"], 2);
+    assert_eq!(inner["entries_count"], 2);
+    // Average score: (4 + 3) / 2 = 3.5
+    assert!((inner["average_score"].as_f64().unwrap() - 3.5).abs() < 1e-6);
+    // Per-item array sorted by total_minutes descending — Sonata (20m) first.
+    let items = inner["items"].as_array().unwrap();
+    assert_eq!(items[0]["title"], "Sonata");
+    assert_eq!(items[0]["total_minutes"], 20);
+    assert_eq!(items[1]["title"], "Etude 1");
+    assert_eq!(items[1]["total_minutes"], 10);
+}

--- a/crates/intrada-api/tests/mcp_test.rs
+++ b/crates/intrada-api/tests/mcp_test.rs
@@ -329,3 +329,189 @@ async fn get_practice_summary_returns_aggregates() {
     assert_eq!(items[1]["title"], "Etude 1");
     assert_eq!(items[1]["total_minutes"], 10);
 }
+
+/// Sub-minute session durations must accumulate to whole minutes — i.e.
+/// the aggregation must sum seconds first and divide once, not divide
+/// per-session. Before the fix, two 90s sessions read as 2min total
+/// instead of the correct 3min.
+#[tokio::test]
+async fn get_practice_summary_handles_sub_minute_sessions() {
+    let app = common::setup_test_app().await;
+
+    let make_session = |seq: u32, started: &str, completed: &str, secs: u64| -> serde_json::Value {
+        json!({
+            "started_at": started,
+            "completed_at": completed,
+            "total_duration_secs": secs,
+            "completion_status": "Completed",
+            "entries": [
+                {
+                    "id": format!("entry-{seq:03}"),
+                    "item_id": "item-x",
+                    "item_title": "Étude",
+                    "item_type": "exercise",
+                    "position": 0,
+                    "duration_secs": secs,
+                    "status": "Completed",
+                    "notes": null
+                }
+            ]
+        })
+    };
+
+    // Two 90-second sessions. Per-session integer division would give
+    // 1 + 1 = 2 minutes; correct sum-first-then-divide gives 3.
+    common::post_json(
+        app.clone(),
+        "/api/sessions",
+        make_session(1, "2026-05-01T10:00:00Z", "2026-05-01T10:01:30Z", 90),
+    )
+    .await;
+    common::post_json(
+        app.clone(),
+        "/api/sessions",
+        make_session(2, "2026-05-01T11:00:00Z", "2026-05-01T11:01:30Z", 90),
+    )
+    .await;
+
+    let (_, body) = common::post_json(
+        app,
+        "/api/mcp",
+        json!({
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": "get_practice_summary",
+                "arguments": {
+                    "start": "2026-05-01T00:00:00Z",
+                    "end": "2026-05-02T00:00:00Z"
+                }
+            },
+            "id": 100
+        }),
+    )
+    .await;
+
+    let v: Value = common::json(&body);
+    let text = v["result"]["content"][0]["text"].as_str().unwrap();
+    let inner: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(inner["sessions_count"], 2);
+    assert_eq!(inner["total_minutes"], 3, "two 90s sessions = 3min total");
+}
+
+#[tokio::test]
+async fn pat_authenticates_mcp_call() {
+    // The PAT path must reach /api/mcp end-to-end. Existing PAT tests
+    // only cover /api/items; this guards the MCP route specifically.
+    let app = common::setup_test_app().await;
+
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "mcp-test"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let token = v["token"].as_str().unwrap().to_string();
+
+    // Use the PAT to invoke an MCP method.
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/api/mcp")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(axum::body::Body::from(
+            serde_json::to_string(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = http_body_util::BodyExt::collect(resp.into_body())
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    let v: Value = common::json(&body);
+    assert!(v["result"]["tools"].is_array());
+}
+
+#[tokio::test]
+async fn revoked_pat_cannot_reach_mcp() {
+    let app = common::setup_test_app().await;
+
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "to-be-revoked"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let id = v["id"].as_str().unwrap().to_string();
+    let token = v["token"].as_str().unwrap().to_string();
+
+    // Revoke first, then try to use it.
+    let (status, _) = common::delete(app.clone(), &format!("/api/account/tokens/{id}")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/api/mcp")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(axum::body::Body::from(
+            serde_json::to_string(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1
+            }))
+            .unwrap(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "revoked PAT must not reach /api/mcp"
+    );
+}
+
+#[tokio::test]
+async fn cors_preflight_returns_permissive_headers_for_mcp() {
+    // CORS decision (#481): permissive on /api/mcp/*, strict elsewhere.
+    // A preflight OPTIONS from an arbitrary origin must succeed; the
+    // strict-allowlist routes would reject the same origin.
+    let app = common::setup_test_app().await;
+
+    let req = axum::http::Request::builder()
+        .method("OPTIONS")
+        .uri("/api/mcp")
+        .header("Origin", "https://example.invalid")
+        .header("Access-Control-Request-Method", "POST")
+        .header(
+            "Access-Control-Request-Headers",
+            "authorization,content-type",
+        )
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    let status = resp.status();
+    let allow_origin = resp
+        .headers()
+        .get("access-control-allow-origin")
+        .map(|v| v.to_str().unwrap().to_string());
+    assert!(
+        status.is_success(),
+        "preflight should succeed; got {status}"
+    );
+    assert_eq!(
+        allow_origin.as_deref(),
+        Some("*"),
+        "MCP preflight should advertise permissive origin; got {allow_origin:?}"
+    );
+}

--- a/scripts/cache-bust-snippets.sh
+++ b/scripts/cache-bust-snippets.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Trunk post_build hook — content-hash the wasm-bindgen snippets folder.
+#
+# Why
+# ───
+# wasm-bindgen emits each `#[wasm_bindgen(inline_js = "…")]` block as a
+# separate file at:
+#
+#     dist/snippets/<crate>-<wasm-bindgen-hash>/inlineN.js
+#
+# - The folder hash (e.g. `intrada-web-45068482bf5d8aa1`) is **stable
+#   across builds** — wasm-bindgen derives it from the crate identity,
+#   not the snippet contents.
+# - The file numbering (`inline0.js`, `inline1.js`, …) is determined by
+#   declaration order across the crate's source. Add or remove an
+#   `inline_js` block and the numbering shifts.
+#
+# Net effect: a build that adds, removes, or reorders an `inline_js`
+# block produces snippets at the **same folder path** but with
+# **different contents**. Any cache that pins the path (browser HTTP
+# cache, Cloudflare, WKWebView data store, service worker) keeps serving
+# the old files, so the new `intrada-web-<hash>.js` module imports a
+# binding (e.g. `set_now_playing`) that the cached snippet no longer
+# exports — and the page errors with:
+#
+#     SyntaxError: Importing binding name 'set_now_playing' is not found.
+#
+# Tracked at jonyardley/intrada#440 and #435.
+#
+# What
+# ────
+# After Trunk has finished its build, this script:
+#
+#   1. Hashes the contents of dist/snippets/<crate>-<wb-hash>/
+#   2. Renames the folder to dist/snippets/<crate>-<content-hash>/
+#   3. Rewrites every `snippets/<old>/` reference in dist/*.js and
+#      dist/*.html to use the new folder name.
+#   4. For any non-HTML file we modified in step 3 (the wasm-bindgen
+#      JS shim), recomputes its SHA-384 base64 digest and patches the
+#      stale `integrity="sha384-…"` value in dist/*.html. Trunk
+#      computes integrity attributes during its build phase — before
+#      `post_build` hooks run — so without this fix the browser blocks
+#      the modified shim with `Failed to find a valid digest in the
+#      'integrity' attribute…`.
+#
+# Folder name now changes whenever the snippet contents change, so the
+# next deploy busts every cache layer naturally — no runtime/protocol
+# changes, no service worker, no header tuning needed.
+#
+# Idempotent: re-running on an already-content-hashed folder produces
+# the same name (same content → same hash).
+
+set -euo pipefail
+
+DIST="${TRUNK_STAGING_DIR:-dist}"
+SNIPPETS_DIR="$DIST/snippets"
+
+if [[ ! -d "$SNIPPETS_DIR" ]]; then
+    # No snippets in this build — nothing to do.
+    exit 0
+fi
+
+shopt -s nullglob
+
+# Compute a file's SHA-384 in the base64 form Trunk uses for SRI
+# (`integrity="sha384-<base64>"`). openssl is universally available on
+# both macOS and the Linux CI runners.
+sri_digest() {
+    openssl dgst -sha384 -binary "$1" | openssl base64 -A
+}
+
+renamed_any=0
+
+for old_path in "$SNIPPETS_DIR"/*/; do
+    old_dir="$(basename "$old_path")"
+
+    # Compute a content hash from every file in the folder. We sort the
+    # paths first so the hash is deterministic regardless of filesystem
+    # iteration order.
+    content_hash="$(
+        find "$old_path" -type f -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 cat \
+            | shasum -a 256 \
+            | cut -c1-16
+    )"
+
+    # Strip any trailing -<hex> suffix from the existing folder name and
+    # append our content hash. wasm-bindgen currently emits 16-char
+    # hashes; allow 16+ to be tolerant of future changes. Also matches
+    # our own previous content-hash run so subsequent runs are
+    # idempotent.
+    base="$(printf '%s' "$old_dir" | sed -E 's/-[0-9a-f]{16,}$//')"
+    new_dir="${base}-${content_hash}"
+
+    if [[ "$old_dir" == "$new_dir" ]]; then
+        continue
+    fi
+
+    mv "$old_path" "$SNIPPETS_DIR/$new_dir"
+
+    # Track integrity hash updates we need to make to index.html after
+    # rewriting imports. Stored as parallel "old<TAB>new" lines.
+    sri_updates="$(mktemp)"
+
+    while IFS= read -r -d '' f; do
+        # Snapshot the SRI hash before modification — this is what Trunk
+        # currently has in index.html for any file it preloads.
+        old_sri=""
+        if [[ "$f" != *.html ]]; then
+            old_sri="$(sri_digest "$f")"
+        fi
+
+        # sed -i.bak is portable across BSD/GNU; drop the backup right
+        # after.
+        sed -i.bak "s|snippets/${old_dir}/|snippets/${new_dir}/|g" "$f"
+        rm -f "${f}.bak"
+
+        if [[ -n "$old_sri" ]]; then
+            new_sri="$(sri_digest "$f")"
+            if [[ "$old_sri" != "$new_sri" ]]; then
+                printf '%s\t%s\n' "$old_sri" "$new_sri" >> "$sri_updates"
+            fi
+        fi
+    done < <(find "$DIST" -maxdepth 2 -type f \( -name '*.js' -o -name '*.html' \) -print0)
+
+    # Apply integrity updates to every HTML file at the dist root.
+    if [[ -s "$sri_updates" ]]; then
+        while IFS= read -r -d '' html_file; do
+            while IFS=$'\t' read -r old_sri new_sri; do
+                # Escape sed-special chars in the base64 digests
+                # (`/`, `+`, `=`); none of `&` / `\` ever appear in
+                # base64 output. Pipe is our chosen sed delimiter.
+                old_escaped="$(printf '%s' "$old_sri" | sed 's/[\&|]/\\&/g')"
+                new_escaped="$(printf '%s' "$new_sri" | sed 's/[\&|]/\\&/g')"
+                sed -i.bak "s|sha384-${old_escaped}|sha384-${new_escaped}|g" "$html_file"
+                rm -f "${html_file}.bak"
+            done < "$sri_updates"
+        done < <(find "$DIST" -maxdepth 1 -type f -name '*.html' -print0)
+    fi
+
+    rm -f "$sri_updates"
+
+    printf '[cache-bust-snippets] %s → %s\n' "$old_dir" "$new_dir"
+    renamed_any=1
+done
+
+if [[ "$renamed_any" -eq 0 ]]; then
+    printf '[cache-bust-snippets] no snippet folder needed renaming\n'
+fi


### PR DESCRIPTION
## Summary

Phase 3 of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477). The actual MCP server. After this PR, an MCP client (Claude Desktop, Cursor, custom agents) can:

1. Connect to \`POST /api/mcp\` with a PAT bearer
2. Call \`initialize\` → get server info + capabilities
3. Call \`tools/list\` → discover the 7 reads-only tools
4. Call \`tools/call\` → invoke any tool

Resolves [#481](https://github.com/jonyardley/intrada/issues/481) (CORS policy decision lands here).

## Tools

| Name | Args | Returns |
|------|------|---------|
| \`list_items\` | \`kind?: \"piece\" \| \"exercise\"\` | All items, optionally filtered |
| \`get_item\` | \`id\` | Item with composer/key/tempo/notes/tags |
| \`list_sets\` | (none) | Routines |
| \`get_set\` | \`id\` | Routine with ordered entries |
| \`list_sessions\` | \`start?\`, \`end?\` (RFC 3339) | Sessions in window |
| \`get_session\` | \`id\` | Session with per-item scores/notes |
| \`get_practice_summary\` | \`start\`, \`end\` | Pre-joined wide view: total minutes, items practiced, score trends, per-item breakdown |

\`get_practice_summary\` is the spec's killer wide-view tool — saves the agent 10 round trips for typical \"how was my week\" questions.

## Design decisions

- **Module inside intrada-api, not a separate crate.** A standalone crate would create a circular dep (it needs \`AppState\`/\`AuthUser\`/\`services::*\`). The spec's rationale for \"separate crate\" was deployment-related, which we get either way.
- **Hand-rolled JSON-RPC, not rmcp.** Per-user state through rmcp's session-factory closure is awkward and we don't need SSE/streaming for reads. Wire protocol is the same; swap is a focused refactor if we want streaming later.
- **Tool errors → \`isError: true\` in JSON-RPC \`result\`** (per MCP spec). JSON-RPC errors are reserved for protocol-level problems (parse, method not found, invalid params).
- **Permissive CORS for /api/mcp/* only**, strict CORS preserved for the existing /api/* surface. Per [#481](https://github.com/jonyardley/intrada/issues/481).
- **Tool descriptions use user-facing language** (\"piece\", \"exercise\", \"routine\") even though wire-protocol field names match the API (\`items\`, \`sets\`).

## Test plan

- [x] 10 new integration tests in \`tests/mcp_test.rs\` (initialize, tools/list, tools/call happy + filter + unknown id + unknown tool, unknown method, invalid jsonrpc, notification → 204, get_practice_summary aggregation)
- [x] \`cargo test -p intrada-api\` — 101 passed (was 91)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio -- -D warnings\` clean
- [ ] CI on this PR

## Manual smoke test

\`\`\`bash
TOKEN=$(curl -sX POST localhost:3001/api/account/tokens \\
  -H 'content-type: application/json' \\
  -d '{\"name\":\"local-mcp\"}' | jq -r .token)

# initialize
curl -sX POST localhost:3001/api/mcp \\
  -H \"Authorization: Bearer $TOKEN\" \\
  -H 'content-type: application/json' \\
  -d '{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}' | jq

# tools/list
curl -sX POST localhost:3001/api/mcp \\
  -H \"Authorization: Bearer $TOKEN\" \\
  -H 'content-type: application/json' \\
  -d '{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":2}' | jq
\`\`\`

## Out of scope (Phase 4 etc.)

- Write tools (create_item, bulk_import_items with dry_run, etc.) — Phase 4.
- Audit log (\`mcp_audit_log\`) — Phase 4. The \`AuthSource::Pat { token_id }\` from #501 is already plumbed through; Phase 4's audit handlers can read it.
- OAuth 2.1 + DCR — Phase 5.
- Rate limits — Phase 6.

## Closing

- Closes [#481](https://github.com/jonyardley/intrada/issues/481) (CORS decision implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)