### PR TITLE
feat(sets): source-aware set save — Update vs Save as new

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -28,7 +28,8 @@ use crate::domain::types::ListQuery;
 use crate::http;
 use crate::model::{
     build_active_session_view, build_summary_view, entry_to_view, lesson_to_view, session_to_view,
-    BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model, SessionStatusView, ViewModel,
+    BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model, SessionStatusView,
+    SetSourceStatus, ViewModel,
 };
 
 /// Root Crux application for the music practice library.
@@ -295,6 +296,42 @@ impl App for Intrada {
             SessionStatus::Building(building) => {
                 let entries: Vec<_> = building.entries.iter().map(entry_to_view).collect();
                 let item_count = entries.len();
+                let source_status = match &building.source_set_id {
+                    None => SetSourceStatus::NoSource,
+                    Some(sid) => {
+                        let set_name = model
+                            .sets
+                            .iter()
+                            .find(|s| &s.id == sid)
+                            .map(|s| s.name.clone());
+                        match set_name {
+                            None => SetSourceStatus::NoSource,
+                            Some(name) => {
+                                let current_ids: Vec<&str> = building
+                                    .entries
+                                    .iter()
+                                    .map(|e| e.item_id.as_str())
+                                    .collect();
+                                let snapshot_ids: Vec<&str> = building
+                                    .source_set_entry_snapshot
+                                    .iter()
+                                    .map(|s| s.as_str())
+                                    .collect();
+                                if current_ids == snapshot_ids {
+                                    SetSourceStatus::UnmodifiedFromSource {
+                                        set_id: sid.clone(),
+                                        set_name: name,
+                                    }
+                                } else {
+                                    SetSourceStatus::ModifiedFromSource {
+                                        set_id: sid.clone(),
+                                        set_name: name,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
                 (
                     None,
                     Some(BuildingSetlistView {
@@ -302,6 +339,7 @@ impl App for Intrada {
                         item_count,
                         session_intention: building.session_intention.clone(),
                         target_duration_mins: building.target_duration_mins,
+                        source_status,
                     }),
                     None,
                 )
@@ -1799,6 +1837,8 @@ mod tests {
                 entries: vec![],
                 session_intention: Some("Focus on dynamics".to_string()),
                 target_duration_mins: None,
+                source_set_id: None,
+                source_set_entry_snapshot: vec![],
             }),
             ..Model::test_default()
         };

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -97,6 +97,10 @@ pub struct BuildingSession {
     /// Optional session-level time target (in minutes) set via presets.
     /// Purely a UI guide — not enforced.
     pub target_duration_mins: Option<u32>,
+    /// Which saved Set this builder was loaded from (if any).
+    pub source_set_id: Option<String>,
+    /// Ordered item_ids at load time — used to detect modifications.
+    pub source_set_entry_snapshot: Vec<String>,
 }
 
 /// State during active practice (Active phase).
@@ -399,6 +403,8 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 entries: vec![],
                 session_intention: None,
                 target_duration_mins: None,
+                source_set_id: None,
+                source_set_entry_snapshot: vec![],
             });
             model.last_error = None;
             crux_core::render::render()
@@ -425,6 +431,8 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 entries: vec![],
                 session_intention: None,
                 target_duration_mins: Some(target_duration_mins),
+                source_set_id: None,
+                source_set_entry_snapshot: vec![],
             });
             model.last_error = None;
             crux_core::render::render()

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -281,6 +281,11 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
                 }
             };
 
+            if building.entries.is_empty() {
+                model.last_error = Some("Cannot update set with an empty setlist".to_string());
+                return crux_core::render::render();
+            }
+
             let source_id = match &building.source_set_id {
                 Some(id) => id.clone(),
                 None => {

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -51,6 +51,7 @@ pub enum SetEvent {
         name: String,
         entries: Vec<SetEntry>,
     },
+    UpdateSetFromBuilding,
 }
 
 // ── Handler ────────────────────────────────────────────────────────────
@@ -178,6 +179,17 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
                 }
             };
 
