### PR TITLE
ci: deploy-smoke job + extract SRI scripts (layer 2 of #605)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,76 @@ jobs:
         working-directory: e2e
         env:
           DIST_DIR: ${{ github.workspace }}/web-dist
-        run: npx playwright test
+        # `--grep-invert "smoke:"` excludes the deploy-smoke spec — that
+        # one runs against the *post-modification* dist in the
+        # `deploy-smoke` job below (where SRI invalidation could be
+        # caught), not the pristine artifact this job uses.
+        run: npx playwright test --grep-invert "smoke:"
+
+  # Deploy smoke — exercises the SAME post-build modification chain as
+  # the production deploy (sentry-cli inject → release placeholder →
+  # SRI recompute → SRI verify) on EVERY PR, then loads the resulting
+  # dist in headless Chromium and asserts the page actually renders.
+  #
+  # Closes the gap that broke prod on 2026-05-09: the post-build chain
+  # only ran on main pushes, so PR CI passed green and a runtime-
+  # blocking regression (stale SRI hashes after inject) shipped to
+  # users before anyone noticed. See #605.
+  deploy-smoke:
+    name: Deploy Smoke
+    runs-on: ubuntu-latest
+    needs: wasm-build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+      - name: Download web-dist artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: crates/intrada-web/dist
+      # Sentry-cli `sourcemaps inject` doesn't need a token (only the
+      # `upload` subcommand does), so this runs unconditionally. The
+      # WHOLE point of the smoke job is to fire the chain that broke
+      # prod, regardless of secret availability on PR builds.
+      - name: Inject Sentry DebugIds
+        run: npx --yes @sentry/cli@latest sourcemaps inject crates/intrada-web/dist
+      # Substitute a fixed placeholder value rather than ${{ github.sha }}.
+      # Smoke job intent is to test the chain, not to mint a real release
+      # tag — and using the SHA would tag PR-time builds with their
+      # commit hash in dist/index.html, confusing post-merge triage.
+      - name: Inject Sentry release placeholder (smoke)
+        run: |
+          sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|pr-smoke|g" crates/intrada-web/dist/index.html
+          grep -q "pr-smoke" crates/intrada-web/dist/index.html
+      - name: Refresh SRI integrity hashes after inject
+        run: python3 scripts/refresh-sri-hashes.py
+      - name: Verify SRI integrity hashes match on-disk files
+        run: python3 scripts/verify-sri-hashes.py
+      - name: Install Playwright dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('e2e/package-lock.json') }}
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install chromium
+      - name: Run smoke spec against post-modification dist
+        working-directory: e2e
+        env:
+          DIST_DIR: ${{ github.workspace }}/crates/intrada-web/dist
+        # `--grep "smoke:"` runs only the deploy-smoke.spec.ts test —
+        # everything else in tests/ is the regular E2E suite, run in
+        # the `e2e` job above (against the pristine artifact).
+        run: npx playwright test --grep "smoke:"
 
   fmt:
     name: Formatting
@@ -333,113 +402,22 @@ jobs:
         run: |
           sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|${{ github.sha }}|g" crates/intrada-web/dist/index.html
           grep -q "${{ github.sha }}" crates/intrada-web/dist/index.html
-      # Recompute SHA-384 integrity hashes in index.html after the steps
-      # above. `sentry-cli sourcemaps inject` modifies JS files in place
-      # to add DebugId snippets, which invalidates the integrity hashes
-      # Trunk computed at build time. Without this step the browser
-      # rejects every modified resource:
-      #   "Failed to find a valid digest in the 'integrity' attribute …
-      #    The resource has been blocked."
-      # and the page renders blank. (Production blank-page incident
-      # 2026-05-09 hit exactly this.)
-      #
-      # Walks every <link>/<script integrity=...> and replaces the hash
-      # with whatever the on-disk file currently hashes to. Files whose
-      # contents weren't touched (CSS, WASM) get their hashes
-      # recomputed too — same value, no-op.
+      # Recompute SHA-384 integrity hashes — `sentry-cli sourcemaps
+      # inject` modifies JS files in place, leaving the SRI attributes
+      # Trunk pre-computed in index.html stale. Without this step the
+      # browser blocks every modified file ("Failed to find a valid
+      # digest in the 'integrity' attribute"), the inline module
+      # script never resolves, and the page renders blank.
+      # Production blank-page incident 2026-05-09 (PR #594) → #604.
       - name: Refresh SRI integrity hashes after inject
