### PR TITLE
fix(web): show "signing you in" on /sso-callback instead of 404

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -22,7 +22,7 @@ use crate::views::{
     AccountDeleteView, AddLibraryItemForm, AnalyticsPage, DetailView, EditLibraryItemForm,
     LibraryListView, LoginView, McpAuditView, McpTokensView, NotFoundView, OAuthConsentView,
     SessionActiveView, SessionNewView, SessionSummaryView, SessionsAllView, SessionsListView,
-    SetDetailView, SetEditView, SettingsView, WelcomeView,
+    SetDetailView, SetEditView, SettingsView, SsoCallbackView, WelcomeView,
 };
 use intrada_web::core_bridge::{init_core, load_session_in_progress, process_effects};
 use intrada_web::js_bridge;
@@ -226,6 +226,7 @@ fn AppRoutes() -> impl IntoView {
             // ─── Public routes ────────────────────────────────────────
             <Route path=path!("/") view=|| view! { <WelcomeView /> } />
             <Route path=path!("/login") view=|| view! { <LoginView /> } />
+            <Route path=path!("/sso-callback") view=|| view! { <SsoCallbackView /> } />
 
             // ─── Private routes ───────────────────────────────────────
             // /library/new MUST come before /library/:id to avoid "new"

--- a/crates/intrada-web/src/views/mod.rs
+++ b/crates/intrada-web/src/views/mod.rs
@@ -19,6 +19,7 @@ pub mod sessions_all;
 pub mod set_detail;
 pub mod set_edit;
 pub mod settings;
+pub mod sso_callback;
 pub mod welcome;
 
 pub use account_delete::AccountDeleteView;
@@ -42,4 +43,5 @@ pub use sessions_all::SessionsAllView;
 pub use set_detail::SetDetailView;
 pub use set_edit::SetEditView;
 pub use settings::SettingsView;
+pub use sso_callback::SsoCallbackView;
 pub use welcome::WelcomeView;

--- a/crates/intrada-web/src/views/sso_callback.rs
+++ b/crates/intrada-web/src/views/sso_callback.rs
@@ -1,0 +1,116 @@
+use leptos::prelude::*;
+use leptos_router::components::A;
+use leptos_router::hooks::use_navigate;
+use leptos_router::NavigateOptions;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+
+use crate::app::AuthState;
+
+/// Landing route for the Clerk OAuth redirect — `/sso-callback`.
+///
+/// The actual callback is processed by the inline JS bridge in `index.html`
+/// (it calls `clerk.handleRedirectCallback` once the SDK finishes loading
+/// from the CDN, then navigates to `/`). On slow networks that download +
+/// callback round-trip can take several seconds, during which Leptos would
+/// otherwise render `NotFoundView` because no route matched. This view
+/// stands in with a friendly "Signing you in…" state until either the
+/// auth listener flips `is_authenticated` true (defence-in-depth: we then
+/// push to `/library` ourselves, in case Clerk's own redirect doesn't
+/// fire), the inline script reports an init failure, or 15s pass with no
+/// progress.
+#[component]
+pub fn SsoCallbackView() -> impl IntoView {
+    let auth = expect_context::<AuthState>();
+    let timed_out = RwSignal::new(false);
+    // No callback params at all → the user reached `/sso-callback` outside
+    // the OAuth flow (manual URL entry, deep link, refresh after success).
+    // Skip the 15s wait and surface a clearer message immediately.
+    let no_callback_params = web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .map(|s| s.is_empty())
+        .unwrap_or(false);
+
+    // Effect runs on every signal tick; guard so we only fire `navigate`
+    // once even if `is_authenticated` flickers (Clerk's listener can fire
+    // multiple times around session establishment).
+    let navigated = RwSignal::new(false);
+    Effect::new(move |_| {
+        if auth.is_authenticated.get() && !navigated.get_untracked() {
+            navigated.set(true);
+            let navigate = use_navigate();
+            navigate(
+                "/library",
+                NavigateOptions {
+                    replace: true,
+                    ..Default::default()
+                },
+            );
+        }
+    });
+
+    // Timeout handle stored in a signal so on_cleanup can cancel it. Without
+    // this the closure runs after the view is disposed and writes to a dead
+    // `timed_out` signal.
+    let timeout_handle: RwSignal<Option<i32>> = RwSignal::new(None);
+    on_cleanup(move || {
+        if let Some(handle) = timeout_handle.get_untracked() {
+            if let Some(window) = web_sys::window() {
+                window.clear_timeout_with_handle(handle);
+            }
+        }
+    });
+
+    if !no_callback_params {
+        if let Some(window) = web_sys::window() {
+            let cb: Closure<dyn FnMut()> = Closure::new(move || {
+                if !auth.is_authenticated.get_untracked() {
+                    timed_out.set(true);
+                }
+            });
+            if let Ok(id) = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+                cb.as_ref().unchecked_ref(),
+                15_000,
+            ) {
+                timeout_handle.set(Some(id));
+            }
+            cb.forget();
+        }
+    }
+
+    view! {
+        <div class="relative z-0 min-h-screen text-primary flex items-center justify-center px-4 pt-safe pb-safe">
+            <div class="text-center max-w-sm" aria-live="polite">
+                <div class="flex items-center justify-center gap-2.5 mb-4">
+                    <svg class="w-7 h-7 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+                    </svg>
+                    <h1 class="page-title">"Intrada"</h1>
+                </div>
+                <Show
+                    when=move || !auth.auth_error.get() && !timed_out.get() && !no_callback_params
+                    fallback=move || view! {
+                        <p class="text-secondary mb-6" role="alert">
+                            {move || if no_callback_params {
+                                "This page is part of signing in. Take me back to sign in."
+                            } else {
+                                "We couldn't finish signing you in. Please try again."
+                            }}
+                        </p>
+                        <A
+                            href="/login"
+                            attr:class="inline-flex items-center gap-2 text-accent-text hover:text-accent-hover font-medium"
+                        >
+                            "Back to sign in"
+                        </A>
+                    }
+                >
+                    <div class="flex items-center justify-center gap-3" role="status">
+                        <span class="animate-spin rounded-full h-5 w-5 border-2 border-accent-focus border-t-transparent" aria-hidden="true"></span>
+                        <p class="text-muted">"Signing you in…"</p>
+                    </div>
+                </Show>
+            </div>
+        </div>
+    }
+}


