### PR TITLE
fix(web): silence unhandled Tauri plugin rejections + filter Sentry noise

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -72,6 +72,17 @@
           // here would drop the event entirely — keep wrapped in try/catch
           // and return the event unchanged on any failure.
           beforeSend: function (event) {
+            // Drop benign errors that can't be fixed in code:
+            // - View transition skipped when app is backgrounded mid-nav
+            // - WASM LinkError from transient cache coherence mismatch
+            try {
+              var msg = (event.message || '');
+              if (event.exception && Array.isArray(event.exception.values)) {
+                msg = event.exception.values.map(function(v){ return v.value || ''; }).join(' ');
+              }
+              if (msg.indexOf('View transition was skipped') !== -1) return null;
+              if (msg.indexOf('must be callable') !== -1 && msg.indexOf('LinkError') !== -1) return null;
+            } catch(e) {}
             try {
               var EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
               var redactEmails = function (s) {

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -78,7 +78,7 @@
             try {
               var msg = (event.message || '');
               if (event.exception && Array.isArray(event.exception.values)) {
-                msg = event.exception.values.map(function(v){ return v.value || ''; }).join(' ');
+                msg += ' ' + event.exception.values.map(function(v){ return v.value || ''; }).join(' ');
               }
               if (msg.indexOf('View transition was skipped') !== -1) return null;
               if (msg.indexOf('must be callable') !== -1 && msg.indexOf('LinkError') !== -1) return null;

--- a/crates/intrada-web/src/background_audio.rs
+++ b/crates/intrada-web/src/background_audio.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(e){ if (typeof console !== 'undefined') console.debug('plugin invoke failed:', cmd, e); });
         } catch(e) {}
     }
     export function begin_session(title, started_at) {

--- a/crates/intrada-web/src/background_audio.rs
+++ b/crates/intrada-web/src/background_audio.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
         } catch(e) {}
     }
     export function begin_session(title, started_at) {

--- a/crates/intrada-web/src/haptics.rs
+++ b/crates/intrada-web/src/haptics.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
         } catch(e) {}
     }
     export function haptic_selection() {

--- a/crates/intrada-web/src/haptics.rs
+++ b/crates/intrada-web/src/haptics.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(e){ if (typeof console !== 'undefined') console.debug('plugin invoke failed:', cmd, e); });
         } catch(e) {}
     }
     export function haptic_selection() {

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(e){ if (typeof console !== 'undefined') console.debug('plugin invoke failed:', cmd, e); });
         } catch(e) {}
     }
     export function begin(item_title, position_label, started_at, planned_duration_secs) {

--- a/crates/intrada-web/src/live_activity.rs
+++ b/crates/intrada-web/src/live_activity.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
             const invoke =
                 window.__TAURI__?.core?.invoke ??
                 window.__TAURI_INTERNALS__?.invoke;
-            if (invoke) invoke(cmd, args ?? {});
+            if (invoke) invoke(cmd, args ?? {}).catch(function(){});
         } catch(e) {}
     }
     export function begin(item_title, position_label, started_at, planned_duration_secs) {


### PR DESCRIPTION
## Summary

- Add `.catch(function(){})` to all three Tauri plugin invoke helpers (`background_audio`, `live_activity`, `haptics`) — the existing `try/catch` only caught synchronous errors while `invoke()` returns a Promise, causing unhandled rejections to surface in Sentry
- Filter two transient single-occurrence errors in Sentry's `beforeSend`: view-transition skip when app is backgrounded mid-nav, and WASM `LinkError` from cache coherence mismatch

Fixes INTRADA-WEB-A, INTRADA-WEB-B, INTRADA-WEB-F, INTRADA-WEB-G, INTRADA-WEB-H, INTRADA-WEB-J

## Context

The `args` wrapping root cause was already fixed in #634. The ongoing Sentry events (26+ occurrences of `begin_session` alone) are from a stale iOS build. Rebuilding with `just ios-build` will stop them. The `.catch()` fix ensures any future plugin command failure won't create Sentry noise.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p intrada-web -- -D warnings` passes
- [x] `cargo test -p intrada-web` — 96 tests pass
- [ ] Rebuild iOS app and verify no new Sentry errors appear during practice sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)