### PR TITLE
fix(welcome): contain feature mocks with card wrapper + max-width on tablet

### DIFF
--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -287,7 +287,17 @@ fn WelcomeFeature(
     let layout_class = "max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-20 sm:py-24 grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-20 items-center";
 
     let text_order = if reverse { "lg:order-2" } else { "" };
-    let mock_order = if reverse { "lg:order-1" } else { "" };
+    // Below the `lg:` breakpoint the grid collapses to a single column and
+    // the mock would otherwise stretch to the full content max-width
+    // (~1280px on tablet). Cap it at `max-w-md` and centre it so the rows
+    // and stat cards keep proportions close to how they're sized inside
+    // the hero PhoneFrame. At `lg:` and up the column itself constrains
+    // the width, so we drop the cap.
+    let mock_order = if reverse {
+        "lg:order-1 w-full max-w-md mx-auto lg:max-w-none lg:mx-0"
+    } else {
+        "w-full max-w-md mx-auto lg:max-w-none lg:mx-0"
+    };
 
     let id = format!("feature-{}", kicker.to_lowercase());
 
@@ -311,7 +321,7 @@ fn WelcomeFeature(
                     }).collect_view()}
                 </ul>
             </div>
-            <div class=mock_order>
+            <div class=format!("card p-5 sm:p-6 flex flex-col gap-3.5 {mock_order}")>
                 {mock()}
             </div>
         </section>


### PR DESCRIPTION
## Summary

Recovers an orphan commit (`fce6725` on `claude/quirky-kalam-2b2f79`) that was pushed onto a merged-PR branch and never made it to main. Original commit by you on 2026-05-08, not landed.

## What it fixes

Below the `lg:` breakpoint the alternating text+mock layout on the public marketing homepage collapses to a single column, and the mock would otherwise stretch to the full content max-width (~1280px on tablet). That makes rows + stat cards inside the mock look stretched, with the right-edge padding reading as too tight.

The fix caps each feature mock at `max-w-md` and centres it on tablet/mobile, then drops the cap at `lg:` and up where the column itself constrains the width. Also wraps the mock in a `card` style so the rows + stat cards inside have a proper container.

## Files changed

`crates/intrada-web/src/views/welcome.rs` — 12 insertions, 2 deletions in `WelcomeFeature`.

## Verified

- Cherry-picked cleanly onto a fresh branch off `origin/main` (no conflicts despite the `clerk_bindings → js_bridge` rename in #524 — this commit doesn't touch those imports)
- `cargo fmt --check` clean
- `cargo clippy -p intrada-web -- -D warnings` clean

## Origin

Caught during a routine audit looking for orphan commits on branches with merged PRs. Same pattern as #520 and #533 — the upcoming pre-push hook in #535 would have blocked the original orphan push at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)