### PR DESCRIPTION
## Summary

A friend on Android Chrome reported a 404 when signing in with Google — saw "Page Not Found" on `myintrada.com/sso-callback` and gave up. Sentry confirms sign-in actually succeeded (`user_3DTn59RtFvTHZYK9yaP7v9SsjHb` reached `/library` 44s later) — the 404 was a UX flicker, not a real failure.

**Root cause**: there was no Leptos route for `/sso-callback`. The inline JS bridge in `index.html` handles the OAuth callback, but it has to download `@clerk/clerk-js` from jsdelivr.net first (5-15s on slow mobile), then call `clerk.handleRedirectCallback()`. Meanwhile the WASM bundle hydrates faster and Leptos renders `NotFoundView` because no route matches. Once Clerk completes, it redirects to `/` — but by then the user has already screenshotted the 404.

**Fix**: add a real `/sso-callback` route that renders "Signing you in…" with a spinner, plus a 15s timeout fallback to a "Back to sign in" link. The view also watches `AuthState.is_authenticated` and pushes to `/library` itself when the listener flips — defence-in-depth in case Clerk's own redirect fails.

Edge cases handled (per self-review):
- One-shot navigated guard prevents redirect loops if `is_authenticated` flickers
- `on_cleanup` cancels the 15s timeout so it can't write to a disposed signal
- Landing on `/sso-callback` with no query params (manual URL entry, refresh after success) shows the friendly fallback immediately instead of waiting 15s

The actual auth wiring in [index.html:170-275](crates/intrada-web/index.html#L170-L275) is unchanged.

## Test plan
- [ ] CI: `cargo fmt --check`, `cargo test`, `cargo clippy -- -D warnings` (locally clean against wasm32 target)
- [ ] Visual: navigate to `/sso-callback` directly while signed out — verify "Signing you in…" spinner instead of 404 (defence-in-depth Effect will redirect to `/library` if signed in)
- [ ] Visual: navigate to `/sso-callback` with no query params — verify friendly fallback ("This page is part of signing in. Take me back…") shows immediately
- [ ] Real device: Android Chrome on cellular, sign in with Google — verify spinner stays visible during Clerk SDK download, no 404 flicker

## Out of scope (deferred)
- Sentry noise from Leptos `transition=true` View Transitions API (`AbortError` / `InvalidStateError`, DOMException 20/11) — cosmetic, not load-bearing
- Bigger refactor: drop the runtime CDN load of `@clerk/clerk-js` in `index.html` — bundle it or `modulepreload` so the SDK is ready before the OAuth callback lands
- Factor the inline `animate-spin` SVG combo (used here, in `button.rs`, and `design_catalogue.rs`) into a `Spinner` primitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)