+            // Track which set was loaded so the review sheet can offer
+            // "Update" instead of "Save as new" when appropriate.
+            if building.entries.is_empty() {
+                building.source_set_id = Some(set_id.clone());
+                building.source_set_entry_snapshot =
+                    set.entries.iter().map(|e| e.item_id.clone()).collect();
+            } else if building.source_set_id.as_deref() != Some(&set_id) {
+                building.source_set_id = None;
+                building.source_set_entry_snapshot = vec![];
+            }
+
             // Create new SetlistEntry objects from set entries (fresh ULIDs)
             for entry in &set.entries {
                 building.entries.push(SetlistEntry {
@@ -258,6 +270,70 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
                 crux_core::render::render(),
             ])
         }
+
+        SetEvent::UpdateSetFromBuilding => {
+            let building = match &mut model.session_status {
+                SessionStatus::Building(b) => b,
+                _ => {
+                    model.last_error =
+                        Some("Can only update set during building phase".to_string());
+                    return crux_core::render::render();
+                }
+            };
+
+            let source_id = match &building.source_set_id {
+                Some(id) => id.clone(),
+                None => {
+                    model.last_error = Some("No source set to update".to_string());
+                    return crux_core::render::render();
+                }
+            };
+
+            let entries: Vec<SetEntry> = building
+                .entries
+                .iter()
+                .enumerate()
+                .map(|(i, e)| SetEntry {
+                    id: ulid::Ulid::new().to_string(),
+                    item_id: e.item_id.clone(),
+                    item_title: e.item_title.clone(),
+                    item_type: e.item_type.clone(),
+                    position: i,
+                })
+                .collect();
+
+            let set = match model.sets.iter_mut().find(|s| s.id == source_id) {
+                Some(s) => s,
+                None => {
+                    model.last_error = Some("Source set not found".to_string());
+                    return crux_core::render::render();
+                }
+            };
+
+            set.entries = entries;
+            set.updated_at = Utc::now();
+
+            for (i, entry) in set.entries.iter_mut().enumerate() {
+                entry.position = i;
+            }
+
+            let updated = set.clone();
+
+            // Update the snapshot so status flips to UnmodifiedFromSource
+            let building = match &mut model.session_status {
+                SessionStatus::Building(b) => b,
+                _ => unreachable!(),
+            };
+            building.source_set_entry_snapshot =
+                building.entries.iter().map(|e| e.item_id.clone()).collect();
+
+            model.last_error = None;
+
+            Command::all([
+                crate::http::update_set(&model.api_base_url, &updated),
+                crux_core::render::render(),
+            ])
+        }
     }
 }
 
@@ -275,6 +351,8 @@ mod tests {
                 entries,
                 session_intention: None,
                 target_duration_mins: None,
+                source_set_id: None,
+                source_set_entry_snapshot: vec![],
             }),
             ..Default::default()
         }
@@ -740,5 +818,228 @@ mod tests {
         } else {
             panic!("Expected building status");
         }
