### PR TITLE
test(mobile): round-trip plugin args against JS bridge payloads

### DIFF
--- a/crates/intrada-mobile/plugins/background-audio/Cargo.toml
+++ b/crates/intrada-mobile/plugins/background-audio/Cargo.toml
@@ -23,3 +23,11 @@ sentry = { version = "0.48", default-features = false }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }
+
+# Args struct round-trip tests (intrada#641) — verify the snake_case
+# field names match what the JS bridge in intrada-web sends. These are
+# only runnable on macOS (`cargo test -p tauri-plugin-background-audio`)
+# because the Linux CI runner can't link `tauri`'s GTK deps; see
+# `.github/workflows/ci.yml`.
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/intrada-mobile/plugins/background-audio/src/lib.rs
+++ b/crates/intrada-mobile/plugins/background-audio/src/lib.rs
@@ -195,3 +195,41 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         })
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    //! Round-trip the literal payloads sent by the JS bridge in
+    //! `crates/intrada-web/src/background_audio.rs`. If anyone renames a
+    //! field on either side without updating the other, these fail at
+    //! `cargo test` instead of at runtime on a physical device. See
+    //! intrada#641.
+    //!
+    //! These don't exercise Tauri's outer `{ args: { ... } }` wrapping
+    //! — the macro handles that — only the inner struct shape that
+    //! Swift's `parseArgs(...)` mirror also has to accept.
+    use super::*;
+
+    #[test]
+    fn begin_session_args_match_js_bridge_payload() {
+        let payload = serde_json::json!({
+            "title": "Chromatic Scale",
+            "started_at": "2026-05-10T10:20:09.914+00:00",
+        });
+        let parsed: BeginSessionArgs = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.title, "Chromatic Scale");
+        assert_eq!(parsed.started_at, "2026-05-10T10:20:09.914+00:00");
+    }
+
+    #[test]
+    fn now_playing_args_match_js_bridge_payload() {
+        let payload = serde_json::json!({
+            "title": "Chromatic Scale",
+            "position_label": "Item 2 of 5",
+            "started_at": "2026-05-10T10:25:30+00:00",
+        });
+        let parsed: NowPlayingArgs = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.title, "Chromatic Scale");
+        assert_eq!(parsed.position_label, "Item 2 of 5");
+        assert_eq!(parsed.started_at, "2026-05-10T10:25:30+00:00");
+    }
+}

--- a/crates/intrada-mobile/plugins/live-activity/Cargo.toml
+++ b/crates/intrada-mobile/plugins/live-activity/Cargo.toml
@@ -22,3 +22,11 @@ sentry = { version = "0.48", default-features = false }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }
+
+# Args struct round-trip tests (intrada#641) — verify the snake_case
+# field names match what the JS bridge in intrada-web sends. Only
+# runnable on macOS (`cargo test -p tauri-plugin-live-activity`)
+# because the Linux CI runner can't link `tauri`'s GTK deps; see
+# `.github/workflows/ci.yml`.
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/intrada-mobile/plugins/live-activity/src/lib.rs
+++ b/crates/intrada-mobile/plugins/live-activity/src/lib.rs
@@ -203,3 +203,63 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
         })
         .build()
 }
