### PR TITLE
ci: build API image once, deploy via Fly registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,11 @@ jobs:
     # only surface when the Deploy API job runs on main. Only runs when paths
     # that could affect the build change — most PRs (frontend/iOS only) skip
     # this and stay fast. Always runs on main pushes (gates deploy).
+    #
+    # On main pushes the resulting image is pushed to Fly's registry tagged
+    # with the commit SHA, and `deploy-api` deploys that image instead of
+    # rebuilding from scratch on Fly's remote builder. PRs build with cache
+    # but don't push.
     name: API Docker Build
     runs-on: ubuntu-latest
     needs: changes
@@ -234,12 +239,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4
+      - name: Log in to Fly registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: registry.fly.io
+          username: x
+          password: ${{ secrets.FLY_API_TOKEN }}
       - name: Build intrada-api image
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: false
-          tags: intrada-api:ci-smoke
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: registry.fly.io/intrada-api:${{ github.sha }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -290,7 +304,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --build-arg GIT_SHA=${{ github.sha }}
+      # Deploy the image already built, tested (via api-docker-build's gate)
+      # and pushed to Fly's registry — no rebuild on Fly's remote builder.
+      # GIT_SHA was baked in at CI build time via the GIT_SHA build-arg.
+      - run: flyctl deploy --image registry.fly.io/intrada-api:${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - name: Create Sentry release (intrada-api)


### PR DESCRIPTION
## Summary
- `api-docker-build` now pushes the built image to `registry.fly.io/intrada-api:<sha>` on main pushes (with `GIT_SHA` baked in at build time).
- `deploy-api` deploys that image via `flyctl deploy --image ...` instead of `flyctl deploy --remote-only`, which rebuilt on Fly's builder and couldn't reuse the GHA cache — `cargo build --release --bin intrada-api` (Dockerfile step #15) was re-running from scratch on every deploy.
- PRs are unchanged: smoke build with cache, no push.

`FLY_API_TOKEN` doubles as the Fly registry password (user `x`), so no new secret is needed.

## Test plan
- [ ] PR build: `api-docker-build` runs (paths-filter triggers on `.github/workflows/ci.yml` change), builds with cache, does NOT push — registry login step is skipped.
- [ ] Merge to main: `api-docker-build` logs in, pushes `registry.fly.io/intrada-api:<sha>`; `deploy-api` runs `flyctl deploy --image ...` and the deploy log shows pull (not build).
- [ ] Verify `/api/health` after deploy.
- [ ] Confirm Sentry release on intrada-api still tags correctly with the sha (build-arg now flows from CI, not flyctl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)