### PR TITLE
chore: add pre-push hook to refuse pushes to merged-PR branches

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# pre-push hook — refuses pushes to branches whose PR is already merged.
+#
+# Why: after a squash merge, the local branch tip "diverges" from main
+# immediately. Pushing more commits to that same branch silently
+# orphans them — the merged PR no longer accepts new commits, and the
+# push goes onto a branch with no open PR. This hook catches that at
+# the moment of push.
+#
+# Install: `bash scripts/install-git-hooks.sh` (sets core.hooksPath).
+#
+# Bypass (rare — only when you know what you're doing):
+#   SKIP_PR_CHECK=1 git push
+
+set -euo pipefail
+
+# Bypass switch.
+if [ "${SKIP_PR_CHECK:-}" = "1" ]; then
+  exit 0
+fi
+
+# Determine the branch being pushed. If we're in a detached HEAD or
+# a branch that isn't being pushed, there's nothing to check.
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+if [ -z "$branch" ]; then
+  exit 0
+fi
+
+# Skip the check on protected branches — pushing to main / master is a
+# separate concern (branch protection on the remote handles it).
+case "$branch" in
+  main|master) exit 0 ;;
+esac
+
+# If `gh` isn't installed, we can't check — pass silently.
+if ! command -v gh >/dev/null 2>&1; then
+  exit 0
+fi
+
+# If `jq` isn't installed, we can't parse the response — pass silently.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Look up the most recent PR (any state) for this branch's HEAD ref.
+# `gh pr list -L 1` returns at most one row, JSON for stable parsing.
+# Network failure or auth issue → we don't want to block legitimate
+# pushes, so swallow errors and pass.
+state=$(gh pr list \
+  --head "$branch" \
+  --state all \
+  --json state \
+  -L 1 \
+  2>/dev/null | jq -r '.[0].state // empty' 2>/dev/null || true)
+
+if [ "$state" = "MERGED" ]; then
+  cat <<EOF >&2
+
+❌ Pre-push blocked: the most recent PR for branch '$branch' was MERGED.
+
+   Pushing more commits to a merged-PR branch silently orphans them —
+   the PR is closed, so the new commits don't show up anywhere.
+
+   To continue with follow-up work, create a fresh branch from main:
+
+     git fetch origin main
+     git checkout -b <new-branch> origin/main
+     git cherry-pick <sha>      # if you've already committed
+     git push -u origin <new-branch>
+     gh pr create               # opens the new PR
+
+   Or, if you really mean to push (rare — extracting a stash, fixing
+   a typo before deletion, etc.):
+
+     SKIP_PR_CHECK=1 git push
+
+EOF
+  exit 1
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ Run `cargo fmt --check` and `cargo clippy -- -D warnings` *locally before pushin
 not just before committing. Pushing then watching CI fail wastes a full ~3-minute
 roundtrip per agent or contributor; better to catch the formatting tab here.
 