-        run: |
-          python3 - <<'PY'
-          import base64, hashlib, pathlib, re
-
-          dist = pathlib.Path("crates/intrada-web/dist")
-          index = dist / "index.html"
-          html = index.read_text()
-          tag_re = re.compile(
-              r'<(?:link|script)\b[^>]*\bintegrity="sha384-[^"]+"[^>]*>', re.I
-          )
-          src_re = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.I)
-
-
-          def patch(m):
-              tag = m.group(0)
-              src = src_re.search(tag)
-              if not src:
-                  return tag
-              rel = src.group(1).lstrip("/")
-              file = dist / rel
-              if not file.is_file():
-                  return tag
-              digest = base64.b64encode(
-                  hashlib.sha384(file.read_bytes()).digest()
-              ).decode()
-              return re.sub(
-                  r'integrity="sha384-[^"]+"',
-                  f'integrity="sha384-{digest}"',
-                  tag,
-              )
-
-
-          new_html, count = tag_re.subn(patch, html)
-          if new_html != html:
-              index.write_text(new_html)
-              print(f"refreshed {count} integrity hashes")
-          PY
-      # Belt-and-braces: read index.html back and assert every
-      # integrity hash matches the on-disk file it references. Catches
-      # the scenario where someone adds a NEW step that modifies dist/
-      # files between this point and wrangler publish (or removes the
-      # recompute step above) — fails the deploy loud rather than
-      # shipping a blank page like 2026-05-09. Same Python pattern as
-      # the recompute, just assertion-only.
+        run: python3 scripts/refresh-sri-hashes.py
+      # Belt-and-braces assertion: any post-build modification step
+      # added between recompute and wrangler publish (or removal of
+      # the recompute step above) fails the deploy loud rather than
+      # silently shipping a blank page. Same script also runs on
+      # every PR via the `deploy-smoke` job — see below.
       - name: Verify SRI integrity hashes match on-disk files
-        run: |
-          python3 - <<'PY'
-          import base64, hashlib, pathlib, re, sys
-
-          dist = pathlib.Path("crates/intrada-web/dist")
-          html = (dist / "index.html").read_text()
-          tag_re = re.compile(
-              r'<(?:link|script)\b[^>]*\bintegrity="sha384-([^"]+)"[^>]*>', re.I
-          )
-          src_re = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.I)
-
-          mismatches = []
-          checked = 0
-          for m in tag_re.finditer(html):
-              declared = m.group(1)
-              src = src_re.search(m.group(0))
-              if not src:
-                  continue
-              file = dist / src.group(1).lstrip("/")
-              if not file.is_file():
-                  mismatches.append(
-                      f"  {src.group(1)}: referenced but not on disk"
-                  )
-                  continue
-              actual = base64.b64encode(
-                  hashlib.sha384(file.read_bytes()).digest()
-              ).decode()
-              if declared != actual:
-                  mismatches.append(
-                      f"  {src.group(1)}: declared sha384-{declared[:12]}…, "
-                      f"actual sha384-{actual[:12]}…"
-                  )
-              checked += 1
-
-          if mismatches:
-              print("SRI integrity mismatch — would ship a blank page:")
-              for line in mismatches:
-                  print(line)
-              print(
-                  "\nLikely cause: a CI step modified dist/ between the "
-                  "recompute step and this verify step. Either move it "
-                  "BEFORE the recompute, or extend the recompute step "
-                  "to run after it."
-              )
-              sys.exit(1)
-          print(f"verified {checked} integrity hashes match on-disk files")
-          PY
+        run: python3 scripts/verify-sri-hashes.py
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:

