### PR TITLE
feat(api): per-IP rate limits on /oauth/register and /api/mcp (#578)

### DIFF
--- a/crates/intrada-api/src/rate_limit.rs
+++ b/crates/intrada-api/src/rate_limit.rs
@@ -1,9 +1,13 @@
-//! Process-local per-token rate limiter for `/api/mcp/*`.
+//! Process-local rate limiters for `/api/mcp/*` and OAuth endpoints.
 //!
-//! Fixed 60-second windows, 60 requests per token. Bucket key is
-//! `mcp_tokens.id` (ULID) so OAuth-minted tokens and manually-created
-//! PATs share the same per-token limit. Bypasses [`AuthSource::Jwt`]
-//! (web/iOS UI) and [`AuthSource::Disabled`] (local dev).
+//! Two flavours:
+//! - [`McpRateLimiter`] — per-token fixed-window bucket (60 req/min/token).
+//!   Applied to `/api/mcp` by `mcp_rate_limit`. Bypasses JWT + Disabled.
+//! - [`IpRateLimiter`] — per-IP fixed-window bucket. Two instances:
+//!   - MCP (300 req/min/IP): early reject for bogus-PAT floods before
+//!     they burn `lookup_by_hash` DB calls.
+//!   - OAuth (20 req/min/IP): DoS guard on the unauthenticated DCR
+//!     endpoint (`/oauth/register`) that creates a DB row per call.
 //!
 //! State is process-local — no Redis, no DB. On Fly with
 //! `auto_stop_machines = 'suspend'` the bucket resets when the machine
@@ -99,38 +103,130 @@ impl McpRateLimiter {
     }
 }
 
-/// Middleware applied to the `/api/mcp` nest. Eagerly resolves PATs so
-/// the bucket can be checked before the handler runs. Note that handlers
-/// will still re-resolve via the `AuthUser` extractor — at 60 req/min/token
-/// the duplicate `lookup_by_hash` is negligible vs. the plumbing cost of
-/// caching the extraction result in `request.extensions`.
+/// Per-IP fixed-window rate limiter. Bucket key is the client IP string
+/// (extracted from `Fly-Client-IP` or `X-Forwarded-For`).
 ///
