### PR TITLE
chore(observability): pass GIT_SHA to local iOS builds via justfile (#484)

### DIFF
--- a/justfile
+++ b/justfile
@@ -93,6 +93,11 @@ e2e: build
 ios-dev:
     #!/usr/bin/env bash
     set -e
+    # Tag local mobile builds with the current commit so events from the
+    # simulator land in Sentry attributed to a release. Empty if not in a
+    # git checkout — `option_env!` filter in src-tauri/src/lib.rs treats
+    # empty as no-release.
+    export GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo '')"
     trap 'kill 0' EXIT
     pkill -f "xcodebuild.*intrada-mobile" 2>/dev/null || true
     pkill -f "trunk serve" 2>/dev/null || true
@@ -146,6 +151,10 @@ ios-dev:
 ios-dev-device:
     #!/usr/bin/env bash
     set -e
+    # Tag local device builds with the current commit so events from the
+    # device land in Sentry attributed to a release. Same defaulting as
+    # `ios-dev`.
+    export GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo '')"
     trap 'kill 0' EXIT
     pkill -f "xcodebuild.*intrada-mobile" 2>/dev/null || true
     pkill -f "trunk serve" 2>/dev/null || true
@@ -192,8 +201,12 @@ ios-dev-device:
     wait
 
 # Build Tauri iOS app for physical device (Xcode sideload — no TestFlight).
+# Tags the build with the current commit so events land in Sentry
+# attributed to a release. Empty if not in a git checkout — the
+# `option_env!` filter in src-tauri/src/lib.rs treats empty as
+# no-release.
 ios-build:
-    cd crates/intrada-mobile/src-tauri && cargo tauri ios build
+    cd crates/intrada-mobile/src-tauri && GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo '')" cargo tauri ios build
 
 # ─────────────────────────────────────────────
 # Diagnostics & cleanup


### PR DESCRIPTION
## Summary

Mobile already reads \`option_env!("GIT_SHA")\` at compile time (see [crates/intrada-mobile/src-tauri/src/lib.rs](crates/intrada-mobile/src-tauri/src/lib.rs)) and build.rs has \`cargo:rerun-if-env-changed=GIT_SHA\`, but the three iOS recipes weren't passing it — so Sentry events from local simulator/device builds landed without a release tag.

Sets \`GIT_SHA=\$(git rev-parse HEAD)\` in:
- \`just ios-dev\` (simulator)
- \`just ios-dev-device\` (physical device over Wi-Fi)
- \`just ios-build\` (Xcode sideload)

Empty fallback for non-git contexts; the \`.filter(|s| !s.is_empty())\` in src-tauri/src/lib.rs treats empty as no-release.

This closes the cheap two-thirds of mobile release tagging — the bigger one-third (mobile CI/CD pipeline that ships to TestFlight automatically) is a separate piece of work.

## Test plan

- [x] \`just --list\` parses cleanly (verified locally)
- [x] \`just --evaluate\` runs without errors
- [ ] Manual verify post-merge: \`just ios-dev\`, force a panic in the host, confirm the Sentry event has \`release = <commit sha>\`

## Closes

#484

🤖 Generated with [Claude Code](https://claude.com/claude-code)