### PR TITLE
ci(observability): inject + upload Sentry DebugIds on web deploy (#485 partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,19 @@ jobs:
         with:
           name: web-dist
           path: crates/intrada-web/dist
+      # Inject Sentry DebugIds into JS + WASM artifacts BEFORE wrangler
+      # publish, so the deployed files match the artifacts uploaded by
+      # action-release later. DebugIds let Sentry symbolicate stack frames
+      # without relying on filename-based source-map lookup (which breaks
+      # under content-hashed filenames or strict CSP). #485.
+      #
+      # Skipped when SENTRY_AUTH_TOKEN is unset — still want deploys to
+      # succeed for the rare case the token is rotated mid-deploy.
+      - name: Inject Sentry DebugIds into dist
+        if: env.SENTRY_AUTH_TOKEN != ''
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: npx --yes @sentry/cli@latest sourcemaps inject crates/intrada-web/dist
       # Inject the release id into the prebuilt index.html before publishing.
       # The placeholder is set in the source — this swap only happens in the
       # main-branch deploy path, so PR builds keep `release: undefined`.
@@ -267,9 +280,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      # Tag the release in Sentry once Cloudflare has the build. Failure
-      # here shouldn't block a successful deploy, so continue-on-error.
-      - name: Create Sentry release (intrada-web)
+      # Tag the release in Sentry + upload sourcemaps once Cloudflare has
+      # the build. The `sourcemaps:` input re-runs `sentry-cli sourcemaps
+      # inject` (idempotent — DebugIds are content-deterministic) and then
+      # uploads the artifact bundle. Failure here shouldn't block a
+      # successful deploy, so continue-on-error.
+      - name: Create Sentry release (intrada-web) + upload sourcemaps
         if: env.SENTRY_AUTH_TOKEN != ''
         continue-on-error: true
         uses: getsentry/action-release@v3
@@ -281,6 +297,7 @@ jobs:
           version: ${{ github.sha }}
           set_commits: auto
           finalize: true
+          sourcemaps: ./crates/intrada-web/dist
 
   deploy-api:
     name: Deploy API to Fly.io


### PR DESCRIPTION
## Summary

Step toward closing [#485](https://github.com/jonyardley/intrada/issues/485) (readable web stack traces in Sentry). Adds two changes to the Cloudflare deploy job:

### Changes

1. **New step BEFORE wrangler publish**: `npx @sentry/cli sourcemaps inject crates/intrada-web/dist`. Modifies JS files in place to embed a `_sentryDebugIds` snippet + `//# debugId=…` comment. Sentry uses these to match an event's stack frame to the right source artifact even if filenames or filename hashes differ between event and uploaded bundle.
2. **The existing `getsentry/action-release@v3` step gains `sourcemaps: ./crates/intrada-web/dist`**. The action re-runs `sentry-cli sourcemaps inject` (idempotent — DebugIds are content-deterministic) then runs `upload`, which ships the JS bundle to Sentry as an Artifact Bundle attached to the release.

Both gated on `SENTRY_AUTH_TOKEN != ''` so a missing token doesn't break deploys.

## What this delivers today

- DebugId injection on the wasm-bindgen JS shim + every snippet file.
- Errors thrown from JS land in Sentry with a working DebugId reference → triage clicks through to the right source artifact.

## What's still TODO (separate issue, see Followups)

- **JS source maps**: Trunk doesn't currently emit `*.js.map` for the wasm-bindgen output, so today the upload is "files that ran" rather than full minified-to-source mapping. Inject is still useful (DebugIds let Sentry match files even without source maps).
- **WASM names section**: still stripped by `wasm-opt -Oz`. Production WASM panics still show as `wasm.<mangled>__h<hex>` (e.g. issue [INTRADA-WEB-4](https://jon-yardley.sentry.io/issues/INTRADA-WEB-4)). To fix needs Trunk + wasm-opt config to preserve the names section, or a post-build hook that re-runs wasm-opt with `--debuginfo`.

## Test plan

- [x] Local verify: `npx @sentry/cli sourcemaps inject` against a fresh `trunk build --release` dist successfully injects DebugIds into all 5 JS files (shim + 4 snippets) and adds the trailing `//# debugId=…` comment.
- [x] WASM file unchanged (no names section to anchor a DebugId to).
- [ ] Manual verify post-deploy: hit a deliberate JS error, confirm Sentry shows a DebugId-matched artifact in the issue's "Source Maps" tab.

## Refs

[#485](https://github.com/jonyardley/intrada/issues/485) — original "readable web stack traces" issue. Will leave open after merge until WASM names section work also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)