--- a/e2e/tests/deploy-smoke.spec.ts
+++ b/e2e/tests/deploy-smoke.spec.ts
@@ -1,0 +1,81 @@
+// Deploy smoke test — runs against the post-build-modification dist
+// (the artifact wrangler would actually publish), not the pristine
+// trunk-build artifact.
+//
+// Catches the class of regression that broke production on 2026-05-09:
+// `sentry-cli sourcemaps inject` modified JS files in place; Trunk's
+// pre-computed SRI integrity hashes in index.html went stale; browser
+// blocked every modified file; page rendered blank.
+//
+// The existing E2E suite tests app behaviour against the pristine
+// dist. This spec specifically guards the deploy pipeline — it only
+// fires alarms when SOMETHING breaks runtime loading. Test name is
+// `smoke:` prefixed so the dedicated CI job can target it via
+// `--grep "smoke:"`.
+
+import { test, expect } from "../fixtures/api-mock";
+
+test("smoke: post-modification dist renders without runtime-blocking console errors", async ({
+  page,
+}) => {
+  // Capture console errors + uncaught page errors. We're looking for
+  // the specific signatures that mean "the runtime is broken at the
+  // load layer" — not arbitrary app-level errors (those are the job
+  // of the rest of the E2E suite).
+  const errors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
+
+  await page.goto("/");
+
+  // Wait for the WASM to mount and put SOMETHING substantial in the
+  // body. We deliberately don't pin to a specific element — the
+  // marketing page, login screen, library, etc. all evolve, and
+  // pinning a selector here would fail for unrelated UI changes.
+  // The smoke test cares about ONE thing: did the runtime load at
+  // all? If WASM was blocked (SRI mismatch, ERR_BLOCKED_BY_CLIENT,
+  // missing import), `document.body.innerText` stays near-empty.
+  // Empirical floor: pristine builds put >100 chars in the body
+  // within a few seconds; a blank-page failure mode leaves under 30.
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(() =>
+          (document.body.innerText || "").trim().length,
+        ),
+      {
+        timeout: 20_000,
+        message:
+          "body.innerText stayed near-empty — WASM likely failed to load (see console errors below)",
+      },
+    )
+    .toBeGreaterThan(100);
+
+  // Filter to the error classes that indicate broken-runtime, not
+  // app-level bugs:
+  // - "Failed to find a valid digest"  →  SRI mismatch (PR #594 case)
+  // - "ERR_BLOCKED_BY_CLIENT"          →  ad-blocker, content-blocker
+  // - "Importing binding name"         →  WASM ↔ JS shim drift (#440)
+  // - "module is not an object"        →  WASM imports point at wrong path (#488)
+  // - "WebAssembly.instantiate"        →  WASM init failure
+  // - "Failed to fetch dynamically imported module" → broken module path
+  const blockingPatterns = [
+    /Failed to find a valid digest/,
+    /ERR_BLOCKED_BY_CLIENT/,
+    /Importing binding name/,
+    /module is not an object/,
+    /WebAssembly\.instantiate/,
+    /Failed to fetch dynamically imported module/,
+  ];
+  const blocking = errors.filter((e) =>
+    blockingPatterns.some((re) => re.test(e)),
+  );
+
+  expect(
+    blocking,
+    "Console errors that would block runtime — see deploy modification chain in ci.yml:\n" +
+      blocking.map((e) => `  ${e}`).join("\n"),
+  ).toEqual([]);
+});

