### PR TITLE
copy(footer): unify app + marketing copy and hide on iOS

### DIFF
--- a/crates/intrada-web/src/components/app_footer.rs
+++ b/crates/intrada-web/src/components/app_footer.rs
@@ -6,7 +6,7 @@ pub fn AppFooter() -> impl IntoView {
     view! {
         <footer class="max-w-4xl mx-auto px-4 sm:px-6 py-6 border-t border-border-default" role="contentinfo">
             <p class="text-xs text-faint text-center">
-                "Built with Rust, Leptos & Crux by Jon Yardley - with help from Claude"
+                "© 2026 Jon Yardley · Built for musicians who practice with intent."
             </p>
         </footer>
     }

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -436,14 +436,14 @@ fn WelcomeFinalCta() -> impl IntoView {
 #[component]
 fn WelcomeFooter() -> impl IntoView {
     view! {
-        <footer class="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-10 border-t border-border-default flex flex-col sm:flex-row items-center justify-between gap-4">
+        <footer class="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-10 border-t border-border-default flex flex-col sm:flex-row items-center justify-between gap-4" role="contentinfo">
             <div class="flex items-center gap-2.5">
                 <svg class="w-4 h-4 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
                 </svg>
                 <span class="text-base font-bold text-primary font-heading">"Intrada"</span>
             </div>
-            <p class="text-sm text-muted">"© 2026 Intrada · Built for musicians who practice with intent."</p>
+            <p class="text-sm text-muted">"© 2026 Jon Yardley · Built for musicians who practice with intent."</p>
             <nav class="flex items-center gap-6">
                 <a href="#" class="text-sm font-medium text-secondary hover:text-primary motion-safe:transition-colors no-underline">"Privacy"</a>
                 <a href="#" class="text-sm font-medium text-secondary hover:text-primary motion-safe:transition-colors no-underline">"Terms"</a>


### PR DESCRIPTION
## Summary

Three small alignment moves on the footers:

- **Marketing footer copyright** now names the maker — *"© 2026 Jon Yardley · Built for musicians who practice with intent."* (was *"© 2026 Intrada · …"*). Aligns with the maker's-note voice used in onboarding card 1.
- **App footer** now uses the same line. Previously read *"Built with Rust, Leptos & Crux by Jon Yardley - with help from Claude"* — fun engineering credit but inconsistent with the marketing voice. Dropped in favour of consistency.
- **Marketing footer gets `role="contentinfo"`** so the existing iOS-hide CSS rule catches it:

  ```css
  /* input.css:1326 */
  [data-platform="ios"] footer[role="contentinfo"] { display: none; }
  ```

  The app footer already had this role, so it was already hidden on iOS — the marketing footer was the only one still visible there.

## Test plan

- [ ] Visual check on web — confirm the new copyright line renders correctly in both surfaces
- [ ] iOS check (`just ios-dev`) — confirm both footers are now hidden
- [ ] No need for an E2E update — no Playwright test asserts on footer text (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)