### PR TITLE
feat(api+core+web): record JWT-authenticated MCP writes in audit log (#528)

### DIFF
--- a/crates/intrada-api/src/db/audit.rs
+++ b/crates/intrada-api/src/db/audit.rs
@@ -20,10 +20,14 @@ use crate::error::ApiError;
 /// than a raw ULID. Both are `Option` because the token row could
 /// theoretically be hard-deleted (we only soft-delete via `revoked_at`,
 /// but defensive against future schema changes).
+///
+/// `token_id` is `Option<String>` because JWT-authenticated MCP writes
+/// are recorded without a PAT — the entry captures the write but has no
+/// token to attribute it to (#528). The UI renders these as "(web app)".
 #[derive(Debug, Serialize)]
 pub struct AuditLogEntry {
     pub id: String,
-    pub token_id: String,
+    pub token_id: Option<String>,
     pub token_name: Option<String>,
     pub token_prefix: Option<String>,
     pub tool: String,
@@ -31,10 +35,12 @@ pub struct AuditLogEntry {
     pub created_at: DateTime<Utc>,
 }
 
+/// Insert an audit-log row. `token_id` is `None` for JWT-authenticated
+/// MCP writes (no PAT to attribute to).
 pub async fn insert(
     conn: &Connection,
     id: &str,
-    token_id: &str,
+    token_id: Option<&str>,
     user_id: &str,
     tool: &str,
     args_hash: &str,
@@ -83,7 +89,7 @@ pub async fn list(
         .map_err(|e| ApiError::Internal(e.to_string()))?
     {
         let id: String = col!(row, 0)?;
-        let token_id: String = col!(row, 1)?;
+        let token_id: Option<String> = col!(row, 1)?;
         let token_name: Option<String> = col!(row, 2)?;
         let token_prefix: Option<String> = col!(row, 3)?;
         let tool: String = col!(row, 4)?;

--- a/crates/intrada-api/src/mcp/handlers.rs
+++ b/crates/intrada-api/src/mcp/handlers.rs
@@ -445,7 +445,7 @@ pub async fn bulk_import_items(
         }
     }
 
-    services::audit::record_pat_write(conn, source, user_id, "bulk_import_items", raw_args).await;
+    services::audit::record_mcp_write(conn, source, user_id, "bulk_import_items", raw_args).await;
 
     serde_json::to_value(json!({
         "dry_run": false,

--- a/crates/intrada-api/src/mcp/server.rs
+++ b/crates/intrada-api/src/mcp/server.rs
@@ -43,9 +43,9 @@ async fn handle(
     // a working URL without an extra env var.
     headers: HeaderMap,
     // `source` is read by `dispatch_tool` to attribute write-tool calls
-    // to the originating PAT in `mcp_audit_log`. JWT-authenticated MCP
-    // calls are accepted but their writes are NOT audited (no token_id
-    // to attribute to); see `services::audit::record_pat_write`.
+    // in `mcp_audit_log`. PAT writes record the resolved token_id; JWT
+    // writes (browser/iOS session) record token_id=NULL (#528); Disabled
+    // (local dev) skips the audit row entirely. See `services::audit::record_mcp_write`.
     AuthUser { user_id, source }: AuthUser,
     Json(req): Json<JsonRpcRequest>,
 ) -> axum::response::Response {

--- a/crates/intrada-api/src/mcp/server.rs
+++ b/crates/intrada-api/src/mcp/server.rs
@@ -306,8 +306,9 @@ async fn dispatch_tool(
 
     // Audit single-write tools after a successful execution. Read tools
     // and the bulk-import tool are excluded — bulk_import audits itself.
+    // JWT writes are now included (#528): the row is recorded with token_id=NULL.
     if result.is_ok() && tools::SINGLE_WRITE_TOOLS.contains(&tool_name.as_str()) {
-        services::audit::record_pat_write(&conn_for_audit, source, user_id, &tool_name, &raw_args)
+        services::audit::record_mcp_write(&conn_for_audit, source, user_id, &tool_name, &raw_args)
             .await;
     }
 

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -434,6 +434,37 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0061_index_oauth_codes_expires",
         "CREATE INDEX IF NOT EXISTS idx_oauth_codes_expires ON oauth_codes(expires_at);",
     ),
+    // Migrations 0062-0066: rebuild mcp_audit_log with nullable token_id so
+    // JWT-authenticated MCP writes can be recorded without a PAT to attribute
+    // to (#528). SQLite doesn't support ALTER COLUMN, so we use the
+    // create-copy-drop-rename pattern split across 5 single-statement migrations.
+    (
+        "0062_mcp_audit_log_new_nullable_token",
+        "CREATE TABLE IF NOT EXISTS mcp_audit_log_new (
+            id TEXT PRIMARY KEY NOT NULL,
+            token_id TEXT,
+            user_id TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            args_hash TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );",
+    ),
+    (
+        "0063_mcp_audit_log_copy_rows",
+        "INSERT INTO mcp_audit_log_new SELECT * FROM mcp_audit_log;",
+    ),
+    (
+        "0064_mcp_audit_log_drop_old",
+        "DROP TABLE IF EXISTS mcp_audit_log;",
+    ),
+    (
+        "0065_mcp_audit_log_rename",
+        "ALTER TABLE mcp_audit_log_new RENAME TO mcp_audit_log;",
+    ),
+    (
+        "0066_mcp_audit_log_recreate_index",
+        "CREATE INDEX IF NOT EXISTS idx_mcp_audit_log_user_created ON mcp_audit_log(user_id, created_at DESC);",
+    ),
 ];
 
 /// Backoff schedule for transient-error retries during migration: try

--- a/crates/intrada-api/src/services/audit.rs
+++ b/crates/intrada-api/src/services/audit.rs
@@ -1,16 +1,15 @@
 //! Audit recording for MCP write tools.
 //!
-//! Only `AuthSource::Pat { token_id }` writes are recorded — the audit
-//! row's `token_id` column is non-nullable and the table's purpose is
-//! to attribute MCP-issued mutations to a specific PAT.
+//! Every successful MCP write by a real user is recorded:
+//! - `AuthSource::Pat { token_id }`: row written with the resolved token id.
+//! - `AuthSource::Jwt`: row written with `token_id = NULL` (#528). The
+//!   browser/iOS session is the auth mechanism; no PAT exists to attribute
+//!   the write to, but the write still appears in the user's audit view
+//!   labelled "(web app)".
+//! - `AuthSource::Disabled`: skipped — dev-mode has no real user id.
 //!
-//! - **Jwt**: writes via `/api/mcp` from a Clerk-authenticated browser
-//!   session don't go through the audit log; the user's regular session
-//!   activity is the audit trail.
-//! - **Disabled**: dev-mode writes have no token to attribute to.
-//!
-//! See `auth.rs::AuthSource::Disabled` for the `// TODO(#477 phase 4)`
-//! marker that originally signposted this contract.
+//! After migration 0062-0066, `mcp_audit_log.token_id` is nullable,
+//! so JWT rows are schema-valid.
 
 use chrono::Utc;
 use libsql::Connection;
@@ -34,24 +33,38 @@ pub fn args_hash(args: &Value) -> String {
     })
 }
 
-/// Record a successful PAT write. No-op for non-PAT auth sources.
-/// Errors are logged but not propagated — failing to record an audit row
-/// shouldn't break a successful write that the user already saw succeed.
-pub async fn record_pat_write(
+/// Record a successful MCP write. Called after every successful single-write
+/// tool call. No-op for `AuthSource::Disabled` (local dev — no real user).
+///
+/// Errors are logged but not propagated — a failed audit row must not roll
+/// back a write the user already saw succeed.
+pub async fn record_mcp_write(
     conn: &Connection,
     source: &AuthSource,
     user_id: &str,
     tool: &str,
     args: &Value,
 ) {
-    let token_id = match source {
-        AuthSource::Pat { token_id } => token_id.clone(),
-        AuthSource::Jwt | AuthSource::Disabled => return,
+    // Resolve the token_id (None for JWT-authenticated calls).
+    let token_id: Option<String> = match source {
+        AuthSource::Pat { token_id } => Some(token_id.clone()),
+        AuthSource::Jwt => None,
+        // Disabled = local dev with no real user — skip entirely.
+        AuthSource::Disabled => return,
     };
 
     let id = ulid::Ulid::new().to_string();
     let hash = args_hash(args);
-    if let Err(e) = db::audit::insert(conn, &id, &token_id, user_id, tool, &hash, Utc::now()).await
+    if let Err(e) = db::audit::insert(
+        conn,
+        &id,
+        token_id.as_deref(),
+        user_id,
+        tool,
+        &hash,
+        Utc::now(),
+    )
+    .await
     {
         tracing::warn!(?e, tool, "audit log write failed; continuing");
     }

--- a/crates/intrada-api/tests/mcp_test.rs
+++ b/crates/intrada-api/tests/mcp_test.rs
@@ -923,7 +923,7 @@ async fn audit_log_excludes_other_users() {
     intrada_api::db::audit::insert(
         &conn,
         "01HXFOREIGN0000000000000000",
-        "01HXFOREIGNTOKEN0000000000",
+        Some("01HXFOREIGNTOKEN0000000000"),
         "other_user",
         "create_item",
         "deadbeef".repeat(8).as_str(),

--- a/crates/intrada-api/tests/mcp_test.rs
+++ b/crates/intrada-api/tests/mcp_test.rs
@@ -609,9 +609,8 @@ async fn cors_preflight_returns_permissive_headers_for_mcp() {
 
 // ── Phase 4 write tools ────────────────────────────────────────────────
 
-/// Helper: drive an MCP `tools/call` against an authed `Router` (the PAT
-/// is required because audit-log rows only get recorded for
-/// `AuthSource::Pat`). Returns the parsed response body.
+/// Helper: drive an MCP `tools/call` against an authed `Router` using a PAT.
+/// Returns the parsed response body.
 async fn mcp_call_with_pat(
     app: axum::Router,
     token: &str,
@@ -949,4 +948,43 @@ async fn audit_log_excludes_other_users() {
     assert_eq!(entries.len(), 1, "must not include foreign-user rows");
     // Sanity: the entry belongs to the legitimate write (token id != foreign).
     assert_ne!(entries[0]["token_id"], "01HXFOREIGNTOKEN0000000000");
+}
+
+#[tokio::test]
+async fn jwt_write_produces_audit_row_with_null_token_id() {
+    // Verifies the #528 fix: writes attributed to AuthSource::Jwt record
+    // a row with token_id = NULL, visible in the audit list as JSON null.
+    //
+    // We use the direct `record_mcp_write` path rather than a full HTTP
+    // roundtrip (which would require a real Clerk JWT) so the test stays
+    // self-contained. This exercises the exact code path that dispatch_tool
+    // hits when source == AuthSource::Jwt.
+    let (app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+
+    intrada_api::services::audit::record_mcp_write(
+        &conn,
+        &intrada_api::auth::AuthSource::Jwt,
+        "", // disabled-mode user_id (empty string)
+        "create_item",
+        &serde_json::json!({"title": "JWT write test"}),
+    )
+    .await;
+
+    let (status, audit_body) = common::get(app, "/api/account/audit").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+
+    let entries: Vec<serde_json::Value> = common::json(&audit_body);
+    assert_eq!(entries.len(), 1, "expected one audit row for JWT write");
+
+    let entry = &entries[0];
+    assert_eq!(entry["tool"], "create_item");
+    // token_id must be JSON null — not a string, not missing.
+    assert_eq!(
+        entry["token_id"],
+        serde_json::Value::Null,
+        "JWT write must produce token_id = null in audit row; got {:?}",
+        entry["token_id"]
+    );
+    // token_name and token_prefix are also null (no token to join).
+    assert_eq!(entry["token_name"], serde_json::Value::Null);
 }

--- a/crates/intrada-core/src/domain/mcp_audit.rs
+++ b/crates/intrada-core/src/domain/mcp_audit.rs
@@ -14,10 +14,12 @@ use crate::model::Model;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct McpAuditEntry {
     pub id: String,
-    pub token_id: String,
-    /// Joined from `mcp_tokens`. `None` only if the token row has been
-    /// hard-deleted (we soft-delete via `revoked_at`, so this is
-    /// defensive — but the UI must handle the case).
+    /// `None` for JWT-authenticated MCP writes (browser/iOS session, no PAT).
+    /// The UI renders these as "(web app)" (#528).
+    pub token_id: Option<String>,
+    /// Joined from `mcp_tokens`. `None` when the token row was hard-deleted,
+    /// or when `token_id` itself is `None` (JWT write). Both cases are
+    /// handled by the UI.
     pub token_name: Option<String>,
     pub token_prefix: Option<String>,
     pub tool: String,
@@ -73,7 +75,7 @@ mod tests {
         model.mcp_audit_loading = true;
         let entry = McpAuditEntry {
             id: "a".into(),
-            token_id: "t".into(),
+            token_id: Some("t".into()),
             token_name: Some("Claude Desktop".into()),
             token_prefix: Some("intrada_pat_xxxx".into()),
             tool: "create_item".into(),

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -84,11 +84,22 @@ class LiveActivityPlugin: Plugin {
       guard let self = self else { return }
 
       if UIDevice.current.userInterfaceIdiom == .pad {
+        NSLog("[live-activity] begin: skipped (iPad — Live Activities unsupported)")
         invoke.resolve()
         return
       }
 
       if #available(iOS 16.1, *) {
+        let auth = ActivityAuthorizationInfo()
+        let priorCount = Activity<IntradaActivityAttributes>.activities.count
+        NSLog(
+          "[live-activity] begin: areActivitiesEnabled=%@ frequentPushesEnabled=%@ priorActivityCount=%d position=%@",
+          auth.areActivitiesEnabled ? "YES" : "NO",
+          auth.frequentPushesEnabled ? "YES" : "NO",
+          priorCount,
+          args.position_label
+        )
+
         // If a previous session left an activity hanging (app crash
         // mid-session, ActivityKit error path), end it before starting
         // the new one. iOS allows only one activity per attribute type
@@ -121,6 +132,11 @@ class LiveActivityPlugin: Plugin {
             )
           }
           self.currentActivity = activity
+          NSLog(
+            "[live-activity] begin: Activity.request succeeded id=%@ totalActivities=%d",
+            activity.id,
+            Activity<IntradaActivityAttributes>.activities.count
+          )
           invoke.resolve()
         } catch {
           // Common failure modes:
@@ -130,12 +146,18 @@ class LiveActivityPlugin: Plugin {
           // The wall-clock timer + background-audio still work; only
           // the lock-screen card is missing. Surface to the bridge so
           // Sentry catches it (per the plugin's Rust-side capture).
+          NSLog(
+            "[live-activity] begin: Activity.request FAILED error=%@ desc=%@",
+            String(describing: error),
+            error.localizedDescription
+          )
           invoke.reject(
             "live-activity: Activity.request failed: \(error.localizedDescription)")
         }
       } else {
         // Older iOS: no Live Activities — resolve silently. Background
         // audio still gives the user a lock-screen Now Playing card.
+        NSLog("[live-activity] begin: skipped (iOS < 16.1)")
         invoke.resolve()
       }
     }
@@ -160,9 +182,14 @@ class LiveActivityPlugin: Plugin {
           // `begin`, or the activity already ended (e.g. user revoked
           // Live Activities mid-session). No-op rather than error: the
           // shell-side lifecycle Effect can race ahead of iOS state.
+          NSLog(
+            "[live-activity] update: no current activity (begin missing or already ended) position=%@",
+            args.position_label
+          )
           invoke.resolve()
           return
         }
+        NSLog("[live-activity] update: position=%@", args.position_label)
 
         let state = IntradaActivityAttributes.ContentState(
           itemTitle: args.item_title,
@@ -200,6 +227,8 @@ class LiveActivityPlugin: Plugin {
       }
 
       if #available(iOS 16.1, *) {
+        let hadActivity = self.currentActivity != nil
+        NSLog("[live-activity] end: hadActivity=%@", hadActivity ? "YES" : "NO")
         self.endCurrentActivityIfAny()
       }
       invoke.resolve()

--- a/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
+++ b/crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift
@@ -84,22 +84,11 @@ class LiveActivityPlugin: Plugin {
       guard let self = self else { return }
 
       if UIDevice.current.userInterfaceIdiom == .pad {
-        NSLog("[live-activity] begin: skipped (iPad — Live Activities unsupported)")
         invoke.resolve()
         return
       }
 
       if #available(iOS 16.1, *) {
-        let auth = ActivityAuthorizationInfo()
-        let priorCount = Activity<IntradaActivityAttributes>.activities.count
-        NSLog(
-          "[live-activity] begin: areActivitiesEnabled=%@ frequentPushesEnabled=%@ priorActivityCount=%d position=%@",
-          auth.areActivitiesEnabled ? "YES" : "NO",
-          auth.frequentPushesEnabled ? "YES" : "NO",
-          priorCount,
-          args.position_label
-        )
-
         // If a previous session left an activity hanging (app crash
         // mid-session, ActivityKit error path), end it before starting
         // the new one. iOS allows only one activity per attribute type
@@ -132,11 +121,6 @@ class LiveActivityPlugin: Plugin {
             )
           }
           self.currentActivity = activity
-          NSLog(
-            "[live-activity] begin: Activity.request succeeded id=%@ totalActivities=%d",
-            activity.id,
-            Activity<IntradaActivityAttributes>.activities.count
-          )
           invoke.resolve()
         } catch {
           // Common failure modes:
@@ -146,18 +130,12 @@ class LiveActivityPlugin: Plugin {
           // The wall-clock timer + background-audio still work; only
           // the lock-screen card is missing. Surface to the bridge so
           // Sentry catches it (per the plugin's Rust-side capture).
-          NSLog(
-            "[live-activity] begin: Activity.request FAILED error=%@ desc=%@",
-            String(describing: error),
-            error.localizedDescription
-          )
           invoke.reject(
             "live-activity: Activity.request failed: \(error.localizedDescription)")
         }
       } else {
         // Older iOS: no Live Activities — resolve silently. Background
         // audio still gives the user a lock-screen Now Playing card.
-        NSLog("[live-activity] begin: skipped (iOS < 16.1)")
         invoke.resolve()
       }
     }
@@ -182,14 +160,9 @@ class LiveActivityPlugin: Plugin {
           // `begin`, or the activity already ended (e.g. user revoked
           // Live Activities mid-session). No-op rather than error: the
           // shell-side lifecycle Effect can race ahead of iOS state.
-          NSLog(
-            "[live-activity] update: no current activity (begin missing or already ended) position=%@",
-            args.position_label
-          )
           invoke.resolve()
           return
         }
-        NSLog("[live-activity] update: position=%@", args.position_label)
 
         let state = IntradaActivityAttributes.ContentState(
           itemTitle: args.item_title,
@@ -227,8 +200,6 @@ class LiveActivityPlugin: Plugin {
       }
 
       if #available(iOS 16.1, *) {
-        let hadActivity = self.currentActivity != nil
-        NSLog("[live-activity] end: hadActivity=%@", hadActivity ? "YES" : "NO")
         self.endCurrentActivityIfAny()
       }
       invoke.resolve()

--- a/crates/intrada-web/src/views/mcp_audit.rs
+++ b/crates/intrada-web/src/views/mcp_audit.rs
@@ -80,12 +80,18 @@ pub fn McpAuditView() -> impl IntoView {
 #[component]
 fn AuditEntryRow(entry: McpAuditEntry) -> impl IntoView {
     let when = format_relative(entry.created_at);
-    let token_label = entry.token_name.clone().unwrap_or_else(|| {
-        entry
-            .token_prefix
-            .clone()
-            .unwrap_or_else(|| "(deleted token)".into())
-    });
+    // token_id is None → write via Clerk session (no PAT). Show "web app"
+    // rather than falling through to "(deleted token)".
+    let token_label = if entry.token_id.is_none() {
+        "web app".to_string()
+    } else {
+        entry.token_name.clone().unwrap_or_else(|| {
+            entry
+                .token_prefix
+                .clone()
+                .unwrap_or_else(|| "(deleted token)".into())
+        })
+    };
     let tool_label = humanize_tool(&entry.tool);
 
     view! {


### PR DESCRIPTION
## Summary

JWT-authenticated MCP writes (from the web/iOS app via a Clerk session) were silently dropped from `mcp_audit_log` — the table's `token_id` column was `NOT NULL`, and JWT calls have no PAT to attribute to. Users couldn't see web/iOS MCP writes in Settings → MCP activity.

- **Migrations 0062–0066**: rebuild `mcp_audit_log` with nullable `token_id`. SQLite doesn't support `ALTER COLUMN`, so we use the create-copy-drop-rename pattern split across 5 single-statement migrations.
- **`db/audit`**: `insert()` now accepts `Option<&str>` for `token_id`; `AuditLogEntry.token_id` is now `Option<String>`
- **`services/audit`**: rename `record_pat_write` → `record_mcp_write`; JWT source now inserts with `token_id = NULL` instead of early-returning; `AuthSource::Disabled` still skips (no real user)
- **`mcp/server` + `mcp/handlers`**: update call sites to `record_mcp_write`
- **`intrada-core`**: `McpAuditEntry.token_id` → `Option<String>`
- **`intrada-web/mcp_audit`**: show `"web app"` label when `token_id` is `None`, rather than falling through to `"(deleted token)"`

## Test plan

- [x] `cargo test -p intrada-api` — 147 passed
- [x] `cargo clippy -p intrada-api -p intrada-core -- -D warnings` — zero warnings
- [x] `cargo fmt --check -p intrada-api -p intrada-core` — passes
- [x] `cargo check -p intrada-web --target wasm32-unknown-unknown` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)