+    }
+
+    // ── Source-aware set save tests ───────────────────────────────────
+
+    #[test]
+    fn load_into_empty_builder_sets_source() {
+        let mut model = model_with_building(vec![]);
+        model.sets.push(sample_set());
+
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.source_set_id.as_deref(), Some("set-1"));
+            assert_eq!(b.source_set_entry_snapshot, vec!["item-a", "item-b"]);
+        } else {
+            panic!("Expected building status");
+        }
+    }
+
+    #[test]
+    fn load_different_set_clears_source() {
+        let mut model = model_with_building(vec![]);
+        model.sets.push(sample_set());
+        model.sets.push(Set {
+            id: "set-2".to_string(),
+            name: "Evening Cool-down".to_string(),
+            entries: vec![SetEntry {
+                id: "re-3".to_string(),
+                item_id: "item-c".to_string(),
+                item_title: "Arpeggios".to_string(),
+                item_type: ItemKind::Exercise,
+                position: 0,
+            }],
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        // Load first set into empty builder — sets source
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        // Load different set — builder is non-empty, different set → clears source
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-2".to_string(),
+            },
+            &mut model,
+        );
+
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.source_set_id, None);
+            assert!(b.source_set_entry_snapshot.is_empty());
+        } else {
+            panic!("Expected building status");
+        }
+    }
+
+    #[test]
+    fn reload_same_set_preserves_source() {
+        let mut model = model_with_building(vec![]);
+        model.sets.push(sample_set());
+
+        // Load set into empty builder
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        // Re-load same set (non-empty, but same set_id)
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.source_set_id.as_deref(), Some("set-1"));
+            assert_eq!(b.source_set_entry_snapshot, vec!["item-a", "item-b"]);
+        } else {
+            panic!("Expected building status");
+        }
+    }
+
+    #[test]
+    fn load_into_non_empty_builder_clears_source() {
+        let mut model = model_with_building(sample_setlist_entries());
+        model.sets.push(sample_set());
+
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        if let SessionStatus::Building(ref b) = model.session_status {
+            assert_eq!(b.source_set_id, None);
+            assert!(b.source_set_entry_snapshot.is_empty());
+        } else {
+            panic!("Expected building status");
+        }
+    }
+
+    #[test]
+    fn update_set_from_building_succeeds() {
+        let mut model = model_with_building(vec![]);
+        model.sets.push(sample_set());
+
+        // Load set to establish source
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        // Add an extra entry to make it modified
+        if let SessionStatus::Building(ref mut b) = model.session_status {
+            b.entries.push(SetlistEntry {
+                id: "entry-new".to_string(),
+                item_id: "item-c".to_string(),
+                item_title: "Arpeggios".to_string(),
+                item_type: ItemKind::Exercise,
+                position: 2,
+                duration_secs: 0,
+                status: EntryStatus::NotAttempted,
+                notes: None,
+                score: None,
+                intention: None,
+                rep_target: None,
+                rep_count: None,
+                rep_target_reached: None,
+                rep_history: None,
+                planned_duration_secs: None,
+                achieved_tempo: None,
+            });
+        }
+
+        let _cmd = handle_set_event(SetEvent::UpdateSetFromBuilding, &mut model);
+
+        assert!(model.last_error.is_none());
+        assert_eq!(model.sets[0].entries.len(), 3);
+        assert_eq!(model.sets[0].entries[2].item_id, "item-c");
+    }
+
+    #[test]
+    fn update_set_from_building_fails_without_source() {
+        let mut model = model_with_building(sample_setlist_entries());
+
+        let _cmd = handle_set_event(SetEvent::UpdateSetFromBuilding, &mut model);
+
+        assert_eq!(model.last_error.as_deref(), Some("No source set to update"));
+    }
+
+    #[test]
+    fn update_set_from_building_updates_snapshot() {
+        use crate::model::SetSourceStatus;
+        use crux_core::App;
+
+        let mut model = model_with_building(vec![]);
+        model.sets.push(sample_set());
+
+        // Load set
+        let _cmd = handle_set_event(
+            SetEvent::LoadSetIntoSetlist {
+                set_id: "set-1".to_string(),
+            },
+            &mut model,
+        );
+
+        // Add entry to make it modified
+        if let SessionStatus::Building(ref mut b) = model.session_status {
+            b.entries.push(SetlistEntry {
+                id: "entry-new".to_string(),
+                item_id: "item-c".to_string(),
+                item_title: "Arpeggios".to_string(),
+                item_type: ItemKind::Exercise,
+                position: 2,
+                duration_secs: 0,
+                status: EntryStatus::NotAttempted,
+                notes: None,
+                score: None,
+                intention: None,
+                rep_target: None,
+                rep_count: None,
+                rep_target_reached: None,
+                rep_history: None,
+                planned_duration_secs: None,
+                achieved_tempo: None,
+            });
+        }
+
+        // Update the source set
+        let _cmd = handle_set_event(SetEvent::UpdateSetFromBuilding, &mut model);
+
+        // After update, snapshot should match current entries
+        if let SessionStatus::Building(ref b) = model.session_status {
+            let current_ids: Vec<&str> = b.entries.iter().map(|e| e.item_id.as_str()).collect();
+            assert_eq!(b.source_set_entry_snapshot, current_ids);
+        } else {
+            panic!("Expected building status");
+        }
+
+        // Verify via view() that status is UnmodifiedFromSource
+        let app = crate::app::Intrada;
+        let vm = app.view(&model);
+        let status = &vm.building_setlist.unwrap().source_status;
+        assert!(matches!(
+            status,
+            SetSourceStatus::UnmodifiedFromSource { .. }
+        ));
     }
 }

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -30,7 +30,8 @@ pub use crux_http::{HttpError, HttpRequest};
 pub use model::{
     ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LessonPhotoView, LessonView,
     LibraryItemView, Model, PracticeSessionView, ScoreHistoryEntry, SessionStatusView,
-    SetEntryView, SetView, SetlistEntryView, SummaryView, TempoHistoryEntry, ViewModel,
+    SetEntryView, SetSourceStatus, SetView, SetlistEntryView, SummaryView, TempoHistoryEntry,
+    ViewModel,
 };
 pub use validation::{
     MAX_ACHIEVED_TEMPO, MAX_BPM, MAX_COMPOSER, MAX_LESSON_NOTES, MAX_NOTES, MAX_SET_NAME, MAX_TAG,

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -337,12 +337,29 @@ pub struct ActiveSessionView {
 }
 
 /// View for the building phase setlist.
+/// Whether the builder's entries originate from, and relate to, a saved Set.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub enum SetSourceStatus {
+    #[default]
+    NoSource,
+    UnmodifiedFromSource {
+        set_id: String,
+        set_name: String,
+    },
+    ModifiedFromSource {
+        set_id: String,
+        set_name: String,
+    },
+}
+
+/// View for the building phase setlist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct BuildingSetlistView {
     pub entries: Vec<SetlistEntryView>,
     pub item_count: usize,
     pub session_intention: Option<String>,
     pub target_duration_mins: Option<u32>,
