### PR TITLE
chore(deps): upgrade rand 0.8 → 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,7 +2911,7 @@ dependencies = [
  "jsonwebtoken",
  "libsql",
  "libsql_migration",
- "rand 0.8.5",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "rsa",
  "rust-s3",

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -36,7 +36,7 @@ rust-s3 = { version = "0.37", default-features = false, features = ["tokio-rustl
 
 # MCP Personal Access Tokens: cryptographically secure RNG for token bytes,
 # SHA-256 for at-rest hashing.
-rand = "0.8"
+rand = "0.9"
 sha2 = "0.11"
 
 # OAuth 2.1: PKCE S256 verification (base64url-no-pad of the SHA-256 of

--- a/crates/intrada-api/src/services/oauth.rs
+++ b/crates/intrada-api/src/services/oauth.rs
@@ -291,7 +291,7 @@ pub async fn exchange_code_for_token(
 
 fn random_hex_32() -> String {
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     hex_encode(&bytes)
 }
 

--- a/crates/intrada-api/src/services/tokens.rs
+++ b/crates/intrada-api/src/services/tokens.rs
@@ -30,7 +30,7 @@ fn validate_name(name: &str) -> Result<&str, ApiError> {
 /// its hex SHA-256 hash (stored at rest), and the visible prefix.
 fn generate_pat() -> (String, String, String) {
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     let body: String = bytes.iter().fold(String::with_capacity(64), |mut s, b| {
         use std::fmt::Write;
         let _ = write!(s, "{b:02x}");

--- a/crates/intrada-api/tests/account_test.rs
+++ b/crates/intrada-api/tests/account_test.rs
@@ -23,8 +23,8 @@ struct TestClaims {
 }
 
 fn test_keys() -> (EncodingKey, AuthConfig) {
-    let mut rng = rand::thread_rng();
-    let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("Failed to generate RSA key");
+    let private_key =
+        RsaPrivateKey::new(&mut rsa::rand_core::OsRng, 2048).expect("Failed to generate RSA key");
     let private_pem = private_key
         .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
         .unwrap();

--- a/crates/intrada-api/tests/auth_test.rs
+++ b/crates/intrada-api/tests/auth_test.rs
@@ -24,8 +24,8 @@ struct TestClaims {
 
 /// Generate an RSA key pair and return (encoding_key, auth_config).
 fn test_keys() -> (EncodingKey, AuthConfig) {
-    let mut rng = rand::thread_rng();
-    let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("Failed to generate RSA key");
+    let private_key =
+        RsaPrivateKey::new(&mut rsa::rand_core::OsRng, 2048).expect("Failed to generate RSA key");
 
     let private_pem = private_key
         .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)


### PR DESCRIPTION
## Summary

- Upgrades `rand` from 0.8 to 0.9 in `intrada-api`
- `rand` 0.9 removed `thread_rng()` — replaced with `rng()` in `tokens.rs` and `oauth.rs`
- `ThreadRng` from rand 0.9 uses `rand_core` 0.9, which is incompatible with `rsa` 0.9's `rand_core` 0.6 `CryptoRng` bound — test key generation switched to `rsa::rand_core::OsRng` instead

Closes #444 (dependabot PR which also included the tauri 2.11.1 bump, already merged in #618).

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -p intrada-api -- -D warnings` passes
- [ ] CI Test + Clippy jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)