### PR TITLE
fix(web): Practice tab jumps to active session or in-progress builder

### DIFF
--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -1,3 +1,4 @@
+use intrada_core::ViewModel;
 use leptos::prelude::*;
 use leptos_router::components::A;
 use leptos_router::hooks::use_location;
@@ -11,6 +12,7 @@ use crate::components::ProfileButton;
 #[component]
 pub fn AppHeader() -> impl IntoView {
     let location = use_location();
+    let view_model = expect_context::<RwSignal<ViewModel>>();
 
     let is_library_active = move || {
         let path = location.pathname.get();
@@ -25,6 +27,21 @@ pub fn AppHeader() -> impl IntoView {
     let is_analytics_active = move || {
         let path = location.pathname.get();
         path.starts_with("/analytics")
+    };
+
+    // Tapping Practice jumps straight to whatever's already in flight so
+    // the user can't accidentally start a second session on top of an
+    // active one. Live > building > idle.
+    let practice_href = move || {
+        view_model.with(|vm| {
+            if vm.active_session.is_some() {
+                "/sessions/active".to_string()
+            } else if vm.building_setlist.is_some() {
+                "/sessions/new".to_string()
+            } else {
+                "/sessions".to_string()
+            }
+        })
     };
 
     view! {
@@ -51,7 +68,7 @@ pub fn AppHeader() -> impl IntoView {
                             "Library"
                         </A>
                         <A
-                            href="/sessions"
+                            href=practice_href
                             attr:class=move || {
                                 if is_sessions_active() {
                                     "text-sm font-medium text-accent-text motion-safe:transition-colors"

--- a/crates/intrada-web/src/components/bottom_tab_bar.rs
+++ b/crates/intrada-web/src/components/bottom_tab_bar.rs
@@ -68,6 +68,15 @@ pub fn BottomTabBar() -> impl IntoView {
         None => "Practice",
     };
 
+    // Tapping Practice jumps straight to whatever's already in flight so
+    // the user can't accidentally start a second session on top of an
+    // active one. Live > building > idle.
+    let practice_href = move || match practice_status.get() {
+        Some(StatusDotState::Live) => "/sessions/active".to_string(),
+        Some(StatusDotState::Building) => "/sessions/new".to_string(),
+        None => "/sessions".to_string(),
+    };
+
     let spring = "flex flex-col items-center gap-0.5 text-accent-text tab-spring min-w-[64px] min-h-[44px] justify-center";
     let active = "flex flex-col items-center gap-0.5 text-accent-text min-w-[64px] min-h-[44px] justify-center";
     let inactive = "flex flex-col items-center gap-0.5 text-muted hover:text-secondary motion-safe:transition-colors min-w-[64px] min-h-[44px] justify-center";
@@ -104,7 +113,7 @@ pub fn BottomTabBar() -> impl IntoView {
                 // building or live (#272). The dot overlays the icon's
                 // top-right corner in the relative-positioned wrapper.
                 <A
-                    href="/sessions"
+                    href=practice_href
                     attr:class=move || {
                         if is_sessions_active() {
                             if has_tapped.get() { spring } else { active }


### PR DESCRIPTION
## Summary
- Tapping **Practice** now routes to whatever's already in flight: `/sessions/active` if a session is live, `/sessions/new` if a setlist is mid-build, otherwise the existing `/sessions` list.
- Stops accidental "second session on top of an active one" — addresses the UX confusion when the user has both a builder and a live session in the air.
- Applied to both nav surfaces: mobile bottom tab (`bottom_tab_bar.rs`) and desktop header (`app_header.rs`).

Reactive `href` derived from the `ViewModel`. Live wins over building, mirroring the existing status-dot precedence in `bottom_tab_bar.rs`.

## Test plan
- [ ] No active session, no builder → tap Practice → lands on `/sessions` (history list, unchanged).
- [ ] Mid-build (preset or custom session selected, items being added) → tap Practice from any other tab → lands back on `/sessions/new` with builder intact.
- [ ] Active session running → tap Practice from any other tab → lands on `/sessions/active` (focus mode), no second-session prompt.
- [ ] Verify on iOS simulator (Tauri shell) that haptics + tab-active highlight still fire correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)