### PR TITLE
fix(mobile): three iOS device-build regressions post-Phase-C

### DIFF
--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -6,12 +6,12 @@ mod sessions;
 mod sets;
 mod tokens;
 
-use axum::http::{header, HeaderValue, Method};
+use axum::http::{header, HeaderName, HeaderValue, Method, Request};
 use axum::Router;
 use sentry::integrations::tower::{NewSentryLayer, SentryHttpLayer};
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tower_http::trace::{DefaultMakeSpan, DefaultOnFailure, DefaultOnResponse, TraceLayer};
-use tracing::Level;
+use tower_http::trace::{DefaultOnFailure, DefaultOnResponse, TraceLayer};
+use tracing::{info_span, Level, Span};
 
 use crate::state::AppState;
 
@@ -37,7 +37,39 @@ pub fn api_router(state: AppState) -> Router {
     let strict_cors = CorsLayer::new()
         .allow_origin(AllowOrigin::list(origins))
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            // Sentry's browser SDK auto-instruments `fetch` to attach W3C
+            // Baggage and Sentry trace headers for distributed tracing.
+            // Without these in the allow-list, cross-origin requests fail
+            // CORS preflight with "Request header field baggage is not
+            // allowed by Access-Control-Allow-Headers." This bites the iOS
+            // shell specifically — its WebView origin is `tauri://localhost`
+            // (cross-origin to the API), so every request preflights. The
+            // web app is same-origin via Trunk's proxy and never preflights,
+            // hiding the issue until you ship to iOS.
+            HeaderName::from_static("baggage"),
+            HeaderName::from_static("sentry-trace"),
+        ]);
+
+    // Custom span includes the Origin header so CORS preflight failures
+    // are debuggable from logs alone — without it, you see "OPTIONS 200"
+    // with no clue what origin the browser sent.
+    let make_span = |req: &Request<_>| -> Span {
+        let origin = req
+            .headers()
+            .get("origin")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-");
+        info_span!(
+            "request",
+            method = %req.method(),
+            uri = %req.uri(),
+            version = ?req.version(),
+            origin = %origin,
+        )
+    };
 
     // Permissive CORS for `/api/mcp/*` only. Per #481 — MCP auth is
     // bearer-token-only (PAT), no cookies are involved, so CORS adds zero
