### PR TITLE
feat(seo): prerender marketing routes to static HTML at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,9 @@ jobs:
         with:
           node-version: 20
       - name: Install prerender dependencies
-        run: npx playwright install chromium --with-deps
+        run: |
+          npm install playwright serve
+          npx playwright install chromium --with-deps
       - name: Prerender marketing routes
         run: node scripts/prerender.mjs crates/intrada-web/dist
       - name: Upload dist artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,14 +395,18 @@ jobs:
         with:
           name: web-dist
           path: crates/intrada-web/dist
-      - name: List prerendered files (diagnostics)
+      - name: Diagnose prerendered file contents
         run: |
-          echo "Top-level dist:"
-          ls -la crates/intrada-web/dist/
-          echo "Prerendered:"
-          ls -la crates/intrada-web/dist/prerendered/ || echo "MISSING: prerendered/ directory"
-          echo "Login file size:"
-          wc -c crates/intrada-web/dist/prerendered/login.html || true
+          echo "=== Files ==="
+          ls -la crates/intrada-web/dist/prerendered/
+          echo "=== /login content check ==="
+          grep -c "Sign in to continue" crates/intrada-web/dist/prerendered/login.html || echo "NO MATCH for 'Sign in to continue'"
+          grep -c "Welcome" crates/intrada-web/dist/prerendered/login.html || echo "NO MATCH for 'Welcome'"
+          grep -c "<body" crates/intrada-web/dist/prerendered/login.html || echo "NO BODY TAG"
+          echo "=== / content check ==="
+          grep -c "Practice with intent" crates/intrada-web/dist/prerendered/index.html || echo "NO MATCH for 'Practice with intent'"
+          echo "=== login.html body excerpt ==="
+          sed -n '/<body/,/<\/body>/p' crates/intrada-web/dist/prerendered/login.html | head -50
       # Sentry-cli `sourcemaps inject` doesn't need a token (only the
       # `upload` subcommand does), so this runs unconditionally. The
       # WHOLE point of the smoke job is to fire the chain that broke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,16 @@ jobs:
           INTRADA_API_URL: https://intrada-api.fly.dev
           CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
         run: trunk build --release
+      # Prerender marketing routes (/, /login) so crawlers see real
+      # HTML content. Runs headless Chromium via Playwright against
+      # the just-built dist/, writes to dist/prerendered/.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - name: Install prerender dependencies
+        run: npx playwright install chromium --with-deps
+      - name: Prerender marketing routes
+        run: node scripts/prerender.mjs crates/intrada-web/dist
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,14 @@ jobs:
         with:
           name: web-dist
           path: crates/intrada-web/dist
+      - name: List prerendered files (diagnostics)
+        run: |
+          echo "Top-level dist:"
+          ls -la crates/intrada-web/dist/
+          echo "Prerendered:"
+          ls -la crates/intrada-web/dist/prerendered/ || echo "MISSING: prerendered/ directory"
+          echo "Login file size:"
+          wc -c crates/intrada-web/dist/prerendered/login.html || true
       # Sentry-cli `sourcemaps inject` doesn't need a token (only the
       # `upload` subcommand does), so this runs unconditionally. The
       # WHOLE point of the smoke job is to fire the chain that broke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,18 +395,6 @@ jobs:
         with:
           name: web-dist
           path: crates/intrada-web/dist
-      - name: Diagnose prerendered file contents
-        run: |
-          echo "=== Files ==="
-          ls -la crates/intrada-web/dist/prerendered/
-          echo "=== /login content check ==="
-          grep -c "Sign in to continue" crates/intrada-web/dist/prerendered/login.html || echo "NO MATCH for 'Sign in to continue'"
-          grep -c "Welcome" crates/intrada-web/dist/prerendered/login.html || echo "NO MATCH for 'Welcome'"
-          grep -c "<body" crates/intrada-web/dist/prerendered/login.html || echo "NO BODY TAG"
-          echo "=== / content check ==="
-          grep -c "Practice with intent" crates/intrada-web/dist/prerendered/index.html || echo "NO MATCH for 'Practice with intent'"
-          echo "=== login.html body excerpt ==="
-          sed -n '/<body/,/<\/body>/p' crates/intrada-web/dist/prerendered/login.html | head -50
       # Sentry-cli `sourcemaps inject` doesn't need a token (only the
       # `upload` subcommand does), so this runs unconditionally. The
       # WHOLE point of the smoke job is to fire the chain that broke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
       # commit hash in dist/index.html, confusing post-merge triage.
       - name: Inject Sentry release placeholder (smoke)
         run: |
-          sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|pr-smoke|g" crates/intrada-web/dist/index.html
+          find crates/intrada-web/dist -name '*.html' -exec sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|pr-smoke|g" {} +
           grep -q "pr-smoke" crates/intrada-web/dist/index.html
       - name: Refresh SRI integrity hashes after inject
         run: python3 scripts/refresh-sri-hashes.py
@@ -530,9 +530,9 @@ jobs:
       # Inject the release id into the prebuilt index.html before publishing.
       # The placeholder is set in the source — this swap only happens in the
       # main-branch deploy path, so PR builds keep `release: undefined`.
