### PR TITLE
chore(api): document libsql dual TLS stack

### DIFF
--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -18,6 +18,12 @@ intrada-core = { path = "../intrada-core" }
 axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
+# `tls` is required for `remote` — Turso connections must use TLS. libsql 0.9
+# hardcodes the `tls` feature to `hyper-rustls` (no `native-tls` variant exists
+# in the v0.9 feature graph, verified against v0.9.30). The rest of the API
+# binary uses `native-tls` (reqwest, rust-s3, sentry, jsonwebtoken's
+# `rust_crypto`) per #623, so two TLS implementations are linked. Tracked at
+# intrada#639 — revisit if libsql adds a native-tls feature upstream.
 libsql = { version = "0.9", default-features = false, features = ["remote", "tls"] }
 
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

Stacked on top of #634. Adds a 6-line comment to `intrada-api/Cargo.toml` documenting why both rustls (libsql's `tls` feature) and native-tls (everything else) are linked into the API binary.

Closes #639.

## Why a comment, not a code fix

[Issue #639](https://github.com/jonyardley/intrada/issues/639) asked us to audit libsql 0.9 for a native-tls transport variant. Confirmed against the published feature graph at v0.9.30:

```
libsql = { ... features }
  cloudflare: ['wasm', 'dep:worker']
  core: ['libsql-sys', 'dep:bitflags', 'dep:bytes', 'dep:futures', 'dep:parking_lot']
  default: ['core', 'replication', 'remote', 'sync', 'tls']
  ...
  tls: ['dep:hyper-rustls']    ← hardcoded
```

There is no `native-tls`-flavoured feature in libsql 0.9. The dual stack is unavoidable until either (a) we move the rest of the API to rustls, or (b) libsql adds a native-tls variant upstream.

## Test plan

- [x] `cargo fmt --check` clean (comment only — no code change)
- [x] No diff to compiled artifacts (Cargo.toml comment lines are stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)