### PR TITLE
fix(onboarding): align dots in card 3 by animating cx (not transform)

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -2400,27 +2400,25 @@ html:not([data-platform="ios"]) .context-menu {
 .welcome-mark--align line:nth-of-type(1) { animation-delay: 0ms; }
 .welcome-mark--align line:nth-of-type(2) { animation-delay: 60ms; }
 .welcome-mark--align line:nth-of-type(3) { animation-delay: 120ms; }
-.welcome-mark--align .welcome-dot {
-  transform-box: fill-box;
-  transform-origin: center;
-}
-/* Each dot starts at its scattered position (set via SVG cx) and
-   translates to the same final column. The keyframes encode the
-   delta so dots end visually aligned. */
+/* Animate the SVG `cx` attribute directly — more reliable than CSS
+   transforms on SVG circles, which can render inconsistently across
+   browsers (especially for negative deltas with transform-box: fill-box).
+   Each dot starts at its scattered cx and animates to cx=40 (centre of
+   the line, which runs from x=12 to x=68). */
 @keyframes welcome-mark-align-1 {
-  0%   { opacity: 0; transform: translateX(0); }
-  30%  { opacity: 1; transform: translateX(0); }
-  100% { opacity: 1; transform: translateX(20px); }
+  0%   { opacity: 0; cx: 20; }
+  30%  { opacity: 1; cx: 20; }
+  100% { opacity: 1; cx: 40; }
 }
 @keyframes welcome-mark-align-2 {
-  0%   { opacity: 0; transform: translateX(0); }
-  30%  { opacity: 1; transform: translateX(0); }
-  100% { opacity: 1; transform: translateX(-20px); }
+  0%   { opacity: 0; cx: 60; }
+  30%  { opacity: 1; cx: 60; }
+  100% { opacity: 1; cx: 40; }
 }
 @keyframes welcome-mark-align-3 {
-  0%   { opacity: 0; transform: translateX(0); }
-  30%  { opacity: 1; transform: translateX(0); }
-  100% { opacity: 1; transform: translateX(10px); }
+  0%   { opacity: 0; cx: 30; }
+  30%  { opacity: 1; cx: 30; }
+  100% { opacity: 1; cx: 40; }
 }
 .welcome-mark--align .welcome-dot:nth-of-type(1) {
   animation: welcome-mark-align-1 700ms var(--welcome-mark-ease) 250ms both;
@@ -2521,12 +2519,12 @@ html:not([data-platform="ios"]) .context-menu {
   .welcome-mark .welcome-ring {
     opacity: 0;
   }
-  /* Dots in card 1, 3, 5 still need to land at their target X — apply
-     the final translate without animation so they sit in alignment. */
+  /* Dots in card 1, 3, 5 still need to land at their target position —
+     opener and track use transform-translate; align uses cx (SVG attr). */
   .welcome-mark--opener .welcome-dot { transform: translateX(30px); }
-  .welcome-mark--align .welcome-dot:nth-of-type(1) { transform: translateX(20px); }
-  .welcome-mark--align .welcome-dot:nth-of-type(2) { transform: translateX(-20px); }
-  .welcome-mark--align .welcome-dot:nth-of-type(3) { transform: translateX(10px); }
+  .welcome-mark--align .welcome-dot:nth-of-type(1) { cx: 40; }
+  .welcome-mark--align .welcome-dot:nth-of-type(2) { cx: 40; }
+  .welcome-mark--align .welcome-dot:nth-of-type(3) { cx: 40; }
   .welcome-mark--track .welcome-dot:nth-of-type(1) { transform: translateX(15px); }
   .welcome-mark--track .welcome-dot:nth-of-type(2) { transform: translateX(28px); }
   .welcome-mark--track .welcome-dot:nth-of-type(3) { transform: translateX(40px); }


### PR DESCRIPTION
## Summary

Followup on #520 (which landed the fill-mode `both` fix). The middle dot on card 3 (PLAN — *"Practise with intention"*) animated past the right edge of the staff lines instead of left toward the centre column.

## Root cause

The middle dot is the only dot in the entire welcome carousel that uses a **negative** `translateX` delta — it starts at SVG `cx=60` and translates `-20px` to land at visual `x=40`. The other two dots in the same mark (and dots in cards 1, 4, 5) use only positive translateX values and animate correctly.

CSS `transform: translateX(-Npx)` on SVG `<circle>` elements with `transform-box: fill-box` renders inconsistently across browsers — particularly for negative deltas. The other browsers/cases work fine because they're translating in the positive direction, but the one negative-direction translate visibly misbehaved on the user's runtime (Tauri WebKit, by report).

## Fix

Switch card 3's three align dots to animate the SVG `cx` attribute directly instead of using a CSS transform.

- `cx` is animatable via CSS in modern browsers, is SVG-native, and removes any `transform-box` reliance.
- Other cards (1, 4, 5) keep their transform-based animations since they only use positive translateX values and render correctly.
- Reduced-motion overrides updated to set `cx: 40` directly for the three align dots.

## Files changed

`crates/intrada-web/input.css` — 19 insertions, 21 deletions.

## Test plan

- [x] `cargo fmt --check` + `cargo clippy -p intrada-web -- -D warnings` clean
- [ ] Manual on `trunk serve`: clear localStorage → step to card 3 → confirm all three dots converge to the centre column (none escape past the line edge)
- [ ] Manual with reduced-motion ON: card 3 dots sit at cx=40 in their final state, no animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)