### PR TITLE
fix(web): app header brand matches marketing nav

### DIFF
--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -46,10 +46,13 @@ pub fn AppHeader() -> impl IntoView {
 
     view! {
         <header class="glass-chrome border-b border-border-default" role="banner">
-            <div class="max-w-4xl mx-auto px-card sm:px-card-comfortable py-card sm:py-card-comfortable flex items-center justify-between">
+            <div class="max-w-4xl mx-auto px-card sm:px-card-comfortable py-4 flex items-center justify-between">
                 <div>
-                    <A href="/library" attr:class="no-underline">
-                        <h1 class="text-2xl sm:text-3xl font-bold tracking-tight text-primary">"Intrada"</h1>
+                    <A href="/library" attr:class="flex items-center gap-2.5 no-underline">
+                        <svg class="w-5 h-5 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+                        </svg>
+                        <span class="text-lg font-bold text-primary font-heading">"Intrada"</span>
                     </A>
                 </div>
                 <div class="flex items-center gap-4">


### PR DESCRIPTION
## Summary

- App header (`AppHeader`) now uses the same brand mark as the marketing nav (`WelcomeNav`): music-note SVG icon + `text-lg font-bold font-heading` "Intrada" wordmark, in a `flex items-center gap-2.5` link.
- Vertical padding aligned to `py-4` to match the marketing header's rhythm.
- Drops the second `<h1>` from every authed page — page views already own their `<h1>` ("Library", "Practice", "Analytics", etc.). The brand wordmark is now a `<span>`, matching marketing.

Horizontal padding kept on the design-system tokens (`px-card sm:px-card-comfortable`) since the app header is `max-w-4xl` vs marketing's `max-w-7xl` — copying the marketing px values would feel cramped in the narrower container.

## Before / after

**Before**: `<h1 class="text-2xl sm:text-3xl font-bold tracking-tight text-primary">"Intrada"</h1>` (no icon)

**After**: music-note SVG (`w-5 h-5 text-accent`) + `<span class="text-lg font-bold text-primary font-heading">"Intrada"</span>` — pixel-identical to `WelcomeNav` brand.

## Test plan

- [ ] /library, /sessions, /analytics — brand shows music-note + smaller wordmark, click goes to /library
- [ ] Marketing /  → app /library nav: brand looks visually identical between the two surfaces
- [ ] iOS shell — header still safe-area-friendly with the tighter `py-4`
- [ ] Page lighthouse / a11y inspector — only one `<h1>` per authed page now

🤖 Generated with [Claude Code](https://claude.com/claude-code)