### PR TITLE
copy(onboarding): align cards 4 & 5 with vision-anchored tone

### DIFF
--- a/crates/intrada-web/src/components/welcome_carousel.rs
+++ b/crates/intrada-web/src/components/welcome_carousel.rs
@@ -48,15 +48,17 @@ const CARDS: [CardContent; CARD_COUNT] = [
     },
     CardContent {
         label: Some("PRACTICE"),
-        anchor: "Focus, reflect, repeat",
+        anchor: "Focus, reflect, move on",
         continuation: Some(
-            "Run timed sessions with real-time reflection \u{2014} score what happened while it\u{2019}s still fresh.",
+            "Run timed sessions. Score what happened while it\u{2019}s still fresh, then on to the next.",
         ),
     },
     CardContent {
         label: Some("TRACK"),
-        anchor: "Watch your progress",
-        continuation: Some("Track every session, achieve your goals."),
+        anchor: "Watch the work add up",
+        continuation: Some(
+            "Music improves between sessions, not within them \u{2014} so the data shows what your ears can\u{2019}t hear yet.",
+        ),
     },
 ];
 

--- a/e2e/tests/welcome.spec.ts
+++ b/e2e/tests/welcome.spec.ts
@@ -37,13 +37,13 @@ test.describe("welcome carousel", () => {
 
     await carousel.click({ position: { x: 200, y: 400 } });
     await page.waitForTimeout(150);
-    // Card 4 anchor — "Focus, reflect, repeat"
-    await expect(page.getByText("Focus, reflect, repeat")).toBeVisible();
+    // Card 4 anchor — "Focus, reflect, move on"
+    await expect(page.getByText("Focus, reflect, move on")).toBeVisible();
 
     await carousel.click({ position: { x: 200, y: 400 } });
     await page.waitForTimeout(150);
-    // Card 5 anchor — "Watch your progress"
-    await expect(page.getByText("Watch your progress")).toBeVisible();
+    // Card 5 anchor — "Watch the work add up"
+    await expect(page.getByText("Watch the work add up")).toBeVisible();
 
     // Use regex to match the button regardless of the → Unicode arrow suffix
     const cta = page.getByRole("button", { name: /Get started/ });

--- a/specs/onboarding-welcome.md
+++ b/specs/onboarding-welcome.md
@@ -68,8 +68,8 @@ the structure that follows feel intentional rather than templated.
 | 1 | *(none — opener)* | "Knowing how to practise well is hard." | "I've struggled with it. So I built this." |
 | 2 | CAPTURE | "Build a library" | "of pieces and exercises — the things you're actually working on." |
 | 3 | PLAN | "Practise with intention" | "Plan each session. Decide where the effort goes before you pick up the instrument." |
-| 4 | PRACTICE | "Focus, reflect, repeat" | "Run timed sessions with real-time reflection — score what happened while it's still fresh." |
-| 5 | TRACK | "Watch your progress" | "Track every session, achieve your goals." |
+| 4 | PRACTICE | "Focus, reflect, move on" | "Run timed sessions. Score what happened while it's still fresh, then on to the next." |
+| 5 | TRACK | "Watch the work add up" | "Music improves between sessions, not within them — so the data shows what your ears can't hear yet." |
 
 Final-card CTA routes to `/` (the Library home, not `/library/new` —
 the welcome should hand off to the empty library, not push the user


### PR DESCRIPTION
## Summary

Follows up on the marketing-page tone refresh (#542 / #545) by aligning two onboarding cards that drifted from the vision the new marketing copy articulates. Cards 1-3 already align with the new tone and stay faithful to the spec's "personal, maker's-note voice" goal; only cards 4 and 5 needed work.

### Card 4 (PRACTICE)

Old:
> **Focus, reflect, repeat**
> Run timed sessions with real-time reflection — score what happened while it's still fresh.

New:
> **Focus, reflect, move on**
> Run timed sessions. Score what happened while it's still fresh, then on to the next.

"Repeat" implied looping (sessions don't loop), and "real-time reflection" was jargon the marketing rewrite deliberately avoided. The new continuation mirrors the linear shape of a real practice session.

### Card 5 (TRACK)

Old:
> **Watch your progress**
> Track every session, achieve your goals.

New:
> **Watch the work add up**
> Music improves between sessions, not within them — so the data shows what your ears can't hear yet.

"Achieve your goals" is generic productivity-app language — the register the marketing rewrite explicitly moved away from. The TRACK pillar's strongest insight is **invisible progress between sessions**, and the onboarding wasn't saying it.

### Why other cards weren't touched

- **Card 1 (opener)** — *"Knowing how to practise well is hard. I've struggled with it. So I built this."* — the maker's-note voice the spec was written for. Untouchable.
- **Card 2 (CAPTURE)** — *"Build a library of pieces and exercises — the things you're actually working on."* — warmer than marketing's version, right register for onboarding.
- **Card 3 (PLAN)** — *"Practise with intention. Plan each session. Decide where the effort goes before you pick up the instrument."* — already directly aligned with the new vision.

The spec (`specs/onboarding-welcome.md`) is updated in lockstep per its own "These lines are the spec — not placeholders" rule.

## Test plan

- [ ] Visual check on web — confirm new card 5 continuation doesn't wrap awkwardly at small widths (it's longer than the previous line)
- [ ] iOS check — confirm card 5 reads well above the safe-area-inset progress dots
- [ ] Read-through end-to-end — does the five-card arc still feel cohesive

🤖 Generated with [Claude Code](https://claude.com/claude-code)