### PR TITLE
style(mobile): remove visual seams + redundant chrome on mobile web

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1322,19 +1322,6 @@ html.router-outlet-0.router-back::view-transition-new(root) {
   display: none;
 }
 
-/* Hide the web header on mobile web too — bottom tab bar is the primary
-   nav surface on small viewports, and the only header content visible on
-   mobile (brand wordmark + ProfileButton) is already covered: the Account
-   tab in the bottom bar replaces the profile button, and Apple-pattern
-   in-app screens don't show app branding inside the app. Aligns mobile
-   web cadence with iOS. 639px (not 640px) so the cut-off doesn't overlap
-   with Tailwind's `sm:` breakpoint. */
-@media (max-width: 639px) {
-  header[role="banner"] {
-    display: none;
-  }
-}
-
 /* Hide the web footer on iOS — attribution is a desktop convention. */
 [data-platform="ios"] footer[role="contentinfo"] {
   display: none;

--- a/crates/intrada-web/src/components/app_footer.rs
+++ b/crates/intrada-web/src/components/app_footer.rs
@@ -4,7 +4,7 @@ use leptos::prelude::*;
 #[component]
 pub fn AppFooter() -> impl IntoView {
     view! {
-        <footer class="max-w-4xl mx-auto px-4 sm:px-6 py-6 border-t border-border-default" role="contentinfo">
+        <footer class="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:border-t sm:border-border-default" role="contentinfo">
             <p class="text-xs text-faint text-center">
                 "© 2026 Jon Yardley · Built for musicians who practice with intent."
             </p>

--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -45,7 +45,7 @@ pub fn AppHeader() -> impl IntoView {
     };
 
     view! {
-        <header class="glass-chrome border-b border-border-default" role="banner">
+        <header class="sm:glass-chrome sm:border-b sm:border-border-default" role="banner">
             <div class="max-w-4xl mx-auto px-card sm:px-card-comfortable py-4 flex items-center justify-between">
                 <div>
                     <A href="/library" attr:class="flex items-center gap-2.5 no-underline">
@@ -55,8 +55,8 @@ pub fn AppHeader() -> impl IntoView {
                         <span class="text-lg font-bold text-primary font-heading">"Intrada"</span>
                     </A>
                 </div>
-                <div class="flex items-center gap-4">
-                    <nav class="hidden sm:flex items-center gap-4">
+                <div class="hidden sm:flex items-center gap-4">
+                    <nav class="flex items-center gap-4">
                         <A
                             href="/library"
                             attr:class=move || {

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -115,7 +115,7 @@ fn WelcomeNav() -> impl IntoView {
     });
 
     view! {
-        <header class="sticky top-0 z-40 glass-chrome border-b border-border-default">
+        <header class="sm:sticky sm:top-0 sm:z-40 sm:glass-chrome sm:border-b sm:border-border-default">
             <div class="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-4 flex items-center justify-between">
                 <A href="/" attr:class="flex items-center gap-2.5 no-underline">
                     <svg class="w-5 h-5 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
@@ -436,7 +436,7 @@ fn WelcomeFinalCta() -> impl IntoView {
 #[component]
 fn WelcomeFooter() -> impl IntoView {
     view! {
-        <footer class="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-10 border-t border-border-default flex flex-col sm:flex-row items-center justify-between gap-4" role="contentinfo">
+        <footer class="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 py-10 sm:border-t sm:border-border-default flex flex-col sm:flex-row items-center justify-between gap-4" role="contentinfo">
             <div class="flex items-center gap-2.5">
                 <svg class="w-4 h-4 text-accent" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />


### PR DESCRIPTION
## Summary

User-flagged three problems on mobile Safari (both routed app and marketing page):

1. The app header's `glass-chrome` band created a visible seam against the body gradient — three different darks (iOS safe-area tint, glass-chrome strip, gradient body) competing at the top.
2. The `ProfileButton` at top-right was redundant with the Account tab in the bottom tab bar — two affordances for the same destination.
3. The marketing nav and footer had the same chrome treatment, so the same seams showed up on the welcome page.

This **reverts the hide-on-mobile rule from #577** (which hid the entire header). That approach fixed the seams by removing the surface but left the viewport top feeling naked. Better fix: keep the header so the viewport top has structure, but remove the chrome that creates the seam.

## Changes

- **App header**: drop `glass-chrome` + `border-b` on mobile (`sm:`-prefixed). Header text floats over the body gradient.
- **App header**: hide the right-hand wrapper (desktop nav + ProfileButton) on mobile via `hidden sm:flex`. Brand logo + wordmark sit alone on the left.
- **App footer**: drop `border-t` on mobile so it merges into the gradient bottom.
- **Marketing nav**: drop `sticky top-0 z-40 glass-chrome border-b` on mobile. Scrolls naturally with content; users have the final-CTA section at the bottom of the page as the second sign-in entry point.
- **Marketing footer**: drop `border-t` on mobile, same reasoning.

## What this preserves

- Desktop layout unchanged across all four surfaces.
- iOS shell still hides the web header entirely via the existing `[data-platform="ios"] header[role="banner"] { display: none }` rule (which has higher specificity than the `sm:` utilities).
- Account tab in the bottom tab bar still routes to `/settings` — no functional loss from hiding the ProfileButton on mobile.

## Deferred (separate concerns)

- **Bottom tab bar vs Safari's bottom toolbar overlap.** Universal mobile-web reality. Revisit with a dedicated PR if it keeps being a problem (scroll-aware hide pattern, or PWA install prompt for serious users).

## Test plan

- [ ] Mobile web at < 640px (Chrome / Safari iOS) — confirm no visible seams between header / body / footer
- [ ] Mobile web — confirm brand logo + wordmark visible at top, no profile button
- [ ] Mobile web — confirm the Account tab in the bottom bar still routes to `/settings`
- [ ] Marketing page on mobile — confirm "Get started" CTA is visible at top of page (scrolls with content)
- [ ] Marketing page on mobile — confirm final-CTA section ("Let's practice.") at the bottom is reachable
- [ ] Tablet / desktop (≥ 640px) — confirm header chrome, footer borders, sticky marketing nav, profile button all return
- [ ] iOS shell (`just ios-dev`) — confirm header still entirely hidden (existing iOS-only rule should win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)