-/// **Known limitation**: any bearer that starts with `intrada_pat_` triggers
-/// one `lookup_by_hash` call here, even if the token is malformed or unknown.
-/// A high-rate flood of bogus tokens will burn DB lookups (and hash CPU)
-/// without consuming any bucket. The bucket-keyed-on-resolved-`token_id`
-/// design protects legitimate tokens from being starved by such a flood,
-/// but does not bound the flood's cost itself. A separate per-IP layer
-/// covering both this surface and unauthenticated `/oauth/register` is
-/// captured as a follow-up under #578.
+/// Used for two purposes with different production limits:
+/// - MCP IP guard (300 req/min/IP): reject bogus-PAT floods before they
+///   reach the per-token bucket and burn `lookup_by_hash` DB calls.
+/// - OAuth register guard (20 req/min/IP): DoS protection on the
+///   unauthenticated DCR endpoint which creates a DB row per call.
+pub struct IpRateLimiter {
+    state: Mutex<HashMap<String, (Instant, u32)>>,
+    limit: u32,
+    window: Duration,
+}
+
+impl IpRateLimiter {
+    pub fn new(limit: u32, window: Duration) -> Self {
+        Self {
+            state: Mutex::new(HashMap::new()),
+            limit,
+            window,
+        }
+    }
+
+    /// MCP IP guard: 300 req/min/IP. Generous enough for multiple agents
+    /// behind a shared home IP (e.g. Claude Desktop + Cursor = 2 × 60
+    /// = 120 req/min) while blocking flood-level abuse.
+    pub fn production_mcp() -> Self {
+        Self::new(300, Duration::from_secs(60))
+    }
+
+    /// OAuth register guard: 20 req/min/IP. Tight because each call
+    /// mints a new OAuth client in the DB; legitimate flows make at
+    /// most 1 registration per session.
+    pub fn production_oauth() -> Self {
+        Self::new(20, Duration::from_secs(60))
+    }
+
+    /// Record a request from `ip` and decide whether to allow it.
+    /// `Ok(())` = allow, `Err(retry_after_seconds)` = reject with 429.
+    pub fn check(&self, ip: &str) -> Result<(), u64> {
+        let now = Instant::now();
+        let mut state = self.state.lock().expect("ip rate-limit state poisoned");
+
+        if let Some((window_start, count)) = state.get_mut(ip) {
+            if now.duration_since(*window_start) >= self.window {
+                *window_start = now;
+                *count = 1;
+                return Ok(());
+            }
+            if *count < self.limit {
+                *count += 1;
+                return Ok(());
+            }
+            let retry_after = self
+                .window
+                .saturating_sub(now.duration_since(*window_start))
+                .as_secs()
+                .max(1);
+            return Err(retry_after);
+        }
+
+        if state.len() >= MAP_SIZE_THRESHOLD {
+            let cutoff = self.window * 2;
+            state.retain(|_, (start, _)| now.duration_since(*start) < cutoff);
+        }
+        state.insert(ip.to_string(), (now, 1));
+        Ok(())
+    }
+}
+
+/// Extract the best available client IP from request headers.
+///
+/// Fly.io sets `Fly-Client-IP` to the real originating IP (trusted).
+/// Falls back to the first entry of `X-Forwarded-For` for non-Fly
+/// deployments. Returns `"unknown"` if neither header is present — rate
+/// limits keyed on `"unknown"` are shared across all such requests, which
+/// is intentionally conservative.
+fn client_ip(headers: &axum::http::HeaderMap) -> String {
+    headers
+        .get("fly-client-ip")
+        .or_else(|| headers.get("x-forwarded-for"))
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(',').next().unwrap_or(s).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Middleware applied to the `/api/mcp` nest. Two-stage check:
+///
+/// 1. **IP bucket** (`state.mcp_ip_limiter`): fast path — any request
+///    from a flooding IP is rejected before hitting the DB. Catches
+///    bogus-PAT floods that previously slipped through to `resolve_pat`
+///    and burned `lookup_by_hash` calls.
+/// 2. **Token bucket** (`state.rate_limiter`): per-PAT check after the IP
+///    check passes. Handlers still re-resolve via the `AuthUser` extractor
+///    — at 60 req/min/token the duplicate `lookup_by_hash` is negligible
+///    vs the plumbing cost of caching the extraction result in extensions.
+///
+/// JWTs (web/iOS UI), missing/invalid auth, and Disabled-mode requests
+/// bypass the token bucket but still pass through the IP check.
 pub async fn mcp_rate_limit(State(state): State<AppState>, req: Request, next: Next) -> Response {
-    // CORS preflight: pass through without consuming the bucket. The
-    // outer CORS layer is what actually responds to OPTIONS, but
-    // short-circuiting here is cheap insurance against a future config
-    // change that lets preflights reach this layer.
+    // CORS preflight: pass through without consuming either bucket.
     if req.method() == Method::OPTIONS {
         return next.run(req).await;
     }
 
+    // Stage 1: IP-level check — catches floods before DB involvement.
+    let ip = client_ip(req.headers());
+    if let Err(retry_after) = state.mcp_ip_limiter.check(&ip) {
+        tracing::info!(%ip, "mcp ip rate limit exceeded");
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(header::RETRY_AFTER, retry_after.to_string())],
+            Json(json!({"error": "rate limit exceeded"})),
+        )
+            .into_response();
+    }
+
+    // Stage 2: per-token check. Only PAT-shaped tokens are bucketed.
     let bearer = req
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .and_then(|h| h.strip_prefix("Bearer "));
 
