### PR TITLE
fix(web): paint marketing route immediately + contain feature mocks

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -195,12 +195,11 @@ pub fn App() -> impl IntoView {
             // Fixed gradient background — stays behind all content, does not scroll
             <div class="fixed inset-0 -z-10 bg-linear-to-b from-[var(--color-bg-gradient-top)] to-[var(--color-bg-gradient-bottom)]"></div>
 
-            <Show
-                when=move || auth_loading.get()
-                fallback=move || view! { <AppRoutes /> }
-            >
-                <AuthLoadingScreen />
-            </Show>
+            // Routes mount immediately — public surfaces (`/`, `/login`)
+            // don't need auth state to render. The auth-loading gate now
+            // lives inside `AuthenticatedShell` so it only blocks private
+            // routes while Clerk initialises.
+            <AppRoutes />
         </Router>
     }
 }
@@ -286,8 +285,19 @@ fn AppRoutes() -> impl IntoView {
 /// bottom tab bar, welcome carousel). Mounts per route navigation; the
 /// underlying Crux core / view_model contexts are provided at App level
 /// so this remount is cheap.
+///
+/// Three rendering states, driven reactively by `AuthState`:
+/// - `auth_loading=true` → `AuthLoadingScreen` (Clerk still initialising;
+///   only private routes wait — public `/` and `/login` paint immediately).
+/// - `auth_loading=false && !is_authenticated` → empty placeholder while
+///   the redirect Effect navigates to `/login`.
+/// - `auth_loading=false && is_authenticated` → full chrome + `children()`.
+///
+/// Children type is `ChildrenFn` so the reactive view-closure can call it
+/// across state transitions (e.g. loading → authed) — `Children` (FnOnce)
+/// would be consumed on the first call and panic on the second.
 #[component]
-fn AuthenticatedShell(children: Children) -> impl IntoView {
+fn AuthenticatedShell(children: ChildrenFn) -> impl IntoView {
     let auth = expect_context::<AuthState>();
     let focus_mode = expect_context::<FocusMode>();
 
@@ -296,9 +306,12 @@ fn AuthenticatedShell(children: Children) -> impl IntoView {
     // is set so future mounts see false.
     let show_welcome = RwSignal::new(!welcome_already_seen());
 
-    // Auth gate: redirect to /login if not authed.
+    // Auth gate: redirect to /login when Clerk has finished initialising
+    // and confirmed the user isn't signed in. Wait for `auth_loading=false`
+    // so we don't bounce in-flight users to /login while Clerk's still
+    // figuring out whether they have a session.
     Effect::new(move |_| {
-        if !auth.is_authenticated.get() {
+        if !auth.auth_loading.get() && !auth.is_authenticated.get() {
             let navigate = use_navigate();
             navigate(
                 "/login",
@@ -310,54 +323,53 @@ fn AuthenticatedShell(children: Children) -> impl IntoView {
         }
     });
 
-    // Skip rendering the private chrome + children when unauthed at mount
-    // time. The Effect above handles the actual redirect; rendering an
-    // empty placeholder while it fires keeps deep-linked unauthed users
-    // from briefly seeing AppHeader / data-fetching private views.
-    // `get_untracked` so we don't subscribe — sign-in/out flows trigger a
-    // route change which unmounts this shell anyway.
-    if !auth.is_authenticated.get_untracked() {
-        return view! { <div></div> }.into_any();
+    move || {
+        if auth.auth_loading.get() {
+            view! { <AuthLoadingScreen /> }.into_any()
+        } else if auth.is_authenticated.get() {
+            view! {
+                <div class="relative z-0 min-h-screen text-primary">
+                    // Welcome carousel overlay — shown once for first-time users.
+                    <Show when=move || show_welcome.get()>
+                        <WelcomeCarousel show=show_welcome />
+                    </Show>
+
+                    // Header — hidden in focus mode
+                    <Show when=move || !focus_mode.get()>
+                        <AppHeader />
+                    </Show>
+
+                    // Main content
+                    <main
+                        class=move || if focus_mode.get() {
+                            "focus-mode-container"
+                        } else {
+                            "max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-20 sm:pb-10"
+                        }
+                        role="main"
+                    >
+                        <ErrorBanner />
+                        <ToastStack />
+                        {children()}
+                    </main>
+
+                    // Footer — hidden in focus mode
+                    <Show when=move || !focus_mode.get()>
+                        <AppFooter />
+                    </Show>
+
+                    // Mobile bottom tab bar (hidden on sm: and wider) — hidden in focus mode
+                    <Show when=move || !focus_mode.get()>
+                        <BottomTabBar />
+                    </Show>
+                </div>
+            }
+            .into_any()
+        } else {
+            // Unauthed: empty placeholder while the redirect Effect fires.
+            view! { <div></div> }.into_any()
+        }
     }
-
-    view! {
-        <div class="relative z-0 min-h-screen text-primary">
-            // Welcome carousel overlay — shown once for first-time users.
-            <Show when=move || show_welcome.get()>
-                <WelcomeCarousel show=show_welcome />
-            </Show>
-
-            // Header — hidden in focus mode
-            <Show when=move || !focus_mode.get()>
-                <AppHeader />
-            </Show>
-
-            // Main content
-            <main
-                class=move || if focus_mode.get() {
-                    "focus-mode-container"
-                } else {
-                    "max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-10 pb-20 sm:pb-10"
-                }
-                role="main"
-            >
-                <ErrorBanner />
-                <ToastStack />
-                {children()}
-            </main>
-
-            // Footer — hidden in focus mode
-            <Show when=move || !focus_mode.get()>
-                <AppFooter />
-            </Show>
-
-            // Mobile bottom tab bar (hidden on sm: and wider) — hidden in focus mode
-            <Show when=move || !focus_mode.get()>
-                <BottomTabBar />
-            </Show>
-        </div>
-    }
-    .into_any()
 }
 
 /// Loading screen shown while Clerk initializes.

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -12,11 +12,15 @@ use intrada_web::platform::is_ios;
 ///
 /// Pencil ref: `fWsUw` (desktop) and `vFOGv` (mobile-web).
 ///
-/// On mount:
+/// Renders immediately — does not wait for Clerk to initialise. Auth-state-
+/// based redirects fire reactively via the Effect below as soon as Clerk
+/// resolves:
 /// - Authed users → redirect to /library.
-/// - iOS users (Tauri WebView) → redirect to /login. They already
-///   downloaded the app; the marketing pitch is redundant.
-/// - Anyone else (web, unauthed) → render the marketing page.
+/// - Unauthed iOS users (Tauri WebView) → redirect to /login. They already
+///   downloaded the app; the marketing pitch is redundant. Held until
+///   `auth_loading=false` so we know they're really unauthed (vs. Clerk
+///   still loading their session).
+/// - Anyone else → render the marketing page.
 ///
 /// Sub-sections live as private components in this file. Phone-frame
 /// graphics in the hero use a small reusable `PhoneFrame` shell with
@@ -24,6 +28,7 @@ use intrada_web::platform::is_ios;
 #[component]
 pub fn WelcomeView() -> impl IntoView {
     let auth = expect_context::<AuthState>();
+    let on_ios = is_ios();
 
     Effect::new(move |_| {
         if auth.is_authenticated.get() {
@@ -35,7 +40,7 @@ pub fn WelcomeView() -> impl IntoView {
                     ..Default::default()
                 },
             );
-        } else if is_ios() {
+        } else if !auth.auth_loading.get() && on_ios {
             let navigate = use_navigate();
             navigate(
                 "/login",
@@ -287,7 +292,17 @@ fn WelcomeFeature(
     let layout_class = "max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-20 sm:py-24 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-center";
 
     let text_order = if reverse { "lg:order-2" } else { "" };
-    let mock_order = if reverse { "lg:order-1" } else { "" };
+    // Below the `lg:` breakpoint the grid collapses to a single column and
+    // the mock would otherwise stretch to the full content max-width
+    // (~1280px on tablet). Cap it at `max-w-md` and centre it so the rows
+    // and stat cards keep proportions close to how they're sized inside
+    // the hero PhoneFrame. At `lg:` and up the column itself constrains
+    // the width, so we drop the cap.
+    let mock_order = if reverse {
+        "lg:order-1 w-full max-w-md mx-auto lg:max-w-none lg:mx-0"
+    } else {
+        "w-full max-w-md mx-auto lg:max-w-none lg:mx-0"
+    };
 
     let id = format!("feature-{}", kicker.to_lowercase());
 
@@ -311,7 +326,7 @@ fn WelcomeFeature(
                     }).collect_view()}
                 </ul>
             </div>
-            <div class=mock_order>
+            <div class=format!("card p-5 sm:p-6 flex flex-col gap-3.5 {mock_order}")>
                 {mock()}
             </div>
         </section>


### PR DESCRIPTION
Two follow-ups to the public marketing homepage shipped in #517.

## Summary

- **`/` and `/login` paint immediately** instead of waiting up to 5s for Clerk to finish initialising (the \"Intrada / Loading…\" flash). The auth-loading gate moves from the App level into \`AuthenticatedShell\` so it only blocks routes that actually need auth state.
- **Feature mocks on tablet** stop stretching to the full ~1280px content width — they're now wrapped in a \`card\` with consistent padding and capped at \`max-w-md\` (~448px) below the \`lg:\` breakpoint.

## Why

The first one's a real perceived-performance issue — every visitor to the marketing page saw the loading screen for the full Clerk-init window before the page paints.

The second showed up at tablet widths where the alternating text+mock layout collapses to a single column. Without a max-width, the mock graphic spread across the whole viewport with edge-flush rows and stat cards that read as too tight on the right and unbalanced overall (screenshots from review).

## Changes

### \`crates/intrada-web/src/app.rs\`

- Drop the App-level \`<Show when=auth_loading>\` wrapper around \`<AppRoutes />\` — routes mount immediately.
- \`AuthenticatedShell\` switches to a reactive \`move ||\` view-closure with three states:
  - \`auth_loading=true\` → \`AuthLoadingScreen\`
  - \`auth_loading=false && !is_authenticated\` → empty placeholder while the redirect Effect navigates to \`/login\`
  - \`auth_loading=false && is_authenticated\` → full chrome + \`children()\`
- Children prop type changes from \`Children\` (FnOnce) to \`ChildrenFn\` (Fn) so the closure can call \`children()\` across state transitions.
- Effect's redirect condition gains \`!auth_loading\` so it doesn't bounce in-flight users to \`/login\` while Clerk's still figuring out their session.

### \`crates/intrada-web/src/views/welcome.rs\`

- \`WelcomeView\`'s iOS-skip redirect now waits for \`auth_loading=false\` so authed iOS users go directly to \`/library\` instead of detouring through \`/login\`.
- \`WelcomeFeature\` wraps the mock in \`card p-5 sm:p-6 flex flex-col gap-3.5\` and applies \`w-full max-w-md mx-auto lg:max-w-none lg:mx-0\` to the wrapper. At \`lg:\` and up the column constrains the width naturally; below that the cap centres the preview at a reasonable size.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -p intrada-web --target wasm32-unknown-unknown -- -D warnings\` clean
- [x] \`cargo test -p intrada-web\` — 96 pass
- [x] Verified \`/\` paints \"Practice with intent.\" without the loading flash on local dev (stub Clerk creds → polling fails after ~1s; before the fix the page stayed loading the full 5s)
- [x] Verified \`/library\` deep-link still gates correctly (loading → redirect to \`/login\` for unauthed users)
- [x] Verified tablet (768×1024) — feature mocks now sit in centered cards at ~448px wide
- [x] Verified desktop (1440×900) — feature sections still alternate text+mock at full column width

🤖 Generated with [Claude Code](https://claude.com/claude-code)