### PR TITLE
fix(web): clean up remaining event listener leaks (#609)

### DIFF
--- a/crates/intrada-web/src/components/autocomplete.rs
+++ b/crates/intrada-web/src/components/autocomplete.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use leptos::prelude::*;
-use web_sys::wasm_bindgen::JsCast;
 
 use crate::components::FormFieldError;
 use intrada_web::helpers::filter_suggestions;
@@ -63,18 +62,15 @@ pub fn Autocomplete(
     let listbox_id = format!("{id}-listbox");
     let listbox_id_clone = listbox_id.clone();
 
-    // Handle focusout with delay to allow click events to fire first
+    // Handle focusout with delay to allow click events to fire first.
+    // spawn_local is safe here because on:focusout runs inside the Leptos
+    // owner; the async block closes over `is_open` which stays valid for
+    // the 150ms window (far shorter than any navigation / unmount path).
     let on_focusout = move |_ev: web_sys::FocusEvent| {
-        let handle = wasm_bindgen::closure::Closure::once(move || {
+        leptos::task::spawn_local(async move {
+            gloo_timers::future::TimeoutFuture::new(150).await;
             is_open.set(false);
         });
-        let _ = web_sys::window()
-            .unwrap()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                handle.as_ref().unchecked_ref(),
-                150,
-            );
-        handle.forget();
     };
 
     // Handle keyboard navigation

--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -199,10 +199,30 @@ pub fn BottomSheet(
             &passive_opts,
         );
 
-        touchstart.forget();
-        touchmove.forget();
-        touchend.forget();
-        touchcancel.forget();
+        // SendWrapper: on_cleanup requires Send+Sync; Closure/HtmlElement
+        // aren't both. Safe on wasm32 — single-threaded by construction.
+        // Same pattern as the Escape handler above.
+        let touchstart = SendWrapper::new(touchstart);
+        let touchmove = SendWrapper::new(touchmove);
+        let touchend = SendWrapper::new(touchend);
+        let touchcancel = SendWrapper::new(touchcancel);
+        let el = SendWrapper::new(el);
+        on_cleanup(move || {
+            let _ = el.remove_event_listener_with_callback(
+                "touchstart",
+                touchstart.as_ref().unchecked_ref(),
+            );
+            let _ = el.remove_event_listener_with_callback(
+                "touchmove",
+                touchmove.as_ref().unchecked_ref(),
+            );
+            let _ = el
+                .remove_event_listener_with_callback("touchend", touchend.as_ref().unchecked_ref());
+            let _ = el.remove_event_listener_with_callback(
+                "touchcancel",
+                touchcancel.as_ref().unchecked_ref(),
+            );
+        });
     });
 
     let backdrop_class = move || {

--- a/crates/intrada-web/src/components/pull_to_refresh.rs
+++ b/crates/intrada-web/src/components/pull_to_refresh.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, TouchEvent};
@@ -182,11 +183,29 @@ pub fn PullToRefresh(
             &passive_opts,
         );
 
-        // Listeners outlive the component; same pattern as use_drag_reorder.
-        touchstart.forget();
-        touchmove.forget();
-        touchend.forget();
-        touchcancel.forget();
+        // SendWrapper: on_cleanup requires Send+Sync; Closure/HtmlElement
+        // aren't both. Safe on wasm32 — single-threaded by construction.
+        let touchstart = SendWrapper::new(touchstart);
+        let touchmove = SendWrapper::new(touchmove);
+        let touchend = SendWrapper::new(touchend);
+        let touchcancel = SendWrapper::new(touchcancel);
+        let el = SendWrapper::new(el);
+        on_cleanup(move || {
+            let _ = el.remove_event_listener_with_callback(
+                "touchstart",
+                touchstart.as_ref().unchecked_ref(),
+            );
+            let _ = el.remove_event_listener_with_callback(
+                "touchmove",
+                touchmove.as_ref().unchecked_ref(),
+            );
+            let _ = el
+                .remove_event_listener_with_callback("touchend", touchend.as_ref().unchecked_ref());
+            let _ = el.remove_event_listener_with_callback(
+                "touchcancel",
+                touchcancel.as_ref().unchecked_ref(),
+            );
+        });
     });
 
     // Drives the wrapper's transform — both content and indicator translate

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use leptos::prelude::*;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
@@ -117,16 +118,20 @@ pub fn SessionTimer() -> impl IntoView {
                 interval_id.set(Some(id));
             }
         }
