### PR TITLE
fix(core): mute error banner after dismiss until system recovers (#346)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -182,25 +182,30 @@ impl App for Intrada {
             Event::DataLoaded { items } => {
                 model.items = items;
                 model.last_error = None;
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::SessionsLoaded { sessions } => {
                 model.sessions = sessions;
                 model.practice_summaries = build_practice_summaries(&model.sessions);
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::SetsLoaded { sets } => {
                 model.sets = sets;
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::LessonsLoaded { lessons } => {
                 model.lessons = lessons;
                 model.last_error = None;
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::LessonLoaded { lesson } => {
                 model.current_lesson = Some(lesson);
                 model.last_error = None;
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
 
@@ -209,24 +214,34 @@ impl App for Intrada {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == item.id) {
                     *existing = item;
                 }
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::SetUpdated { set } => {
                 if let Some(existing) = model.sets.iter_mut().find(|r| r.id == set.id) {
                     *existing = set;
                 }
+                model.error_dismissed = false;
                 crux_core::render::render()
             }
             Event::DeleteConfirmed | Event::SessionSaved => {
                 // Model was already updated optimistically; no action needed.
+                model.error_dismissed = false;
                 Command::done()
             }
 
             // ── Error handling ───────────────────────────────────────
             Event::LoadFailed(msg) => {
-                // Dedupe identical messages (#346) — avoids unnecessary
-                // re-renders. Distinct messages still replace the current
-                // error so user-action failures (save/delete) aren't
+                // After the user dismisses the banner, swallow further errors
+                // until a successful response confirms the system has
+                // recovered. Without this, every retry/refetch with a still-
+                // broken backend pops the banner back up — see #346.
+                if model.error_dismissed {
+                    return Command::done();
+                }
+                // Dedupe identical messages — avoids unnecessary re-renders
+                // during burst failures. Distinct messages still replace the
+                // current error so user-action failures (save/delete) aren't
                 // silently swallowed by a stale load-error banner. The
                 // slide-in animation only re-fires on a true None → Some
                 // transition; the shell mounts the banner stably, so
@@ -239,6 +254,7 @@ impl App for Intrada {
             }
             Event::ClearError => {
                 model.last_error = None;
+                model.error_dismissed = true;
                 crux_core::render::render()
             }
             Event::SetQuery(query) => {
@@ -1695,16 +1711,58 @@ mod tests {
     }
 
     #[test]
-    fn test_load_failed_after_clear_shows_new_error() {
-        // After the user dismisses, the next failure surfaces as expected.
+    fn test_load_failed_after_dismiss_is_muted_until_success() {
+        // After the user dismisses the banner, subsequent failures stay
+        // suppressed — otherwise every retry/refetch against a still-broken
+        // backend pops the banner back up (#346). Once a success arrives,
+        // the mute clears and new failures surface again.
         let app = Intrada;
         let mut model = Model::test_default();
 
         let _ = app.update(Event::LoadFailed("first".to_string()), &mut model);
         let _ = app.update(Event::ClearError, &mut model);
-        let _ = app.update(Event::LoadFailed("second".to_string()), &mut model);
+        assert!(model.error_dismissed);
 
-        assert_eq!(model.last_error, Some("second".to_string()));
+        // Muted: a different LoadFailed while still broken stays hidden.
+        let _ = app.update(Event::LoadFailed("second".to_string()), &mut model);
+        assert_eq!(model.last_error, None);
+
+        // Success unmutes — system has recovered.
+        let _ = app.update(Event::DataLoaded { items: vec![] }, &mut model);
+        assert!(!model.error_dismissed);
+
+        // Now a new failure surfaces.
+        let _ = app.update(Event::LoadFailed("third".to_string()), &mut model);
+        assert_eq!(model.last_error, Some("third".to_string()));
+    }
+
+    #[test]
+    fn test_clear_error_sets_dismissed_flag() {
+        let app = Intrada;
+        let mut model = Model {
+            last_error: Some("some error".to_string()),
+            ..Model::test_default()
+        };
+
+        let _ = app.update(Event::ClearError, &mut model);
+
+        assert_eq!(model.last_error, None);
+        assert!(model.error_dismissed);
+    }
+
+    #[test]
+    fn test_sessions_loaded_unmutes_dismissed_state() {
+        // Any successful Loaded event should unmute, not just DataLoaded —
+        // otherwise the dismissed state could persist forever if items
+        // never load again.
+        let app = Intrada;
+        let mut model = Model {
+            error_dismissed: true,
+            ..Model::test_default()
+        };
+
+        let _ = app.update(Event::SessionsLoaded { sessions: vec![] }, &mut model);
+        assert!(!model.error_dismissed);
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -181,31 +181,28 @@ impl App for Intrada {
             // ── Data loaded callbacks ────────────────────────────────
             Event::DataLoaded { items } => {
                 model.items = items;
-                model.last_error = None;
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::SessionsLoaded { sessions } => {
                 model.sessions = sessions;
                 model.practice_summaries = build_practice_summaries(&model.sessions);
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::SetsLoaded { sets } => {
                 model.sets = sets;
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::LessonsLoaded { lessons } => {
                 model.lessons = lessons;
-                model.last_error = None;
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::LessonLoaded { lesson } => {
                 model.current_lesson = Some(lesson);
-                model.last_error = None;
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
 
@@ -214,47 +211,36 @@ impl App for Intrada {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == item.id) {
                     *existing = item;
                 }
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::SetUpdated { set } => {
                 if let Some(existing) = model.sets.iter_mut().find(|r| r.id == set.id) {
                     *existing = set;
                 }
-                model.error_dismissed = false;
+                model.record_success();
                 crux_core::render::render()
             }
             Event::DeleteConfirmed | Event::SessionSaved => {
-                // Model was already updated optimistically; no action needed.
-                model.error_dismissed = false;
-                Command::done()
+                // Model was already updated optimistically; no action needed
+                // beyond recording the success (clears any pending error +
+                // dismiss-mute).
+                model.record_success();
+                crux_core::render::render()
             }
 
             // ── Error handling ───────────────────────────────────────
             Event::LoadFailed(msg) => {
-                // After the user dismisses the banner, swallow further errors
-                // until a successful response confirms the system has
-                // recovered. Without this, every retry/refetch with a still-
-                // broken backend pops the banner back up — see #346.
-                if model.error_dismissed {
-                    return Command::done();
-                }
-                // Dedupe identical messages — avoids unnecessary re-renders
-                // during burst failures. Distinct messages still replace the
-                // current error so user-action failures (save/delete) aren't
-                // silently swallowed by a stale load-error banner. The
-                // slide-in animation only re-fires on a true None → Some
-                // transition; the shell mounts the banner stably, so
-                // Some → Some swaps just update the text in place.
-                if model.last_error.as_deref() == Some(msg.as_str()) {
-                    return Command::done();
-                }
-                model.last_error = Some(msg);
+                // surface_error encapsulates the dismiss-mute check (#346)
+                // and message dedupe to avoid render storms during burst
+                // failures. Always render — domain *Failed handlers may have
+                // other state changes (loading flags, optimistic rollback)
+                // that need to flush.
+                model.surface_error(msg);
                 crux_core::render::render()
             }
             Event::ClearError => {
-                model.last_error = None;
-                model.error_dismissed = true;
+                model.dismiss_error();
                 crux_core::render::render()
             }
             Event::SetQuery(query) => {
@@ -1721,7 +1707,7 @@ mod tests {
 
         let _ = app.update(Event::LoadFailed("first".to_string()), &mut model);
         let _ = app.update(Event::ClearError, &mut model);
-        assert!(model.error_dismissed);
+        assert!(model.error_muted);
 
         // Muted: a different LoadFailed while still broken stays hidden.
         let _ = app.update(Event::LoadFailed("second".to_string()), &mut model);
@@ -1729,7 +1715,7 @@ mod tests {
 
         // Success unmutes — system has recovered.
         let _ = app.update(Event::DataLoaded { items: vec![] }, &mut model);
-        assert!(!model.error_dismissed);
+        assert!(!model.error_muted);
 
         // Now a new failure surfaces.
         let _ = app.update(Event::LoadFailed("third".to_string()), &mut model);
@@ -1737,7 +1723,30 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_error_sets_dismissed_flag() {
+    fn test_burst_after_dismiss_stays_muted() {
+        // Mirrors the user-reported reproduction in #346: dismiss, then a
+        // burst of distinct failures (e.g. parallel refetches against a
+        // still-broken backend) all stay suppressed.
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let _ = app.update(Event::LoadFailed("Failed to load items".into()), &mut model);
+        let _ = app.update(Event::ClearError, &mut model);
+
+        for msg in [
+            "Failed to load items: timeout",
+            "Failed to load sessions: 503",
+            "Failed to load sets: connection refused",
+            "Failed to load lessons: timeout",
+        ] {
+            let _ = app.update(Event::LoadFailed(msg.into()), &mut model);
+            assert_eq!(model.last_error, None, "burst msg should stay muted: {msg}");
+            assert!(model.error_muted, "mute should persist across burst");
+        }
+    }
+
+    #[test]
+    fn test_clear_error_sets_muted_flag() {
         let app = Intrada;
         let mut model = Model {
             last_error: Some("some error".to_string()),
@@ -1747,22 +1756,22 @@ mod tests {
         let _ = app.update(Event::ClearError, &mut model);
 
         assert_eq!(model.last_error, None);
-        assert!(model.error_dismissed);
+        assert!(model.error_muted);
     }
 
     #[test]
-    fn test_sessions_loaded_unmutes_dismissed_state() {
-        // Any successful Loaded event should unmute, not just DataLoaded —
-        // otherwise the dismissed state could persist forever if items
-        // never load again.
+    fn test_sessions_loaded_unmutes() {
+        // Any confirmed API success should unmute, not just DataLoaded —
+        // otherwise the muted state could persist forever if items never
+        // load again (e.g. user goes straight into the sessions tab).
         let app = Intrada;
         let mut model = Model {
-            error_dismissed: true,
+            error_muted: true,
             ..Model::test_default()
         };
 
         let _ = app.update(Event::SessionsLoaded { sessions: vec![] }, &mut model);
-        assert!(!model.error_dismissed);
+        assert!(!model.error_muted);
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/account.rs
+++ b/crates/intrada-core/src/domain/account.rs
@@ -61,6 +61,7 @@ pub fn handle_account_event(event: AccountEvent, model: &mut Model) -> Command<E
 
         AccountEvent::PreferencesLoaded(prefs) => {
             model.account_preferences = Some(prefs);
+            model.record_success();
             crux_core::render::render()
         }
 
@@ -78,12 +79,13 @@ pub fn handle_account_event(event: AccountEvent, model: &mut Model) -> Command<E
 
         AccountEvent::PreferencesSaved(prefs) => {
             model.account_preferences = Some(prefs);
+            model.record_success();
             crux_core::render::render()
         }
 
         AccountEvent::SavePreferencesFailed { previous, message } => {
             model.account_preferences = previous;
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
 
@@ -98,12 +100,13 @@ pub fn handle_account_event(event: AccountEvent, model: &mut Model) -> Command<E
         AccountEvent::AccountDeleted => {
             model.delete_in_flight = false;
             model.account_deleted = true;
+            model.record_success();
             crux_core::render::render()
         }
 
         AccountEvent::DeleteAccountFailed(msg) => {
             model.delete_in_flight = false;
-            model.last_error = Some(msg);
+            model.surface_error(msg);
             crux_core::render::render()
         }
     }

--- a/crates/intrada-core/src/domain/mcp_audit.rs
+++ b/crates/intrada-core/src/domain/mcp_audit.rs
@@ -47,11 +47,12 @@ pub fn handle_mcp_audit_event(event: McpAuditEvent, model: &mut Model) -> Comman
             model.mcp_audit = entries;
             model.mcp_audit_loaded = true;
             model.mcp_audit_loading = false;
+            model.record_success();
             crux_core::render::render()
         }
         McpAuditEvent::LoadAuditFailed(message) => {
             model.mcp_audit_loading = false;
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
     }

--- a/crates/intrada-core/src/domain/mcp_tokens.rs
+++ b/crates/intrada-core/src/domain/mcp_tokens.rs
@@ -84,12 +84,13 @@ pub fn handle_mcp_token_event(event: McpTokenEvent, model: &mut Model) -> Comman
             model.mcp_tokens = tokens;
             model.mcp_tokens_loaded = true;
             model.mcp_tokens_loading = false;
+            model.record_success();
             crux_core::render::render()
         }
 
         McpTokenEvent::LoadTokensFailed(message) => {
             model.mcp_tokens_loading = false;
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
 
@@ -113,11 +114,12 @@ pub fn handle_mcp_token_event(event: McpTokenEvent, model: &mut Model) -> Comman
                 },
             );
             model.just_created_token = Some(created);
+            model.record_success();
             crux_core::render::render()
         }
 
         McpTokenEvent::CreateTokenFailed(message) => {
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
 
@@ -134,11 +136,12 @@ pub fn handle_mcp_token_event(event: McpTokenEvent, model: &mut Model) -> Comman
             if let Some(token) = model.mcp_tokens.iter_mut().find(|t| t.id == id) {
                 token.revoked_at = Some(revoked_at);
             }
+            model.record_success();
             crux_core::render::render()
         }
 
         McpTokenEvent::RevokeTokenFailed { id: _, message } => {
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
     }

--- a/crates/intrada-core/src/domain/oauth.rs
+++ b/crates/intrada-core/src/domain/oauth.rs
@@ -55,11 +55,12 @@ pub fn handle_oauth_event(event: OAuthEvent, model: &mut Model) -> Command<Effec
         OAuthEvent::ConsentFinalized { redirect_url } => {
             model.oauth_in_flight = false;
             model.oauth_redirect_url = Some(redirect_url);
+            model.record_success();
             crux_core::render::render()
         }
         OAuthEvent::ConsentFailed(message) => {
             model.oauth_in_flight = false;
-            model.last_error = Some(message);
+            model.surface_error(message);
             crux_core::render::render()
         }
         OAuthEvent::ResetConsent => {

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -25,14 +25,14 @@ pub struct Model {
     pub session_status: SessionStatus,
     pub active_query: Option<ListQuery>,
     pub last_error: Option<String>,
-    /// Set when the user dismisses the error banner. While true, further
-    /// `LoadFailed` events are swallowed instead of re-popping the banner —
-    /// avoids the "dismiss → next refetch fails → banner reappears" loop
-    /// when the underlying problem (network down, auth expired) hasn't been
-    /// resolved. Cleared by any successful `*Loaded` callback, signalling
-    /// the system has recovered and new failures are worth surfacing again
-    /// (#346).
-    pub error_dismissed: bool,
+    /// Set when the user dismisses the error banner. While true, errors from
+    /// HTTP failures routed through [`Model::surface_error`] are silently
+    /// swallowed — avoids the "dismiss → next refetch fails → banner
+    /// reappears" loop when the underlying problem (network down, auth
+    /// expired) hasn't been resolved. Cleared by any confirmed API success
+    /// via [`Model::record_success`], signalling the system has recovered
+    /// and new failures are worth surfacing again (#346).
+    pub error_muted: bool,
     pub sets: Vec<Set>,
     pub lessons: Vec<Lesson>,
     pub current_lesson: Option<Lesson>,
@@ -70,6 +70,42 @@ pub struct Model {
     /// reacts by navigating the browser to this URL (which contains the
     /// auth code + state for the OAuth client).
     pub oauth_redirect_url: Option<String>,
+}
+
+impl Model {
+    /// Surface an error from a background HTTP failure. Respects the
+    /// dismiss-mute state set by [`Model::dismiss_error`]: if the user has
+    /// already dismissed the banner and the system has not yet recovered,
+    /// the error is silently swallowed to stop the banner re-popping. Also
+    /// dedupes identical messages to avoid render storms during burst
+    /// failures (#346).
+    pub fn surface_error(&mut self, msg: impl Into<String>) {
+        if self.error_muted {
+            return;
+        }
+        let msg = msg.into();
+        if self.last_error.as_deref() == Some(msg.as_str()) {
+            return;
+        }
+        self.last_error = Some(msg);
+    }
+
+    /// Mark a confirmed API success. Clears any active error and exits the
+    /// dismiss-mute state — the system has demonstrably recovered, so
+    /// future failures are worth showing again. Call from any handler that
+    /// receives a successful API response.
+    pub fn record_success(&mut self) {
+        self.last_error = None;
+        self.error_muted = false;
+    }
+
+    /// User explicitly dismissed the error banner. Clears the active error
+    /// and enters the mute state so subsequent background failures don't
+    /// immediately re-pop the banner.
+    pub fn dismiss_error(&mut self) {
+        self.last_error = None;
+        self.error_muted = true;
+    }
 }
 
 #[cfg(test)]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -25,6 +25,14 @@ pub struct Model {
     pub session_status: SessionStatus,
     pub active_query: Option<ListQuery>,
     pub last_error: Option<String>,
+    /// Set when the user dismisses the error banner. While true, further
+    /// `LoadFailed` events are swallowed instead of re-popping the banner —
+    /// avoids the "dismiss → next refetch fails → banner reappears" loop
+    /// when the underlying problem (network down, auth expired) hasn't been
+    /// resolved. Cleared by any successful `*Loaded` callback, signalling
+    /// the system has recovered and new failures are worth surfacing again
+    /// (#346).
+    pub error_dismissed: bool,
     pub sets: Vec<Set>,
     pub lessons: Vec<Lesson>,
     pub current_lesson: Option<Lesson>,


### PR DESCRIPTION
## Summary

Fixes #346 — the error banner kept popping back after dismissal whenever the API was still broken. The previous attempt (#582) deduped identical messages but distinct \`LoadFailed\` events still re-surfaced the banner.

## Root cause

\`Event::ClearError\` only cleared \`last_error\` to \`None\`. The next \`LoadFailed\` (from any retry or navigation-triggered refetch with the API still down) would set it to \`Some(...)\` again and re-render the banner. Every page-load burst, tab switch, or focus-triggered refetch produced a fresh banner the user had to dismiss again.

## Fix

Track an \`error_dismissed: bool\` flag on \`Model\`:
- \`Event::ClearError\` sets it to \`true\` (and clears \`last_error\` as before)
- \`Event::LoadFailed\` early-returns when the flag is true — incoming errors stay muted
- Any successful \`*Loaded\` / write-confirmation event clears the flag (the system has demonstrably recovered, so new failures are worth showing again): \`DataLoaded\`, \`SessionsLoaded\`, \`SetsLoaded\`, \`LessonsLoaded\`, \`LessonLoaded\`, \`ItemUpdated\`, \`SetUpdated\`, \`DeleteConfirmed\`, \`SessionSaved\`

## Tests

- \`test_load_failed_after_dismiss_is_muted_until_success\` — full cycle: dismiss → muted → success → unmuted → next failure surfaces
- \`test_clear_error_sets_dismissed_flag\` — the dismiss path itself
- \`test_sessions_loaded_unmutes_dismissed_state\` — not just \`DataLoaded\` clears the mute

## Test plan

- [x] \`cargo test --workspace --exclude intrada-mobile --exclude tauri-plugin-background-audio --exclude tauri-plugin-live-activity\` (528 passed)
- [x] \`cargo clippy --workspace ... -- -D warnings\`
- [x] \`cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings\`
- [x] \`cargo fmt --check\`
- [ ] Manual verification: stop API, dismiss banner, confirm it stays dismissed; restart API, confirm subsequent failure surfaces

## Caveats

User-action failures (Save / Update / Delete) while still muted will be silently swallowed until the next successful response. This is an acceptable edge case — the user just dismissed something seconds ago. We can revisit if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)