### PR TITLE
ci: iOS-target clippy job for Tauri plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
+      mobile-plugins: ${{ steps.filter.outputs.mobile-plugins }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -49,6 +50,11 @@ jobs:
               - 'crates/intrada-web/**'
               - 'crates/intrada-core/**'
               - 'e2e/**'
+              - '.github/workflows/ci.yml'
+            mobile-plugins:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/intrada-mobile/plugins/**'
               - '.github/workflows/ci.yml'
 
   test:
@@ -93,6 +99,44 @@ jobs:
       - run: cargo clippy --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity -- -D warnings
       - name: Clippy (WASM target)
         run: cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings
+
+  ios-clippy:
+    # Lints iOS-only branches inside the Tauri plugins. Linux runners
+    # can't compile these (Tauri 2 pulls in glib/GTK system libs that
+    # the Ubuntu base image doesn't have), so they're --excluded from
+    # the main clippy job above. That left `#[cfg(target_os = "ios")]`
+    # branches with zero CI coverage — a stale `needless_return` or
+    # unused-import inside an iOS-only block would slip past every PR
+    # and only fail the next time someone ran `just ios-build` locally.
+    #
+    # macos-latest is ~10x the per-minute cost of Linux runners, so this
+    # job is path-filtered: it only runs on PRs that actually touch
+    # `crates/intrada-mobile/plugins/**` (or workspace Cargo files /
+    # this workflow). Always runs on main pushes regardless. Tracks #497.
+    name: iOS Clippy (Tauri plugins)
+    runs-on: macos-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.mobile-plugins == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: clippy
+          # Device target is enough — simulator targets (x86_64-apple-ios,
+          # aarch64-apple-ios-sim) don't add coverage clippy doesn't already
+          # get from the device target. Mirrors CLAUDE.md's recommendation.
+          targets: aarch64-apple-ios
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Separate cache key from native/wasm jobs — different target
+          # triple, different sysroot, different cached artefacts. No
+          # other job populates this cache, so we let it save (the other
+          # clippy job uses save-if:false because `test` populates the
+          # native cache).
+          prefix-key: "ios"
+      - run: cargo clippy -p tauri-plugin-background-audio --target aarch64-apple-ios -- -D warnings
+      - run: cargo clippy -p tauri-plugin-live-activity --target aarch64-apple-ios -- -D warnings
 
   wasm-build:
     name: WASM Build


### PR DESCRIPTION
## Summary

Closes #497.

The two Tauri plugins (\`tauri-plugin-background-audio\`, \`tauri-plugin-live-activity\`) are \`--exclude\`d from the workspace clippy job because they depend on \`tauri = \"2\"\`, which pulls in glib/GTK system libs the Ubuntu runners don't have. That left every \`#[cfg(target_os = \"ios\")]\`-gated branch inside those plugins with zero CI coverage — a stale \`needless_return\` or unused import inside an iOS-only block would slip through every PR and only fail the next time someone ran \`just ios-build\` locally.

This adds a \`macos-latest\` runner that runs the device-target clippy invocation for both plugins, gated by a \`paths-filter\` so most PRs (frontend / API / iOS-shell-only) skip it.

## What changed

- New \`mobile-plugins\` filter on the existing \`changes\` job — matches \`crates/intrada-mobile/plugins/**\`, workspace \`Cargo.toml\` / \`Cargo.lock\`, and this workflow file
- New \`ios-clippy\` job: \`macos-latest\`, \`aarch64-apple-ios\` target, runs clippy with \`-D warnings\` for both plugins
- Cache uses a separate \`ios\` prefix-key (different target triple = different sysroot than native / wasm caches)

Mirrors CLAUDE.md's existing recommendation to run \`--target aarch64-apple-ios\` locally — the device target is enough; simulator targets don't add coverage clippy doesn't already get from device.

## Cost

\`macos-latest\` is ~10x Linux per-minute. Path-filtering keeps this off most PRs (~3-4 min on matching PRs, per the issue estimate). Always runs on main pushes.

## Test plan

- [ ] CI on this PR triggers the new \`ios-clippy\` job (this PR touches \`.github/workflows/ci.yml\`, which is in the filter — that's the right shape for a self-test)
- [ ] \`ios-clippy\` job runs and passes (verified locally — both \`cargo clippy -p tauri-plugin-{background-audio,live-activity} --target aarch64-apple-ios -- -D warnings\` are clean against current main)
- [ ] PRs touching only frontend / API / docs do NOT trigger \`ios-clippy\` (verifiable on the next PR after this lands)
- [ ] Intentionally-bad warning in a plugin's iOS-gated block fails the job (untested in this PR — would need a follow-up sacrificial PR to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)