-        closure.forget();
-    }
-
-    on_cleanup(move || {
-        if let Some(id) = interval_id.get_untracked() {
-            if let Some(window) = web_sys::window() {
-                window.clear_interval_with_handle(id);
+        // SendWrapper: on_cleanup requires Send+Sync; Closure isn't.
+        // Safe on wasm32 — single-threaded by construction.
+        let closure = SendWrapper::new(closure);
+        on_cleanup(move || {
+            if let Some(id) = interval_id.get_untracked() {
+                if let Some(window) = web_sys::window() {
+                    window.clear_interval_with_handle(id);
+                }
             }
-        }
-    });
+            // Drop the Closure after clearing the interval so the JS
+            // function is freed and can't fire a final time.
+            drop(closure);
+        });
+    }
 
     view! {
         // space-y-6 between major zones — hero, optional rep card,

--- a/crates/intrada-web/src/components/welcome_carousel.rs
+++ b/crates/intrada-web/src/components/welcome_carousel.rs
@@ -1,6 +1,7 @@
 use leptos::ev;
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
+use send_wrapper::SendWrapper;
 use wasm_bindgen::prelude::*;
 use web_sys::TouchEvent;
 
@@ -222,16 +223,23 @@ pub fn WelcomeCarousel(
             touch_start_y.set(None);
         });
 
-        let el_target: &web_sys::EventTarget = el.as_ref();
-        let _ = el_target
-            .add_event_listener_with_callback("touchstart", touchstart.as_ref().unchecked_ref());
-        let _ = el_target
-            .add_event_listener_with_callback("touchend", touchend.as_ref().unchecked_ref());
+        let _ =
+            el.add_event_listener_with_callback("touchstart", touchstart.as_ref().unchecked_ref());
+        let _ = el.add_event_listener_with_callback("touchend", touchend.as_ref().unchecked_ref());
 
-        // Leak intentionally — carousel lives for app lifetime or until
-        // dismissed, and cleanup isn't worth the complexity.
-        touchstart.forget();
-        touchend.forget();
+        // SendWrapper: on_cleanup requires Send+Sync; Closure/HtmlElement
+        // aren't both. Safe on wasm32 — single-threaded by construction.
+        let touchstart = SendWrapper::new(touchstart);
+        let touchend = SendWrapper::new(touchend);
+        let el = SendWrapper::new(el);
+        on_cleanup(move || {
+            let _ = el.remove_event_listener_with_callback(
+                "touchstart",
+                touchstart.as_ref().unchecked_ref(),
+            );
+            let _ = el
+                .remove_event_listener_with_callback("touchend", touchend.as_ref().unchecked_ref());
+        });
     });
 
     // ── Callbacks for Leptos event handlers ─────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces `.forget()` on wasm-bindgen Closures with `SendWrapper` + `on_cleanup` in 5 components
- Eliminates the same root-cause WASM panic fixed for ContextMenu/SwipeActions in #610 (INTRADA-WEB-4)
- Closes #609

| Component | Fix |
|-----------|-----|
| `PullToRefresh` | 4 touch listeners (touchstart/move/end/cancel) on wrapper div → `SendWrapper` + `on_cleanup` |
| `BottomSheet` | 4 touch listeners on drag handle → same pattern (Escape handler already correct) |
| `WelcomeCarousel` | 2 touch listeners (touchstart/end) on carousel overlay → `SendWrapper` + `on_cleanup`; removed stale "leak intentionally" comment |
| `SessionTimer` | `setInterval` Closure → merged two `on_cleanup` blocks so interval is cleared and closure dropped together |
| `Autocomplete` | `on_focusout` 150ms delay → replaced `Closure::once` + `forget` with `spawn_local` + `TimeoutFuture` |

**Not in this PR** — `week_strip.rs` has two one-shot setTimeout/rAF closures that are already protected by `clear_timeout_with_handle` in `on_cleanup`. Those are memory-only leaks (not correctness issues) and tracked as a follow-up item on #609.

## Test plan

- [x] `cargo check -p intrada-web --target wasm32-unknown-unknown` — clean build
- [x] `cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — passes
- [ ] iOS simulator: pull-to-refresh, bottom sheet swipe dismiss, welcome carousel swipe, session timer tick, autocomplete focusout — confirm no WASM panics after component unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)