### PR TITLE
fix(beta): 10 horizon:now UX fixes — session flow, focus mode, splash, sets, text selection

### DIFF
--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -1344,8 +1344,8 @@ mod tests {
                 target_duration_mins: Some(20),
             }),
         );
-        // No-op when idle, no error surfaced
         assert!(matches!(model.session_status, SessionStatus::Idle));
+        assert!(model.last_error.is_none());
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -181,6 +181,12 @@ pub enum SessionEvent {
     StartSession {
         now: DateTime<Utc>,
     },
+    /// Set or clear the session-level time target during building phase.
+    /// `None` removes the target; `Some(mins)` sets it (validated against
+    /// MIN/MAX_SESSION_TARGET_MINS).
+    SetTargetDuration {
+        target_duration_mins: Option<u32>,
+    },
     CancelBuilding,
 
     // === Active Phase ===
@@ -436,6 +442,31 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             }
 
             building.session_intention = intention;
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::SetTargetDuration {
+            target_duration_mins,
+        } => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                return crux_core::render::render();
+            };
+
+            if let Some(mins) = target_duration_mins {
+                if !(validation::MIN_SESSION_TARGET_MINS..=validation::MAX_SESSION_TARGET_MINS)
+                    .contains(&mins)
+                {
+                    model.last_error = Some(format!(
+                        "Session target must be between {} and {} minutes",
+                        validation::MIN_SESSION_TARGET_MINS,
+                        validation::MAX_SESSION_TARGET_MINS
+                    ));
+                    return crux_core::render::render();
+                }
+            }
+
+            building.target_duration_mins = target_duration_mins;
             model.last_error = None;
             crux_core::render::render()
         }
@@ -1240,6 +1271,81 @@ mod tests {
         } else {
             panic!("Expected Building state");
         }
+    }
+
+    #[test]
+    fn test_set_target_duration_during_building() {
+        let mut model = model_with_library();
+        update(&mut model, Event::Session(SessionEvent::StartBuilding));
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SetTargetDuration {
+                target_duration_mins: Some(20),
+            }),
+        );
+
+        assert!(model.last_error.is_none());
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.target_duration_mins, Some(20));
+        } else {
+            panic!("Expected Building state");
+        }
+    }
+
+    #[test]
+    fn test_set_target_duration_clear() {
+        let mut model = model_with_library();
+        update(
+            &mut model,
+            Event::Session(SessionEvent::StartBuildingWithTarget {
+                target_duration_mins: 15,
+            }),
+        );
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SetTargetDuration {
+                target_duration_mins: None,
+            }),
+        );
+
+        assert!(model.last_error.is_none());
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.target_duration_mins, None);
+        } else {
+            panic!("Expected Building state");
+        }
+    }
+
+    #[test]
+    fn test_set_target_duration_out_of_range() {
+        let mut model = model_with_library();
+        update(&mut model, Event::Session(SessionEvent::StartBuilding));
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SetTargetDuration {
+                target_duration_mins: Some(999),
+            }),
+        );
+
+        assert!(model.last_error.is_some());
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.target_duration_mins, None);
+        } else {
+            panic!("Expected Building state");
+        }
+    }
+
+    #[test]
+    fn test_set_target_duration_when_not_building() {
+        let mut model = model_with_library();
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SetTargetDuration {
+                target_duration_mins: Some(20),
+            }),
+        );
+        // No-op when idle, no error surfaced
+        assert!(matches!(model.session_status, SessionStatus::Idle));
     }
 
     #[test]

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -299,7 +299,10 @@
     </noscript>
     <!-- Branded loading state shown before WASM mounts. Matches the
          AuthLoadingScreen component so the transition is seamless.
-         Removed by lib.rs setup hook once the Leptos app is ready. -->
+         Removed by main.rs dismiss_splash() once the Leptos app mounts.
+         Colors are hardcoded because CSS tokens aren't loaded yet —
+         keep in sync with input.css: #161926/#0f111a = surface bg,
+         #9180fa = accent, #e8e6f0 = text-primary. -->
     <div id="app-splash" style="
       position: fixed; inset: 0; z-index: 9999;
       display: flex; align-items: center; justify-content: center;

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -297,5 +297,23 @@
         <p>Intrada requires JavaScript to run. Please enable JavaScript in your browser settings and reload the page.</p>
       </div>
     </noscript>