-    // Only PAT-shaped tokens trigger the rate limit. JWTs (web/iOS UI),
-    // missing/invalid auth, and Disabled-mode requests pass straight through —
-    // the handler-level `AuthUser` extractor produces the right 200/401.
     if let Some(token) = bearer.filter(|t| t.starts_with(PAT_PREFIX)) {
         if let Ok(AuthUser {
             source: AuthSource::Pat { token_id },
@@ -155,9 +251,43 @@ pub async fn mcp_rate_limit(State(state): State<AppState>, req: Request, next: N
     next.run(req).await
 }
 
+/// Middleware applied to the `/oauth/register` route. Enforces a per-IP
+/// fixed-window limit (production: 20 req/min/IP) to prevent a single
+/// client from flooding the DB with DCR registrations.
+///
+/// OPTIONS preflights are passed through without consuming the bucket.
+/// All other methods — including unauthenticated POST — are subject to
+/// the limit. This is intentional: OAuth registration is a one-time
+/// operation per client; 20/min is generous for legitimate automated
+/// registrations while blocking obvious abuse.
+pub async fn oauth_ip_rate_limit(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if req.method() == Method::OPTIONS {
+        return next.run(req).await;
+    }
+
+    let ip = client_ip(req.headers());
+    if let Err(retry_after) = state.oauth_ip_limiter.check(&ip) {
+        tracing::info!(%ip, "oauth register rate limit exceeded");
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(header::RETRY_AFTER, retry_after.to_string())],
+            Json(json!({"error": "rate limit exceeded"})),
+        )
+            .into_response();
+    }
+
+    next.run(req).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── McpRateLimiter (per-token) ────────────────────────────────────────
 
     #[test]
     fn check_allows_up_to_limit_then_returns_retry_after() {
@@ -217,5 +347,69 @@ mod tests {
             "stale entries should have been reaped; got {}",
             state.len()
         );
+    }
+
+    // ── IpRateLimiter (per-IP) ────────────────────────────────────────────
+
+    #[test]
+    fn ip_limiter_allows_up_to_limit_then_rejects() {
+        let limiter = IpRateLimiter::new(3, Duration::from_secs(60));
+
+        assert!(limiter.check("1.2.3.4").is_ok());
+        assert!(limiter.check("1.2.3.4").is_ok());
+        assert!(limiter.check("1.2.3.4").is_ok());
+        let err = limiter
+            .check("1.2.3.4")
+            .expect_err("4th call should be rejected");
+        assert!(
+            (1..=60).contains(&err),
+            "retry_after should be in (0, window]; got {err}"
+        );
+    }
+
+    #[test]
+    fn ip_limiter_separate_ips_have_separate_buckets() {
+        let limiter = IpRateLimiter::new(1, Duration::from_secs(60));
+
+        assert!(limiter.check("1.1.1.1").is_ok());
+        assert!(limiter.check("2.2.2.2").is_ok());
+        assert!(limiter.check("1.1.1.1").is_err());
+        assert!(limiter.check("2.2.2.2").is_err());
+    }
+
+    #[test]
+    fn ip_limiter_resets_after_window() {
+        let limiter = IpRateLimiter::new(1, Duration::from_millis(50));
+
+        assert!(limiter.check("1.2.3.4").is_ok());
+        assert!(limiter.check("1.2.3.4").is_err());
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            limiter.check("1.2.3.4").is_ok(),
+            "bucket should reset after window"
+        );
+    }
+
+    // ── client_ip helper ─────────────────────────────────────────────────
+
+    #[test]
+    fn client_ip_prefers_fly_client_ip() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("fly-client-ip", "1.2.3.4".parse().unwrap());
+        headers.insert("x-forwarded-for", "5.6.7.8, 9.10.11.12".parse().unwrap());
+        assert_eq!(client_ip(&headers), "1.2.3.4");
+    }
+
+    #[test]
+    fn client_ip_falls_back_to_x_forwarded_for_first_entry() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "5.6.7.8, 9.10.11.12".parse().unwrap());
+        assert_eq!(client_ip(&headers), "5.6.7.8");
+    }
+
+    #[test]
+    fn client_ip_returns_unknown_when_no_headers() {
+        let headers = axum::http::HeaderMap::new();
+        assert_eq!(client_ip(&headers), "unknown");
     }
 }

--- a/crates/intrada-api/src/routes/mod.rs
+++ b/crates/intrada-api/src/routes/mod.rs
@@ -137,7 +137,14 @@ pub fn api_router(state: AppState) -> Router {
     // 2025-11-25). Cross-origin clients fetch it, so it gets the
     // permissive OAuth-style CORS allowing GET from any origin.
     let asset_routes = assets::router().layer(oauth_cors.clone());
-    let oauth_routes = oauth::router().layer(oauth_cors);
+    // OAuth: IP rate-limit (innermost) → CORS (outermost) so 429s
+    // still carry Access-Control-Allow-Origin: * headers.
+    let oauth_routes = oauth::router()
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::rate_limit::oauth_ip_rate_limit,
+        ))
+        .layer(oauth_cors);
 
     Router::new()
         // Sibling nests: axum routes by path specificity. The OAuth