--- a/scripts/refresh-sri-hashes.py
+++ b/scripts/refresh-sri-hashes.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Recompute SHA-384 integrity hashes in dist/index.html.
+
+Walks every `<link>/<script integrity="sha384-…">` tag, computes the
+SHA-384 of the file the tag references, and rewrites the attribute.
+Files whose contents weren't touched recompute to the same value
+(no-op).
+
+Why this exists
+───────────────
+Trunk computes integrity hashes at build time. Anything that modifies
+dist/ files AFTER trunk's build (`sentry-cli sourcemaps inject`,
+`sed`-based placeholder injection, etc.) leaves the integrity attributes
+stale, which causes the browser to refuse the modified file:
+
+    Failed to find a valid digest in the 'integrity' attribute …
+    The resource has been blocked.
+
+Run this AFTER any post-build modification step and BEFORE wrangler
+publish. The companion `verify-sri-hashes.py` script asserts that all
+hashes match — run it last to catch any modification step that slipped
+in without calling refresh.
+
+Usage
+─────
+    scripts/refresh-sri-hashes.py [DIST_DIR]
+
+Defaults to `crates/intrada-web/dist`. Exits 0 on success.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import pathlib
+import re
+import sys
+
+DEFAULT_DIST = "crates/intrada-web/dist"
+
+TAG_RE = re.compile(
+    r'<(?:link|script)\b[^>]*\bintegrity="sha384-[^"]+"[^>]*>', re.IGNORECASE
+)
+SRC_RE = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.IGNORECASE)
+
+
+def main() -> int:
+    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
+    index = dist / "index.html"
+    if not index.is_file():
+        print(f"refresh-sri-hashes: {index} not found", file=sys.stderr)
+        return 1
+
+    html = index.read_text()
+
+    def patch(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        src = SRC_RE.search(tag)
+        if not src:
+            return tag
+        rel = src.group(1).lstrip("/")
+        file = dist / rel
+        if not file.is_file():
+            return tag
+        digest = base64.b64encode(hashlib.sha384(file.read_bytes()).digest()).decode()
+        return re.sub(
+            r'integrity="sha384-[^"]+"',
+            f'integrity="sha384-{digest}"',
+            tag,
+        )
+
+    new_html, count = TAG_RE.subn(patch, html)
+    if new_html != html:
+        index.write_text(new_html)
+        print(f"refresh-sri-hashes: refreshed {count} integrity hashes")
+    else:
+        print(f"refresh-sri-hashes: all {count} integrity hashes already match")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-sri-hashes.py
+++ b/scripts/verify-sri-hashes.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Assert every SRI hash in dist/index.html matches the on-disk file.
+
+Walks every `<link>/<script integrity="sha384-…">` tag, recomputes
+SHA-384 from the file the tag references, and exits 1 with a pointed
+error message if any mismatch is found. Pure check — never modifies
+files.
+
+Why this exists
+───────────────
+Belt-and-braces guard. Run AFTER `refresh-sri-hashes.py` (and any other
+dist/ modification step) so the deploy fails loudly if some new step
+shipped between recompute and wrangler. Without this, a stale
+integrity attribute means the browser blocks the file at runtime, the
+inline `<script type="module">` import silently never resolves, and the
+page renders blank — no CI signal at all.
+
+Production blank-page incident 2026-05-09 (PR #594) was caught by user
+DevTools, not CI. This script is the gap-filler.
+
+Usage
+─────
+    scripts/verify-sri-hashes.py [DIST_DIR]
+
+Defaults to `crates/intrada-web/dist`. Exits 0 if all hashes match;
+exits 1 with a human-readable mismatch report otherwise.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import pathlib
+import re
+import sys
+
+DEFAULT_DIST = "crates/intrada-web/dist"
+
+TAG_RE = re.compile(
+    r'<(?:link|script)\b[^>]*\bintegrity="sha384-([^"]+)"[^>]*>', re.IGNORECASE
+)
+SRC_RE = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.IGNORECASE)
+
+
+def main() -> int:
+    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
+    index = dist / "index.html"
+    if not index.is_file():
+        print(f"verify-sri-hashes: {index} not found", file=sys.stderr)
+        return 1
+
+    html = index.read_text()
+    mismatches: list[str] = []
+    checked = 0
+    for match in TAG_RE.finditer(html):
+        declared = match.group(1)
+        src = SRC_RE.search(match.group(0))
+        if not src:
+            continue
+        rel = src.group(1).lstrip("/")
+        file = dist / rel
+        if not file.is_file():
+            mismatches.append(f"  {src.group(1)}: referenced but not on disk")
+            continue
+        actual = base64.b64encode(hashlib.sha384(file.read_bytes()).digest()).decode()
+        if declared != actual:
+            mismatches.append(
+                f"  {src.group(1)}: declared sha384-{declared[:12]}…, "
+                f"actual sha384-{actual[:12]}…"
+            )
+        checked += 1
+
+    if mismatches:
+        print("verify-sri-hashes: SRI integrity mismatch — would ship a blank page:")
+        for line in mismatches:
+            print(line)
+        print(
+            "\nLikely cause: a step modified dist/ between the refresh-sri-hashes "
+            "step and this verify step. Either move it BEFORE the refresh, or "
+            "re-run refresh after it.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"verify-sri-hashes: {checked} integrity hashes match on-disk files")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Layer 2 of [#605](https://github.com/jonyardley/intrada/issues/605) (CI safety net for post-build dist/ modifications). Layer 1 (SRI verify in deploy job) shipped in [#604](https://github.com/jonyardley/intrada/pull/604) — this builds on it.

## Why

The gap that broke prod on 2026-05-09 ([#594](https://github.com/jonyardley/intrada/pull/594)): the deploy modification chain only ran on main pushes, so PR CI passed on the pristine \`trunk build\` artifact while the post-modification artifact wrangler actually ships had stale integrity hashes. No CI signal until users opened DevTools.

## What

### 1. Extract SRI helpers into reusable scripts
- \`scripts/refresh-sri-hashes.py\` — recompute logic (was inline Python in the deploy job after #604)
- \`scripts/verify-sri-hashes.py\` — assertion (was inline Python in the deploy job after #604)

The deploy job now calls them directly. Same behaviour, less YAML, can be invoked from any other CI job.

### 2. Add \`deploy-smoke\` job that runs on every PR

- Downloads the \`web-dist\` artifact (already built by \`wasm-build\`)
- Runs the **same** modification chain as the deploy job: \`sentry-cli sourcemaps inject\` → release-placeholder \`sed\` → \`refresh-sri-hashes.py\` → \`verify-sri-hashes.py\`
- Serves the resulting dist via the existing Playwright web-server config
- Runs \`e2e/tests/deploy-smoke.spec.ts\` — loads \`/\` in headless Chromium, polls for \`body.innerText > 100 chars\` (= WASM mounted and rendered), filters captured console errors against the runtime-blocking classes we've actually hit:
  - \`Failed to find a valid digest\` ([#594](https://github.com/jonyardley/intrada/pull/594))
  - \`Importing binding name\` ([#440](https://github.com/jonyardley/intrada/issues/440))
  - \`module is not an object\` ([#488](https://github.com/jonyardley/intrada/pull/488))
  - \`WebAssembly.instantiate\`, \`Failed to fetch dynamically imported module\`, \`ERR_BLOCKED_BY_CLIENT\`

The smoke spec uses a \`smoke:\` test-name prefix so it runs ONLY in the new job; the existing \`e2e\` job uses \`--grep-invert "smoke:"\` to skip it.

## Verified locally

| Scenario | refresh | verify | smoke |
|---|---|---|---|
| Pristine post-mod dist | refreshed 7 hashes | 7/7 match ✓ | PASS |
| JS modified, no recompute | n/a | exit 1, names file | FAIL (body empty) |

Both layers catch the regression — verify with a pointed file-level message, smoke with a generic-but-loud "page is blank."

## Out of scope (layer 3 of #605)

Sentry alert on pageload-event drop. That's Sentry-side config, no code — handle separately.

## Refs

- [#605](https://github.com/jonyardley/intrada/issues/605) — tracking issue
- [#604](https://github.com/jonyardley/intrada/pull/604) — layer 1 (just merged)
- [#594](https://github.com/jonyardley/intrada/pull/594) — the regression that prompted this

🤖 Generated with [Claude Code](https://claude.com/claude-code)