-      - name: Inject Sentry release into index.html
+      - name: Inject Sentry release into HTML files
         run: |
-          sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|${{ github.sha }}|g" crates/intrada-web/dist/index.html
+          find crates/intrada-web/dist -name '*.html' -exec sed -i "s|__SENTRY_RELEASE_PLACEHOLDER__|${{ github.sha }}|g" {} +
           grep -q "${{ github.sha }}" crates/intrada-web/dist/index.html
       # Recompute SHA-384 integrity hashes — `sentry-cli sourcemaps
       # inject` modifies JS files in place, leaving the SRI attributes

--- a/e2e/tests/deploy-smoke.spec.ts
+++ b/e2e/tests/deploy-smoke.spec.ts
@@ -93,7 +93,7 @@ test("smoke: prerendered homepage contains marketing content", async ({
   expect(response!.status()).toBe(200);
 
   const html = await response!.text();
-  expect(html).toContain("Music practice with intent");
+  expect(html).toContain("Practice with intent");
   expect(html).toContain("<h1");
 });
 
@@ -105,5 +105,5 @@ test("smoke: prerendered login page contains sign-in content", async ({
   expect(response!.status()).toBe(200);
 
   const html = await response!.text();
-  expect(html).toContain("Sign in");
+  expect(html).toContain("Sign in to continue");
 });

--- a/e2e/tests/deploy-smoke.spec.ts
+++ b/e2e/tests/deploy-smoke.spec.ts
@@ -88,11 +88,14 @@ test("smoke: post-modification dist renders without runtime-blocking console err
 test("smoke: prerendered homepage contains marketing content", async ({
   page,
 }) => {
-  const response = await page.goto("/prerendered/index.html");
-  expect(response).not.toBeNull();
-  expect(response!.status()).toBe(200);
+  // Use page.request.get() instead of page.goto() to fetch the raw
+  // file without triggering page navigation / WASM mount. This
+  // returns exactly what serve sent on the wire.
+  const response = await page.request.get("/prerendered/index.html");
+  expect(response.status()).toBe(200);
 
-  const html = await response!.text();
+  const html = await response.text();
+  console.log(`prerendered/index.html: ${html.length} bytes`);
   expect(html).toContain("Practice with intent");
   expect(html).toContain("<h1");
 });
@@ -100,10 +103,10 @@ test("smoke: prerendered homepage contains marketing content", async ({
 test("smoke: prerendered login page contains sign-in content", async ({
   page,
 }) => {
-  const response = await page.goto("/prerendered/login.html");
-  expect(response).not.toBeNull();
-  expect(response!.status()).toBe(200);
+  const response = await page.request.get("/prerendered/login.html");
+  expect(response.status()).toBe(200);
 
-  const html = await response!.text();
+  const html = await response.text();
+  console.log(`prerendered/login.html: ${html.length} bytes`);
   expect(html).toContain("Sign in to continue");
 });

--- a/e2e/tests/deploy-smoke.spec.ts
+++ b/e2e/tests/deploy-smoke.spec.ts
@@ -14,6 +14,20 @@
 // `--grep "smoke:"`.
 
 import { test, expect } from "../fixtures/api-mock";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// Read prerendered files directly from disk rather than via the test
+// HTTP server. `npx serve` defaults to `cleanUrls: true` which strips
+// the `.html` extension and 301-redirects, breaking direct file serving
+// for `/prerendered/foo.html`. Production serves these via worker.js +
+// Cloudflare Workers Assets (exact-path lookup, no clean-URL stripping),
+// so the relevant invariant is "does the file on disk have the right
+// content after the post-build modification chain" — exactly what
+// fs.readFileSync verifies.
+const DIST_DIR =
+  process.env.DIST_DIR ||
+  path.resolve(__dirname, "../../crates/intrada-web/dist");
 
 test("smoke: post-modification dist renders without runtime-blocking console errors", async ({
   page,
@@ -81,32 +95,19 @@ test("smoke: post-modification dist renders without runtime-blocking console err
 });
 
 // Prerendered HTML check — verifies the build-time prerender step
-// produced files that contain real marketing content. In production
-// worker.js serves these for marketing routes; here we load the
-// prerendered file directly to confirm it has the expected content
-// before WASM even loads.
-test("smoke: prerendered homepage contains marketing content", async ({
-  page,
-}) => {
-  // Use page.request.get() instead of page.goto() to fetch the raw
-  // file without triggering page navigation / WASM mount. This
-  // returns exactly what serve sent on the wire.
-  const response = await page.request.get("/prerendered/index.html");
-  expect(response.status()).toBe(200);
-
-  const html = await response.text();
+// produced files containing real marketing content, and that the
+// post-build chain (sentry inject → sed → SRI refresh) preserved it.
+test("smoke: prerendered homepage contains marketing content", () => {
+  const filePath = path.join(DIST_DIR, "prerendered", "index.html");
+  const html = fs.readFileSync(filePath, "utf-8");
   console.log(`prerendered/index.html: ${html.length} bytes`);
   expect(html).toContain("Practice with intent");
   expect(html).toContain("<h1");
 });
 
-test("smoke: prerendered login page contains sign-in content", async ({
-  page,
-}) => {
-  const response = await page.request.get("/prerendered/login.html");
-  expect(response.status()).toBe(200);
-
-  const html = await response.text();
+test("smoke: prerendered login page contains sign-in content", () => {
+  const filePath = path.join(DIST_DIR, "prerendered", "login.html");
+  const html = fs.readFileSync(filePath, "utf-8");
   console.log(`prerendered/login.html: ${html.length} bytes`);
   expect(html).toContain("Sign in to continue");
 });

--- a/e2e/tests/deploy-smoke.spec.ts
+++ b/e2e/tests/deploy-smoke.spec.ts
@@ -79,3 +79,31 @@ test("smoke: post-modification dist renders without runtime-blocking console err
       blocking.map((e) => `  ${e}`).join("\n"),
   ).toEqual([]);
 });
+
+// Prerendered HTML check — verifies the build-time prerender step
+// produced files that contain real marketing content. In production
+// worker.js serves these for marketing routes; here we load the
+// prerendered file directly to confirm it has the expected content
+// before WASM even loads.
+test("smoke: prerendered homepage contains marketing content", async ({
+  page,
+}) => {
+  const response = await page.goto("/prerendered/index.html");
+  expect(response).not.toBeNull();
+  expect(response!.status()).toBe(200);
+
+  const html = await response!.text();
+  expect(html).toContain("Music practice with intent");
+  expect(html).toContain("<h1");
+});
+
+test("smoke: prerendered login page contains sign-in content", async ({
+  page,
+}) => {
+  const response = await page.goto("/prerendered/login.html");
+  expect(response).not.toBeNull();
+  expect(response!.status()).toBe(200);
+
+  const html = await response!.text();
+  expect(html).toContain("Sign in");
+});

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -20,7 +20,7 @@ import { join, resolve } from "node:path";
 import { createConnection } from "node:net";
 
 const DEFAULT_DIST = "crates/intrada-web/dist";
-const PORT = 9222;
+const PORT = 9333;
 const TIMEOUT_MS = 30_000;
 
 const ROUTES = [

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -10,8 +10,8 @@
 // Usage:
 //   node scripts/prerender.mjs [DIST_DIR]
 //
-// Defaults to crates/intrada-web/dist. Requires Playwright browsers
-// installed (`npx playwright install chromium`).
+// Defaults to crates/intrada-web/dist. Requires `playwright` and `serve`
+// npm packages plus Playwright browsers (`npx playwright install chromium`).
 
 import { chromium } from "playwright";
 import { spawn } from "node:child_process";

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Build-time prerender for marketing routes.
+//
+// Launches headless Chromium against the Trunk-built dist/, waits for
+// WASM to render each marketing route, and writes the captured HTML to
+// dist/prerendered/. The Cloudflare Worker serves these files for the
+// matching paths so crawlers (and all users) see real content on first
+// fetch. WASM loads on top and takes over interactively.
+//
+// Usage:
+//   node scripts/prerender.mjs [DIST_DIR]
+//
+// Defaults to crates/intrada-web/dist. Requires Playwright browsers
+// installed (`npx playwright install chromium`).
+
+import { chromium } from "playwright";
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { createConnection } from "node:net";
+
+const DEFAULT_DIST = "crates/intrada-web/dist";
+const PORT = 9222;
+const TIMEOUT_MS = 30_000;
+
+const ROUTES = [
+  { path: "/", output: "index.html", waitFor: "Music practice with intent" },
+  { path: "/login", output: "login.html", waitFor: "Sign in" },
+];
+
+const distDir = resolve(process.argv[2] || DEFAULT_DIST);
+
+async function waitForPort(port, timeoutMs = 10_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const open = await new Promise((res) => {
+      const sock = createConnection({ port, host: "127.0.0.1" }, () => {
+        sock.destroy();
+        res(true);
+      });
+      sock.on("error", () => res(false));
+    });
+    if (open) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Port ${port} not ready within ${timeoutMs}ms`);
+}
+
+async function main() {
+  console.log(`prerender: dist=${distDir}, routes=${ROUTES.length}`);
+
+  // Start a local static server with SPA fallback (--single).
+  const server = spawn("npx", ["serve", distDir, "-l", String(PORT), "--single"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+  server.stderr.on("data", (d) => {
+    const msg = d.toString().trim();
+    if (msg) console.error(`  serve: ${msg}`);
+  });
+
+  try {
+    await waitForPort(PORT);
+    console.log(`prerender: server ready on port ${PORT}`);
+
+    const outDir = join(distDir, "prerendered");
+    await mkdir(outDir, { recursive: true });
+
+    const browser = await chromium.launch();
+    try {
+      for (const route of ROUTES) {
+        const page = await browser.newPage();
+        const url = `http://127.0.0.1:${PORT}${route.path}`;
+        console.log(`prerender: ${route.path} → ${route.output}`);
+
+        await page.goto(url, { waitUntil: "networkidle" });
+
+        // Wait for the WASM app to render the expected content.
+        await page.waitForFunction(
+          (text) => document.body?.innerText?.includes(text),
+          route.waitFor,
+          { timeout: TIMEOUT_MS },
+        );
+
+        const html = await page.content();
+        const outPath = join(outDir, route.output);
+        await writeFile(outPath, html, "utf-8");
+        console.log(`prerender: wrote ${outPath} (${html.length} bytes)`);
+        await page.close();
+      }
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    server.kill("SIGTERM");
+  }
+
+  console.log("prerender: done");
+}
+
+main().catch((err) => {
+  console.error("prerender: FAILED", err);
+  process.exit(1);
+});

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -144,7 +144,9 @@ async function main() {
   console.log("prerender: done");
 }
 
-main().catch((err) => {
-  console.error("prerender: FAILED", err);
-  process.exit(1);
-});
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("prerender: FAILED", err);
+    process.exit(1);
+  });

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -23,9 +23,12 @@ const DEFAULT_DIST = "crates/intrada-web/dist";
 const PORT = 9333;
 const TIMEOUT_MS = 30_000;
 
+// `waitFor` strings must match text actually rendered by the WASM
+// (not meta tags / OG descriptions). Source: views/welcome.rs h1 and
+// views/login.rs h1 + subtitle.
 const ROUTES = [
-  { path: "/", output: "index.html", waitFor: "Music practice with intent" },
-  { path: "/login", output: "login.html", waitFor: "Sign in" },
+  { path: "/", output: "index.html", waitFor: "Practice with intent" },
+  { path: "/login", output: "login.html", waitFor: "Sign in to continue" },
 ];
 
 const distDir = resolve(process.argv[2] || DEFAULT_DIST);
@@ -92,17 +95,38 @@ async function main() {
           window.Clerk = class { async load() {} };
         });
 
+        // Capture console errors for diagnostics on timeout.
+        const consoleErrors = [];
+        page.on("console", (msg) => {
+          if (msg.type() === "error") consoleErrors.push(msg.text());
+        });
+        page.on("pageerror", (err) => consoleErrors.push(`pageerror: ${err.message}`));
+
         const url = `http://127.0.0.1:${PORT}${route.path}`;
         console.log(`prerender: ${route.path} → ${route.output}`);
 
         await page.goto(url, { waitUntil: "networkidle" });
 
         // Wait for the WASM app to render the expected content.
-        await page.waitForFunction(
-          (text) => document.body?.innerText?.includes(text),
-          route.waitFor,
-          { timeout: TIMEOUT_MS },
-        );
+        try {
+          await page.waitForFunction(
+            (text) => document.body?.innerText?.includes(text),
+            route.waitFor,
+            { timeout: TIMEOUT_MS },
+          );
+        } catch (err) {
+          const bodyText = await page
+            .evaluate(() => (document.body?.innerText || "").slice(0, 500))
+            .catch(() => "<could not read body>");
+          console.error(
+            `prerender: timeout waiting for "${route.waitFor}" on ${route.path}`,
+          );
+          console.error(`  body.innerText (first 500 chars): ${bodyText}`);
+          if (consoleErrors.length) {
+            console.error(`  console errors:\n    ${consoleErrors.join("\n    ")}`);
+          }
+          throw err;
+        }
 
         const html = await page.content();
         const outPath = join(outDir, route.output);

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -70,6 +70,28 @@ async function main() {
     try {
       for (const route of ROUTES) {
         const page = await browser.newPage();
+
+        // Block the Clerk CDN script and stub window.__intrada_auth
+        // as an unauthenticated user so the WASM app renders marketing
+        // content without waiting for the real Clerk SDK.
+        await page.route("**/cdn.jsdelivr.net/npm/@clerk/**", (r) =>
+          r.fulfill({ status: 200, contentType: "application/javascript", body: "// blocked" }),
+        );
+        await page.addInitScript(() => {
+          window.__intrada_auth = {
+            _clerk: null,
+            _ready: true,
+            init() {},
+            isSignedIn() { return false; },
+            async getToken() { return null; },
+            getUserId() { return null; },
+            async signOut() {},
+            async signInWithGoogle() {},
+            addListener() {},
+          };
+          window.Clerk = class { async load() {} };
+        });
+
         const url = `http://127.0.0.1:${PORT}${route.path}`;
         console.log(`prerender: ${route.path} → ${route.output}`);
 

--- a/scripts/refresh-sri-hashes.py
+++ b/scripts/refresh-sri-hashes.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Recompute SHA-384 integrity hashes in dist/index.html.
+"""Recompute SHA-384 integrity hashes in all HTML files under dist/.
 
 Walks every `<link>/<script integrity="sha384-…">` tag, computes the
 SHA-384 of the file the tag references, and rewrites the attribute.
 Files whose contents weren't touched recompute to the same value
 (no-op).
+
+Scans index.html and any prerendered HTML files (dist/prerendered/*.html)
+so that SRI hashes stay valid after sentry-cli inject modifies JS files.
 
 Why this exists
 ───────────────
@@ -44,14 +47,9 @@ TAG_RE = re.compile(
 SRC_RE = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.IGNORECASE)
 
 
-def main() -> int:
-    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
-    index = dist / "index.html"
-    if not index.is_file():
-        print(f"refresh-sri-hashes: {index} not found", file=sys.stderr)
-        return 1
-
-    html = index.read_text()
+def refresh_file(html_path: pathlib.Path, dist: pathlib.Path) -> tuple[int, bool]:
+    """Refresh SRI hashes in a single HTML file. Returns (count, changed)."""
+    html = html_path.read_text()
 
     def patch(match: re.Match[str]) -> str:
         tag = match.group(0)
@@ -70,11 +68,43 @@ def main() -> int:
         )
 
     new_html, count = TAG_RE.subn(patch, html)
-    if new_html != html:
-        index.write_text(new_html)
-        print(f"refresh-sri-hashes: refreshed {count} integrity hashes")
+    changed = new_html != html
+    if changed:
+        html_path.write_text(new_html)
+    return count, changed
+
+
+def main() -> int:
+    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
+    index = dist / "index.html"
+    if not index.is_file():
+        print(f"refresh-sri-hashes: {index} not found", file=sys.stderr)
+        return 1
+
+    html_files = [index] + sorted(
+        f for f in dist.rglob("*.html") if f != index
+    )
+
+    total_count = 0
+    total_changed = 0
+    for html_path in html_files:
+        count, changed = refresh_file(html_path, dist)
+        total_count += count
+        if changed:
+            total_changed += 1
+            rel = html_path.relative_to(dist)
+            print(f"refresh-sri-hashes: refreshed {count} hashes in {rel}")
+
+    if total_changed == 0:
+        print(
+            f"refresh-sri-hashes: all {total_count} integrity hashes already "
+            f"match across {len(html_files)} file(s)"
+        )
     else:
-        print(f"refresh-sri-hashes: all {count} integrity hashes already match")
+        print(
+            f"refresh-sri-hashes: refreshed {total_count} hashes across "
+            f"{total_changed}/{len(html_files)} file(s)"
+        )
     return 0
 
 

--- a/scripts/verify-sri-hashes.py
+++ b/scripts/verify-sri-hashes.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Assert every SRI hash in dist/index.html matches the on-disk file.
+"""Assert every SRI hash in all HTML files under dist/ matches on-disk files.
 
 Walks every `<link>/<script integrity="sha384-…">` tag, recomputes
 SHA-384 from the file the tag references, and exits 1 with a pointed
 error message if any mismatch is found. Pure check — never modifies
 files.
+
+Scans index.html and any prerendered HTML files (dist/prerendered/*.html)
+so that SRI mismatches in prerendered pages are caught before deploy.
 
 Why this exists
 ───────────────
@@ -42,16 +45,14 @@ TAG_RE = re.compile(
 SRC_RE = re.compile(r'(?:href|src)="(/?[^"#?]+)"', re.IGNORECASE)
 
 
-def main() -> int:
-    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
-    index = dist / "index.html"
-    if not index.is_file():
-        print(f"verify-sri-hashes: {index} not found", file=sys.stderr)
-        return 1
-
-    html = index.read_text()
+def verify_file(
+    html_path: pathlib.Path, dist: pathlib.Path
+) -> tuple[int, list[str]]:
+    """Verify SRI hashes in a single HTML file. Returns (checked, mismatches)."""
+    html = html_path.read_text()
     mismatches: list[str] = []
     checked = 0
+    rel_name = html_path.relative_to(dist)
     for match in TAG_RE.finditer(html):
         declared = match.group(1)
         src = SRC_RE.search(match.group(0))
@@ -60,19 +61,43 @@ def main() -> int:
         rel = src.group(1).lstrip("/")
         file = dist / rel
         if not file.is_file():
-            mismatches.append(f"  {src.group(1)}: referenced but not on disk")
+            mismatches.append(
+                f"  {rel_name}: {src.group(1)}: referenced but not on disk"
+            )
             continue
-        actual = base64.b64encode(hashlib.sha384(file.read_bytes()).digest()).decode()
+        actual = base64.b64encode(
+            hashlib.sha384(file.read_bytes()).digest()
+        ).decode()
         if declared != actual:
             mismatches.append(
-                f"  {src.group(1)}: declared sha384-{declared[:12]}…, "
+                f"  {rel_name}: {src.group(1)}: declared sha384-{declared[:12]}…, "
                 f"actual sha384-{actual[:12]}…"
             )
         checked += 1
+    return checked, mismatches
 
-    if mismatches:
+
+def main() -> int:
+    dist = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_DIST)
+    index = dist / "index.html"
+    if not index.is_file():
+        print(f"verify-sri-hashes: {index} not found", file=sys.stderr)
+        return 1
+
+    html_files = [index] + sorted(
+        f for f in dist.rglob("*.html") if f != index
+    )
+
+    total_checked = 0
+    all_mismatches: list[str] = []
+    for html_path in html_files:
+        checked, mismatches = verify_file(html_path, dist)
+        total_checked += checked
+        all_mismatches.extend(mismatches)
+
+    if all_mismatches:
         print("verify-sri-hashes: SRI integrity mismatch — would ship a blank page:")
-        for line in mismatches:
+        for line in all_mismatches:
             print(line)
         print(
             "\nLikely cause: a step modified dist/ between the refresh-sri-hashes "
@@ -81,7 +106,10 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    print(f"verify-sri-hashes: {checked} integrity hashes match on-disk files")
+    print(
+        f"verify-sri-hashes: {total_checked} integrity hashes match on-disk "
+        f"files across {len(html_files)} file(s)"
+    )
     return 0
 
 

--- a/specs/seo-prerender.md
+++ b/specs/seo-prerender.md
@@ -46,21 +46,19 @@ the visual transition is seamless.
 
 ### Worker.js routing
 
-Currently, `wrangler.toml` uses `not_found_handling = "single-page-application"`
-which serves `index.html` for all unmatched paths. After prerendering,
-`index.html` contains the WelcomeView HTML — we don't want `/library` to show
-marketing content while WASM loads.
+Prerendered HTML lives in `dist/prerendered/` (not overwriting `index.html`).
+`wrangler.toml` keeps `not_found_handling = "single-page-application"` — the
+SPA shell (`index.html`) is still the fallback for all app routes. Worker.js
+intercepts marketing routes and serves from `dist/prerendered/` before the
+SPA fallback triggers:
 
-Change: remove `not_found_handling` from wrangler.toml and route in worker.js:
-
+```javascript
+const PRERENDERED = { "/": "/prerendered/index.html", "/login": "/prerendered/login.html" };
+// ... in fetch handler: lookup normalizedPath in PRERENDERED, serve via env.ASSETS.fetch()
 ```
-if path matches a file in dist → serve it (assets, prerendered HTML)
-else → serve dist/_app.html (SPA shell)
-```
 
-This uses `env.ASSETS.fetch()` for file matches (Cloudflare handles this
-natively) and falls back to fetching `_app.html` explicitly. The sentry-tunnel
-intercept stays as-is.
+This avoids the `_app.html` rename approach from the original design — simpler,
+and no changes to `wrangler.toml` are needed.
 
 ### Auth during prerender
 
@@ -111,33 +109,16 @@ regardless.
 pipeline. Using it for prerender avoids adding a new tool and guarantees the
 snapshot matches what a real browser renders.
 
-## Open questions
-
-1. **Clerk publishable key in prerender** — the prerender runs the full WASM
-   app, which reads `CLERK_PUBLISHABLE_KEY` at compile time. CI already sets
-   this for `trunk build`. Should work, but need to verify Clerk doesn't
-   block rendering on init failure in headless mode.
-
-2. **`_app.html` and Cloudflare assets** — need to verify that
-   `env.ASSETS.fetch(new Request(url.origin + '/_app.html'))` works for
-   serving the SPA shell from worker.js. Alternative: use a KV lookup or
-   `env.ASSETS.fetch()` with path rewrite.
-
-3. **Prerender timing** — how long to wait for WASM to fully render? The
-   deploy-smoke test uses 20s timeout with polling. Prerender can use the
-   same approach but may need route-specific content assertions (e.g., wait
-   for "Music practice with intent" on `/`).
-
 ## Files changed
 
 | File | Change |
 |------|--------|
 | `scripts/prerender.mjs` | New — Playwright prerender script |
-| `worker.js` | Route non-asset requests to `_app.html` instead of relying on wrangler SPA fallback |
-| `wrangler.toml` | Remove `not_found_handling` |
-| `.github/workflows/ci.yml` | Add prerender step after trunk build |
-| `e2e/tests/deploy-smoke.spec.ts` | Assert prerendered `/` contains hero text |
-| `crates/intrada-web/static/sitemap.xml` | Add `/login` if not already present |
+| `worker.js` | Intercept marketing routes, serve from `dist/prerendered/` |
+| `scripts/refresh-sri-hashes.py` | Scan all HTML files in dist/ (not just index.html) |
+| `scripts/verify-sri-hashes.py` | Same — scan all HTML files |
+| `.github/workflows/ci.yml` | Add prerender step + widen sed placeholder injection to all HTML |
+| `e2e/tests/deploy-smoke.spec.ts` | Assert prerendered `/` and `/login` contain expected content |
 
 ## Acceptance
 

--- a/specs/seo-prerender.md
+++ b/specs/seo-prerender.md
@@ -1,0 +1,149 @@
+# SEO: Prerender Marketing Routes (#637)
+
+## Problem
+
+After #636 (meta tags), crawlers see `<meta>` and `<noscript>` content but
+the `<body>` is effectively empty — the marketing homepage's hero, pillars,
+features, and CTAs only exist after WASM mounts. Google will crawl JS-rendered
+pages eventually, but rankings and previews suffer. The fix is to ship
+prerendered HTML so crawlers see real content on first fetch.
+
+## Routes to prerender
+
+| Route    | View          | Notes |
+|----------|---------------|-------|
+| `/`      | WelcomeView   | Full marketing page — hero, pillars, features, CTA |
+| `/login` | LoginView     | Sign-in card with brand |
+
+Future routes (`/privacy`, `/terms`, `/about`, `/pricing`) join the list when
+they exist. The script is route-list-driven — adding a new one is a one-line
+change.
+
+## Approach
+
+### Build-time prerender with Playwright
+
+A Node.js script (`scripts/prerender.mjs`) runs **after** `trunk build` and
+**before** the Sentry inject / SRI refresh / wrangler publish chain in CI.
+
+Steps:
+1. Copy `dist/index.html` → `dist/_app.html` (SPA shell, kept for non-marketing routes)
+2. Start a local HTTP server on `dist/` with SPA fallback to `_app.html`
+3. For each marketing route:
+   a. Open headless Chromium via Playwright
+   b. Navigate to the route
+   c. Wait for substantial body content (same heuristic as deploy-smoke: `body.innerText.length > 100`)
+   d. Capture `document.documentElement.outerHTML`
+   e. Write to the correct path in dist:
+      - `/` → `dist/index.html`
+      - `/login` → `dist/login/index.html`
+4. Shut down the server
+
+The prerendered HTML includes all `<script>` and `<link>` tags from the
+original shell — WASM still loads and Leptos takes over the DOM. Since the
+prerendered content matches what CSR produces for an unauthenticated user,
+the visual transition is seamless.
+
+### Worker.js routing
+
+Currently, `wrangler.toml` uses `not_found_handling = "single-page-application"`
+which serves `index.html` for all unmatched paths. After prerendering,
+`index.html` contains the WelcomeView HTML — we don't want `/library` to show
+marketing content while WASM loads.
+
+Change: remove `not_found_handling` from wrangler.toml and route in worker.js:
+
+```
+if path matches a file in dist → serve it (assets, prerendered HTML)
+else → serve dist/_app.html (SPA shell)
+```
+
+This uses `env.ASSETS.fetch()` for file matches (Cloudflare handles this
+natively) and falls back to fetching `_app.html` explicitly. The sentry-tunnel
+intercept stays as-is.
+
+### Auth during prerender
+
+`WelcomeView` calls `expect_context::<AuthState>()`. During prerender in
+headless Chrome:
+- Clerk init fires but has no valid session → `auth_loading` eventually
+  resolves to false, `is_authenticated` stays false
+- The marketing content renders immediately (before auth resolves)
+- The redirect `Effect` never fires (user isn't authenticated)
+- Snapshot is captured after marketing content appears but before any
+  potential timeout/error states
+
+This is proven to work — `deploy-smoke.spec.ts` already loads the WASM app
+in headless Chromium and asserts body content > 100 chars.
+
+`LoginView` similarly renders its sign-in card for unauthenticated users.
+
+### CI pipeline integration
+
+Current: `trunk build` → artifact → sentry inject → SRI refresh → deploy
+
+New: `trunk build` → **prerender** → artifact → sentry inject → SRI refresh → deploy
+
+The prerender step runs in the `wasm-build` job (or a new job after it) and
+the prerendered HTML is included in the `web-dist` artifact. This means:
+- deploy-smoke tests exercise the prerendered dist
+- E2E tests run against the prerendered dist
+- The sentry inject step modifies JS files (not HTML body content), so SRI
+  recompute still works
+
+## Key decisions
+
+**CSR re-render, not hydration.** True Leptos hydration requires SSR mode
+(server-side rendering), which is a fundamentally different architecture.
+CSR re-render means the WASM replaces the prerendered DOM when it loads —
+since content matches, there's no visible flash. The tradeoff: a brief moment
+where interactive elements (buttons, links) are visible but inert. For
+marketing pages this is acceptable — the CTA just needs to work within a few
+seconds of page load, and the prerendered content provides immediate visual
+feedback.
+
+**Universal prerender, not bot-only.** All users see prerendered HTML, not
+just crawlers. Benefits: faster first paint for everyone, no user-agent
+sniffing (which is fragile and borderline cloaking). The WASM loads on top
+regardless.
+
+**Playwright, not a custom renderer.** We already have Playwright in the E2E
+pipeline. Using it for prerender avoids adding a new tool and guarantees the
+snapshot matches what a real browser renders.
+
+## Open questions
+
+1. **Clerk publishable key in prerender** — the prerender runs the full WASM
+   app, which reads `CLERK_PUBLISHABLE_KEY` at compile time. CI already sets
+   this for `trunk build`. Should work, but need to verify Clerk doesn't
+   block rendering on init failure in headless mode.
+
+2. **`_app.html` and Cloudflare assets** — need to verify that
+   `env.ASSETS.fetch(new Request(url.origin + '/_app.html'))` works for
+   serving the SPA shell from worker.js. Alternative: use a KV lookup or
+   `env.ASSETS.fetch()` with path rewrite.
+
+3. **Prerender timing** — how long to wait for WASM to fully render? The
+   deploy-smoke test uses 20s timeout with polling. Prerender can use the
+   same approach but may need route-specific content assertions (e.g., wait
+   for "Music practice with intent" on `/`).
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `scripts/prerender.mjs` | New — Playwright prerender script |
+| `worker.js` | Route non-asset requests to `_app.html` instead of relying on wrangler SPA fallback |
+| `wrangler.toml` | Remove `not_found_handling` |
+| `.github/workflows/ci.yml` | Add prerender step after trunk build |
+| `e2e/tests/deploy-smoke.spec.ts` | Assert prerendered `/` contains hero text |
+| `crates/intrada-web/static/sitemap.xml` | Add `/login` if not already present |
+
+## Acceptance
+
+- `curl https://myintrada.com/` returns HTML with hero copy, h1, CTAs visible in body
+- `curl https://myintrada.com/login` returns HTML with sign-in card content
+- Lighthouse SEO score > 90 on marketing routes
+- SPA routing still works for authenticated users (no regression)
+- E2E smoke test asserts prerendered `/` contains expected hero text
+- `cargo test` + `cargo clippy` still pass (no Rust changes expected)

--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,11 @@
 // Cloudflare Worker entry. Default behaviour: serve the Trunk-built
-// dist/ via the [assets] binding (configured in wrangler.toml). One
-// route is intercepted before that fallback: `/sentry-tunnel`.
+// dist/ via the [assets] binding (configured in wrangler.toml). Two
+// concerns are handled before that fallback:
+//
+// 1. `/sentry-tunnel` — forwards Sentry envelopes through our origin.
+// 2. Prerendered marketing routes — `/`, `/login` are served from
+//    `dist/prerendered/` so crawlers (and all users) get real HTML on
+//    first fetch. WASM loads on top and takes over interactively.
 //
 // ## Why /sentry-tunnel exists
 //
@@ -50,12 +55,32 @@ const MAX_ENVELOPE_BYTES = 1_000_000;
 // trust on attacker-controlled input.
 const SENTRY_CONTENT_TYPE = "application/x-sentry-envelope";
 
+// Marketing routes prerendered at build time. Map from public path to
+// the asset path inside dist/prerendered/. Adding a new marketing page
+// is a one-line change here + a matching entry in scripts/prerender.mjs.
+const PRERENDERED = {
+  "/": "/prerendered/index.html",
+  "/login": "/prerendered/login.html",
+};
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     if (url.pathname === "/sentry-tunnel") {
       return tunnelToSentry(request);
     }
+
+    // Serve prerendered HTML for marketing routes so crawlers see real
+    // content without waiting for WASM. The SPA shell (index.html) is
+    // still the fallback for all app routes via wrangler.toml's
+    // not_found_handling = "single-page-application".
+    const prerendered = PRERENDERED[url.pathname];
+    if (prerendered) {
+      const prerenderUrl = new URL(request.url);
+      prerenderUrl.pathname = prerendered;
+      return env.ASSETS.fetch(new Request(prerenderUrl, request));
+    }
+
     return env.ASSETS.fetch(request);
   },
 };

--- a/worker.js
+++ b/worker.js
@@ -74,7 +74,9 @@ export default {
     // content without waiting for WASM. The SPA shell (index.html) is
     // still the fallback for all app routes via wrangler.toml's
     // not_found_handling = "single-page-application".
-    const prerendered = PRERENDERED[url.pathname];
+    const normalizedPath =
+      url.pathname === "/" ? "/" : url.pathname.replace(/\/+$/, "");
+    const prerendered = PRERENDERED[normalizedPath];
     if (prerendered) {
       const prerenderUrl = new URL(request.url);
       prerenderUrl.pathname = prerendered;


### PR DESCRIPTION
## Summary

Closes #637.

- Adds a build-time prerender step (`scripts/prerender.mjs`) that launches headless Chromium via Playwright after `trunk build`, navigates to marketing routes (`/`, `/login`), waits for WASM to render content, and captures the full-page HTML to `dist/prerendered/`
- Updates `worker.js` to intercept marketing route requests and serve prerendered HTML — all other routes fall through to the SPA shell via the existing `not_found_handling = "single-page-application"` in `wrangler.toml`
- Updates SRI hash scripts (`refresh-sri-hashes.py`, `verify-sri-hashes.py`) to scan all `.html` files in `dist/` (not just `index.html`), ensuring prerendered pages get correct integrity hashes after `sentry-cli sourcemaps inject`
- Adds prerender step to CI `wasm-build` job (between `trunk build` and artifact upload)
- Adds deploy-smoke tests asserting prerendered files contain expected marketing content

### Architecture

```
trunk build → prerender (Playwright) → artifact → sentry inject → SRI refresh → deploy
```

Prerendered HTML lives in `dist/prerendered/` (not overwriting `index.html`) so the SPA shell remains the fallback for authenticated app routes. Worker.js routing:

| Request path | Response |
|---|---|
| `/` | `dist/prerendered/index.html` (full marketing page HTML) |
| `/login` | `dist/prerendered/login.html` (sign-in card HTML) |
| `/library`, `/sessions`, etc. | `dist/index.html` (SPA shell, client-side routing) |

WASM still loads on every page — for marketing routes it takes over the prerendered DOM seamlessly (content matches what CSR produces for unauthenticated users).

### Spec

`specs/seo-prerender.md` — included in this PR per Tier 3 workflow.

## Test plan

- [ ] CI green — prerender step produces files, deploy-smoke tests pass
- [ ] `curl https://myintrada.com/` returns HTML with hero copy in `<body>` (not just `<noscript>`)
- [ ] `curl https://myintrada.com/login` returns HTML with sign-in content
- [ ] SPA routing still works for authenticated routes (no flash of marketing content)
- [ ] Lighthouse SEO score > 90 on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)