+
+#[cfg(test)]
+mod tests {
+    //! Round-trip the literal payloads sent by the JS bridge in
+    //! `crates/intrada-web/src/live_activity.rs`. If anyone renames a
+    //! field on either side without updating the other, these fail at
+    //! `cargo test` instead of at runtime on a physical device. See
+    //! intrada#641.
+    //!
+    //! These don't exercise Tauri's outer `{ args: { ... } }` wrapping
+    //! — the macro handles that — only the inner struct shape that
+    //! Swift's `parseArgs(...)` mirror also has to accept.
+    use super::*;
+
+    #[test]
+    fn begin_args_match_js_bridge_payload_with_planned_duration() {
+        let payload = serde_json::json!({
+            "item_title": "Chromatic Scale",
+            "position_label": "Item 1 of 5",
+            "started_at": "2026-05-10T10:20:09.914+00:00",
+            "planned_duration_secs": 300,
+        });
+        let parsed: BeginArgs = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.item_title, "Chromatic Scale");
+        assert_eq!(parsed.position_label, "Item 1 of 5");
+        assert_eq!(parsed.started_at, "2026-05-10T10:20:09.914+00:00");
+        assert_eq!(parsed.planned_duration_secs, Some(300));
+    }
+
+    #[test]
+    fn begin_args_accept_null_planned_duration() {
+        // The JS bridge emits `planned_duration_secs ?? null`, so the
+        // None case is JSON `null`, not a missing key. serde maps both
+        // to `Option::None` for `Option<u32>`, but pin it down explicitly
+        // here so a future `#[serde(skip_serializing_if = ...)]` doesn't
+        // accidentally diverge from what the bridge sends.
+        let payload = serde_json::json!({
+            "item_title": "Free Practice",
+            "position_label": "Item 1 of 1",
+            "started_at": "2026-05-10T10:20:09Z",
+            "planned_duration_secs": null,
+        });
+        let parsed: BeginArgs = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.planned_duration_secs, None);
+    }
+
+    #[test]
+    fn update_args_match_js_bridge_payload() {
+        let payload = serde_json::json!({
+            "item_title": "G Major Scale",
+            "position_label": "Item 2 of 5",
+            "started_at": "2026-05-10T10:30:00Z",
+            "planned_duration_secs": 180,
+        });
+        let parsed: UpdateArgs = serde_json::from_value(payload).unwrap();
+        assert_eq!(parsed.item_title, "G Major Scale");
+        assert_eq!(parsed.position_label, "Item 2 of 5");
+        assert_eq!(parsed.planned_duration_secs, Some(180));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 serde round-trip tests to the two Tauri plugins, mirroring the literal JSON payloads sent by the JS bridges in `crates/intrada-web/src/{background_audio,live_activity}.rs`. These would have caught the field-rename half of the bug class debugged in #634, but at \`cargo test\` time instead of from a real-device crash log.

Closes #641 (Rust half).

## What's tested

- `BeginSessionArgs` / `NowPlayingArgs` — `crates/intrada-mobile/plugins/background-audio/src/lib.rs`
- `BeginArgs` / `UpdateArgs` — `crates/intrada-mobile/plugins/live-activity/src/lib.rs`
- `Option<u32>` handling for `planned_duration_secs` (the JS bridge emits `?? null`; pinning the None case prevents silent divergence if anyone later adds `#[serde(skip_serializing_if = ...)]`)

## Out of scope

- **Tauri's outer `{ args: { ... } }` wrapping**: enforced by the `#[tauri::command]` proc macro, not by these structs. These tests cover only the inner shape that Swift's `parseArgs(...)` mirror sees. A full Tauri-runtime test would need a headless Tauri host — not worth the surface area for two plugins.
- **Swift WAV header smoke test** mentioned in #641 — deferred. There's no Swift test infrastructure in the repo yet, and adding it (Tests target in Package.swift, separate `swift test` runner, no CI integration) is heavier than the value of one regression test on static byte math. If we ever hit a WAV regression in the wild, opening it then.

## CI gap (worth knowing)

CI doesn't run these. The Ubuntu runner can't link `tauri`'s GTK deps, so both plugins are excluded from the workspace nextest command at `.github/workflows/ci.yml`:

```
cargo nextest run --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity
```

Run locally on macOS:

```
cargo test -p tauri-plugin-background-audio -p tauri-plugin-live-activity
```

Adding Mac CI to actually exercise these is a worthwhile follow-up — but it's a runner / cost decision, not a code one. Filing as a separate concern if you want to track it.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p tauri-plugin-background-audio -p tauri-plugin-live-activity --tests -- -D warnings` clean
- [x] `cargo test -p tauri-plugin-background-audio` — 2 passed
- [x] `cargo test -p tauri-plugin-live-activity` — 3 passed
- [ ] Behaviour unchanged on iOS device (these are pure unit tests; no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)