### PR TITLE
feat(web): back link on settings sub-pages

### DIFF
--- a/crates/intrada-web/src/views/account_delete.rs
+++ b/crates/intrada-web/src/views/account_delete.rs
@@ -9,7 +9,7 @@ use intrada_web::core_bridge::process_effects;
 use intrada_web::js_bridge;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-use crate::components::{Button, ButtonVariant, TextField};
+use crate::components::{BackLink, Button, ButtonVariant, TextField};
 
 const CONFIRM_PHRASE: &str = "delete my account";
 
@@ -81,6 +81,8 @@ pub fn AccountDeleteView() -> impl IntoView {
 
     view! {
         <div class="max-w-md mx-auto py-card-comfortable space-y-card-comfortable pb-[env(safe-area-inset-bottom)]">
+            <BackLink label="Back to Settings" href="/settings".to_string() />
+
             <h1 class="page-title">"Delete your account?"</h1>
 
             <p class="text-sm text-secondary">

--- a/crates/intrada-web/src/views/mcp_audit.rs
+++ b/crates/intrada-web/src/views/mcp_audit.rs
@@ -4,7 +4,7 @@ use intrada_core::{Event, McpAuditEntry, McpAuditEvent, ViewModel};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-use crate::components::{EmptyState, GroupedList, GroupedListRow, IconName};
+use crate::components::{BackLink, EmptyState, GroupedList, GroupedListRow, IconName};
 
 /// Account-settings sub-page that shows the user's MCP audit log —
 /// every successful write tool call attributed to one of their PATs.
@@ -32,6 +32,8 @@ pub fn McpAuditView() -> impl IntoView {
 
     view! {
         <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
+            <BackLink label="Back to Settings" href="/settings".to_string() />
+
             <div class="space-y-card">
                 <h1 class="page-title">"MCP activity"</h1>
                 <p class="text-sm text-secondary">

--- a/crates/intrada-web/src/views/mcp_tokens.rs
+++ b/crates/intrada-web/src/views/mcp_tokens.rs
@@ -8,7 +8,8 @@ use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 use crate::components::{
-    Button, ButtonVariant, Card, EmptyState, GroupedList, GroupedListRow, IconName, TextField,
+    BackLink, Button, ButtonVariant, Card, EmptyState, GroupedList, GroupedListRow, IconName,
+    TextField,
 };
 
 /// Account-settings sub-page for managing MCP Personal Access Tokens —
@@ -112,6 +113,8 @@ pub fn McpTokensView() -> impl IntoView {
 
     view! {
         <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
+            <BackLink label="Back to Settings" href="/settings".to_string() />
+
             // Title + description grouped tighter than the section spacing
             // so the lede reads as belonging to the title, with the
             // section-sized gap reserved for the page's distinct sections


### PR DESCRIPTION
Surfaces a back link on the three Settings sub-pages that were missing one:

- Settings → MCP tokens → \"Back to Settings\"
- Settings → MCP activity → \"Back to Settings\"
- Settings → Delete your account → \"Back to Settings\"

Caught while reviewing the just-merged Phase 6C of #477 — the MCP pages didn't have a back link in the page header, and account_delete didn't either. Settings landing page itself is the parent, so it doesn't need one.

## Approach

Reuses the existing \`BackLink\` component already used on \`sessions_all\`, \`set_edit\`, \`edit_form\`, \`add_form\`, \`session_new\`. Pattern: top of page, above \`<h1>\`, left-aligned, \`<-\` icon.

No new design tokens, no new component, no behaviour change beyond the navigation link.

## Note on positioning

Original feedback was \"top right\" but every BackLink in the codebase is top-left (matches iOS HIG nav-bar convention + existing app convention). Going with the established pattern — deviating would create design drift per CLAUDE.md \"Don't deviate from the system unless you're explicitly redesigning\". If right-aligned is specifically desired, it'd be a separate redesign of the BackLink component (Pencil first, then Plan mode).

## Verification

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\` clean
- [ ] CI on this PR
- [ ] After merge: navigate to /settings/mcp-tokens, /settings/mcp-audit, /settings/delete-account — each shows \"← Back to Settings\" at the top, clicking returns to /settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)