--- a/crates/intrada-api/src/state.rs
+++ b/crates/intrada-api/src/state.rs
@@ -7,7 +7,7 @@ use crate::auth::AuthConfig;
 use crate::clerk::ClerkClient;
 use crate::db::is_transient_db_error;
 use crate::error::ApiError;
-use crate::rate_limit::McpRateLimiter;
+use crate::rate_limit::{IpRateLimiter, McpRateLimiter};
 use crate::storage::R2Client;
 
 /// Heartbeat interval for the background liveness probe.
@@ -153,6 +153,14 @@ pub struct AppState {
     /// limits (60 req/min/token); tests can swap in a tighter bucket
     /// via [`AppState::with_rate_limiter`].
     pub rate_limiter: Arc<McpRateLimiter>,
+    /// Per-IP rate limiter for `/api/mcp/*`. Guards against bogus-PAT
+    /// floods that would otherwise burn `lookup_by_hash` DB calls
+    /// (300 req/min/IP in production).
+    pub mcp_ip_limiter: Arc<IpRateLimiter>,
+    /// Per-IP rate limiter for OAuth endpoints. Guards the unauthenticated
+    /// `/oauth/register` DCR endpoint against DB-flooding abuse
+    /// (20 req/min/IP in production).
+    pub oauth_ip_limiter: Arc<IpRateLimiter>,
 }
 
 impl AppState {
@@ -170,13 +178,27 @@ impl AppState {
             r2,
             clerk,
             rate_limiter: Arc::new(McpRateLimiter::production()),
+            mcp_ip_limiter: Arc::new(IpRateLimiter::production_mcp()),
+            oauth_ip_limiter: Arc::new(IpRateLimiter::production_oauth()),
         }
     }
 
-    /// Replace the rate limiter — used by integration tests to inject a
-    /// tighter bucket without breaking the existing `new()` arity.
+    /// Replace the per-token MCP rate limiter — used by integration tests
+    /// to inject a tighter bucket without breaking the existing `new()` arity.
     pub fn with_rate_limiter(mut self, rate_limiter: Arc<McpRateLimiter>) -> Self {
         self.rate_limiter = rate_limiter;
+        self
+    }
+
+    /// Replace the per-IP MCP rate limiter — used by integration tests.
+    pub fn with_mcp_ip_limiter(mut self, limiter: Arc<IpRateLimiter>) -> Self {
+        self.mcp_ip_limiter = limiter;
+        self
+    }
+
+    /// Replace the per-IP OAuth rate limiter — used by integration tests.
+    pub fn with_oauth_ip_limiter(mut self, limiter: Arc<IpRateLimiter>) -> Self {
+        self.oauth_ip_limiter = limiter;
         self
     }
 

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -7,7 +7,7 @@ use tower::ServiceExt;
 
 use intrada_api::auth::AuthConfig;
 use intrada_api::migrations;
-use intrada_api::rate_limit::McpRateLimiter;
+use intrada_api::rate_limit::{IpRateLimiter, McpRateLimiter};
 use intrada_api::routes;
 use intrada_api::state::{AppState, Db};
 use std::sync::Arc;
@@ -30,7 +30,7 @@ pub async fn setup_test_app_with_origin(allowed_origin: &str) -> Router {
     setup_test_app_inner(None, allowed_origin).await
 }
 
-/// Create a test router with a tightened rate-limiter — used by
+/// Create a test router with a tightened per-token rate-limiter — used by
 /// `tests/rate_limit_test.rs` to exercise 429 responses without
 /// hammering the default 60-req/min bucket.
 #[allow(dead_code)]
@@ -56,6 +56,62 @@ pub async fn setup_test_app_with_rate_limit(limit: u32, window: Duration) -> Rou
         None,
     )
     .with_rate_limiter(limiter);
