### PR TITLE
fix(pull-to-refresh): disable on web — restore native browser refresh

### DIFF
--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, TouchEvent};
 
 use intrada_web::haptics::haptic_light;
+use intrada_web::platform::is_ios;
 
 /// Pixels of pull required to commit to a refresh on release. Sized so the
 /// indicator (32px tall) is fully clear of the safe area / status bar by the
@@ -70,6 +71,16 @@ pub fn PullToRefresh(
     let wrapper_ref = NodeRef::<leptos::html::Div>::new();
 
     Effect::new(move || {
+        // Pull-to-refresh is iOS-only. Skipping listener registration on
+        // non-iOS leaves the browser's native pull-to-refresh in charge —
+        // wiring up touchmove with preventDefault here would otherwise
+        // silently steal the gesture from mobile Safari / Chrome on
+        // Android with no visual feedback (the indicator is CSS-hidden
+        // on non-iOS via input.css:1576). Same conceptual switch as the
+        // indicator-hide rule, just at the JS layer.
+        if !is_ios() {
+            return;
+        }
         let Some(el) = wrapper_ref.get() else {
             return;
         };


### PR DESCRIPTION
## Summary

`PullToRefresh` always registered `touchmove` listeners that called `preventDefault()` on the browser's gesture. The CSS hides the indicator on non-iOS (`input.css:1576`), but the JS gesture-stealing still ran — so mobile Safari and Chrome on Android got *neither* the browser's native pull-to-refresh *nor* any visual feedback that the gesture was even seen. Worst-of-both.

Fix is one early-return inside the `Effect` that wires the listeners:

```rust
Effect::new(move || {
    if !is_ios() {
        return;
    }
    let Some(el) = wrapper_ref.get() else { return; };
    // ... existing listener wiring ...
});
```

Uses the existing `is_ios()` helper from `intrada_web::platform` (already used by `views/welcome.rs` to gate iOS-specific copy). Same conceptual switch as the CSS indicator-hide rule, just at the JS layer.

## What this restores / preserves

- **Browser-native pull-to-refresh** works again on mobile web (Safari, Chrome on Android)
- **No visual artifacts on non-iOS** — `pull_distance` never moves off `0.0` because no listeners fire, so the wrapper transform stays at `translate(0)` and spoke opacities all evaluate to 0
- **iOS keeps everything** — same gesture, same haptics, same indicator

## Risk audit

- Only call site is `library_list.rs`. Web users have a manual refresh button (and now the browser's pull-to-refresh, restored).
- Design catalogue demo (`views/design_catalogue.rs:2116`) still renders the visual showcase. The gesture won't fire on a desktop developer machine, but the catalogue is `#[cfg(debug_assertions)]`-gated dev-only territory.

## Test plan

- [ ] Mobile Chrome on Android — pull down at `/library`, confirm browser's native pull-to-refresh fires (and the in-app one doesn't)
- [ ] Mobile Safari (real device) — same
- [ ] iOS shell — pull down at `/library`, confirm in-app refresh + indicator + haptic still work
- [ ] Desktop browser at `/design#pull-to-refresh` — confirm the catalogue entry still renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)