### PR TITLE
fix(web): persist focus-mode preference per session + diagonal-arrow icons

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -53,6 +53,15 @@ pub struct AuthState {
     pub auth_error: RwSignal<bool>,
 }
 
+/// Remembers the user's focus-mode toggle for the currently-active session,
+/// keyed by `ActiveSessionView::started_at` (RFC3339, unique per session).
+///
+/// Re-entering the active-session route looks this up so a user who
+/// explicitly exited focus mode mid-session isn't snapped back into it on
+/// return. Cleared when the session ends so the next session starts fresh.
+#[derive(Clone, Copy)]
+pub struct SessionFocusPref(pub RwSignal<Option<(String, bool)>>);
+
 #[component]
 pub fn App() -> impl IntoView {
     // Auth state signals — drive the auth gate
@@ -143,6 +152,7 @@ pub fn App() -> impl IntoView {
     let is_loading = IsLoading::new(true);
     let is_submitting = IsSubmitting::new(false);
     let focus_mode = FocusMode(RwSignal::new(false));
+    let session_focus_pref = SessionFocusPref(RwSignal::new(None));
 
     provide_context(auth);
     provide_context(core.clone());
@@ -150,6 +160,7 @@ pub fn App() -> impl IntoView {
     provide_context(is_loading);
     provide_context(is_submitting);
     provide_context(focus_mode);
+    provide_context(session_focus_pref);
     provide_toast();
 
     // Session-lifecycle Effect (#309 Phase D + #474 Phase B). Drives

--- a/crates/intrada-web/src/components/icon.rs
+++ b/crates/intrada-web/src/components/icon.rs
@@ -22,6 +22,8 @@ pub enum IconName {
     ChevronUp,
     Clock,
     ListChecks,
+    Maximize,
+    Minimize,
     Minus,
     Music,
     Pause,
@@ -129,6 +131,20 @@ pub fn Icon(
             <path d="M13 6h8" />
             <path d="M13 12h8" />
             <path d="M13 18h8" />
+        }
+        .into_any(),
+        IconName::Maximize => view! {
+            <polyline points="15 3 21 3 21 9" />
+            <polyline points="9 21 3 21 3 15" />
+            <line x1="21" y1="3" x2="14" y2="10" />
+            <line x1="3" y1="21" x2="10" y2="14" />
+        }
+        .into_any(),
+        IconName::Minimize => view! {
+            <polyline points="4 14 10 14 10 20" />
+            <polyline points="20 10 14 10 14 4" />
+            <line x1="14" y1="10" x2="21" y2="3" />
+            <line x1="3" y1="21" x2="10" y2="14" />
         }
         .into_any(),
         IconName::Minus => view! {

--- a/crates/intrada-web/src/views/session_active.rs
+++ b/crates/intrada-web/src/views/session_active.rs
@@ -4,7 +4,7 @@ use leptos_router::NavigateOptions;
 
 use intrada_core::{SessionStatusView, ViewModel};
 
-use crate::app::FocusMode;
+use crate::app::{FocusMode, SessionFocusPref};
 use crate::components::{Icon, IconName, SessionTimer};
 
 /// Active session view: wraps the SessionTimer, redirects when session state changes.
@@ -12,11 +12,30 @@ use crate::components::{Icon, IconName, SessionTimer};
 pub fn SessionActiveView() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let focus_mode = expect_context::<FocusMode>();
+    let focus_pref = expect_context::<SessionFocusPref>();
     let navigate = use_navigate();
 
-    // Enter focus mode on mount, exit on unmount
-    focus_mode.set(true);
+    // Restore focus-mode preference for this session if we have one.
+    // Fresh sessions default to ON; returning to a session the user
+    // explicitly exited focus on stays OFF.
+    let active_started_at =
+        view_model.with_untracked(|vm| vm.active_session.as_ref().map(|s| s.started_at.clone()));
+    let initial_focus = match (&active_started_at, focus_pref.0.get_untracked()) {
+        (Some(id), Some((stored_id, val))) if id == &stored_id => val,
+        _ => true,
+    };
+    focus_mode.set(initial_focus);
+
     on_cleanup(move || {
+        // Save current toggle keyed by session id so re-entering the same
+        // session restores it. If the session ended (no active_session),
+        // clear the pref so the next session starts fresh.
+        let started_at = view_model
+            .with_untracked(|vm| vm.active_session.as_ref().map(|s| s.started_at.clone()));
+        match started_at {
+            Some(id) => focus_pref.0.set(Some((id, focus_mode.0.get_untracked()))),
+            None => focus_pref.0.set(None),
+        }
         focus_mode.set(false);
     });
 
@@ -93,9 +112,9 @@ pub fn SessionActiveView() -> impl IntoView {
                     on:click=move |_| focus_signal.set(!focus_signal.get_untracked())
                 >
                     {move || if focus_signal.get() {
-                        view! { <Icon name=IconName::ChevronDown class="w-5 h-5" /> }
+                        view! { <Icon name=IconName::Minimize class="w-5 h-5" /> }
                     } else {
-                        view! { <Icon name=IconName::ChevronUp class="w-5 h-5" /> }
+                        view! { <Icon name=IconName::Maximize class="w-5 h-5" /> }
                     }}
                 </button>
             </div>

--- a/crates/intrada-web/src/views/session_active.rs
+++ b/crates/intrada-web/src/views/session_active.rs
@@ -36,6 +36,7 @@ pub fn SessionActiveView() -> impl IntoView {
             Some(id) => focus_pref.0.set(Some((id, focus_mode.0.get_untracked()))),
             None => focus_pref.0.set(None),
         }
+        // FocusMode is app-level; reset it so chrome reappears off-route.
         focus_mode.set(false);
     });
 


### PR DESCRIPTION
## Summary

Two related practice-flow polish items reported together.

### 1. Focus mode no longer auto-snaps back on
Today every mount of `/sessions/active` forces `focus_mode=true`, every unmount forces `false`. So: start a session (focus on, by design), exit focus, navigate away, come back — and you're slammed into focus mode again, overriding the user's choice.

Now we remember the toggle keyed by \`ActiveSessionView::started_at\` (RFC3339, unique per session). Re-entering the same session restores the user's last toggle. Fresh sessions still default to focus-on. When the session ends (no \`active_session\`), the pref clears so the next session starts fresh.

Implementation: new \`SessionFocusPref(RwSignal<Option<(String, bool)>>)\` context provided at app level; \`SessionActiveView\` reads it on mount and writes it on \`on_cleanup\`.

### 2. Diagonal-arrow icons for the focus toggle
\`ChevronUp/Down\` read as \"expand/collapse list\" — doesn't match what the button actually does (toggle full-screen focus mode). Swapped for Lucide-style \`maximize-2\` / \`minimize-2\` (the diagonal-arrow pair) which is the conventional fullscreen toggle iconography.

## Test plan
- [x] Start a session → lands in focus mode with **Minimize** icon top-right (header + tab bar hidden).
- [x] Click Minimize → focus off, **Maximize** icon, header + tab bar return.
- [x] Navigate to Library → tap Practice tab → returns to \`/sessions/active\` with focus still **off** (this is the bug fix).
- [x] Toggle back on, navigate away, return → focus still **on**.
- [ ] Verify on iOS simulator that haptics still fire correctly on toggle.

Verified in-browser end-to-end via dev preview. \`cargo check\` / \`cargo clippy -p intrada-web -- -D warnings\` / \`cargo fmt --check\` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)