+Optional one-time hook install (catches the "pushed onto a merged-PR
+branch and the commits orphaned" pitfall):
+```bash
+bash scripts/install-git-hooks.sh   # sets core.hooksPath = .githooks
+```
+The pre-push hook uses `gh` + `jq` to refuse pushes to a branch whose
+most recent PR is already MERGED, with a hint to create a fresh branch
+from `origin/main`. Bypass for legitimate edge cases:
+`SKIP_PR_CHECK=1 git push`. Opt out: `git config --unset core.hooksPath`.
+
 First-time iOS setup (run once after cloning or pulling this branch):
 ```bash
 cargo install tauri-cli --version "^2" --locked   # Tauri CLI

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Opt in to the repo-tracked git hooks under .githooks/.
+#
+# What it does: sets `core.hooksPath` to `.githooks` for this clone,
+# which makes git look there for pre-commit / pre-push / etc. instead
+# of the default `.git/hooks/`.
+#
+# Run once after cloning:
+#   bash scripts/install-git-hooks.sh
+#
+# To opt out:
+#   git config --unset core.hooksPath
+#
+# This is a per-clone, opt-in setting — it does not affect other
+# contributors automatically. Required dependencies for the hooks to
+# function: `gh` (GitHub CLI) and `jq`. If either is missing, the
+# affected hook will pass silently rather than block.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if [ ! -d .githooks ]; then
+  echo "❌ .githooks/ not found at repo root." >&2
+  exit 1
+fi
+
+# Make every hook executable (in case it was checked out without +x).
+chmod +x .githooks/* 2>/dev/null || true
+
+# Set in the main repo config (shared across all worktrees by default).
+git config core.hooksPath .githooks
+
+# Worktrees can carry their own `core.hooksPath` override (some tooling
+# sets this when a worktree is created so hooks default to the main
+# repo's .git/hooks/). That override shadows our setting. Clear it
+# from any worktree-local config so the repo-shared value takes effect.
+worktree_configs=$(find .git/worktrees -name config.worktree 2>/dev/null || true)
+for cfg in $worktree_configs; do
+  if grep -q "^[[:space:]]*hookspath" "$cfg" 2>/dev/null; then
+    git --git-dir="$(dirname "$cfg")" config --worktree --unset core.hooksPath 2>/dev/null || true
+  fi
+done
+
+# If the current invocation IS in a worktree, the loop above may not
+# reach our own config (paths are tricky). Belt-and-braces.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git config --worktree --unset core.hooksPath 2>/dev/null || true
+fi
+
+echo "✅ Git hooks installed (core.hooksPath = .githooks)."
+echo
+echo "Hooks active:"
+for h in .githooks/*; do
+  [ -f "$h" ] && echo "  - $(basename "$h")"
+done
+echo
+echo "To opt out:  git config --unset core.hooksPath"
+
+# Light dependency hint, doesn't block install.
+missing=""
+command -v gh >/dev/null 2>&1 || missing="${missing} gh"
+command -v jq >/dev/null 2>&1 || missing="${missing} jq"
+if [ -n "$missing" ]; then
+  echo
+  echo "⚠️  Missing dependencies for full hook coverage:${missing}"
+  echo "    Install via Homebrew: brew install${missing}"
+fi


### PR DESCRIPTION
## Summary

Catches a real workflow trap: after a squash merge, the local branch tip diverges from `main` immediately. Pushing more commits to the same branch silently orphans them — the merged PR no longer accepts new commits, so the push goes onto a branch with no open PR.

Two recent incidents hit exactly this:

1. **#516 (v2 onboarding)** merged → I committed a follow-up fill-mode fix to the same branch and pushed → had to spot it manually and open #520.
2. **#520 (fill-mode fix)** merged → I committed a follow-up cx-animation fix to the same branch and pushed → had to spot it manually and open #533.

## What this adds

- `.githooks/pre-push` — checks the most recent PR for the current branch via `gh pr list`. Exits 1 with a hint if MERGED:
  ```
  ❌ Pre-push blocked: the most recent PR for branch 'foo' was MERGED.
     Pushing more commits to a merged-PR branch silently orphans them...
     To continue with follow-up work, create a fresh branch from main: ...
  ```
  Passes silently if `gh`/`jq` missing, if no PR exists, or if branch is `main`/`master`. Bypass for legitimate edge cases: `SKIP_PR_CHECK=1 git push`.

- `scripts/install-git-hooks.sh` — opt-in installer that sets `core.hooksPath = .githooks`. Also clears any worktree-local `core.hooksPath` override (Claude Code's worktree harness sets one that would otherwise shadow the repo-shared value).

- `CLAUDE.md` — one-paragraph note on installing under the existing pre-push checks block.

## Why opt-in

`core.hooksPath` is per-clone, not committed-to-repo behaviour. Contributors who don't run the installer get the default git behaviour (no hook). The hook is only for those who want a guard rail; the installer is a one-line ask in CLAUDE.md.

## Verified

- Syntax-checked both scripts
- Installer ran cleanly + correctly handled the worktree-local override
- Hook fires correctly:
  - On a branch with a MERGED PR (`fix/onboarding-animation-final-state`): exits 1 with the block message ✓
  - On a branch with no PR yet (this branch, before pushing): exits 0 silently ✓
- `--dry-run` push was allowed for this branch (no PR yet)

## Test plan

- [ ] Reviewer runs `bash scripts/install-git-hooks.sh` — see "✅ Git hooks installed"
- [ ] Reviewer runs `git push` from a branch whose PR is merged — see the block message + exit 1
- [ ] Reviewer runs `SKIP_PR_CHECK=1 git push` — bypasses the hook
- [ ] Reviewer runs `git config --unset core.hooksPath` to opt out — pushes work without the hook again

🤖 Generated with [Claude Code](https://claude.com/claude-code)