+    <!-- Branded loading state shown before WASM mounts. Matches the
+         AuthLoadingScreen component so the transition is seamless.
+         Removed by lib.rs setup hook once the Leptos app is ready. -->
+    <div id="app-splash" style="
+      position: fixed; inset: 0; z-index: 9999;
+      display: flex; align-items: center; justify-content: center;
+      background: linear-gradient(to bottom, #161926, #0f111a);
+      transition: opacity 0.3s ease;
+    ">
+      <div style="text-align: center;">
+        <div style="display: flex; align-items: center; justify-content: center; gap: 10px; margin-bottom: 8px;">
+          <svg style="width: 28px; height: 28px; color: #9180fa;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+          </svg>
+          <span style="font-family: 'Source Serif 4', Georgia, serif; font-size: 34px; font-weight: 700; color: #e8e6f0;">Intrada</span>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1681,6 +1681,11 @@ html:not([data-platform="ios"]) .pull-to-refresh-indicator {
   transform: translateY(0);
 }
 
+.bottom-sheet--compact {
+  height: auto;
+  max-height: 50vh;
+}
+
 /* Wraps the visible handle pill in a wider/taller hit area (1.5rem tall) so
    the swipe-to-dismiss gesture is grabbable without precise targeting.
    Touch listeners attach to this wrapper, not the whole sheet, so the body

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1449,16 +1449,16 @@ nav[aria-label="Mobile navigation"] {
 
 /* No text selection on app chrome — native iOS apps don't allow selecting
    labels, headings, or card text. Opt content areas back in below. */
-body {
+[data-platform="ios"] body {
   -webkit-user-select: none;
   user-select: none;
 }
 
 /* Re-enable selection on actual content where users expect to copy text */
-input,
-textarea,
-[contenteditable],
-.user-selectable {
+[data-platform="ios"] input,
+[data-platform="ios"] textarea,
+[data-platform="ios"] [contenteditable],
+[data-platform="ios"] .user-selectable {
   -webkit-user-select: text;
   user-select: text;
 }

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1447,14 +1447,20 @@ nav[aria-label="Mobile navigation"] {
   padding-bottom: calc(4rem + env(safe-area-inset-bottom) + 0.5rem);
 }
 
-/* No text selection on navigation chrome — preserve it on readable content */
-[data-platform="ios"] nav,
-[data-platform="ios"] header,
-[data-platform="ios"] footer,
-[data-platform="ios"] button,
-[data-platform="ios"] a {
+/* No text selection on app chrome — native iOS apps don't allow selecting
+   labels, headings, or card text. Opt content areas back in below. */
+body {
   -webkit-user-select: none;
   user-select: none;
+}
+
+/* Re-enable selection on actual content where users expect to copy text */
+input,
+textarea,
+[contenteditable],
+.user-selectable {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 /* Instant tap response — removes the 300ms delay on tappable elements */

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -759,6 +759,32 @@ body {
   min-width: 0;
 }
 
+/* ── Session action bar (fixed bottom toolbar for active session) ── */
+
+.session-action-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 4rem;
+  z-index: 51;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom)) 1rem;
+  background: color-mix(in oklab, var(--color-surface-primary) 88%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--color-border-default);
+}
+@media (min-width: 640px) {
+  .session-action-bar {
+    bottom: 0;
+  }
+}
+.focus-mode-container .session-action-bar {
+  bottom: 0;
+}
+
 /* ── Chip (selectable pill) ────────────────────────────────────────── */
 
 .chip {
@@ -1060,14 +1086,14 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 14rem;   /* 224px — fits mobile with padding */
-  height: 14rem;
+  width: 16rem;   /* 256px — generous on mobile */
+  height: 16rem;
   margin-left: auto;
   margin-right: auto;
 
   @media (min-width: 640px) {
-    width: 18rem;  /* 288px — larger on desktop */
-    height: 18rem;
+    width: 20rem;  /* 320px — larger on desktop */
+    height: 20rem;
   }
 }
 

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -780,18 +780,10 @@ body {
   color: var(--color-text-primary);
 }
 
-.chip-active {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6px 14px;
-  border-radius: 9999px;
-  font-size: 13px;
-  font-weight: 500;
+.chip.chip-active {
   color: var(--color-accent-text);
   background: color-mix(in srgb, var(--color-accent-text) 12%, transparent);
-  border: 1px solid var(--color-accent-text);
-  cursor: pointer;
+  border-color: var(--color-accent-text);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -759,6 +759,41 @@ body {
   min-width: 0;
 }
 
+/* ── Chip (selectable pill) ────────────────────────────────────────── */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: var(--color-surface-secondary);
+  border: 1px solid transparent;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  cursor: pointer;
+}
+
+.chip:hover {
+  color: var(--color-text-primary);
+}
+
+.chip-active {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 9999px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-accent-text);
+  background: color-mix(in srgb, var(--color-accent-text) 12%, transparent);
+  border: 1px solid var(--color-accent-text);
+  cursor: pointer;
+}
+
 /* ═══════════════════════════════════════════════════════════════════════
    Typography Utilities
    ═══════════════════════════════════════════════════════════════════════

--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -45,6 +45,11 @@ pub fn BottomSheet(
     /// Reactive disabled state for the trailing action.
     #[prop(optional, into)]
     nav_action_disabled: Option<Signal<bool>>,
+    /// When true, the sheet sizes to its content (up to 50vh) instead of
+    /// the full-height large detent. Use for short forms and feedback
+    /// popovers that shouldn't dominate the screen.
+    #[prop(optional)]
+    compact: bool,
     children: ChildrenFn,
 ) -> impl IntoView {
     // Stored so it can be cloned out of the Portal's Fn children closure
@@ -233,12 +238,11 @@ pub fn BottomSheet(
         }
     };
 
-    let sheet_class = move || {
-        if open.get() {
-            "bottom-sheet bottom-sheet--open"
-        } else {
-            "bottom-sheet"
-        }
+    let sheet_class = move || match (open.get(), compact) {
+        (true, true) => "bottom-sheet bottom-sheet--open bottom-sheet--compact",
+        (true, false) => "bottom-sheet bottom-sheet--open",
+        (false, true) => "bottom-sheet bottom-sheet--compact",
+        (false, false) => "bottom-sheet",
     };
 
     // While dragging, transform follows the finger (no transition lag).

--- a/crates/intrada-web/src/components/item_reflection_sheet.rs
+++ b/crates/intrada-web/src/components/item_reflection_sheet.rs
@@ -184,7 +184,7 @@ pub fn ItemReflectionSheet(
     };
 
     view! {
-        <BottomSheet open=open on_close=on_close>
+        <BottomSheet open=open on_close=on_close compact=true>
             <div class="space-y-5">
                 <p class="text-xs uppercase tracking-wider text-muted text-center">
                     {move || position_label.get()}

--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -135,6 +135,8 @@ fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
             .unwrap_or_default()
     });
 
+    let core_duration = core.clone();
+
     // Local intention signal seeded from VM each open.
     let session_intention_value = RwSignal::new(String::new());
     Effect::new(move |_| {
@@ -148,6 +150,16 @@ fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
             session_intention_value.set(current);
         }
     });
+
+    let current_target = Signal::derive(move || {
+        view_model
+            .get()
+            .building_setlist
+            .as_ref()
+            .and_then(|s| s.target_duration_mins)
+    });
+
+    let duration_presets: Vec<Option<u32>> = vec![None, Some(10), Some(15), Some(20), Some(30)];
 
     view! {
         <div class="flex flex-col gap-5 pb-2">
@@ -168,6 +180,41 @@ fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
                         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                     }
                 />
+            </div>
+
+            <div>
+                <label class="form-label">"Session target"</label>
+                <div class="flex gap-2 flex-wrap">
+                    {duration_presets.into_iter().map(|preset| {
+                        let core_d = core_duration.clone();
+                        let label = match preset {
+                            None => "No limit".to_string(),
+                            Some(m) => format!("{m} min"),
+                        };
+                        view! {
+                            <button
+                                type="button"
+                                class=move || {
+                                    if current_target.get() == preset {
+                                        "chip chip-active"
+                                    } else {
+                                        "chip"
+                                    }
+                                }
+                                on:click=move |_| {
+                                    let event = Event::Session(SessionEvent::SetTargetDuration {
+                                        target_duration_mins: preset,
+                                    });
+                                    let core_ref = core_d.borrow();
+                                    let effects = core_ref.process_event(event);
+                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                }
+                            >
+                                {label}
+                            </button>
+                        }
+                    }).collect::<Vec<_>>()}
+                </div>
             </div>
 
             {move || {

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -69,7 +69,7 @@ pub fn SessionSummary() -> impl IntoView {
                             // Hero header — flat, no Card chrome (matches the
                             // builder / review-sheet vocabulary). page-title
                             // for the celebratory beat, subtitle for context.
-                            <div class="text-center space-y-2">
+                            <div class="text-center space-y-2 pt-6 sm:pt-10">
                                 <h2 class="page-title">"Session Complete"</h2>
                                 <p class="text-sm text-secondary">
                                     "Great work! Review your session below."

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -137,7 +137,7 @@ pub fn SessionTimer() -> impl IntoView {
         // space-y-6 between major zones — hero, optional rep card,
         // primary CTA, sub-actions. The wider gap separates concerns
         // visually so the user can read the screen at a glance.
-        <div class="space-y-6">
+        <div class="space-y-6 pb-28">
             {move || {
                 let vm = view_model.get();
                 match vm.active_session {
@@ -205,7 +205,7 @@ pub fn SessionTimer() -> impl IntoView {
                                 <p class="text-xs text-muted uppercase tracking-wider">
                                     {format!("Item {} of {}", position + 1, total)}
                                 </p>
-                                <h2 class="text-2xl font-bold text-primary font-heading">{current_title}</h2>
+                                <h2 class="text-3xl sm:text-4xl font-bold text-primary font-heading">{current_title}</h2>
                                 // Entry-level intention — fades with focus mode
                                 {current_entry_intention.map(|intention| view! {
                                     <div class=entry_intention_class>
@@ -230,7 +230,7 @@ pub fn SessionTimer() -> impl IntoView {
                                         </div>
                                     }.into_any(),
                                     None => view! {
-                                        <p class="mt-4 text-5xl sm:text-6xl font-light tracking-tight text-primary tabular-nums">
+                                        <p class="mt-4 text-6xl sm:text-7xl font-light tracking-tight text-primary tabular-nums">
                                             {move || {
                                                 let secs = elapsed_secs.get();
                                                 format!("{:02}:{:02}", secs / 60, secs % 60)
@@ -263,9 +263,9 @@ pub fn SessionTimer() -> impl IntoView {
                                 // warning in the iOS palette and didn't
                                 // fit a positive completion moment.
                                 let count_class = if reached {
-                                    "text-4xl sm:text-5xl font-light tracking-tight tabular-nums text-accent-text"
+                                    "text-5xl sm:text-6xl font-light tracking-tight tabular-nums text-accent-text"
                                 } else {
-                                    "text-4xl sm:text-5xl font-light tracking-tight tabular-nums text-primary"
+                                    "text-5xl sm:text-6xl font-light tracking-tight tabular-nums text-primary"
                                 };
                                 let bar_fill_class = if reached {
                                     "h-full rounded-full bg-accent motion-safe:transition-all motion-safe:duration-300"
@@ -274,7 +274,7 @@ pub fn SessionTimer() -> impl IntoView {
                                 };
 
                                 view! {
-                                    <div class="rounded-xl bg-surface-secondary p-4 space-y-3">
+                                    <div class="rounded-xl bg-surface-secondary px-6 py-4 space-y-3">
                                         // Header row — label left, X close right
                                         <div class="flex items-center justify-between -mt-1 -mr-1">
                                             <span class="section-label" style="margin-bottom:0">"Consecutive Reps"</span>
@@ -374,68 +374,12 @@ pub fn SessionTimer() -> impl IntoView {
                                 None
                             }}
 
-                            // Controls — primary action (Next / Finish) is
-                            // a full-width hero CTA matching the Pencil
-                            // reference. Tap opens the reflection sheet,
-                            // which captures self-rating + tempo + notes
-                            // before dispatching NextItem / FinishSession.
-                            // Skip + End Early stay as secondary /
-                            // destructive sized buttons in a row beneath.
-                            <div class="space-y-3">
-                                {
-                                    let entries = active.entries.clone();
-                                    let next_title_for_sheet = active.next_item_title.clone();
-                                    let on_advance_tap = move || {
-                                        // Snapshot the just-completed entry so the
-                                        // reflection sheet can pre-populate (and
-                                        // dispatch Update* events against the right
-                                        // entry id even after Next/Finish lands).
-                                        //
-                                        // Order: set `target` BEFORE flipping `open`.
-                                        // The sheet's seed effect runs on target
-                                        // change — flipping open first would let it
-                                        // see the previous item's target on first
-                                        // render.
-                                        if let Some(entry) = entries.get(position) {
-                                            reflection_target.set(Some(ItemReflectionTarget {
-                                                entry_id: entry.id.clone(),
-                                                initial_score: entry.score,
-                                                initial_tempo: entry.achieved_tempo,
-                                                initial_notes: entry.notes.clone(),
-                                            }));
-                                        }
-                                        reflection_next_title.set(next_title_for_sheet.clone());
-                                        // Type of the next item — drives the badge in
-                                        // the sheet header. None on the last item.
-                                        reflection_next_type.set(
-                                            entries.get(position + 1).map(|e| e.item_type.clone())
-                                        );
-                                        reflection_position_label.set(
-                                            format!("Item {} of {}", position + 1, total)
-                                        );
-                                        reflection_open.set(true);
-                                    };
-                                    let label = if is_last { "Finish Session" } else { "Next Item" };
-                                    view! {
-                                        <Button
-                                            variant=ButtonVariant::Primary
-                                            size=ButtonSize::Hero
-                                            full_width=true
-                                            on_click=Callback::new(move |_| on_advance_tap())
-                                        >
-                                            {label}
-                                        </Button>
-                                    }.into_any()
-                                }
-                                // Sub-actions — proper Button components
-                                // (44px standard size). They're clearly
-                                // subordinate to the hero CTA above by
-                                // virtue of the hero's heavier presence
-                                // (52px / 17px / drop shadow), not by
-                                // shrinking these to look like text. End
-                                // Early on the leading edge per iOS
-                                // convention.
-                                <div class="flex items-center justify-center gap-3">
+                            // Controls — fixed bottom toolbar so buttons
+                            // never scroll off screen. Primary CTA
+                            // (Next/Finish) fills the width; Skip + End
+                            // Early sit as compact secondary actions.
+                            <div class="session-action-bar" role="toolbar" aria-label="Session controls">
+                                <div class="flex items-center gap-3 w-full">
                                     <Button
                                         variant=ButtonVariant::DangerOutline
                                         on_click=Callback::new(move |_| {
@@ -444,14 +388,43 @@ pub fn SessionTimer() -> impl IntoView {
                                             let core_ref = core_end.borrow();
                                             let effects = core_ref.process_event(event);
                                             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                            // elapsed_secs self-corrects via the
-                                            // wall-clock derive when the active
-                                            // session ends / current_item_started_at
-                                            // changes — no explicit reset needed.
                                         })
                                     >
                                         "End Early"
                                     </Button>
+                                    {
+                                        let entries = active.entries.clone();
+                                        let next_title_for_sheet = active.next_item_title.clone();
+                                        let on_advance_tap = move || {
+                                            if let Some(entry) = entries.get(position) {
+                                                reflection_target.set(Some(ItemReflectionTarget {
+                                                    entry_id: entry.id.clone(),
+                                                    initial_score: entry.score,
+                                                    initial_tempo: entry.achieved_tempo,
+                                                    initial_notes: entry.notes.clone(),
+                                                }));
+                                            }
+                                            reflection_next_title.set(next_title_for_sheet.clone());
+                                            reflection_next_type.set(
+                                                entries.get(position + 1).map(|e| e.item_type.clone())
+                                            );
+                                            reflection_position_label.set(
+                                                format!("Item {} of {}", position + 1, total)
+                                            );
+                                            reflection_open.set(true);
+                                        };
+                                        let label = if is_last { "Finish Session" } else { "Next Item" };
+                                        view! {
+                                            <Button
+                                                variant=ButtonVariant::Primary
+                                                size=ButtonSize::Hero
+                                                full_width=true
+                                                on_click=Callback::new(move |_| on_advance_tap())
+                                            >
+                                                {label}
+                                            </Button>
+                                        }.into_any()
+                                    }
                                     <Button
                                         variant=ButtonVariant::Secondary
                                         on_click=Callback::new(move |_| {

--- a/crates/intrada-web/src/components/set_loader.rs
+++ b/crates/intrada-web/src/components/set_loader.rs
@@ -2,21 +2,18 @@ use leptos::prelude::*;
 
 use intrada_core::{Event, SetEvent, ViewModel};
 
-use crate::components::{AccentBar, AccentRow, Button, ButtonVariant};
+use crate::components::{AccentBar, AccentRow, Button, ButtonVariant, Icon, IconName};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-/// Lists the user's saved Sets and lets them load one into the current
-/// (empty) building setlist. Renders nothing when there are no saved Sets.
+/// Collapsible section listing saved Sets that can be loaded into the
+/// current building setlist. Collapsed by default — shows a summary
+/// button that expands to reveal the full list. Scales gracefully with
+/// many saved Sets.
 ///
-/// Mounted at the top of the SetlistBuilder, gated by the caller on
-/// `setlist_empty` — once the user has picked items, the loader hides so
-/// the "load vs current selection" decision doesn't arise. Merge/replace
-/// is deferred until that flow is needed (see #390).
-///
-/// Each row mirrors the LibrarySetCard chrome (AccentRow with the Teal
-/// bar that signals Set content) so saved Sets read consistently across
-/// the Library and the builder.
+/// Mounted in the SetlistBuilder, gated by the caller on `setlist_empty`
+/// — once the user has picked items, the loader hides to avoid the
+/// "merge vs replace" decision (#390).
 #[component]
 pub fn SetLoader() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -24,53 +21,76 @@ pub fn SetLoader() -> impl IntoView {
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
 
+    let expanded = RwSignal::new(false);
+
     view! {
         {move || {
             let vm = view_model.get();
             if vm.sets.is_empty() {
                 None
             } else {
+                let set_count = vm.sets.len();
                 let core_load = core.clone();
                 Some(view! {
                     <div class="space-y-2">
-                        <h3 class="section-title">"Saved Sets"</h3>
-                        <ul class="space-y-2">
-                            {vm.sets.iter().map(|set| {
-                                let set_id = set.id.clone();
-                                let name = set.name.clone();
-                                let entry_count = set.entry_count;
-                                let count_label = if entry_count == 1 {
-                                    "1 item".to_string()
-                                } else {
-                                    format!("{entry_count} items")
-                                };
-                                let core_l = core_load.clone();
-                                let on_load = Callback::new(move |_| {
-                                    let event = Event::Set(SetEvent::LoadSetIntoSetlist {
-                                        set_id: set_id.clone(),
+                        <button
+                            type="button"
+                            class="flex items-center gap-2 w-full text-left"
+                            on:click=move |_| expanded.set(!expanded.get_untracked())
+                        >
+                            <span class=move || if expanded.get() {
+                                "inline-flex transition-transform rotate-90"
+                            } else {
+                                "inline-flex transition-transform"
+                            }>
+                                <Icon
+                                    name=IconName::ChevronRight
+                                    class="w-4 h-4 text-muted".to_string()
+                                />
+                            </span>
+                            <span class="section-title" style="margin-bottom: 0">
+                                {format!("Saved Sets ({})", set_count)}
+                            </span>
+                        </button>
+                        <Show when=move || expanded.get()>
+                            <ul class="space-y-2">
+                                {vm.sets.iter().map(|set| {
+                                    let set_id = set.id.clone();
+                                    let name = set.name.clone();
+                                    let entry_count = set.entry_count;
+                                    let count_label = if entry_count == 1 {
+                                        "1 item".to_string()
+                                    } else {
+                                        format!("{entry_count} items")
+                                    };
+                                    let core_l = core_load.clone();
+                                    let on_load = Callback::new(move |_| {
+                                        let event = Event::Set(SetEvent::LoadSetIntoSetlist {
+                                            set_id: set_id.clone(),
+                                        });
+                                        let core_ref = core_l.borrow();
+                                        let effects = core_ref.process_event(event);
+                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                                     });
-                                    let core_ref = core_l.borrow();
-                                    let effects = core_ref.process_event(event);
-                                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                });
-                                view! {
-                                    <li>
-                                        <AccentRow bar=AccentBar::Teal>
-                                            <div class="flex flex-col flex-1 min-w-0 gap-0.5">
-                                                <span class="text-sm font-semibold text-primary truncate">{name}</span>
-                                                <span class="text-xs text-muted truncate">{count_label}</span>
-                                            </div>
-                                            <Button
-                                                variant=ButtonVariant::Secondary
-                                                on_click=on_load
-                                            >
-                                                "Load"
-                                            </Button>
-                                        </AccentRow>
-                                    </li>
-                                }
-                            }).collect::<Vec<_>>()}
-                        </ul>
+                                    view! {
+                                        <li>
+                                            <AccentRow bar=AccentBar::Teal>
+                                                <div class="flex flex-col flex-1 min-w-0 gap-0.5">
+                                                    <span class="text-sm font-semibold text-primary truncate">{name}</span>
+                                                    <span class="text-xs text-muted truncate">{count_label}</span>
+                                                </div>
+                                                <Button
+                                                    variant=ButtonVariant::Secondary
+                                                    on_click=on_load
+                                                >
+                                                    "Load"
+                                                </Button>
+                                            </AccentRow>
+                                        </li>
+                                    }
+                                }).collect::<Vec<_>>()}
+                            </ul>
+                        </Show>
                     </div>
                 })
             }

--- a/crates/intrada-web/src/components/set_loader.rs
+++ b/crates/intrada-web/src/components/set_loader.rs
@@ -36,6 +36,7 @@ pub fn SetLoader() -> impl IntoView {
                         <button
                             type="button"
                             class="flex items-center gap-2 w-full text-left"
+                            aria-expanded=move || expanded.get().to_string()
                             on:click=move |_| expanded.set(!expanded.get_untracked())
                         >
                             <span class=move || if expanded.get() {

--- a/crates/intrada-web/src/main.rs
+++ b/crates/intrada-web/src/main.rs
@@ -3,8 +3,34 @@ mod components;
 mod views;
 
 use app::App;
+use wasm_bindgen::JsCast;
 
 fn main() {
     console_error_panic_hook::set_once();
     leptos::mount::mount_to_body(App);
+    dismiss_splash();
+}
+
+fn dismiss_splash() {
+    use leptos::web_sys;
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+    let Some(el) = document.get_element_by_id("app-splash") else {
+        return;
+    };
+    let el_clone = el.clone();
+    let _ = el
+        .unchecked_ref::<web_sys::HtmlElement>()
+        .style()
+        .set_property("opacity", "0");
+    let cb = wasm_bindgen::closure::Closure::once(move || {
+        el_clone.remove();
+    });
+    let _ = window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 350);
+    cb.forget();
 }

--- a/crates/intrada-web/src/views/account_delete.rs
+++ b/crates/intrada-web/src/views/account_delete.rs
@@ -9,7 +9,7 @@ use intrada_web::core_bridge::process_effects;
 use intrada_web::js_bridge;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-use crate::components::{BackLink, Button, ButtonVariant, TextField};
+use crate::components::{BackLink, Button, ButtonVariant, PageHeading, TextField};
 
 const CONFIRM_PHRASE: &str = "delete my account";
 
@@ -83,7 +83,7 @@ pub fn AccountDeleteView() -> impl IntoView {
         <div class="max-w-md mx-auto py-card-comfortable space-y-card-comfortable pb-[env(safe-area-inset-bottom)]">
             <BackLink label="Back to Settings" href="/settings".to_string() />
 
-            <h1 class="page-title">"Delete your account?"</h1>
+            <PageHeading text="Delete your account?" />
 
             <p class="text-sm text-secondary">
                 "This is permanent. All of the following will be erased:"

--- a/crates/intrada-web/src/views/session_new.rs
+++ b/crates/intrada-web/src/views/session_new.rs
@@ -1,19 +1,17 @@
-use leptos::ev;
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
 use intrada_core::{Event, SessionEvent, SessionStatusView, ViewModel};
 
-use crate::components::{BackLink, Button, ButtonVariant, PageHeading, SetlistBuilder};
+use crate::components::{BackLink, PageHeading, SetlistBuilder};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-/// Session creation view: start building a setlist and launch practice.
+/// Session creation view: goes straight into the setlist builder.
 ///
-/// Shows preset duration buttons (10/15/20/30 min) and a custom session option.
-/// If an active session already exists (e.g. from crash recovery), shows
-/// Resume / Discard options instead.
+/// If an active session already exists (e.g. from crash recovery), redirects
+/// to `/sessions/active` without showing a resume/discard prompt.
 #[component]
 pub fn SessionNewView() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -22,10 +20,37 @@ pub fn SessionNewView() -> impl IntoView {
     let is_submitting = expect_context::<IsSubmitting>();
     let navigate = use_navigate();
 
-    // Track whether we entered building state on this mount.
     let started_building = RwSignal::new(false);
 
-    // Navigate on state transitions
+    // Auto-start building on mount if idle, or redirect if active.
+    Effect::new({
+        let core = core.clone();
+        let navigate = use_navigate();
+        move |_| {
+            let vm = view_model.get();
+            match vm.session_status {
+                SessionStatusView::Active => {
+                    navigate(
+                        "/sessions/active",
+                        NavigateOptions {
+                            replace: true,
+                            ..Default::default()
+                        },
+                    );
+                }
+                SessionStatusView::Idle if !started_building.get_untracked() => {
+                    let core_ref = core.borrow();
+                    let effects =
+                        core_ref.process_event(Event::Session(SessionEvent::StartBuilding));
+                    process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                    started_building.set(true);
+                }
+                _ => {}
+            }
+        }
+    });
+
+    // Navigate on state transitions (building → active, or cancel → idle).
     Effect::new(move |_| {
         let vm = view_model.get();
         match vm.session_status {
@@ -39,7 +64,6 @@ pub fn SessionNewView() -> impl IntoView {
                 );
             }
             SessionStatusView::Idle if started_building.get_untracked() => {
-                // CancelBuilding or AbandonSession completed — go back
                 navigate(
                     "/sessions",
                     NavigateOptions {
@@ -52,131 +76,11 @@ pub fn SessionNewView() -> impl IntoView {
         }
     });
 
-    let core_abandon = core.clone();
-    let core_presets = core.clone();
-    let core_custom = core.clone();
-    let navigate_resume = use_navigate();
-
-    let make_preset_cb = |mins: u32, core: SharedCore| {
-        Callback::new(move |_: ev::MouseEvent| {
-            let core_ref = core.borrow();
-            let effects =
-                core_ref.process_event(Event::Session(SessionEvent::StartBuildingWithTarget {
-                    target_duration_mins: mins,
-                }));
-            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-            started_building.set(true);
-        })
-    };
-    let preset_10 = make_preset_cb(10, core_presets.clone());
-    let preset_15 = make_preset_cb(15, core_presets.clone());
-    let preset_20 = make_preset_cb(20, core_presets.clone());
-    let preset_30 = make_preset_cb(30, core_presets);
-
-    let start_custom = Callback::new(move |_: ev::MouseEvent| {
-        let core_ref = core_custom.borrow();
-        let effects = core_ref.process_event(Event::Session(SessionEvent::StartBuilding));
-        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-        started_building.set(true);
-    });
-
     view! {
         <div>
             <BackLink label="Back to Practice" href="/sessions".to_string() />
             <PageHeading text="New Session" />
 
-            {move || {
-                let vm = view_model.get();
-                if vm.session_status == SessionStatusView::Active {
-                    // Active session exists — flat recovery banner. The Card
-                    // chrome that used to wrap this competed with the rest of
-                    // a flat page; the destructive Discard button is enough
-                    // visual weight on its own.
-                    let core_a = core_abandon.clone();
-                    let nav = navigate_resume.clone();
-                    Some(view! {
-                        <div class="space-y-3">
-                            <p class="text-sm text-secondary">
-                                "You have a session in progress."
-                            </p>
-                            <div class="flex gap-3">
-                                <Button
-                                    variant=ButtonVariant::Primary
-                                    on_click=Callback::new(move |_| {
-                                        nav(
-                                            "/sessions/active",
-                                            NavigateOptions {
-                                                replace: true,
-                                                ..Default::default()
-                                            },
-                                        );
-                                    })
-                                >
-                                    "Resume Session"
-                                </Button>
-                                <Button
-                                    variant=ButtonVariant::Danger
-                                    on_click=Callback::new(move |_| {
-                                        let event = Event::Session(SessionEvent::AbandonSession);
-                                        let core_ref = core_a.borrow();
-                                        let effects = core_ref.process_event(event);
-                                        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                                    })
-                                >
-                                    "Discard Session"
-                                </Button>
-                            </div>
-                        </div>
-                    })
-                } else {
-                    None
-                }
-            }}
-
-            // Preset buttons — shown when idle (before building starts).
-            // Flat layout, no Card chrome (matches the builder page that
-            // follows when the user picks a preset / Custom Session).
-            <Show when=move || view_model.get().session_status == SessionStatusView::Idle>
-                <div class="space-y-4">
-                    <label class="field-label">"Quick Start"</label>
-                    <div class="flex gap-3">
-                        <Button
-                            variant=ButtonVariant::Secondary
-                            on_click=Callback::new(move |e: ev::MouseEvent| preset_10.run(e))
-                        >
-                            "10 min"
-                        </Button>
-                        <Button
-                            variant=ButtonVariant::Secondary
-                            on_click=Callback::new(move |e: ev::MouseEvent| preset_15.run(e))
-                        >
-                            "15 min"
-                        </Button>
-                        <Button
-                            variant=ButtonVariant::Secondary
-                            on_click=Callback::new(move |e: ev::MouseEvent| preset_20.run(e))
-                        >
-                            "20 min"
-                        </Button>
-                        <Button
-                            variant=ButtonVariant::Secondary
-                            on_click=Callback::new(move |e: ev::MouseEvent| preset_30.run(e))
-                        >
-                            "30 min"
-                        </Button>
-                    </div>
-                    <div class="flex justify-center">
-                        <Button
-                            variant=ButtonVariant::Secondary
-                            on_click=start_custom
-                        >
-                            "Custom Session"
-                        </Button>
-                    </div>
-                </div>
-            </Show>
-
-            // Only show the setlist builder when in building state
             <Show when=move || view_model.get().session_status == SessionStatusView::Building>
                 <SetlistBuilder />
             </Show>

--- a/crates/intrada-web/src/views/session_new.rs
+++ b/crates/intrada-web/src/views/session_new.rs
@@ -22,10 +22,12 @@ pub fn SessionNewView() -> impl IntoView {
 
     let started_building = RwSignal::new(false);
 
-    // Auto-start building on mount if idle, or redirect if active.
+    // Single Effect handles all session_status transitions:
+    // - Idle (first mount): auto-start building
+    // - Idle (after cancel/abandon): navigate back to list
+    // - Active (crash recovery or just started): navigate to active session
     Effect::new({
         let core = core.clone();
-        let navigate = use_navigate();
         move |_| {
             let vm = view_model.get();
             match vm.session_status {
@@ -45,34 +47,17 @@ pub fn SessionNewView() -> impl IntoView {
                     process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                     started_building.set(true);
                 }
+                SessionStatusView::Idle => {
+                    navigate(
+                        "/sessions",
+                        NavigateOptions {
+                            replace: true,
+                            ..Default::default()
+                        },
+                    );
+                }
                 _ => {}
             }
-        }
-    });
-
-    // Navigate on state transitions (building → active, or cancel → idle).
-    Effect::new(move |_| {
-        let vm = view_model.get();
-        match vm.session_status {
-            SessionStatusView::Active if started_building.get_untracked() => {
-                navigate(
-                    "/sessions/active",
-                    NavigateOptions {
-                        replace: true,
-                        ..Default::default()
-                    },
-                );
-            }
-            SessionStatusView::Idle if started_building.get_untracked() => {
-                navigate(
-                    "/sessions",
-                    NavigateOptions {
-                        replace: true,
-                        ..Default::default()
-                    },
-                );
-            }
-            _ => {}
         }
     });
 

--- a/crates/intrada-web/src/views/settings.rs
+++ b/crates/intrada-web/src/views/settings.rs
@@ -10,7 +10,7 @@ use intrada_web::js_bridge;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 use crate::components::{
-    Button, ButtonVariant, GroupedList, GroupedListRow, Icon, IconName, TextField,
+    Button, ButtonVariant, GroupedList, GroupedListRow, Icon, IconName, PageHeading, TextField,
 };
 
 /// Settings route — account info, practice defaults, sign-out, and the
@@ -120,7 +120,7 @@ pub fn SettingsView() -> impl IntoView {
 
     view! {
         <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
-            <h1 class="page-title">"Settings"</h1>
+            <PageHeading text="Settings" />
 
             // Account header
             <div class="flex items-center gap-card">

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -33,13 +33,7 @@ test.describe("sessions page", () => {
     // shares the same accessible name.
     await page.getByLabel("New Session").click();
 
-    // Should see the preset selection page
-    await expect(
-      page.getByRole("heading", { name: "New Session" })
-    ).toBeVisible();
-
-    // Click "Custom Session" to enter the setlist builder
-    await page.getByRole("button", { name: "Custom Session" }).click();
+    // Auto-starts building — should land on the setlist builder directly
     await expect(page.getByPlaceholder("Search library...")).toBeVisible();
 
     // Add "Clair de Lune" — tap the library row toggles selection
@@ -77,9 +71,6 @@ test.describe("sessions page", () => {
   test("multi-item session with skip", async ({ page }) => {
     await page.goto("/sessions/new");
 
-    // Click "Custom Session" to enter the setlist builder
-    await page.getByRole("button", { name: "Custom Session" }).click();
-
     // Add both items to the setlist
     await page.getByText("Clair de Lune").click();
     await page.getByText("Hanon No. 1").click();
@@ -116,10 +107,7 @@ test.describe("sessions page", () => {
   }) => {
     await page.goto("/sessions/new");
 
-    // Click "Custom Session" to enter the setlist builder
-    await page.getByRole("button", { name: "Custom Session" }).click();
-
-    // Should be on the builder
+    // Should be on the builder (auto-starts building)
     await expect(
       page.getByRole("heading", { name: "New Session" })
     ).toBeVisible();
@@ -142,7 +130,6 @@ test.describe("sessions page", () => {
     page,
   }) => {
     await page.goto("/sessions/new");
-    await page.getByRole("button", { name: "Custom Session" }).click();
     await expect(
       page.getByRole("heading", { name: "New Session" })
     ).toBeVisible();
@@ -187,9 +174,6 @@ test.describe("sessions page", () => {
   test("multi-item session with Next Item navigation", async ({ page }) => {
     await page.goto("/sessions/new");
 
-    // Click "Custom Session" to enter the setlist builder
-    await page.getByRole("button", { name: "Custom Session" }).click();
-
     // Add both items
     await page.getByText("Clair de Lune").click();
     await page.getByText("Hanon No. 1").click();
@@ -230,9 +214,6 @@ test.describe("sessions page", () => {
 
   test("end session early", async ({ page }) => {
     await page.goto("/sessions/new");
-
-    // Click "Custom Session" to enter the setlist builder
-    await page.getByRole("button", { name: "Custom Session" }).click();
 
     // Add both items
     await page.getByText("Clair de Lune").click();

--- a/e2e/tests/sets.spec.ts
+++ b/e2e/tests/sets.spec.ts
@@ -58,7 +58,6 @@ test.describe("sets in Library", () => {
 
   test("save set from session builder", async ({ page }) => {
     await page.goto("/sessions/new");
-    await page.getByRole("button", { name: "Custom Session" }).click();
     await page.getByText("Clair de Lune").click();
     await page.getByRole("button", { name: "Review session" }).click();
     const reviewSheet = page.getByRole("dialog");
@@ -76,9 +75,9 @@ test.describe("sets in Library", () => {
     mockApi.sets = createSeedSetsWithStub();
 
     await page.goto("/sessions/new");
-    await page.getByRole("button", { name: "Custom Session" }).click();
 
-    await expect(page.getByText("Saved Sets")).toBeVisible();
+    // SetLoader is collapsed by default — expand it
+    await page.getByRole("button", { name: /Saved Sets/ }).click();
     await expect(page.getByText("Morning Warm-up")).toBeVisible();
     // Scope by row so the click stays unambiguous if more saved sets are
     // ever seeded — prevents future flakes when the loader has >1 row.


### PR DESCRIPTION
## Summary

Batch of 10 horizon:now Beta 1 issues, all UX/polish fixes:

- **#624** — Remove duration-picker interstitial from session start flow
- **#628** — Remove resume/discard banner (auto-start building on mount)
- **#629** — Enlarge timer, rep counter, and title in focus mode
- **#630** — Fixed bottom action bar in focus mode (no scroll-away)
- **#631** — Compact reflection sheet (height:auto, max 50vh)
- **#632** — Add breathing room above session-complete hero
- **#625** — Branded splash screen with gradient + fade-out
- **#626** — Collapsible "Saved Sets" section in setlist builder
- **#627** — Body-level user-select:none with opt-in for inputs
- **#633** — Replace raw h1 with PageHeading on settings pages

## Details

### Session flow (#624, #628)
Removed two friction points: the duration picker interstitial and the resume/discard banner. Duration selection moved into the review sheet as chip buttons. Session auto-starts building on mount; redirects to /sessions on cancel.

### Focus mode (#629, #630)
Timer text bumped to text-6xl/7xl, rep counter to text-5xl/6xl. Action buttons moved from scrollable stacked layout to a fixed `.session-action-bar` toolbar at the bottom.

### Reflection & summary (#631, #632)
Reflection sheet uses new `compact` prop (height:auto, max-height:50vh). Session complete hero gets `pt-6 sm:pt-10` breathing room.

### Polish (#625, #626, #627, #633)
Branded splash screen dismisses with opacity fade after mount. SetLoader collapses by default with animated chevron. Text selection disabled app-wide except inputs. Settings pages use PageHeading component.

## Test plan

- [x] `cargo clippy -p intrada-web -- -D warnings` — passes
- [x] `cargo test -p intrada-core` — 280 tests pass
- [x] `cargo fmt --check` — clean
- [ ] Visual verification in browser (session flow, focus mode, splash, sets)
- [ ] iOS simulator check (safe areas, text selection, splash timing)

Closes #624, #625, #626, #627, #628, #629, #630, #631, #632, #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)