### PR TITLE
feat(web): connection instructions on MCP tokens page

### DIFF
--- a/crates/intrada-web/src/views/mcp_tokens.rs
+++ b/crates/intrada-web/src/views/mcp_tokens.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use leptos::prelude::*;
 
 use intrada_core::{Event, McpToken, McpTokenEvent, ViewModel};
+use intrada_web::api_client::API_BASE_URL;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
@@ -121,6 +122,36 @@ pub fn McpTokensView() -> impl IntoView {
                     "Personal Access Tokens let an AI client (Claude Desktop, Cursor, custom MCP agent) act on your behalf. Generate one for each device or app that needs access."
                 </p>
             </div>
+
+            // Connection details. Permanently visible (not collapsible) since
+            // a first-time user needs the URL + auth instructions to get
+            // anywhere — burying these behind a disclosure adds friction.
+            <Card>
+                <div class="space-y-card">
+                    <div>
+                        <h3 class="card-title">"Connecting your AI client"</h3>
+                        <p class="hint-text">
+                            "Configure your MCP client to point at this endpoint and authenticate with one of the tokens below. Speaks "
+                            <span class="font-mono text-xs">"streamable HTTP"</span>
+                            " + JSON-RPC 2.0."
+                        </p>
+                    </div>
+                    <div class="space-y-card-compact">
+                        <div>
+                            <span class="field-label">"MCP endpoint"</span>
+                            <code class="block w-full px-card-compact py-card-compact mt-1 rounded-md bg-surface-secondary border border-border-default font-mono text-xs text-primary select-all break-all">
+                                {format!("{API_BASE_URL}/api/mcp")}
+                            </code>
+                        </div>
+                        <div>
+                            <span class="field-label">"Authentication"</span>
+                            <code class="block w-full px-card-compact py-card-compact mt-1 rounded-md bg-surface-secondary border border-border-default font-mono text-xs text-primary select-all break-all">
+                                "Authorization: Bearer <your token>"
+                            </code>
+                        </div>
+                    </div>
+                </div>
+            </Card>
 
             // Show-once card for the just-created token. Sits at the top so
             // the user can copy without losing it under the list.


### PR DESCRIPTION
## Summary

A first-time user lands on \`/settings/mcp-tokens\`, creates a token, then needs to know two things to actually plug it into their AI client:

1. The MCP endpoint URL — different domain from the web app (production web is \`myintrada.com\`, API is \`intrada-api.fly.dev\`).
2. How to authenticate (\`Authorization: Bearer <token>\`).

Without these, the token is useless. The page previously assumed the user already knew this from the spec.

## Changes

Adds a permanent **\"Connecting your AI client\"** Card between the page description and the create flow, showing:

- **MCP endpoint** — full URL, sourced from \`intrada_web::api_client::API_BASE_URL\` so it always matches the rest of the app's HTTP layer (no chance of drift between the URL we tell users to use and the URL the rest of the app talks to).
- **Authentication** — \`Authorization: Bearer <your token>\`.
- Brief note on the transport (\"streamable HTTP + JSON-RPC 2.0\") for agents that need to know.

URLs and the auth-header snippet are rendered as \`<code>\` blocks with \`select-all\` so triple-click selects the whole line for copy-paste.

## Design notes

- **Permanent, not collapsible.** A first-time user needs setup info; burying it behind a disclosure adds friction. Token-management for repeat visits has plenty of room without this getting in the way.
- **Reuses design-system primitives** (\`Card\`, \`field-label\`, code-block styling matching the just-created token textarea). No new components.
- **No client-specific config snippets.** Each MCP client has its own format (Claude Desktop's \`claude_desktop_config.json\`, Cursor's settings, etc.) and they evolve. Pointing at the URL + auth shape is durable; example snippets would go stale.

## Test plan

- [x] \`cargo check --target wasm32-unknown-unknown -p intrada-web\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\` clean
- [ ] Visual verification on \`/settings/mcp-tokens\` — Card appears below the description, URL is the right production value, code blocks select cleanly on triple-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)