### PR TITLE
fix(ci): refresh SRI integrity hashes after sentry-cli inject (HOT FIX — #594 broke prod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,61 @@ jobs:
               index.write_text(new_html)
               print(f"refreshed {count} integrity hashes")
           PY
+      # Belt-and-braces: read index.html back and assert every
+      # integrity hash matches the on-disk file it references. Catches
+      # the scenario where someone adds a NEW step that modifies dist/
+      # files between this point and wrangler publish (or removes the
+      # recompute step above) — fails the deploy loud rather than
+      # shipping a blank page like 2026-05-09. Same Python pattern as
+      # the recompute, just assertion-only.
+      - name: Verify SRI integrity hashes match on-disk files
+        run: |
+          python3 - <<'PY'
+          import base64, hashlib, pathlib, re, sys
+
+          dist = pathlib.Path("crates/intrada-web/dist")
+          html = (dist / "index.html").read_text()
+          tag_re = re.compile(
+              r'<(?:link|script)\b[^>]*\bintegrity="sha384-([^"]+)"[^>]*>', re.I
+          )
+          src_re = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.I)
+
+          mismatches = []
+          checked = 0
+          for m in tag_re.finditer(html):
+              declared = m.group(1)
+              src = src_re.search(m.group(0))
+              if not src:
+                  continue
+              file = dist / src.group(1).lstrip("/")
+              if not file.is_file():
+                  mismatches.append(
+                      f"  {src.group(1)}: referenced but not on disk"
+                  )
+                  continue
+              actual = base64.b64encode(
+                  hashlib.sha384(file.read_bytes()).digest()
+              ).decode()
+              if declared != actual:
+                  mismatches.append(
+                      f"  {src.group(1)}: declared sha384-{declared[:12]}…, "
+                      f"actual sha384-{actual[:12]}…"
+                  )
+              checked += 1
+
+          if mismatches:
+              print("SRI integrity mismatch — would ship a blank page:")
+              for line in mismatches:
+                  print(line)
+              print(
+                  "\nLikely cause: a CI step modified dist/ between the "
+                  "recompute step and this verify step. Either move it "
+                  "BEFORE the recompute, or extend the recompute step "
+                  "to run after it."
+              )
+              sys.exit(1)
+          print(f"verified {checked} integrity hashes match on-disk files")
+          PY
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,58 @@ jobs:
         run: |
           sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|${{ github.sha }}|g" crates/intrada-web/dist/index.html
           grep -q "${{ github.sha }}" crates/intrada-web/dist/index.html
+      # Recompute SHA-384 integrity hashes in index.html after the steps
+      # above. `sentry-cli sourcemaps inject` modifies JS files in place
+      # to add DebugId snippets, which invalidates the integrity hashes
+      # Trunk computed at build time. Without this step the browser
+      # rejects every modified resource:
+      #   "Failed to find a valid digest in the 'integrity' attribute …
+      #    The resource has been blocked."
+      # and the page renders blank. (Production blank-page incident
+      # 2026-05-09 hit exactly this.)
+      #
+      # Walks every <link>/<script integrity=...> and replaces the hash
+      # with whatever the on-disk file currently hashes to. Files whose
+      # contents weren't touched (CSS, WASM) get their hashes
+      # recomputed too — same value, no-op.
+      - name: Refresh SRI integrity hashes after inject
+        run: |
+          python3 - <<'PY'
+          import base64, hashlib, pathlib, re
+
+          dist = pathlib.Path("crates/intrada-web/dist")
+          index = dist / "index.html"
+          html = index.read_text()
+          tag_re = re.compile(
+              r'<(?:link|script)\b[^>]*\bintegrity="sha384-[^"]+"[^>]*>', re.I
+          )
+          src_re = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.I)
+
+
+          def patch(m):
+              tag = m.group(0)
+              src = src_re.search(tag)
+              if not src:
+                  return tag
+              rel = src.group(1).lstrip("/")
+              file = dist / rel
+              if not file.is_file():
+                  return tag
+              digest = base64.b64encode(
+                  hashlib.sha384(file.read_bytes()).digest()
+              ).decode()
+              return re.sub(
+                  r'integrity="sha384-[^"]+"',
+                  f'integrity="sha384-{digest}"',
+                  tag,
+              )
+
+
+          new_html, count = tag_re.subn(patch, html)
+          if new_html != html:
+              index.write_text(new_html)
+              print(f"refreshed {count} integrity hashes")
+          PY
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## TL;DR

**Production is currently blank.** [#594](https://github.com/jonyardley/intrada/pull/594) added \`sentry-cli sourcemaps inject\` before wrangler publish, which modifies JS file contents — invalidating the SHA-384 \`integrity\` attributes Trunk had already embedded in \`index.html\`. The browser blocks every modified file:

> \`Failed to find a valid digest in the 'integrity' attribute for resource '…intrada-web-<hash>.js' with computed SHA-384 …. The resource has been blocked.\`

Once the JS files are blocked, the inline \`<script type="module">\` import silently never resolves and the page renders blank. (Visible in user's DevTools right now on \`myintrada.com\`.)

Same class of bug as the one we hit when \`cache-bust-snippets.sh\` modified the WASM-embedded snippet paths.

## Fix

Add a Python step right after \`sentry-cli sourcemaps inject\` and the release-placeholder \`sed\`, before \`wrangler deploy\`. It walks every \`<link>\` / \`<script>\` with an \`integrity="sha384-…"\` attribute in \`index.html\`, recomputes SHA-384 from the on-disk file the tag references, and replaces the hash. Files whose contents weren't modified (CSS, WASM) recompute to the same value — no-op.

## Verified locally

Built fresh dist (7 integrity-bearing tags: CSS, WASM, JS shim, 4 snippet preloads), simulated the inject by appending a comment to JS files, ran the recompute step, all 7 hashes refreshed.

## After this lands

- \`myintrada.com\` should render again on next deploy.
- Future \`sentry-cli inject\` runs continue to inject DebugIds for Sentry; integrity attributes stay in sync.

## Refs

- [#594](https://github.com/jonyardley/intrada/pull/594) — the PR that introduced the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)