### PR TITLE
fix(web): use real spacing utilities on MCP tokens page

### DIFF
--- a/crates/intrada-web/src/views/mcp_tokens.rs
+++ b/crates/intrada-web/src/views/mcp_tokens.rs
@@ -110,17 +110,25 @@ pub fn McpTokensView() -> impl IntoView {
     });
 
     view! {
-        <div class="max-w-md mx-auto py-comfortable space-y-comfortable pb-[env(safe-area-inset-bottom)]">
-            <h1 class="page-title">"MCP tokens"</h1>
-            <p class="text-sm text-secondary">
-                "Personal Access Tokens let an AI client (Claude Desktop, Cursor, custom MCP agent) act on your behalf. Generate one for each device or app that needs access."
-            </p>
+        <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
+            // Title + description grouped tighter than the section spacing
+            // so the lede reads as belonging to the title, with the
+            // section-sized gap reserved for the page's distinct sections
+            // below.
+            <div class="space-y-card">
+                <h1 class="page-title">"MCP tokens"</h1>
+                <p class="text-sm text-secondary">
+                    "Personal Access Tokens let an AI client (Claude Desktop, Cursor, custom MCP agent) act on your behalf. Generate one for each device or app that needs access."
+                </p>
+            </div>
 
             // Show-once card for the just-created token. Sits at the top so
             // the user can copy without losing it under the list.
             <Show when=move || just_created.get().is_some() fallback=|| view! { <></> }>
                 <Card>
-                    <div class="space-y-card-compact p-card-compact">
+                    // Card provides its own padding (p-card sm:p-card-comfortable);
+                    // the inner div only handles vertical rhythm.
+                    <div class="space-y-card">
                         <div>
                             <h3 class="card-title">"Token created"</h3>
                             <p class="hint-text">
@@ -164,7 +172,7 @@ pub fn McpTokensView() -> impl IntoView {
                 }
             >
                 <Card>
-                    <div class="space-y-card-compact p-card-compact">
+                    <div class="space-y-card">
                         <TextField
                             id="mcp-token-name"
                             label="Name"
@@ -241,7 +249,13 @@ fn TokenRow(token: McpToken, on_revoke: Callback<String>) -> impl IntoView {
     });
 
     view! {
-        <div class="flex items-center justify-between gap-card-compact px-card-compact py-card-compact min-h-[64px]">
+        // Standard card padding (16px) rather than card-compact (12px) —
+        // this row carries two lines of text + an action button, so the
+        // tighter 12px reads as cramped (and the row is taller than a
+        // typical settings row anyway). gap-card between the text block
+        // and the button keeps them visually separated rather than
+        // butting up under the touch target.
+        <div class="flex items-center justify-between gap-card p-card min-h-[64px]">
             <div class="flex flex-col gap-1 min-w-0">
                 <div class="flex items-baseline gap-card-compact">
                     <span class="text-sm font-medium text-primary truncate">


### PR DESCRIPTION
## Summary

The MCP tokens settings page (shipped in #511) had three padding issues that compounded:

1. **Page-level no-op classes.** \`py-comfortable space-y-comfortable\` aren't defined in [input.css](crates/intrada-web/input.css) (the real names are \`py-card-comfortable\` and \`space-y-section\`). The classes resolved to no-ops, so heading + description + button all stacked with zero gap. Same fix as #515.

2. **Token row content too tight.** \`TokenRow\` used \`p-card-compact\` (12px), the same as a single-line settings row — but a token row carries two lines of text plus an action button, so 12px reads cramped. Bumped to \`p-card\` (16px) and the gap between text and button to \`gap-card\`.

3. **Cards double-padded.** The just-created card and the create-form card wrapped their content in \`<div class=\"space-y-card-compact p-card-compact\">\`, but \`<Card>\` already applies \`p-card sm:p-card-comfortable\` — so children were sitting 28-36px from the outer edge. Removed the redundant inner padding; inner div now only handles vertical rhythm.

## Changes

- \`py-comfortable space-y-comfortable\` → \`py-card-comfortable space-y-section\`. Matches settings.rs.
- Title + description grouped in a \`space-y-card\` sub-div so they read as one unit (heading + lede), with the section-sized gap (48px) reserved for the page's distinct sections.
- \`TokenRow\` outer: \`px-card-compact py-card-compact gap-card-compact\` → \`p-card gap-card\`.
- Just-created and create-form cards: drop the redundant \`p-card-compact\` from the inner div; bump inner spacing to \`space-y-card\`.

## Test plan

- [x] \`cargo check --target wasm32-unknown-unknown -p intrada-web\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\` clean
- [ ] Visual verification on \`/settings/mcp-tokens\` — title + description tight, section-sized gap before the Create button, token row has comfortable internal padding, just-created card has consistent breathing room around heading/textarea/Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)