### PR TITLE
fix(web): stop error banner re-popping on API burst failures (#346)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -221,15 +221,14 @@ impl App for Intrada {
 
             // ── Error handling ───────────────────────────────────────
             Event::LoadFailed(msg) => {
-                // Suppress duplicates and overlapping bursts (#346):
-                //   - identical message: no-op (avoids re-render and re-firing
-                //     the slide-in animation with the same text)
-                //   - already-showing different error: keep the first one
-                //     (StartApp fans out 3 parallel fetches; on a dead API
-                //     the user got 3 slide-downs in succession)
-                // Once the user dismisses (`ClearError`), the next failure
-                // shows again as expected.
-                if model.last_error.is_some() {
+                // Dedupe identical messages (#346) — avoids unnecessary
+                // re-renders. Distinct messages still replace the current
+                // error so user-action failures (save/delete) aren't
+                // silently swallowed by a stale load-error banner. The
+                // slide-in animation only re-fires on a true None → Some
+                // transition; the shell mounts the banner stably, so
+                // Some → Some swaps just update the text in place.
+                if model.last_error.as_deref() == Some(msg.as_str()) {
                     return Command::done();
                 }
                 model.last_error = Some(msg);
@@ -1652,29 +1651,41 @@ mod tests {
     }
 
     #[test]
-    fn test_load_failed_preserves_first_error_during_burst() {
-        // StartApp fans out three parallel fetches (items, sessions, sets);
-        // on a dead API all three call LoadFailed in succession. The user
-        // should see one banner, not three slide-downs. (#346)
+    fn test_load_failed_dedupes_identical_messages() {
+        // Identical messages no-op so the shell doesn't re-render with the
+        // same text. (#346) Separate from mount-stability — this is just
+        // belt-and-braces for repeated retries with the same error.
         let app = Intrada;
         let mut model = Model::test_default();
 
+        let _ = app.update(Event::LoadFailed("timeout".to_string()), &mut model);
+        let _ = app.update(Event::LoadFailed("timeout".to_string()), &mut model);
+        let _ = app.update(Event::LoadFailed("timeout".to_string()), &mut model);
+
+        assert_eq!(model.last_error, Some("timeout".to_string()));
+    }
+
+    #[test]
+    fn test_load_failed_distinct_message_replaces_existing() {
+        // A user-action error (save/delete) must surface even if a stale
+        // load-error banner is still up — otherwise the user has no
+        // feedback that their action failed. Burst re-animation is
+        // suppressed at the shell mount level, not by swallowing distinct
+        // messages here.
+        let app = Intrada;
+        let mut model = Model {
+            last_error: Some("Failed to load items".to_string()),
+            ..Model::test_default()
+        };
+
         let _ = app.update(
-            Event::LoadFailed("Failed to load items: timeout".to_string()),
-            &mut model,
-        );
-        let _ = app.update(
-            Event::LoadFailed("Failed to load sessions: timeout".to_string()),
-            &mut model,
-        );
-        let _ = app.update(
-            Event::LoadFailed("Failed to load sets: timeout".to_string()),
+            Event::LoadFailed("Failed to save item: 409 conflict".to_string()),
             &mut model,
         );
 
         assert_eq!(
             model.last_error,
-            Some("Failed to load items: timeout".to_string())
+            Some("Failed to save item: 409 conflict".to_string())
         );
     }
 

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -221,6 +221,17 @@ impl App for Intrada {
 
             // ── Error handling ───────────────────────────────────────
             Event::LoadFailed(msg) => {
+                // Suppress duplicates and overlapping bursts (#346):
+                //   - identical message: no-op (avoids re-render and re-firing
+                //     the slide-in animation with the same text)
+                //   - already-showing different error: keep the first one
+                //     (StartApp fans out 3 parallel fetches; on a dead API
+                //     the user got 3 slide-downs in succession)
+                // Once the user dismisses (`ClearError`), the next failure
+                // shows again as expected.
+                if model.last_error.is_some() {
+                    return Command::done();
+                }
                 model.last_error = Some(msg);
                 crux_core::render::render()
             }
@@ -1638,6 +1649,46 @@ mod tests {
         );
 
         assert_eq!(model.last_error, Some("Connection refused".to_string()));
+    }
+
+    #[test]
+    fn test_load_failed_preserves_first_error_during_burst() {
+        // StartApp fans out three parallel fetches (items, sessions, sets);
+        // on a dead API all three call LoadFailed in succession. The user
+        // should see one banner, not three slide-downs. (#346)
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let _ = app.update(
+            Event::LoadFailed("Failed to load items: timeout".to_string()),
+            &mut model,
+        );
+        let _ = app.update(
+            Event::LoadFailed("Failed to load sessions: timeout".to_string()),
+            &mut model,
+        );
+        let _ = app.update(
+            Event::LoadFailed("Failed to load sets: timeout".to_string()),
+            &mut model,
+        );
+
+        assert_eq!(
+            model.last_error,
+            Some("Failed to load items: timeout".to_string())
+        );
+    }
+
+    #[test]
+    fn test_load_failed_after_clear_shows_new_error() {
+        // After the user dismisses, the next failure surfaces as expected.
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let _ = app.update(Event::LoadFailed("first".to_string()), &mut model);
+        let _ = app.update(Event::ClearError, &mut model);
+        let _ = app.update(Event::LoadFailed("second".to_string()), &mut model);
+
+        assert_eq!(model.last_error, Some("second".to_string()));
     }
 
     #[test]

--- a/crates/intrada-web/src/components/error_banner.rs
+++ b/crates/intrada-web/src/components/error_banner.rs
@@ -42,7 +42,7 @@ pub fn ErrorBanner() -> impl IntoView {
     let error_text = Memo::new(move |_| view_model.get().error.unwrap_or_default());
 
     view! {
-        <Show when=move || has_error.get() fallback=|| ()>
+        <Show when=move || has_error.get()>
             <div
                 class=move || {
                     let base = "error-banner rounded-lg bg-danger-surface border border-danger-text/20 p-4";

--- a/crates/intrada-web/src/components/error_banner.rs
+++ b/crates/intrada-web/src/components/error_banner.rs
@@ -21,6 +21,14 @@ const DISMISS_ANIM_MS: u32 = 280;
 /// platforms get a slide-out animation when dismissed — the banner
 /// keeps its `is-dismissing` class for one animation cycle before
 /// the underlying error state actually clears.
+///
+/// Mount stability matters (#346): the wrapper `<div class="error-banner">`
+/// is rendered through `<Show>` so it stays mounted across Some→Some
+/// transitions in the underlying error signal. Without this, Leptos would
+/// reconcile by replacing the node and the slide-in keyframe would re-fire
+/// each time a new error message arrived. The slide-in only plays on the
+/// None → Some transition; subsequent message updates just swap the inner
+/// text in place.
 #[component]
 pub fn ErrorBanner() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -30,49 +38,53 @@ pub fn ErrorBanner() -> impl IntoView {
 
     let is_dismissing = RwSignal::new(false);
 
+    let has_error = Memo::new(move |_| view_model.get().error.is_some());
+    let error_text = Memo::new(move |_| view_model.get().error.unwrap_or_default());
+
     view! {
-        {move || {
-            view_model.get().error.map(|err| {
-                let core = core.clone();
-                let class = move || {
+        <Show when=move || has_error.get() fallback=|| ()>
+            <div
+                class=move || {
                     let base = "error-banner rounded-lg bg-danger-surface border border-danger-text/20 p-4";
                     if is_dismissing.get() {
                         format!("{base} is-dismissing")
                     } else {
                         base.to_string()
                     }
-                };
-                view! {
-                    <div class=class role="alert">
-                        <div class="flex items-start justify-between gap-3">
-                            <p class="text-sm text-danger-text">
-                                <span class="font-medium">"Error: "</span>{err}
-                            </p>
-                            <button
-                                class="error-banner-dismiss shrink-0"
-                                aria-label="Dismiss error"
-                                on:click=move |_| {
-                                    if is_dismissing.get_untracked() {
-                                        return;
-                                    }
-                                    haptic_selection();
-                                    is_dismissing.set(true);
-                                    let core = core.clone();
-                                    spawn_local(async move {
-                                        gloo_timers::future::TimeoutFuture::new(DISMISS_ANIM_MS).await;
-                                        is_dismissing.set(false);
-                                        let core_ref = core.borrow();
-                                        let effects = core_ref.process_event(Event::ClearError);
-                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                    });
-                                }
-                            >
-                                <Icon name=IconName::X class="w-4 h-4" />
-                            </button>
-                        </div>
-                    </div>
                 }
-            })
-        }}
+                role="alert"
+            >
+                <div class="flex items-start justify-between gap-3">
+                    <p class="text-sm text-danger-text">
+                        <span class="font-medium">"Error: "</span>
+                        {move || error_text.get()}
+                    </p>
+                    <button
+                        class="error-banner-dismiss shrink-0"
+                        aria-label="Dismiss error"
+                        on:click={
+                            let core = core.clone();
+                            move |_| {
+                                if is_dismissing.get_untracked() {
+                                    return;
+                                }
+                                haptic_selection();
+                                is_dismissing.set(true);
+                                let core = core.clone();
+                                spawn_local(async move {
+                                    gloo_timers::future::TimeoutFuture::new(DISMISS_ANIM_MS).await;
+                                    is_dismissing.set(false);
+                                    let core_ref = core.borrow();
+                                    let effects = core_ref.process_event(Event::ClearError);
+                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                });
+                            }
+                        }
+                    >
+                        <Icon name=IconName::X class="w-4 h-4" />
+                    </button>
+                </div>
+            </div>
+        </Show>
     }
 }


### PR DESCRIPTION
## Summary

Fixes #346 — the global error banner kept sliding back down after dismissal whenever the API was failing.

Two compounding causes:

1. **Burst storm.** `Event::StartApp` fans out 3 parallel fetches (items, sessions, sets). On a dead API, each one fired `Event::LoadFailed`, unconditionally overwriting `model.last_error` and emitting a Render. A single page load produced 3 banners in succession.

2. **Animation re-fires on remount.** The banner was rendered via `view_model.error.map(|err| view!{ <div…>})`. On every Some→Some message change, Leptos reconciled by replacing the wrapper node, re-firing the `error-banner-slide-in` keyframe.

## Changes

- **Core**: dedupe in `Event::LoadFailed` — if `last_error` is already populated, no-op. The first error of a burst wins; subsequent burst failures are silently swallowed. After the user dismisses (`ClearError` resets `last_error` to None), the next failure surfaces normally.
- **Shell**: render the wrapper through `<Show>` and put reactive bits inside (`error_text`, `class`) so the `<div>` stays mounted across message updates. Slide-in now only plays on the None → Some transition; slide-out still fires on dismiss.
- **Tests**: two new core tests cover (a) burst preserves first error, (b) post-dismiss new errors still surface.

## Test plan

- [x] `cargo test --workspace --exclude tauri-plugin-background-audio` (478 passed)
- [x] `cargo clippy --workspace --exclude tauri-plugin-background-audio -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Manual verification on iOS sim with API stopped: banner appears once, dismiss sticks, subsequent navigation/refresh shows a fresh banner only when a *new* failure happens
- [ ] Manual verification on web with API stopped: same expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)