### PR TITLE
style(header): hide app header on mobile web to match iOS cadence

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1322,6 +1322,19 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   display: none;
 }
 
+/* Hide the web header on mobile web too — bottom tab bar is the primary
+   nav surface on small viewports, and the only header content visible on
+   mobile (brand wordmark + ProfileButton) is already covered: the Account
+   tab in the bottom bar replaces the profile button, and Apple-pattern
+   in-app screens don't show app branding inside the app. Aligns mobile
+   web cadence with iOS. 639px (not 640px) so the cut-off doesn't overlap
+   with Tailwind's `sm:` breakpoint. */
+@media (max-width: 639px) {
+  header[role="banner"] {
+    display: none;
+  }
+}
+
 /* Hide the web footer on iOS — attribution is a desktop convention. */
 [data-platform="ios"] footer[role="contentinfo"] {
   display: none;


### PR DESCRIPTION
## Summary

The app header on mobile web showed the brand wordmark + ProfileButton above the routed content while the bottom tab bar was already pinned at the bottom of the viewport. The double-bar arrangement competed for visual weight and burned ~64px of vertical real estate on a surface that's already space-constrained.

iOS already lives without the web header (rule above this one in `input.css`, set when the Tauri shell shipped). Mobile web should match — the bottom tab bar is the primary nav surface on small viewports, and the Account tab covers what the ProfileButton was doing.

```css
@media (max-width: 639px) {
  header[role="banner"] {
    display: none;
  }
}
```

Pure CSS — no markup change. `639px` (not `640px`) so the cut-off doesn't overlap with Tailwind's `sm:` breakpoint.

## What survived the audit

- **ProfileButton.** Was the only mobile-rendered header element with a unique destination (the desktop nav links inside `<header>` are already `hidden sm:flex`). The Account tab in `BottomTabBar` routes to the same `/settings` destination, so no functional loss.
- **Brand wordmark.** Each routed view provides its own `page-title` near the top of the content area — same pattern Apple's first-party apps follow on iOS, where the app icon and the welcome carry the brand instead of in-app chrome.
- **iPad (iOS shell at sm+ widths).** Still hides the header via the pre-existing `[data-platform="ios"]` rule, which has higher specificity (0,2,1) than any Tailwind utility (0,1,0) at that breakpoint.

## Test plan

- [ ] Mobile web at < 640px (Chrome/Safari) — confirm header is gone, bottom tab bar still works
- [ ] Tablet web (≥ 640px) — confirm header is back with the desktop Library/Practice/Analytics nav links
- [ ] iOS simulator — confirm no regression (same display state as before)
- [ ] iPad in iOS shell — confirm header still hidden (existing iOS rule should win)
- [ ] Verify each routed view (Library / Sessions / Analytics / Settings) has its own `page-title` so identity isn't lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)