+    routes::api_router(state)
+}
+
+/// Create a test router with a tightened per-IP OAuth rate-limiter — used by
+/// `tests/rate_limit_test.rs` to exercise 429 on `/oauth/register`.
+#[allow(dead_code)]
+pub async fn setup_test_app_with_oauth_ip_limit(limit: u32, window: Duration) -> Router {
+    let limiter = Arc::new(IpRateLimiter::new(limit, window));
+
+    let tmp_dir = std::env::temp_dir();
+    let db_path = tmp_dir.join(format!("intrada_test_{}.db", ulid::Ulid::new()));
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("Failed to build test database");
+    let conn = db.connect().expect("Failed to connect to test database");
+    migrations::run_migrations_direct(&conn)
+        .await
+        .expect("Failed to run migrations");
+
+    let state = AppState::new(
+        Db::new(db, conn),
+        "http://localhost:3000".to_string(),
+        None,
+        None,
+        None,
+    )
+    .with_oauth_ip_limiter(limiter);
+    routes::api_router(state)
+}
+
+/// Create a test router with a tightened per-IP MCP rate-limiter — used by
+/// `tests/rate_limit_test.rs` to exercise bogus-PAT flood protection.
+#[allow(dead_code)]
+pub async fn setup_test_app_with_mcp_ip_limit(limit: u32, window: Duration) -> Router {
+    let limiter = Arc::new(IpRateLimiter::new(limit, window));
+
+    let tmp_dir = std::env::temp_dir();
+    let db_path = tmp_dir.join(format!("intrada_test_{}.db", ulid::Ulid::new()));
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("Failed to build test database");
+    let conn = db.connect().expect("Failed to connect to test database");
+    migrations::run_migrations_direct(&conn)
+        .await
+        .expect("Failed to run migrations");
+
+    let state = AppState::new(
+        Db::new(db, conn),
+        "http://localhost:3000".to_string(),
+        None,
+        None,
+        None,
+    )
+    .with_mcp_ip_limiter(limiter);
     routes::api_router(state)
 }
 

--- a/crates/intrada-api/tests/rate_limit_test.rs
+++ b/crates/intrada-api/tests/rate_limit_test.rs
@@ -1,8 +1,9 @@
-//! Integration tests for the MCP rate limiter (Phase 6A of #477).
+//! Integration tests for the MCP + OAuth rate limiters (#578).
 //!
 //! Sibling unit tests live in `intrada-api/src/rate_limit.rs`; these
 //! cover the wiring: middleware position, bypass logic, CORS-on-429,
-//! end-to-end against `setup_test_app_with_rate_limit`.
+//! end-to-end against `setup_test_app_with_rate_limit`,
+//! `setup_test_app_with_oauth_ip_limit`, and `setup_test_app_with_mcp_ip_limit`.
 
 mod common;
 
@@ -13,6 +14,33 @@ use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use tower::ServiceExt;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a minimal `POST /oauth/register` DCR request, optionally from
+/// a specific IP (set via `Fly-Client-IP`).
+fn oauth_register_request(ip: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/oauth/register")
+        .header("content-type", "application/json")
+        .header("origin", "https://claude.ai");
+    if let Some(ip_val) = ip {
+        builder = builder.header("fly-client-ip", ip_val);
+    }
+    builder
+        .body(Body::from(
+            serde_json::to_string(&json!({
+                "client_name": "Test Client",
+                "redirect_uris": ["https://example.com/callback"],
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none"
+            }))
+            .unwrap(),
+        ))
+        .unwrap()
+}
 
 /// Helper: build an MCP `tools/list` JSON-RPC request authed with the
 /// given Bearer token (or no Authorization header when `token` is None).
@@ -214,6 +242,130 @@ async fn revoked_pat_does_not_consume_bucket() {
             "valid token's budget {i} should not be consumed by revoked-token traffic"
         );
     }
