### PR TITLE
fix(ci): pin wasm-bindgen-cli to avoid transient download failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
           prefix-key: "wasm"
           cache-on-failure: true
       - uses: jetli/trunk-action@v0.5.1
+      # Pin wasm-bindgen-cli so trunk finds it locally instead of downloading
+      # from GitHub Releases at build time (avoids transient 502 failures).
+      # Version must match the wasm-bindgen dependency in Cargo.lock.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
       # Tailwind v4 standalone binary doesn't change between runs — cache it.
       - name: Cache Tailwind CSS binary
         id: tailwind-cache


### PR DESCRIPTION
## Summary

- Pre-install `wasm-bindgen-cli@0.2.121` via `taiki-e/install-action` in the WASM Build job so trunk finds it locally instead of downloading from GitHub Releases at build time
- Avoids transient 502 failures like the one that broke the main branch build (run 25624699279)
- Version pinned to match `Cargo.lock` — comment notes this must stay in sync

## Test plan

- [ ] CI WASM Build job passes without downloading wasm-bindgen at build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)