### PR TITLE
feat(seo): meta tags, OG/Twitter cards, JSON-LD, robots.txt, sitemap

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -4,8 +4,53 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Intrada | Music practice with intent.</title>
+    <meta name="description" content="Plan, practise, and track your music sessions. Build setlists, run timed practice with scoring, and see your progress over time." />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://myintrada.com/" />
+    <meta property="og:title" content="Intrada | Music practice with intent." />
+    <meta property="og:description" content="Plan, practise, and track your music sessions. Build setlists, run timed practice with scoring, and see your progress over time." />
+    <meta property="og:image" content="https://myintrada.com/og-image.svg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="Intrada" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Intrada | Music practice with intent." />
+    <meta name="twitter:description" content="Plan, practise, and track your music sessions. Build setlists, run timed practice with scoring, and see your progress over time." />
+    <meta name="twitter:image" content="https://myintrada.com/og-image.svg" />
+
+    <!-- JSON-LD structured data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Intrada",
+      "url": "https://myintrada.com",
+      "applicationCategory": "MultimediaApplication",
+      "operatingSystem": "Web, iOS",
+      "description": "Plan, practise, and track your music sessions. Build setlists, run timed practice with scoring, and see your progress over time.",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      },
+      "author": {
+        "@type": "Organization",
+        "name": "Intrada",
+        "url": "https://myintrada.com"
+      }
+    }
+    </script>
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href="https://myintrada.com/" />
     <link data-trunk rel="copy-file" href="favicon.svg" />
+    <link data-trunk rel="copy-file" href="static/robots.txt" />
+    <link data-trunk rel="copy-file" href="static/sitemap.xml" />
+    <link data-trunk rel="copy-file" href="static/og-image.svg" />
 
     <!-- Release tag for Sentry. Defaults to null (PR builds, local dev) and
          is replaced by CI's deploy step with `sed` before publishing to
@@ -303,9 +348,13 @@
   </head>
   <body>
     <noscript>
-      <div style="padding: 2rem; text-align: center; font-family: system-ui, sans-serif;">
-        <h1>JavaScript Required</h1>
+      <div style="padding: 2rem; max-width: 600px; margin: 0 auto; font-family: system-ui, sans-serif; color: #e8e6f0;">
+        <h1>Intrada — Music practice with intent</h1>
+        <p>Intrada is a practice companion for musicians. Build setlists from your library of pieces and exercises, run timed practice sessions with per-item scoring, and track your progress with analytics over time. Available on web and iOS.</p>
         <p>Intrada requires JavaScript to run. Please enable JavaScript in your browser settings and reload the page.</p>
+        <nav>
+          <a href="/login" style="color: #9180fa;">Sign in</a>
+        </nav>
       </div>
     </noscript>
     <!-- Branded loading state shown before WASM mounts. Matches the

--- a/crates/intrada-web/static/og-image.svg
+++ b/crates/intrada-web/static/og-image.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#161926"/>
+      <stop offset="100%" stop-color="#0f111a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <g transform="translate(600,260)" text-anchor="middle">
+    <path d="M-14 -50 L-14 -50" fill="none" stroke="#9180fa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="d" dur="0s" fill="freeze"/>
+    </path>
+    <svg x="-22" y="-70" width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="#9180fa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z"/>
+    </svg>
+    <text y="10" font-family="Georgia, 'Times New Roman', serif" font-size="56" font-weight="700" fill="#e8e6f0">Intrada</text>
+    <text y="60" font-family="system-ui, -apple-system, sans-serif" font-size="22" fill="#8b8a9a">Music practice with intent.</text>
+  </g>
+</svg>

--- a/crates/intrada-web/static/robots.txt
+++ b/crates/intrada-web/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://myintrada.com/sitemap.xml

--- a/crates/intrada-web/static/sitemap.xml
+++ b/crates/intrada-web/static/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://myintrada.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://myintrada.com/login</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

- Meta description, OG tags, Twitter card, JSON-LD structured data in `index.html`
- Static `robots.txt` (allow all, sitemap link) and `sitemap.xml` (marketing routes)
- Branded OG image placeholder (SVG, 1200x630) — replace with Pencil export later
- Improved `<noscript>` block with h1, description paragraph, and nav link for crawlers
- Canonical URL and `og:site_name`

Closes #636.

## Test plan

- [ ] `curl -s https://myintrada.com/ | grep 'og:title'` shows OG tags after deploy
- [ ] `curl https://myintrada.com/robots.txt` returns 200 with sitemap link
- [ ] `curl https://myintrada.com/sitemap.xml` returns 200 with URL entries
- [ ] Twitter card validator shows summary_large_image
- [ ] Facebook sharing debugger shows OG preview
- [ ] View source shows JSON-LD block
- [ ] `<noscript>` block has h1 + description (visible to `curl -A Googlebot`)

## Notes

- OG image is a placeholder SVG matching the app's splash screen branding. Some social platforms don't render SVG previews — swap for a PNG export from Pencil when ready.
- Only `/` and `/login` in sitemap — no `/privacy` or `/terms` routes exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)