+}
+
+// ── IP rate limit tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn oauth_register_ip_rate_limit_returns_429() {
+    // limit=2 so we don't need many requests. Window long so bucket
+    // doesn't reset mid-test.
+    let app = common::setup_test_app_with_oauth_ip_limit(2, Duration::from_secs(60)).await;
+
+    // First two registrations succeed.
+    for i in 1..=2 {
+        let resp = app
+            .clone()
+            .oneshot(oauth_register_request(Some("1.2.3.4")))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "registration {i} should succeed"
+        );
+    }
+
+    // Third registration from same IP is rate-limited.
+    let resp = app
+        .clone()
+        .oneshot(oauth_register_request(Some("1.2.3.4")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    let retry_after = resp
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    let retry_secs: u64 = retry_after.parse().expect("retry-after must be an integer");
+    assert!(
+        (1..=60).contains(&retry_secs),
+        "retry-after should be in (0, window]; got {retry_secs}"
+    );
+
+    // CORS headers must appear on the 429 — rate-limit is innermost,
+    // CORS wraps it so the browser sees the real error, not a CORS failure.
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("*"),
+        "429 from OAuth register must carry CORS headers"
+    );
+
+    // Different IP is unaffected.
+    let resp = app
+        .oneshot(oauth_register_request(Some("9.9.9.9")))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "different IP should have its own clean bucket"
+    );
+}
+
+#[tokio::test]
+async fn oauth_register_options_preflight_bypasses_ip_limit() {
+    let app = common::setup_test_app_with_oauth_ip_limit(1, Duration::from_secs(60)).await;
+
+    // One successful POST exhausts the limit=1 bucket.
+    let resp = app
+        .clone()
+        .oneshot(oauth_register_request(Some("1.2.3.4")))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // OPTIONS preflight should NOT be blocked even though bucket is full.
+    let preflight = Request::builder()
+        .method("OPTIONS")
+        .uri("/oauth/register")
+        .header("origin", "https://claude.ai")
+        .header("access-control-request-method", "POST")
+        .header("access-control-request-headers", "content-type")
+        .header("fly-client-ip", "1.2.3.4")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(preflight).await.unwrap();
+    assert!(
+        resp.status().is_success() || resp.status() == StatusCode::NO_CONTENT,
+        "OPTIONS preflight should bypass IP rate limit; got {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn mcp_ip_rate_limit_blocks_bogus_pat_flood() {
+    // Tight IP limit (3 req/60s). Bogus PATs all come from the same
+    // "IP" (no Fly-Client-IP → "unknown"), so after 3 requests the IP
+    // bucket is full and further bogus-PAT requests return 429 — even
+    // though no token bucket was ever created.
+    let app = common::setup_test_app_with_mcp_ip_limit(3, Duration::from_secs(60)).await;
+
+    let bogus = "intrada_pat_0000000000000000000000000000000000000000000000000000000000000000";
+    for i in 1..=3 {
+        let resp = app.clone().oneshot(mcp_request(Some(bogus))).await.unwrap();
+        // The first 3 bogus-PAT requests pass the IP check, hit the handler,
+        // and get a 401 (no valid token). The IP bucket is still consumed
+        // because the IP check happens before auth resolution.
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "bogus-PAT request {i} should 401 (within IP budget)"
+        );
+    }
+
+    // 4th request from the same IP (no Fly-Client-IP → "unknown") is
+    // blocked at the IP layer — returns 429 regardless of the token.
+    let resp = app.oneshot(mcp_request(Some(bogus))).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "IP rate limit should block further requests after budget exhausted"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Add `IpRateLimiter` (fixed-window, per-IP bucket) to guard two unauthenticated / lightly-authenticated attack surfaces:

- **`/oauth/register`** (20 req/min/IP): unauthenticated DCR creates a DB row per call; a flood would saturate Turso without this guard
- **`/api/mcp`** (300 req/min/IP): blocks bogus-PAT floods that previously bypassed the per-token bucket and burned `lookup_by_hash` DB calls

**Implementation details:**
- IP extracted from `Fly-Client-IP` (trusted Fly.io header), falling back to the first entry of `X-Forwarded-For`, then `"unknown"`
- 429 responses carry `Retry-After` + `Access-Control-Allow-Origin: *` headers (rate-limit middleware is innermost, CORS layer wraps it)
- OPTIONS preflights short-circuit before bucket check
- Same MAP_SIZE_THRESHOLD cleanup + sampled retain as `McpRateLimiter`
- `with_mcp_ip_limiter()` / `with_oauth_ip_limiter()` builder methods on `AppState` for test injection

**New tests (8 total across 3 integration + 10 unit):**
- `oauth_register_ip_rate_limit_returns_429` — 429 + Retry-After + CORS, per-IP isolation
- `oauth_register_options_preflight_bypasses_ip_limit` — preflights never consume bucket
- `mcp_ip_rate_limit_blocks_bogus_pat_flood` — IP bucket blocks floods before DB touch
- Unit tests: `ip_limiter_allows_up_to_limit_then_rejects`, `ip_limiter_separate_ips_have_separate_buckets`, `ip_limiter_resets_after_window`, `client_ip_prefers_fly_client_ip`, `client_ip_falls_back_to_x_forwarded_for_first_entry`, `client_ip_returns_unknown_when_no_headers`

## Test plan

- [x] `cargo test -p intrada-api` — 156 passed
- [x] `cargo clippy -p intrada-api -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p intrada-api` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)