### PR TITLE
copy(web): add tagline to browser tab title

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Intrada</title>
+    <title>Intrada | Music practice with intent.</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link data-trunk rel="copy-file" href="favicon.svg" />
 


### PR DESCRIPTION
## Summary

Page title was bare *"Intrada"* — no SEO surface and no brand voice. Updated:

```diff
- <title>Intrada</title>
+ <title>Intrada | Music practice with intent.</title>
```

## Why this option

Considered four directions:

| Option | Strength | Trade |
|---|---|---|
| `Intrada \| Practice with intent.` | Hero echo | No SEO surface |
| **`Intrada \| Music practice with intent.`** | **Hero echo + "music practice" SEO** | **+7 chars** |
| `Intrada \| The music practice companion.` | SEO strongest | Generic, not on-brand |
| `Intrada \| Practice that adds up.` | Vision-anchored | "Music" missing for SEO |

Picked the second — keeps the hero verbatim (so the tab title and the page header rhyme), adds the *music* keyword for Google snippets, only +7 characters over the cleanest brand-only option. Best brand-vs-SEO trade for a beta-stage product where discovery still matters.

## Test plan

- [ ] Tab title shows "Intrada | Music practice with intent." in Chrome / Safari
- [ ] No truncation in typical desktop tab widths (38 chars total — should fit)
- [ ] Confirm no E2E tests assert on the literal `<title>` string (verified via grep — none)

## Future

A meta `description` tag could compound the SEO win once the page is in serious discovery mode. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)