### PR TITLE
feat(api): per-token rate limit on /api/mcp/* (Phase 6A of #477)

### DIFF
--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -116,7 +116,12 @@ impl FromRequestParts<AppState> for AuthUser {
     }
 }
 
-async fn resolve_pat(state: &AppState, token: &str) -> Result<AuthUser, ApiError> {
+/// Resolve a Bearer-PAT token to an [`AuthUser`].
+///
+/// Visible to the rate-limit middleware so it can attribute requests to a
+/// `token_id` before the handler-level extractor runs. Reused by the
+/// [`AuthUser`] `FromRequestParts` impl below.
+pub(crate) async fn resolve_pat(state: &AppState, token: &str) -> Result<AuthUser, ApiError> {
     let conn = state.conn();
     let hash = db::tokens::hash_token(token);
 

--- a/crates/intrada-api/src/lib.rs
+++ b/crates/intrada-api/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod error;
 pub mod mcp;
 pub mod migrations;
+pub mod rate_limit;
 pub mod routes;
 pub mod services;
 pub mod state;

--- a/crates/intrada-api/src/rate_limit.rs
+++ b/crates/intrada-api/src/rate_limit.rs
@@ -1,0 +1,221 @@
+//! Process-local per-token rate limiter for `/api/mcp/*`.
+//!
+//! Fixed 60-second windows, 60 requests per token. Bucket key is
+//! `mcp_tokens.id` (ULID) so OAuth-minted tokens and manually-created
+//! PATs share the same per-token limit. Bypasses [`AuthSource::Jwt`]
+//! (web/iOS UI) and [`AuthSource::Disabled`] (local dev).
+//!
+//! State is process-local — no Redis, no DB. On Fly with
+//! `auto_stop_machines = 'suspend'` the bucket resets when the machine
+//! suspends; this is fine for v1 (`specs/mcp-server.md` §238 acknowledges
+//! it). If we ever pin multiple machines, "60/min" becomes "60/min/machine
+//! × N" and we'd need a distributed bucket.
+//!
+//! Window-edge bursting (up to ~120 reqs in a 2-second sliver across the
+//! window boundary) is acceptable per spec wording — it asks for 60/min,
+//! not "smoothed". A sliding-window / GCRA upgrade is captured as a
+//! follow-up under #578.
+//!
+//! [`AuthSource::Jwt`]: crate::auth::AuthSource::Jwt
+//! [`AuthSource::Disabled`]: crate::auth::AuthSource::Disabled
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::extract::{Request, State};
+use axum::http::{header, Method, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+
+use crate::auth::{resolve_pat, AuthSource, AuthUser};
+use crate::db::tokens::TOKEN_PREFIX as PAT_PREFIX;
+use crate::state::AppState;
+
+/// When the bucket map grows past this, run an opportunistic cleanup pass
+/// on the next insert. At ~32 bytes per entry the ceiling is ~32 KiB —
+/// we'd never actually OOM, but unbounded growth is sloppy.
+const MAP_SIZE_THRESHOLD: usize = 1024;
+
+/// Per-token request bucket. Lock contention is bounded (one lock per
+/// MCP request, held for the duration of a HashMap update) so a plain
+/// `std::sync::Mutex` is fine — no async locking is needed.
+pub struct McpRateLimiter {
+    state: Mutex<HashMap<String, (Instant, u32)>>,
+    limit: u32,
+    window: Duration,
+}
+
+impl McpRateLimiter {
+    pub fn new(limit: u32, window: Duration) -> Self {
+        Self {
+            state: Mutex::new(HashMap::new()),
+            limit,
+            window,
+        }
+    }
+
+    /// Production setting: 60 requests per 60 seconds, per token.
+    pub fn production() -> Self {
+        Self::new(60, Duration::from_secs(60))
+    }
+
+    /// Record a request against `token_id` and decide whether to allow it.
+    /// `Ok(())` = allow, `Err(retry_after_seconds)` = reject with 429.
+    pub fn check(&self, token_id: &str) -> Result<(), u64> {
+        let now = Instant::now();
+        let mut state = self.state.lock().expect("rate-limit state poisoned");
+
+        if let Some((window_start, count)) = state.get_mut(token_id) {
+            if now.duration_since(*window_start) >= self.window {
+                *window_start = now;
+                *count = 1;
+                return Ok(());
+            }
+            if *count < self.limit {
+                *count += 1;
+                return Ok(());
+            }
+            let retry_after = self
+                .window
+                .saturating_sub(now.duration_since(*window_start))
+                .as_secs()
+                // Never advertise 0 — clients then retry instantly and
+                // amplify the burst we're trying to suppress.
+                .max(1);
+            return Err(retry_after);
+        }
+
+        // New entry. Run sampled cleanup before insert if the map has
+        // grown past the threshold — keeps it bounded without a reaper task.
+        if state.len() >= MAP_SIZE_THRESHOLD {
+            let cutoff = self.window * 2;
+            state.retain(|_, (start, _)| now.duration_since(*start) < cutoff);
+        }
+        state.insert(token_id.to_string(), (now, 1));
+        Ok(())
+    }
+}
+
+/// Middleware applied to the `/api/mcp` nest. Eagerly resolves PATs so
+/// the bucket can be checked before the handler runs. Note that handlers
+/// will still re-resolve via the `AuthUser` extractor — at 60 req/min/token
+/// the duplicate `lookup_by_hash` is negligible vs. the plumbing cost of
+/// caching the extraction result in `request.extensions`.
+///
+/// **Known limitation**: any bearer that starts with `intrada_pat_` triggers
+/// one `lookup_by_hash` call here, even if the token is malformed or unknown.
+/// A high-rate flood of bogus tokens will burn DB lookups (and hash CPU)
+/// without consuming any bucket. The bucket-keyed-on-resolved-`token_id`
+/// design protects legitimate tokens from being starved by such a flood,
+/// but does not bound the flood's cost itself. A separate per-IP layer
+/// covering both this surface and unauthenticated `/oauth/register` is
+/// captured as a follow-up under #578.
+pub async fn mcp_rate_limit(State(state): State<AppState>, req: Request, next: Next) -> Response {
+    // CORS preflight: pass through without consuming the bucket. The
+    // outer CORS layer is what actually responds to OPTIONS, but
+    // short-circuiting here is cheap insurance against a future config
+    // change that lets preflights reach this layer.
+    if req.method() == Method::OPTIONS {
+        return next.run(req).await;
+    }
+
+    let bearer = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
+
+    // Only PAT-shaped tokens trigger the rate limit. JWTs (web/iOS UI),
+    // missing/invalid auth, and Disabled-mode requests pass straight through —
+    // the handler-level `AuthUser` extractor produces the right 200/401.
+    if let Some(token) = bearer.filter(|t| t.starts_with(PAT_PREFIX)) {
+        if let Ok(AuthUser {
+            source: AuthSource::Pat { token_id },
+            ..
+        }) = resolve_pat(&state, token).await
+        {
+            if let Err(retry_after) = state.rate_limiter.check(&token_id) {
+                // info!, not warn! — rate-limit hits are expected operational
+                // signal, not errors. We want them greppable in logs without
+                // tripping Sentry's default ERROR-only event capture.
+                tracing::info!(token_id = %token_id, "mcp rate limit exceeded");
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [(header::RETRY_AFTER, retry_after.to_string())],
+                    Json(json!({"error": "rate limit exceeded"})),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_allows_up_to_limit_then_returns_retry_after() {
+        let limiter = McpRateLimiter::new(2, Duration::from_secs(60));
+
+        assert!(limiter.check("tok").is_ok());
+        assert!(limiter.check("tok").is_ok());
+        let err = limiter
+            .check("tok")
+            .expect_err("3rd call should be rejected");
+        assert!(
+            (1..=60).contains(&err),
+            "retry_after should be in (0, window]; got {err}"
+        );
+    }
+
+    #[test]
+    fn check_resets_after_window() {
+        let limiter = McpRateLimiter::new(2, Duration::from_millis(50));
+
+        assert!(limiter.check("tok").is_ok());
+        assert!(limiter.check("tok").is_ok());
+        assert!(limiter.check("tok").is_err());
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            limiter.check("tok").is_ok(),
+            "bucket should reset after window"
+        );
+    }
+
+    #[test]
+    fn separate_tokens_have_separate_buckets() {
+        let limiter = McpRateLimiter::new(1, Duration::from_secs(60));
+
+        assert!(limiter.check("tok_a").is_ok());
+        assert!(limiter.check("tok_b").is_ok());
+        assert!(limiter.check("tok_a").is_err());
+        assert!(limiter.check("tok_b").is_err());
+    }
+
+    #[test]
+    fn cleanup_drops_stale_entries_when_map_grows() {
+        // Limit large so we never reject; window short so entries become
+        // stale fast. Insert MAP_SIZE_THRESHOLD entries to trip cleanup.
+        let limiter = McpRateLimiter::new(1000, Duration::from_millis(10));
+        for i in 0..MAP_SIZE_THRESHOLD {
+            let _ = limiter.check(&format!("tok_{i}"));
+        }
+        // Wait past 2× window so all entries are eligible for cleanup.
+        std::thread::sleep(Duration::from_millis(25));
+        // One more insert triggers the retain pass.
+        let _ = limiter.check("trigger");
+
+        let state = limiter.state.lock().unwrap();
+        assert!(
+            state.len() <= 1,
+            "stale entries should have been reaped; got {}",
+            state.len()
+        );
+    }
+}

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -101,7 +101,16 @@ pub fn api_router(state: AppState) -> Router {
         // ERROR-only event capture.
         .on_failure(DefaultOnFailure::new().level(Level::WARN));
 
-    let mcp_routes = crate::mcp::router().layer(mcp_cors);
+    // Layer order matters: rate-limit applied first (innermost), CORS
+    // wraps it. That way a 429 from the limiter still passes through
+    // the CORS layer on its way out and gets `Access-Control-Allow-Origin: *`
+    // headers — verified in `tests/rate_limit_test.rs`.
+    let mcp_routes = crate::mcp::router()
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::rate_limit::mcp_rate_limit,
+        ))
+        .layer(mcp_cors);
     let oauth_routes = oauth::router().layer(oauth_cors);
 
     Router::new()

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -6,6 +6,7 @@ use libsql::{Connection, Database};
 use crate::auth::AuthConfig;
 use crate::clerk::ClerkClient;
 use crate::error::ApiError;
+use crate::rate_limit::McpRateLimiter;
 use crate::storage::R2Client;
 
 /// Heartbeat interval for the background liveness probe.
@@ -101,6 +102,10 @@ pub struct AppState {
     pub auth_config: Option<AuthConfig>,
     pub r2: Option<R2Client>,
     pub clerk: Option<ClerkClient>,
+    /// Per-token rate limiter for `/api/mcp/*`. Defaults to production
+    /// limits (60 req/min/token); tests can swap in a tighter bucket
+    /// via [`AppState::with_rate_limiter`].
+    pub rate_limiter: Arc<McpRateLimiter>,
 }
 
 impl AppState {
@@ -117,7 +122,15 @@ impl AppState {
             auth_config,
             r2,
             clerk,
+            rate_limiter: Arc::new(McpRateLimiter::production()),
         }
+    }
+
+    /// Replace the rate limiter — used by integration tests to inject a
+    /// tighter bucket without breaking the existing `new()` arity.
+    pub fn with_rate_limiter(mut self, rate_limiter: Arc<McpRateLimiter>) -> Self {
+        self.rate_limiter = rate_limiter;
+        self
     }
 
     /// Get the R2 client, or return an error if not configured.

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -7,8 +7,11 @@ use tower::ServiceExt;
 
 use intrada_api::auth::AuthConfig;
 use intrada_api::migrations;
+use intrada_api::rate_limit::McpRateLimiter;
 use intrada_api::routes;
 use intrada_api::state::{AppState, Db};
+use std::sync::Arc;
+use std::time::Duration;
 
 /// Create a fresh Axum router backed by a temporary SQLite database file.
 /// Each call returns an isolated database — tests don't share state.
@@ -25,6 +28,35 @@ pub async fn setup_test_app_with_auth(auth_config: AuthConfig) -> Router {
 /// comma-separated values to exercise multi-origin CORS).
 pub async fn setup_test_app_with_origin(allowed_origin: &str) -> Router {
     setup_test_app_inner(None, allowed_origin).await
+}
+
+/// Create a test router with a tightened rate-limiter — used by
+/// `tests/rate_limit_test.rs` to exercise 429 responses without
+/// hammering the default 60-req/min bucket.
+#[allow(dead_code)]
+pub async fn setup_test_app_with_rate_limit(limit: u32, window: Duration) -> Router {
+    let limiter = Arc::new(McpRateLimiter::new(limit, window));
+
+    let tmp_dir = std::env::temp_dir();
+    let db_path = tmp_dir.join(format!("intrada_test_{}.db", ulid::Ulid::new()));
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("Failed to build test database");
+    let conn = db.connect().expect("Failed to connect to test database");
+    migrations::run_migrations_direct(&conn)
+        .await
+        .expect("Failed to run migrations");
+
+    let state = AppState::new(
+        Db::new(db, conn),
+        "http://localhost:3000".to_string(),
+        None,
+        None,
+        None,
+    )
+    .with_rate_limiter(limiter);
+    routes::api_router(state)
 }
 
 async fn setup_test_app_inner(auth_config: Option<AuthConfig>, allowed_origin: &str) -> Router {

--- a/crates/intrada-api/tests/rate_limit_test.rs
+++ b/crates/intrada-api/tests/rate_limit_test.rs
@@ -1,0 +1,273 @@
+//! Integration tests for the MCP rate limiter (Phase 6A of #477).
+//!
+//! Sibling unit tests live in `intrada-api/src/rate_limit.rs`; these
+//! cover the wiring: middleware position, bypass logic, CORS-on-429,
+//! end-to-end against `setup_test_app_with_rate_limit`.
+
+mod common;
+
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// Helper: build an MCP `tools/list` JSON-RPC request authed with the
+/// given Bearer token (or no Authorization header when `token` is None).
+fn mcp_request(token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/mcp")
+        .header("content-type", "application/json")
+        // `Origin` triggers the CORS layer to attach
+        // `Access-Control-Allow-Origin` to the response — needed for the
+        // 429-still-has-CORS-headers assertion.
+        .header("origin", "https://claude.ai");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder
+        .body(Body::from(
+            serde_json::to_string(&json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1
+            }))
+            .unwrap(),
+        ))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn pat_rate_limit_returns_429_with_retry_after() {
+    // limit=2 so we don't have to send 60 requests; window=60s so the
+    // bucket doesn't reset mid-test under CI load.
+    let app = common::setup_test_app_with_rate_limit(2, Duration::from_secs(60)).await;
+
+    // Mint a PAT via the auth-disabled `/api/account/tokens` endpoint
+    // (same pattern as `mcp_test::pat_authenticates_mcp_call`).
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "rate-limit-test"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let token = v["token"].as_str().unwrap().to_string();
+
+    // First two MCP calls should succeed.
+    for i in 1..=2 {
+        let resp = app
+            .clone()
+            .oneshot(mcp_request(Some(&token)))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "request {i} should succeed within bucket"
+        );
+    }
+
+    // Third call should be rate-limited.
+    let resp = app.oneshot(mcp_request(Some(&token))).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let retry_after = resp
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    let retry_secs: u64 = retry_after.parse().expect("retry-after must be integer");
+    assert!(
+        (1..=60).contains(&retry_secs),
+        "retry-after should be in (0, window]; got {retry_secs}"
+    );
+
+    // CORS headers must still be on the 429 — verifies the rate-limit
+    // layer is wrapped by the CORS layer (rate-limit is innermost).
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("*"),
+        "429 responses must carry CORS headers, otherwise browser MCP \
+         clients see a CORS error instead of the actual rate-limit signal"
+    );
+}
+
+#[tokio::test]
+async fn auth_disabled_calls_bypass_rate_limit() {
+    // No CLERK_ISSUER_URL → AuthSource::Disabled. These calls don't
+    // attribute to a token_id and must bypass the limiter entirely.
+    // (JWT bypass exercises the same code path — there's no PAT to
+    // resolve, so middleware passes through.)
+    let app = common::setup_test_app_with_rate_limit(2, Duration::from_secs(60)).await;
+
+    for i in 1..=10 {
+        let resp = app.clone().oneshot(mcp_request(None)).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unauthed-but-disabled-mode request {i} should pass through"
+        );
+    }
+}
+
+#[tokio::test]
+async fn invalid_pat_does_not_consume_bucket_for_valid_one() {
+    // A flood of malformed/unknown PATs from one client must not exhaust
+    // the bucket of a legitimate token — the bucket is keyed on
+    // resolved `token_id`, so unresolved PATs simply pass through to
+    // the handler-level extractor (which 401s). Verifies that the
+    // first 100 garbage requests don't impact the legitimate token's
+    // budget.
+    let app = common::setup_test_app_with_rate_limit(2, Duration::from_secs(60)).await;
+
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "real-token"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let valid_token = v["token"].as_str().unwrap().to_string();
+
+    let bogus = "intrada_pat_0000000000000000000000000000000000000000000000000000000000000000";
+    for _ in 0..100 {
+        let _ = app.clone().oneshot(mcp_request(Some(bogus))).await.unwrap();
+    }
+
+    // Real token's bucket should still be intact — 2 OKs.
+    for i in 1..=2 {
+        let resp = app
+            .clone()
+            .oneshot(mcp_request(Some(&valid_token)))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid token's budget {i} should not be consumed by bogus-token flood"
+        );
+    }
+}
+
+#[tokio::test]
+async fn revoked_pat_does_not_consume_bucket() {
+    // Locks in the contract that the middleware swallows
+    // `resolve_pat` errors (revoked token → Err(Unauthorized)) and
+    // passes the request through untouched. If a future change ever
+    // started charging unresolved-PAT requests against a bucket, the
+    // legitimate token below would lose its budget — this test catches
+    // that regression. The 401 itself is produced by the handler-level
+    // `AuthUser` extractor, not the middleware.
+    let app = common::setup_test_app_with_rate_limit(2, Duration::from_secs(60)).await;
+
+    // Mint a token, then revoke it.
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "to-be-revoked"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let revoked_id = v["id"].as_str().unwrap().to_string();
+    let revoked_token = v["token"].as_str().unwrap().to_string();
+    let (status, _) =
+        common::delete(app.clone(), &format!("/api/account/tokens/{revoked_id}")).await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    // Mint a separate token that should keep its full budget despite
+    // the revoked-token flood below.
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "still-valid"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let valid_token = v["token"].as_str().unwrap().to_string();
+
+    // 100 requests on the revoked token — all 401, none counted.
+    for _ in 0..100 {
+        let resp = app
+            .clone()
+            .oneshot(mcp_request(Some(&revoked_token)))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // Valid token still has its full budget.
+    for i in 1..=2 {
+        let resp = app
+            .clone()
+            .oneshot(mcp_request(Some(&valid_token)))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid token's budget {i} should not be consumed by revoked-token traffic"
+        );
+    }
+}
+
+#[tokio::test]
+async fn options_preflight_does_not_consume_bucket() {
+    // Browser MCP clients preflight every request. CORS preflights
+    // must short-circuit before the bucket check, otherwise 60 preflights
+    // would silently exhaust a token's minute budget.
+    let app = common::setup_test_app_with_rate_limit(1, Duration::from_secs(60)).await;
+
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/account/tokens",
+        json!({"name": "preflight-test"}),
+    )
+    .await;
+    let v: Value = common::json(&body);
+    let token = v["token"].as_str().unwrap().to_string();
+
+    // Send 5 OPTIONS preflights. None should count.
+    for i in 1..=5 {
+        let preflight = Request::builder()
+            .method("OPTIONS")
+            .uri("/api/mcp")
+            .header("origin", "https://claude.ai")
+            .header("access-control-request-method", "POST")
+            .header(
+                "access-control-request-headers",
+                "authorization,content-type",
+            )
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(preflight).await.unwrap();
+        // CorsLayer responds 200 (with allow-origin) for preflights.
+        assert!(
+            resp.status().is_success() || resp.status() == StatusCode::NO_CONTENT,
+            "preflight {i} should return success; got {}",
+            resp.status()
+        );
+    }
+
+    // The real call should still succeed — bucket wasn't burnt by preflights.
+    let resp = app.oneshot(mcp_request(Some(&token))).await.unwrap();
+    let status = resp.status();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "limit=1 request after 5 preflights should still succeed; body: {}",
+        String::from_utf8_lossy(&body)
+    );
+}


### PR DESCRIPTION
Phase 6A of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477), tracked under #578. Closes the launch blocker called out in `specs/mcp-server.md` §242: a runaway agent or leaked token can no longer hammer `/api/mcp` at full throttle.

## Summary

- 60 req/60s per token on `/api/mcp/*`. Returns 429 + `Retry-After: <seconds>`.
- Bypasses `AuthSource::Jwt` (web/iOS UI) and `AuthSource::Disabled` (local dev).
- Bucket keyed on resolved `mcp_tokens.id` (ULID) — OAuth-minted tokens and manually-created PATs share the same per-token budget.
- Process-local fixed-window — no Redis, no DB. Spec §238 acknowledges single-machine v1; module rustdoc documents the implication on Fly's `auto_stop_machines = 'suspend'`.

## Approach

`axum::middleware::from_fn_with_state` on the `/api/mcp` nest only, layered **inside** the `mcp_cors` `CorsLayer` so 429 responses still carry `Access-Control-Allow-Origin: *` headers (verified by an integration test — without this, browser-based MCP clients see CORS errors instead of the actual rate-limit signal).

`auth::resolve_pat` made `pub(crate)` so the middleware can resolve eagerly and key the bucket on `token_id` before the handler runs. Handler-level `AuthUser` extractor still re-resolves; at 60 req/min/token the duplicate `lookup_by_hash` is negligible vs. the plumbing complexity of caching extraction in `request.extensions`.

OPTIONS preflights short-circuit before the bucket check (the outer CORS layer handles them anyway, but cheap insurance).

## Out of scope (deferred to follow-ups under #578)

- **Per-IP rate limit on bogus PATs.** Bearers shaped like `intrada_pat_*` still hit `lookup_by_hash` once even when malformed — the bucket-keyed-on-resolved-`token_id` design protects legitimate tokens from being starved by a bogus-PAT flood, but doesn't bound the flood's DB cost. Documented in the `mcp_rate_limit` rustdoc.
- **Per-IP rate limit on unauthenticated `/oauth/register`.** Same surface, separate concern.
- Sliding window / GCRA smoothing (window-edge bursting up to ~120 reqs in a 2-second sliver is acceptable per spec wording).
- Distributed bucket (Redis) for multi-machine.
- Sentry breadcrumb on rate-limit hit — `tracing::info!` is enough for v1; structured Sentry events come in piece B (telemetry) of #578.

## Test plan

Unit tests in `intrada-api/src/rate_limit.rs` (4):
- [x] limit + retry-after value
- [x] window reset
- [x] per-token isolation
- [x] sampled cleanup of stale entries past `MAP_SIZE_THRESHOLD`

Integration tests in `intrada-api/tests/rate_limit_test.rs` (5):
- [x] PAT 429 with valid `Retry-After` AND `Access-Control-Allow-Origin: *` header
- [x] Unauthed (Disabled-mode) calls bypass the limiter
- [x] Bogus-PAT flood (100 reqs) doesn't burn a real token's budget
- [x] **Revoked-token flood (100 reqs) doesn't burn a different token's budget** (locks in the contract that the middleware swallows `resolve_pat` errors and passes through)
- [x] 5 OPTIONS preflights don't burn the bucket (limit=1 still passes the next real call)

Verification:
- [x] `cargo test --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio`: 503 passed (was 494 + 9 new)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity -- -D warnings` clean (matches CI invocation exactly)
- [x] `cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings` clean
- [ ] CI on this PR

Manual sanity check on staging deploy:
\`\`\`bash
for i in {1..65}; do
  curl -sI -H "Authorization: Bearer \$PAT" https://intrada-api.fly.dev/api/mcp -X POST | head -1
done
# Expect 60× HTTP/2 200, then 5× HTTP/2 429 with \`retry-after: 60\`.
\`\`\`

## Self-review

Pre-PR review via \`superpowers:code-reviewer\` returned APPROVE with two polish items, both addressed in the same commit:
1. Rustdoc note on \`mcp_rate_limit\` calling out the per-bogus-PAT DB-lookup cost (limitation of bucket-keyed-on-token_id design) and linking #578 for the per-IP follow-up.
2. New integration test \`revoked_pat_does_not_consume_bucket\` locking in the contract that revoked tokens (and any \`resolve_pat\` error) pass through the middleware untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)