+    pub source_status: SetSourceStatus,
 }
 
 /// View for the end-of-session summary.

--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -1,6 +1,6 @@
 use leptos::prelude::*;
 
-use intrada_core::{Event, SessionEvent, SetEvent, ViewModel};
+use intrada_core::{Event, SessionEvent, SetEvent, SetSourceStatus, ViewModel};
 
 use crate::components::{
     BottomSheet, Button, ButtonSize, ButtonVariant, EditorEntry, EntryListEditor, SetSaveForm,
@@ -272,23 +272,65 @@ fn ReviewSheetBody(
                 </Button>
             </Show>
 
-            // Save as Set — gated on a non-empty setlist (matches the
-            // core precondition; saving with no entries surfaces an
-            // error). Hidden until the user has at least one item so the
-            // sheet's empty state stays clean.
             <Show when=move || has_entries.get()>
                 {
                     let core_save = core_save_set.clone();
-                    view! {
-                        <SetSaveForm
-                            sheet_open=sheet_open
-                            on_save=Callback::new(move |name: String| {
-                                let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
-                                let core_ref = core_save.borrow();
-                                let effects = core_ref.process_event(event);
-                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-                            })
-                        />
+                    let core_update = core.clone();
+                    move || {
+                        let core_save_inner = core_save.clone();
+                        let core_update_inner = core_update.clone();
+                        let vm = view_model.get();
+                        let status = vm.building_setlist
+                            .as_ref()
+                            .map(|s| s.source_status.clone())
+                            .unwrap_or_default();
+                        match status {
+                            SetSourceStatus::UnmodifiedFromSource { .. } => {
+                                view! { <div></div> }.into_any()
+                            }
+                            SetSourceStatus::ModifiedFromSource { set_name, .. } => {
+                                let core_s = core_save_inner.clone();
+                                let label = format!("Update \u{201c}{set_name}\u{201d}");
+                                view! {
+                                    <div class="flex flex-col gap-2">
+                                        <Button
+                                            variant=ButtonVariant::Secondary
+                                            full_width=true
+                                            on_click=Callback::new(move |_| {
+                                                let event = Event::Set(SetEvent::UpdateSetFromBuilding);
+                                                let core_ref = core_update_inner.borrow();
+                                                let effects = core_ref.process_event(event);
+                                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                            })
+                                        >
+                                            {label}
+                                        </Button>
+                                        <SetSaveForm
+                                            sheet_open=sheet_open
+                                            on_save=Callback::new(move |name: String| {
+                                                let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
+                                                let core_ref = core_s.borrow();
+                                                let effects = core_ref.process_event(event);
+                                                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                            })
+                                        />
+                                    </div>
+                                }.into_any()
+                            }
+                            SetSourceStatus::NoSource => {
+                                view! {
+                                    <SetSaveForm
+                                        sheet_open=sheet_open
+                                        on_save=Callback::new(move |name: String| {
+                                            let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
+                                            let core_ref = core_save_inner.borrow();
+                                            let effects = core_ref.process_event(event);
+                                            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                        })
+                                    />
+                                }.into_any()
+                            }
+                        }
                     }
                 }
             </Show>

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -136,14 +136,7 @@ pub fn SetlistBuilder() -> impl IntoView {
 
     view! {
         <div class="space-y-4 pb-32">
-            // Saved Sets — visible while the setlist is empty so the user
-            // can start from a saved Set rather than picking items
-            // individually. Hides once they've added their first item to
-            // keep the library list uncluttered (merge/replace flow is
-            // out of scope here — see #390).
-            <Show when=move || setlist_empty.get()>
-                <SetLoader />
-            </Show>
+            <SetLoader />
 
             // Search bar with built-in clear button (mirrors the library
             // list's affordance — clear the query without clearing tabs).


### PR DESCRIPTION
## Summary

- Track which saved Set was loaded into the builder (`source_set_id` + entry snapshot on `BuildingSession`)
- Review sheet shows "Update <name>" + "Save as new" when entries diverge from the source set, hides the save section when unchanged, and shows "Save as Set" (existing) when built from scratch
- SetLoader no longer disappears after loading a set (removed `setlist_empty` gate) — stays visible collapsed so users can re-expand it

Closes #647 bullet 3 (save-as-set semantics).

## Changes

| File | What |
|------|------|
| `session.rs` | Added `source_set_id` + `source_set_entry_snapshot` to `BuildingSession` |
| `set.rs` | Source tracking in `LoadSetIntoSetlist`, new `UpdateSetFromBuilding` event + handler, 7 tests |
| `model.rs` | `SetSourceStatus` enum + field on `BuildingSetlistView` |
| `app.rs` | Compute `source_status` in `view()` Building arm |
| `lib.rs` | Export `SetSourceStatus` |
| `session_review_sheet.rs` | Render conditionally: Update button / Save as new / hidden |
| `setlist_builder.rs` | Remove `<Show when=setlist_empty>` gate on `<SetLoader />` |

## Test plan

- [x] `cargo test -p intrada-core` — 287 tests pass (7 new source-tracking tests)
- [x] `cargo clippy -p intrada-core -p intrada-web -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Browser: load a set → review sheet hides save section. Add/remove item → "Update X" + "Save as new" appear. Tap Update → status flips to unmodified
- [ ] Browser: build from scratch → existing "Save as Set" form shown
- [ ] E2E: existing session/set tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)