### PR TITLE
feat(api): Sentry spans on MCP tools + OAuth endpoints (Phase 6B of #477)

### DIFF
--- a/crates/intrada-api/src/lib.rs
+++ b/crates/intrada-api/src/lib.rs
@@ -8,3 +8,4 @@ pub mod routes;
 pub mod services;
 pub mod state;
 pub mod storage;
+pub mod telemetry;

--- a/crates/intrada-api/src/mcp/server.rs
+++ b/crates/intrada-api/src/mcp/server.rs
@@ -30,6 +30,11 @@ pub fn router() -> Router<AppState> {
 /// Top-level JSON-RPC handler. Routes by `method` to either MCP-protocol
 /// methods (`initialize`, `tools/list`, `tools/call`) or returns a
 /// JSON-RPC `METHOD_NOT_FOUND` error. Notifications (no `id`) get a 204.
+#[tracing::instrument(
+    name = "mcp.request",
+    skip_all,
+    fields(jsonrpc.method = %req.method)
+)]
 async fn handle(
     State(state): State<AppState>,
     // `source` is read by `dispatch_tool` to attribute write-tool calls
@@ -123,6 +128,21 @@ async fn handle(
 /// embedded in the result with `is_error: true` per the MCP spec, not
 /// surfaced as JSON-RPC errors (those are reserved for protocol-level
 /// problems).
+///
+/// Wrapped in a `mcp.tool` span so Sentry dashboards can group call
+/// volume + latency + error rate by tool name and (hashed) identity.
+/// `tool.name` is recorded eagerly; `user.id.hash`, `token.id.hash`,
+/// and `result` are recorded inside the body.
+#[tracing::instrument(
+    name = "mcp.tool",
+    skip_all,
+    fields(
+        tool.name = %params.name,
+        user.id.hash = tracing::field::Empty,
+        token.id.hash = tracing::field::Empty,
+        result = tracing::field::Empty,
+    )
+)]
 async fn dispatch_tool(
     state: &AppState,
     user_id: &str,
@@ -131,6 +151,21 @@ async fn dispatch_tool(
     id: Value,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
+
+    // Identity attributes — hashed so Sentry never sees raw user IDs
+    // or token IDs. `user.id.hash` is recorded for every call (empty
+    // string in `AuthSource::Disabled` mode); `token.id.hash` only for
+    // PAT-authenticated calls (Jwt + Disabled leave it empty).
+    {
+        let span = tracing::Span::current();
+        span.record("user.id.hash", crate::telemetry::hash_id(user_id).as_str());
+        if let AuthSource::Pat { token_id } = source {
+            span.record(
+                "token.id.hash",
+                crate::telemetry::hash_id(token_id).as_str(),
+            );
+        }
+    }
 
     let conn = state.conn();
     // Keep a clone available for the post-match audit recording —
@@ -239,6 +274,7 @@ async fn dispatch_tool(
         }
 
         unknown => {
+            tracing::Span::current().record("result", "method_not_found");
             return Json(JsonRpcResponse::error(
                 id,
                 error_code::METHOD_NOT_FOUND,
@@ -247,6 +283,14 @@ async fn dispatch_tool(
             .into_response();
         }
     };
+
+    tracing::Span::current().record(
+        "result",
+        match &result {
+            Ok(_) => "ok",
+            Err(_) => "error",
+        },
+    );
 
     // Audit single-write tools after a successful execution. Read tools
     // and the bulk-import tool are excluded — bulk_import audits itself.

--- a/crates/intrada-api/src/routes/oauth.rs
+++ b/crates/intrada-api/src/routes/oauth.rs
@@ -42,6 +42,7 @@ pub fn router() -> Router<AppState> {
 
 // ── Discovery (RFC 8414) ───────────────────────────────────────────────
 
+#[tracing::instrument(name = "oauth.discovery", skip_all)]
 async fn discovery(headers: HeaderMap) -> Response {
     // Build the issuer URL from the request's `Host` header so the
     // discovery doc reflects whatever domain the client used to fetch
@@ -76,6 +77,7 @@ async fn discovery(headers: HeaderMap) -> Response {
 
 // ── DCR (RFC 7591) ─────────────────────────────────────────────────────
 
+#[tracing::instrument(name = "oauth.register", skip_all, fields(client_name = %req.client_name))]
 async fn register(
     State(state): State<AppState>,
     Json(req): Json<RegisterClientRequest>,
@@ -87,6 +89,11 @@ async fn register(
 
 // ── Authorize (RFC 6749 §4.1.1) ────────────────────────────────────────
 
+#[tracing::instrument(
+    name = "oauth.authorize",
+    skip_all,
+    fields(client_id = %params.client_id)
+)]
 async fn authorize(
     State(state): State<AppState>,
     Query(params): Query<AuthorizeParams>,
@@ -149,6 +156,11 @@ struct FinalizeResponse {
 /// would let a stolen PAT chain into an OAuth grant attributed to
 /// "the user" without the user actually clicking Allow. Disabled mode
 /// is rejected because there's no user to attribute the code to.
+#[tracing::instrument(
+    name = "oauth.finalize",
+    skip_all,
+    fields(client_id = %req.client_id)
+)]
 async fn finalize(
     State(state): State<AppState>,
     AuthUser { user_id, source }: AuthUser,
@@ -227,6 +239,11 @@ async fn finalize(
 /// RFC 6749 §3.2 — `application/x-www-form-urlencoded` is the canonical
 /// content-type for the token endpoint. Most OAuth clients use it; JSON
 /// is a non-standard extension that we don't accept here.
+#[tracing::instrument(
+    name = "oauth.token",
+    skip_all,
+    fields(client_id = %req.client_id, grant_type = %req.grant_type)
+)]
 async fn token(
     State(state): State<AppState>,
     Form(req): Form<TokenRequest>,

--- a/crates/intrada-api/src/telemetry.rs
+++ b/crates/intrada-api/src/telemetry.rs
@@ -1,0 +1,60 @@
+//! Helpers for safe-to-log identifiers in tracing spans + Sentry.
+//!
+//! Phase 6B of #477. The MCP dispatcher and OAuth endpoints record
+//! `user.id.hash` / `token.id.hash` on their spans so dashboards can
+//! group by identity (e.g. "which token spiked errors?") without raw
+//! user IDs or token IDs ever leaving the API process.
+
+use sha2::{Digest, Sha256};
+
+/// Stable, non-reversible hash for use as a span attribute.
+///
+/// Truncated to 16 hex chars (8 bytes / 64 bits) — enough to bucket
+/// requests by identity in dashboards without surfacing raw identifiers
+/// in Sentry. The truncation is a deliberate one-way reduction; we do
+/// not need (and explicitly do not want) the ability to map a hash back
+/// to its source.
+///
+/// Empty input returns empty output rather than the SHA-256 of the
+/// empty string, so "no identity" is visually distinguishable from "the
+/// empty-string user" in dashboards. (`AuthSource::Disabled` produces an
+/// empty `user_id`; we don't want every dev-mode request to share a
+/// non-empty hash bucket.)
+pub fn hash_id(id: &str) -> String {
+    if id.is_empty() {
+        return String::new();
+    }
+    let digest = Sha256::digest(id.as_bytes());
+    let mut out = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_id_is_stable() {
+        assert_eq!(hash_id("user_42"), hash_id("user_42"));
+    }
+
+    #[test]
+    fn hash_id_is_16_hex_chars() {
+        let h = hash_id("user_42");
+        assert_eq!(h.len(), 16);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_id_distinguishes_inputs() {
+        assert_ne!(hash_id("user_a"), hash_id("user_b"));
+    }
+
+    #[test]
+    fn empty_in_empty_out() {
+        assert_eq!(hash_id(""), "");
+    }
+}


### PR DESCRIPTION
Phase 6B of the [MCP server epic](https://github.com/jonyardley/intrada/issues/477), tracked under #578. Lands the telemetry piece of Phase 6 — rate limits in #585, docs still to come.

After this merges, the Sentry dashboard will show per-tool call volume, latency, and error rate for MCP, plus per-endpoint visibility on the OAuth surface.

## Summary

- New module \`crates/intrada-api/src/telemetry.rs\` with a \`hash_id()\` helper (SHA-256 truncated to 16 hex chars) for safe-to-log identifiers.
- \`mcp.request\` span on the JSON-RPC dispatcher with \`jsonrpc.method\`.
- \`mcp.tool\` span on \`dispatch_tool\` with \`tool.name\`, \`user.id.hash\`, \`token.id.hash\`, and \`result\` (\`ok\` / \`error\` / \`method_not_found\`).
- \`oauth.discovery\` / \`oauth.register\` / \`oauth.authorize\` / \`oauth.finalize\` / \`oauth.token\` spans, each with relevant non-PII fields.

## Privacy

- User IDs and token IDs are hashed before being attached as span attributes — raw identifiers never leave the API process.
- Empty input → empty output so \`AuthSource::Disabled\` requests are distinguishable from real users.
- No request bodies recorded (MCP tool arguments, OAuth form data).
- Existing \`before_send\` scrubber in \`main.rs\` continues to strip auth headers.

## Why no new behavioural tests

The acceptance criterion in #578 is *"Sentry dashboard shows per-tool call volume + latency histograms after deploy"* — that's the real test, post-deploy. Pre-deploy I have:

- Compilation: macros apply, span fields type-check.
- 501/501 workspace tests pass — proves no regression in MCP / OAuth handler behaviour.
- 4 unit tests on \`hash_id\` cover stability, length, distinguishability, empty-passthrough.

Adding \`tracing-test\` as a dev-dep just to assert structurally that spans fire isn't worth the dependency — the macro is well-tested upstream and the integration with Sentry's tracing layer is the same one already in production for the existing \`info_span!(\"request\", ...)\` in \`routes/mod.rs\`.

## Verification

- [x] \`cargo test --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio\`: 501 passed
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity -- -D warnings\` clean
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\` clean
- [ ] CI on this PR
- [ ] Post-deploy: confirm Sentry's Performance tab shows \`mcp.tool\` transactions / spans grouped by \`tool.name\`

## Out of scope (deferred to piece C of #578)

- Public-facing docs page (Claude Desktop / claude.ai / Cursor setup instructions) — separate PR.
- Sentry alerting rules on rate-limit hit volume / OAuth error rate — once we have a few days of dashboard data to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)