### PR TITLE
fix(ux): splash flicker, reflection card, focus width

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -325,7 +325,7 @@
           <svg style="width: 28px; height: 28px; color: #9180fa;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
           </svg>
-          <span style="font-family: 'Source Serif 4', Georgia, serif; font-size: 34px; font-weight: 700; color: #e8e6f0;">Intrada</span>
+          <span style="font-family: 'Source Serif 4', Georgia, serif; font-size: 34px; font-weight: 700; letter-spacing: -0.02em; color: #e8e6f0;">Intrada</span>
         </div>
       </div>
     </div>

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1066,7 +1066,6 @@ body {
 @utility focus-mode-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   min-height: 100vh;
   min-height: 100dvh;

--- a/crates/intrada-web/src/components/item_reflection_sheet.rs
+++ b/crates/intrada-web/src/components/item_reflection_sheet.rs
@@ -43,6 +43,12 @@ pub struct ItemReflectionTarget {
 #[component]
 pub fn ItemReflectionSheet(
     open: RwSignal<bool>,
+    /// Title of the item the user just completed (the one being reflected on).
+    #[prop(into)]
+    current_item_title: Signal<String>,
+    /// Type of the current item — drives the badge under the title.
+    #[prop(into)]
+    current_item_type: Signal<ItemKind>,
     /// Title of the next item, or `None` for the last item.
     #[prop(into)]
     next_item_title: Signal<Option<String>>,
@@ -155,29 +161,33 @@ pub fn ItemReflectionSheet(
         dispatch_advance.run(false);
     });
 
-    let header_label = move || -> &'static str {
-        if next_item_title.with(|t| t.is_some()) {
-            "Up Next"
-        } else {
-            "Last Item"
+    let current_badge_view = move || {
+        let kind = current_item_type.get();
+        let item_type = match kind {
+            ItemKind::Piece => ItemType::Piece,
+            ItemKind::Exercise => ItemType::Exercise,
+        };
+        view! {
+            <div class="mt-1">
+                <InlineTypeIndicator item_type=item_type />
+            </div>
         }
     };
 
-    let title_text = move || -> String {
-        next_item_title
-            .get()
-            .unwrap_or_else(|| "Session complete".to_string())
-    };
-
-    let badge_view = move || {
-        next_item_type.get().map(|kind| {
-            let item_type = match kind {
-                ItemKind::Piece => ItemType::Piece,
-                ItemKind::Exercise => ItemType::Exercise,
-            };
+    let up_next_view = move || {
+        next_item_title.get().map(|title| {
+            let next_type = next_item_type.get().map(|kind| {
+                let item_type = match kind {
+                    ItemKind::Piece => ItemType::Piece,
+                    ItemKind::Exercise => ItemType::Exercise,
+                };
+                view! { <InlineTypeIndicator item_type=item_type /> }
+            });
             view! {
-                <div class="mt-1">
-                    <InlineTypeIndicator item_type=item_type />
+                <div class="flex items-center gap-2 text-sm text-muted">
+                    <span class="uppercase tracking-wider text-xs">"Up next:"</span>
+                    <span class="text-secondary">{title}</span>
+                    {next_type}
                 </div>
             }
         })
@@ -191,13 +201,10 @@ pub fn ItemReflectionSheet(
                 </p>
 
                 <div class="space-y-2">
-                    <p class="text-xs uppercase tracking-wider text-muted">
-                        {header_label}
-                    </p>
                     <h3 class="text-xl font-bold text-primary font-heading">
-                        {title_text}
+                        {move || current_item_title.get()}
                     </h3>
-                    {badge_view}
+                    {current_badge_view}
                 </div>
 
                 <div class="border-t border-border-default pt-4 space-y-4">
@@ -247,6 +254,8 @@ pub fn ItemReflectionSheet(
                         />
                     </div>
                 </div>
+
+                {up_next_view}
 
                 <div class="space-y-3 pt-2">
                     <Button

--- a/crates/intrada-web/src/components/session_timer.rs
+++ b/crates/intrada-web/src/components/session_timer.rs
@@ -50,6 +50,8 @@ pub fn SessionTimer() -> impl IntoView {
     // just-completed entry's score/tempo/notes before advancing.
     let reflection_open = RwSignal::new(false);
     let reflection_target = RwSignal::new(Option::<ItemReflectionTarget>::None);
+    let reflection_current_title = RwSignal::new(String::new());
+    let reflection_current_type = RwSignal::new(ItemKind::Piece);
     let reflection_next_title = RwSignal::new(Option::<String>::None);
     let reflection_next_type = RwSignal::new(Option::<ItemKind>::None);
     let reflection_position_label = RwSignal::new(String::new());
@@ -205,7 +207,7 @@ pub fn SessionTimer() -> impl IntoView {
                                 <p class="text-xs text-muted uppercase tracking-wider">
                                     {format!("Item {} of {}", position + 1, total)}
                                 </p>
-                                <h2 class="text-3xl sm:text-4xl font-bold text-primary font-heading">{current_title}</h2>
+                                <h2 class="text-3xl sm:text-4xl font-bold text-primary font-heading">{current_title.clone()}</h2>
                                 // Entry-level intention — fades with focus mode
                                 {current_entry_intention.map(|intention| view! {
                                     <div class=entry_intention_class>
@@ -213,7 +215,7 @@ pub fn SessionTimer() -> impl IntoView {
                                     </div>
                                 })}
                                 <div class="flex justify-center">
-                                    <InlineTypeIndicator item_type=item_kind_to_type(current_type) />
+                                    <InlineTypeIndicator item_type=item_kind_to_type(current_type.clone()) />
                                 </div>
                                 // Timer: progress ring when planned duration exists,
                                 // bare digital otherwise. The digital variant uses Inter
@@ -395,6 +397,8 @@ pub fn SessionTimer() -> impl IntoView {
                                     {
                                         let entries = active.entries.clone();
                                         let next_title_for_sheet = active.next_item_title.clone();
+                                        let current_title_for_sheet = current_title.clone();
+                                        let current_type_for_sheet = current_type.clone();
                                         let on_advance_tap = move || {
                                             if let Some(entry) = entries.get(position) {
                                                 reflection_target.set(Some(ItemReflectionTarget {
@@ -404,6 +408,8 @@ pub fn SessionTimer() -> impl IntoView {
                                                     initial_notes: entry.notes.clone(),
                                                 }));
                                             }
+                                            reflection_current_title.set(current_title_for_sheet.clone());
+                                            reflection_current_type.set(current_type_for_sheet.clone());
                                             reflection_next_title.set(next_title_for_sheet.clone());
                                             reflection_next_type.set(
                                                 entries.get(position + 1).map(|e| e.item_type.clone())
@@ -499,6 +505,8 @@ pub fn SessionTimer() -> impl IntoView {
                                 view! {
                                     <ItemReflectionSheet
                                         open=reflection_open
+                                        current_item_title=Signal::derive(move || reflection_current_title.get())
+                                        current_item_type=Signal::derive(move || reflection_current_type.get())
                                         next_item_title=Signal::derive(move || reflection_next_title.get())
                                         next_item_type=Signal::derive(move || reflection_next_type.get())
                                         target=Signal::derive(move || reflection_target.get())

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -2043,6 +2043,8 @@ fn ItemReflectionSheetDemo() -> impl IntoView {
             </Button>
             <ItemReflectionSheet
                 open=open
+                current_item_title=Signal::derive(move || "Clair de Lune".to_string())
+                current_item_type=Signal::derive(move || ItemKind::Piece)
                 next_item_title=Signal::derive(move || next_title.get())
                 next_item_type=Signal::derive(move || next_type.get())
                 target=Signal::derive(move || target.get())


### PR DESCRIPTION
## Summary

- **Splash logo flicker** — added `letter-spacing: -0.02em` to the HTML splash inline style to match the `page-title` CSS class, eliminating the subtle text shift during fade-out
- **Reflection sheet shows current item** — added `current_item_title` / `current_item_type` props so the sheet displays the item being reflected on as the primary heading, with "Up next:" as a compact secondary line
- **Focus mode width** — removed `align-items: center` from `focus-mode-container` so content stretches to full container width, matching non-focus mode

## Test plan

- [ ] Launch app on iOS — verify splash fades without any text shift
- [ ] Start a multi-item session, tap Next Item — verify the reflection sheet heading shows the item just completed (not the next one)
- [ ] Verify "Up next:" line appears below the form with the next item name
- [ ] On the last item, verify no "Up next:" line appears
- [ ] Toggle focus mode during a session — verify content width stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)