@@ -49,7 +81,7 @@ pub fn api_router(state: AppState) -> Router {
         .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
 
     let trace = TraceLayer::new_for_http()
-        .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+        .make_span_with(make_span)
         .on_response(DefaultOnResponse::new().level(Level::INFO))
         // Lower the on_failure event (default ERROR → WARN). Without this,
         // every 5xx generates a generic `tracing::error!("response failed")`

--- a/crates/intrada-mobile/scripts/add-live-activity-target.rb
+++ b/crates/intrada-mobile/scripts/add-live-activity-target.rb
@@ -92,23 +92,30 @@ end
 # ── Load + check ──────────────────────────────────────────────────────
 project = YAML.load_file(PROJECT_YML)
 
-if project['targets']&.key?(TARGET_NAME)
-  puts "✓ #{TARGET_NAME} target already present in project.yml — nothing to do."
-  exit 0
-end
-
 main_target_name = 'intrada-mobile_iOS'
 unless project['targets']&.key?(main_target_name)
   abort "ERROR: expected main target '#{main_target_name}' in project.yml — Tauri may have changed the target name. Update this script."
 end
 
+# If the widget extension target is already present, the only thing left
+# to (potentially) apply is the ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES fix
+# below. Fall through and let the script idempotently ensure that
+# setting is present, then re-run xcodegen if it changed anything.
+target_already_present = project['targets'].key?(TARGET_NAME)
+if target_already_present
+  puts "✓ #{TARGET_NAME} target already present — checking build settings."
+end
+
 # ── Mutate ────────────────────────────────────────────────────────────
+mutated = false
+
 # Paths in project.yml are relative to gen/apple/. We need to express
 # the path back up to crates/intrada-mobile/widget-extension/ and the
 # shared SwiftPM package directory.
 widget_rel = WIDGET_EXTENSION_ROOT.relative_path_from(GEN_DIR).to_s
 shared_rel = SHARED_PACKAGE_ROOT.relative_path_from(GEN_DIR).to_s
 
+unless target_already_present
 # Declare the shared SwiftPM package at project scope so multiple
 # targets can depend on it. xcodegen merges this with whatever existing
 # `packages:` section Tauri's template has (currently empty).
@@ -172,9 +179,51 @@ unless already_dep
   main_target['dependencies'] << { 'target' => TARGET_NAME, 'embed' => true }
 end
 
+mutated = true
+end # unless target_already_present
+
+main_target = project['targets'][main_target_name]
+
+# Force-embed the Swift standard libraries on the main app target.
+#
+# Why: before Phase C the main app was pure Rust — Xcode never ran the
+# "Embed Swift Standard Libraries" build phase, because nothing in the
+# main target linked Swift. Phase C adds a Swift app-extension dependency
+# (IntradaLiveActivity) and pulls in the IntradaActivityShared SwiftPM
+# product. That partially activates Swift toolchain behavior: Xcode copies
+# the back-deployment shim libswift_Concurrency.dylib into Frameworks/,
+# but without ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES, the
+# swift-stdlib-tool pass that would copy libswiftCore.dylib (and friends)
+# alongside it never runs.
+#
+# Result on device: dyld tries to resolve @rpath/libswiftCore.dylib for
+# libswift_Concurrency.dylib at launch, fails, and halts the process
+# before main runs. Symptom is "white screen then disappears" — launch
+# storyboard renders, then SIGABRT from dyld with
+# "Library not loaded: @rpath/libswiftCore.dylib".
+#
+# The simulator masks this — its dyld cache resolves Swift stdlib
+# regardless of bundle contents — so the bug only shows up on device.
+#
+# Setting it on the main target tells Xcode to run the embed pass for
+# the whole .app bundle. The widget extension nested inside picks up
+# the same dylibs from the parent bundle's Frameworks/ via @rpath.
+main_target['settings'] ||= {}
+main_target['settings']['base'] ||= {}
+if main_target['settings']['base']['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] != 'YES'
+  main_target['settings']['base']['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'YES'
+  mutated = true
+  puts '✓ Set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES on main app target.'
+end
+
 # ── Save ──────────────────────────────────────────────────────────────
+unless mutated
+  puts '✓ Nothing to do — project.yml already up to date.'
+  exit 0
+end
+
 PROJECT_YML.write(project.to_yaml)
-puts "✓ Added '#{TARGET_NAME}' target to #{PROJECT_YML.relative_path_from(MOBILE_ROOT)}"
+puts "✓ Wrote #{PROJECT_YML.relative_path_from(MOBILE_ROOT)}"
 
 # ── Re-run xcodegen ───────────────────────────────────────────────────
 puts '→ Re-running xcodegen to regenerate .xcodeproj…'

--- a/crates/intrada-mobile/src-tauri/Info.ios.plist
+++ b/crates/intrada-mobile/src-tauri/Info.ios.plist
@@ -25,5 +25,33 @@
 	-->
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+
+	<!--
+		Local Network access — required for `just ios-dev-device` so the
+		WebView's `fetch()` calls can reach the Mac's Trunk dev server
+		(http://192.168.x.x:8080) over Wi-Fi.
+
+		Why this is needed even though the WKWebView main-document load
+		works without it: the initial page load goes through WebKit's
+		privileged loader, but `fetch()` from JS uses NSURLSession,
+		which on iOS 14+ enforces Local Network Privacy. Without
+		NSLocalNetworkUsageDescription, requests to RFC1918 addresses
+		are silently blocked with `TypeError: Load failed` and no
+		permission prompt is ever shown.
+
+		NSAllowsLocalNetworking relaxes ATS for local-network
+		destinations only — it does NOT disable ATS globally. Production
+		traffic still goes over HTTPS to intrada-api.fly.dev.
+
+		Both keys are no-ops in production (the app never reaches a
+		local-network address) so they're safe to ship.
+	-->
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Intrada needs local network access during development to reach the Trunk dev server on your Mac.</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/crates/intrada-mobile/src-tauri/tauri.conf.json
+++ b/crates/intrada-mobile/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
   "bundle": {
     "active": true,
     "iOS": {
-      "developmentTeam": "9S5FG4LQAF"
+      "developmentTeam": "9S5FG4LQAF",
+      "minimumSystemVersion": "17.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Three independent device-only regressions surfaced after #506 (Phase C — Live Activities). All three are masked by the simulator (dyld cache, lax ATS, same-origin proxy chain) and only fail when running on a physical iPhone via \`just ios-dev-device\`. Found and fixed during a single device-deploy session.

- **dyld halt** — main app missing \`libswiftCore.dylib\`. Tauri's iOS template defaults to iOS 14, which pulls in the Swift Concurrency back-deployment shim but doesn't run the full \`swift-stdlib-tool\` embed pass (the main binary is pure Rust). Fixed by bumping \`minimumSystemVersion\` to iOS 17 (matches CLAUDE.md's stated floor).
- **Local Network Privacy blocking fetch()** — WKWebView's main-document load bypasses \`NSURLSession\`'s local-network check, but \`fetch()\` from JS doesn't. Without \`NSLocalNetworkUsageDescription\`, every request to the dev server's LAN IP silently failed with \`TypeError: Load failed\` — no permission prompt ever fires.
- **CORS preflight rejecting \`baggage\` header** — Sentry's browser SDK auto-instruments fetch with W3C Baggage + \`sentry-trace\` headers. Web app is same-origin via Trunk so never preflights; iOS WebView origin is \`tauri://localhost\`, so every request preflights and fails on \`Access-Control-Allow-Headers\`. Bug shipped silently the moment Sentry was integrated.

Also extended the API request span to include the \`Origin\` header — debugging this without it took several iterations of "OPTIONS 200, no GET follows, why?". Future CORS issues will be one log line away.

## Test plan

- [ ] \`just ios-dev-device\` launches Intrada on a physical iPhone (no dyld halt)
- [ ] On first run, iOS prompts: "Intrada Would Like to Find and Connect to Devices on your Local Network" → tap Allow
- [ ] Library loads items from the local API (no error toast)
- [ ] API logs show \`origin=tauri://localhost\` with both OPTIONS preflights AND follow-up GETs
- [ ] Existing web-app and simulator paths unchanged (web is same-origin, simulator gets Local Network for free)
- [ ] CI green: workspace tests, clippy (workspace + WASM), fmt

## Followup

- Recommend adding \`just ios-dev-device\` to the release-prep checklist — none of these would have been caught by simulator-only smoke tests.
- The \`gen/apple/project.yml\` deployment target gets regenerated from \`tauri.conf.json\` on every \`cargo tauri ios init\`, so the source-of-truth fix is safe across re-inits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)