### PR TITLE
fix(ux): PR #647 feedback — splash, settings header, reflection sheet, review CTA, focus width

### DIFF
--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -769,16 +769,20 @@ body {
   z-index: 51;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom)) 1rem;
   background: color-mix(in oklab, var(--color-surface-primary) 88%, transparent);
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
   border-top: 1px solid var(--color-border-default);
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 @media (min-width: 640px) {
   .session-action-bar {
     bottom: 0;
+    gap: 0.75rem;
   }
 }
 .focus-mode-container .session-action-bar {
@@ -1066,6 +1070,9 @@ body {
   justify-content: center;
   min-height: 100vh;
   min-height: 100dvh;
+  max-width: 56rem;
+  margin-left: auto;
+  margin-right: auto;
   padding-left: 1rem;
   padding-right: 1rem;
   padding-top: 2rem;

--- a/crates/intrada-web/src/components/item_reflection_sheet.rs
+++ b/crates/intrada-web/src/components/item_reflection_sheet.rs
@@ -184,7 +184,7 @@ pub fn ItemReflectionSheet(
     };
 
     view! {
-        <BottomSheet open=open on_close=on_close compact=true>
+        <BottomSheet open=open on_close=on_close>
             <div class="space-y-5">
                 <p class="text-xs uppercase tracking-wider text-muted text-center">
                     {move || position_label.get()}

--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -2,7 +2,9 @@ use leptos::prelude::*;
 
 use intrada_core::{Event, SessionEvent, SetEvent, ViewModel};
 
-use crate::components::{BottomSheet, EditorEntry, EntryListEditor, SetSaveForm};
+use crate::components::{
+    BottomSheet, Button, ButtonSize, ButtonVariant, EditorEntry, EntryListEditor, SetSaveForm,
+};
 use intrada_web::core_bridge::{process_effects, process_effects_with_core};
 use intrada_web::js_bridge;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
@@ -51,7 +53,7 @@ pub fn SessionReviewSheet(open: Signal<bool>, on_close: Callback<()>) -> impl In
             on_nav_action=on_start
             nav_action_disabled=setlist_empty
         >
-            <ReviewSheetBody sheet_open=open />
+            <ReviewSheetBody sheet_open=open on_start=on_start setlist_empty=setlist_empty />
         </BottomSheet>
     }
 }
@@ -64,7 +66,11 @@ pub fn SessionReviewSheet(open: Signal<bool>, on_close: Callback<()>) -> impl In
 /// `sheet_open` is forwarded to [`SetSaveForm`] so it can reset its
 /// "Saved" state when the sheet closes.
 #[component]
-fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
+fn ReviewSheetBody(
+    sheet_open: Signal<bool>,
+    on_start: Callback<()>,
+    setlist_empty: Signal<bool>,
+) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
     let is_loading = expect_context::<IsLoading>();
@@ -250,6 +256,21 @@ fn ReviewSheetBody(sheet_open: Signal<bool>) -> impl IntoView {
                     }.into_any(),
                 }
             }}
+
+            // Prominent Start button — duplicates the nav-bar action so
+            // users don't accidentally hit Save as Set when they mean to
+            // start practising.
+            <Show when=move || has_entries.get()>
+                <Button
+                    variant=ButtonVariant::Primary
+                    size=ButtonSize::Hero
+                    full_width=true
+                    disabled=Signal::derive(move || setlist_empty.get())
+                    on_click=Callback::new(move |_| on_start.run(()))
+                >
+                    "Start practising"
+                </Button>
+            </Show>
 
             // Save as Set — gated on a non-empty setlist (matches the
             // core precondition; saving with no entries surfaces an

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -390,7 +390,7 @@ pub fn SessionTimer() -> impl IntoView {
                                             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                                         })
                                     >
-                                        "End Early"
+                                        "End"
                                     </Button>
                                     {
                                         let entries = active.entries.clone();

--- a/crates/intrada-web/src/main.rs
+++ b/crates/intrada-web/src/main.rs
@@ -22,15 +22,27 @@ fn dismiss_splash() {
     let Some(el) = document.get_element_by_id("app-splash") else {
         return;
     };
-    let el_clone = el.clone();
-    let _ = el
-        .unchecked_ref::<web_sys::HtmlElement>()
-        .style()
-        .set_property("opacity", "0");
-    let cb = wasm_bindgen::closure::Closure::once(move || {
-        el_clone.remove();
+    // Hold the splash for a minimum duration so it reads as intentional
+    // branding rather than a flicker. The fade-out starts after the hold,
+    // then the element is removed after the CSS transition completes.
+    let fade = wasm_bindgen::closure::Closure::once(move || {
+        let el_remove = el.clone();
+        let _ = el
+            .unchecked_ref::<web_sys::HtmlElement>()
+            .style()
+            .set_property("opacity", "0");
+        let remove_cb = wasm_bindgen::closure::Closure::once(move || {
+            el_remove.remove();
+        });
+        if let Some(w) = web_sys::window() {
+            let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
+                remove_cb.as_ref().unchecked_ref(),
+                400,
+            );
+        }
+        remove_cb.forget();
     });
     let _ = window
-        .set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 350);
-    cb.forget();
+        .set_timeout_with_callback_and_timeout_and_arguments_0(fade.as_ref().unchecked_ref(), 600);
+    fade.forget();
 }

--- a/crates/intrada-web/src/views/settings.rs
+++ b/crates/intrada-web/src/views/settings.rs
@@ -119,7 +119,7 @@ pub fn SettingsView() -> impl IntoView {
     });
 
     view! {
-        <div class="max-w-md mx-auto py-card-comfortable space-y-section pb-[env(safe-area-inset-bottom)]">
+        <div class="max-w-md mx-auto space-y-section pb-[env(safe-area-inset-bottom)]">
             <PageHeading text="Settings" />
 
             // Account header

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -228,7 +228,7 @@ test.describe("sessions page", () => {
     await expect(page.getByText("Item 1 of 2")).toBeVisible();
 
     // End early
-    await page.getByRole("button", { name: "End Early" }).click();
+    await page.getByRole("button", { name: "End" }).click();
 
     // Should see summary with "Ended Early" indicator
     await expect(page.getByText("Session Complete")).toBeVisible();


### PR DESCRIPTION
## Summary

Follow-up to #647 addressing user feedback from testing:

- **Splash screen**: hold for 600ms before fading (positive friction, no flicker)
- **Settings header**: remove `py-card-comfortable` top padding — header now aligns with other views
- **Reflection sheet**: revert to full-height (compact was too small for the rating/tempo/notes form)
- **Review sheet**: add prominent "Start practising" hero button above Save as Set to prevent accidental saves
- **Focus mode**: add `max-width: 56rem` to match normal layout width
- **Action bar**: `max-width` constraint + shorter "End" label to prevent button overflow on narrow screens
- **E2E**: update button name "End Early" → "End"

## Test plan

- [x] `cargo clippy -p intrada-web -- -D warnings` — clean
- [x] `cargo test -p intrada-core` — 280 tests pass
- [x] `cargo fmt --check` — clean
- [x] Web preview: splash holds, app loads without errors
- [ ] iOS simulator: verify splash timing, reflection sheet height, action bar fit
- [ ] E2E: verify "End" button name change passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)