### PR TITLE
fix(ux): post-edit Set lands on Set Detail; Summary state redirects to /sessions/summary

### DIFF
--- a/crates/intrada-web/src/views/session_new.rs
+++ b/crates/intrada-web/src/views/session_new.rs
@@ -26,6 +26,9 @@ pub fn SessionNewView() -> impl IntoView {
     // - Idle (first mount): auto-start building
     // - Idle (after cancel/abandon): navigate back to list
     // - Active (crash recovery or just started): navigate to active session
+    // - Summary (previous session not yet saved/discarded): redirect to
+    //   /sessions/summary so the user resolves it before starting a new one.
+    //   Without this branch the view renders an empty page (#503).
     Effect::new({
         let core = core.clone();
         move |_| {
@@ -34,6 +37,15 @@ pub fn SessionNewView() -> impl IntoView {
                 SessionStatusView::Active => {
                     navigate(
                         "/sessions/active",
+                        NavigateOptions {
+                            replace: true,
+                            ..Default::default()
+                        },
+                    );
+                }
+                SessionStatusView::Summary => {
+                    navigate(
+                        "/sessions/summary",
                         NavigateOptions {
                             replace: true,
                             ..Default::default()

--- a/crates/intrada-web/src/views/set_edit.rs
+++ b/crates/intrada-web/src/views/set_edit.rs
@@ -192,7 +192,9 @@ pub fn SetEditView() -> impl IntoView {
                         let effects = core_ref.process_event(event);
                         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
                         toast.show("Set updated");
-                        navigate("/library?type=set", NavigateOptions { replace: true, ..Default::default() });
+                        // Land back on the Set Detail surface the user came from,
+                        // not the Library list — preserves iPad split-view context.
+                        navigate(&format!("/library/sets/{}", set_id), NavigateOptions { replace: true, ..Default::default() });
                     }
                 }>
                     <div>
@@ -244,8 +246,9 @@ pub fn SetEditView() -> impl IntoView {
                         </Button>
                         <Button variant=ButtonVariant::Secondary on_click={
                             let navigate = navigate.clone();
+                            let set_id = set_id.clone();
                             Callback::new(move |_| {
-                                navigate("/library?type=set", NavigateOptions::default());
+                                navigate(&format!("/library/sets/{}", set_id), NavigateOptions::default());
                             })
                         }>"Cancel"</Button>
                     </div>


### PR DESCRIPTION
## Summary

Two small UX bugs bundled together — both are single-file navigation fixes in the Leptos shell.

### Closes #418 — Set edit: post-save lands on Library list, not Set Detail
`set_edit.rs` was navigating to `/library?type=set` (the Library Sets tab) on Save and Cancel. That bypasses the iPad split-view's Set Detail pane — the user just edited a Set, so the natural destination is back at that Set's detail surface.

- **Save** → `/library/sets/{id}`
- **Cancel** → `/library/sets/{id}`
- **Not-found fallback** stays at `/library?type=set` (no detail to land on)

### Closes #503 — "Start Session" lands on empty page when session_status == Summary
`SessionNewView` only handled Idle/Active/Building in its state-routing Effect. If the user had completed a session but not yet saved/discarded it (session_status = Summary), tapping "Start Session" on the Practice list landed them on a near-empty `/sessions/new` page.

The issue offered three options; I chose option C (redirect to `/sessions/summary`) over the suggested option B for safety. Option B would have required transitioning Summary → Building, but the state machine requires `Idle` for `StartBuilding`, so option B would silently discard the user's unsaved session summary. Redirecting to `/sessions/summary` forces the user to save or discard before starting a new session.

### Deferred to a separate PR
**#449** (reset "Saved" state when SaveBuildingAsSet fails) — the cleanest fix requires a core change (a `SetSaveSucceeded` event/signal) so the shell can flip `saved=true` on confirmed success rather than optimistically on dispatch. Out of scope for this small bundle.

## Test plan

- [ ] Edit a Set, save → land on `/library/sets/{id}` (Set Detail, not Library list)
- [ ] Edit a Set, cancel → same
- [ ] Set-not-found state still shows "Back to Sets" → `/library?type=set`
- [ ] Finish a session, leave summary unsaved, navigate to Practice tab, tap "Start Session" → redirected to `/sessions/summary`
- [ ] From Idle state, "Start Session" still goes to the setlist builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)