### PR TITLE
fix(core,security): reset Model on sign-out (#645)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -52,6 +52,11 @@ pub enum Event {
     RefetchSessions,
     RefetchSets,
     RefetchLessons,
+    /// User signed out — reset all user-scoped state so the next sign-in
+    /// (possibly a different user on the same browser) doesn't inherit the
+    /// previous user's items, sessions, MCP tokens/audit, errors, etc.
+    /// Shell dispatches this on the signed_in → signed_out transition (#645).
+    SignedOut,
 
     // ── Domain ──────────────────────────────────────────────────────
     Item(ItemEvent),
@@ -168,6 +173,10 @@ impl App for Intrada {
             Event::RefetchSessions => http::fetch_sessions(&model.api_base_url),
             Event::RefetchSets => http::fetch_sets(&model.api_base_url),
             Event::RefetchLessons => http::fetch_lessons(&model.api_base_url),
+            Event::SignedOut => {
+                model.reset_for_sign_out();
+                crux_core::render::render()
+            }
 
             // ── Domain handlers ──────────────────────────────────────
             Event::Item(item_event) => handle_item_event(item_event, model),
@@ -599,6 +608,53 @@ mod tests {
         let _cmd = app.update(Event::ClearError, &mut model);
 
         assert!(model.last_error.is_none());
+    }
+
+    #[test]
+    fn test_signed_out_resets_user_scoped_state() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+
+        // Populate a model with state from a fully signed-in user across
+        // every field that could leak to the next user (#645).
+        let mut model = Model {
+            api_base_url: "http://localhost:3001".to_string(),
+            items: vec![Item {
+                id: "i1".to_string(),
+                title: "Clair de Lune".to_string(),
+                kind: ItemKind::Piece,
+                composer: Some("Debussy".to_string()),
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+                created_at: now,
+                updated_at: now,
+            }],
+            last_error: Some("connection lost".to_string()),
+            error_muted: true,
+            mcp_tokens: vec![crate::domain::mcp_tokens::McpToken {
+                id: "tok1".to_string(),
+                name: "ci-bot".to_string(),
+                prefix: "intr_pat_".to_string(),
+                last_used_at: None,
+                created_at: now,
+                revoked_at: None,
+            }],
+            mcp_tokens_loaded: true,
+            ..Default::default()
+        };
+
+        let _cmd = app.update(Event::SignedOut, &mut model);
+
+        // api_base_url is set at startup, not per-user — must survive.
+        assert_eq!(model.api_base_url, "http://localhost:3001");
+        // Everything else returns to Default.
+        assert!(model.items.is_empty());
+        assert!(model.last_error.is_none());
+        assert!(!model.error_muted);
+        assert!(model.mcp_tokens.is_empty());
+        assert!(!model.mcp_tokens_loaded);
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -175,7 +175,14 @@ impl App for Intrada {
             Event::RefetchLessons => http::fetch_lessons(&model.api_base_url),
             Event::SignedOut => {
                 model.reset_for_sign_out();
-                crux_core::render::render()
+                // Also clear the crash-recovery blob in localStorage —
+                // it isn't user-scoped, so user A's in-progress session
+                // would otherwise hydrate into user B's model on next
+                // sign-in (#645).
+                Command::all([
+                    Command::notify_shell(AppEffect::ClearSessionInProgress).into(),
+                    crux_core::render::render(),
+                ])
             }
 
             // ── Domain handlers ──────────────────────────────────────
@@ -616,7 +623,7 @@ mod tests {
         let now = chrono::Utc::now();
 
         // Populate a model with state from a fully signed-in user across
-        // every field that could leak to the next user (#645).
+        // every sensitive field that could leak to the next user (#645).
         let mut model = Model {
             api_base_url: "http://localhost:3001".to_string(),
             items: vec![Item {
@@ -631,6 +638,24 @@ mod tests {
                 created_at: now,
                 updated_at: now,
             }],
+            sessions: vec![PracticeSession {
+                id: "sess1".to_string(),
+                entries: vec![],
+                session_notes: Some("private notes".to_string()),
+                session_intention: Some("focus".to_string()),
+                started_at: now,
+                completed_at: now,
+                total_duration_secs: 60,
+                completion_status: CompletionStatus::Completed,
+            }],
+            session_status: SessionStatus::Active(ActiveSession {
+                id: "active1".to_string(),
+                entries: vec![],
+                current_index: 0,
+                current_item_started_at: now,
+                session_started_at: now,
+                session_intention: Some("in-progress intention".to_string()),
+            }),
             last_error: Some("connection lost".to_string()),
             error_muted: true,
             mcp_tokens: vec![crate::domain::mcp_tokens::McpToken {
@@ -642,6 +667,16 @@ mod tests {
                 revoked_at: None,
             }],
             mcp_tokens_loaded: true,
+            mcp_audit: vec![crate::domain::mcp_audit::McpAuditEntry {
+                id: "audit1".to_string(),
+                token_id: None,
+                token_name: None,
+                token_prefix: None,
+                tool: "list_items".to_string(),
+                args_hash: "abc".to_string(),
+                created_at: now,
+            }],
+            mcp_audit_loaded: true,
             ..Default::default()
         };
 
@@ -649,12 +684,18 @@ mod tests {
 
         // api_base_url is set at startup, not per-user — must survive.
         assert_eq!(model.api_base_url, "http://localhost:3001");
-        // Everything else returns to Default.
+        // Everything else returns to Default — exhaustive checks across the
+        // most sensitive fields (anything visible in the ViewModel between
+        // sign-out and first refetch).
         assert!(model.items.is_empty());
+        assert!(model.sessions.is_empty());
+        assert!(matches!(model.session_status, SessionStatus::Idle));
         assert!(model.last_error.is_none());
         assert!(!model.error_muted);
         assert!(model.mcp_tokens.is_empty());
         assert!(!model.mcp_tokens_loaded);
+        assert!(model.mcp_audit.is_empty());
+        assert!(!model.mcp_audit_loaded);
     }
 
     #[test]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -106,6 +106,21 @@ impl Model {
         self.last_error = None;
         self.error_muted = true;
     }
+
+    /// Reset all user-scoped state on sign-out so a subsequent sign-in
+    /// (potentially as a different user on the same browser) starts from a
+    /// clean slate. Preserves `api_base_url` (set once at app startup; not
+    /// per-user). Without this, the next user briefly sees the previous
+    /// user's data — most concerning for MCP tokens / audit which are a
+    /// soft information disclosure until the first refetch overwrites them
+    /// (#645).
+    pub fn reset_for_sign_out(&mut self) {
+        let api_base_url = std::mem::take(&mut self.api_base_url);
+        *self = Self {
+            api_base_url,
+            ..Self::default()
+        };
+    }
 }
 
 #[cfg(test)]

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -197,6 +197,13 @@ pub fn App() -> impl IntoView {
 
             initialized.set(true);
         } else if !authed && initialized.get_untracked() {
+            // Reset the in-memory Model so the next sign-in (potentially a
+            // different user on the same browser) doesn't inherit the
+            // previous user's items, sessions, MCP tokens/audit, etc.
+            // (#645).
+            let core_ref = core_for_init.borrow();
+            let effects = core_ref.process_event(Event::SignedOut);
+            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
             initialized.set(false);
         }
     });


### PR DESCRIPTION
## Summary

Closes #645.

When user A signs out and user B signs in on the same browser, A's in-memory Model state was visible to B until the first refetch overwrote it. Most concerning fields: `mcp_tokens` and `mcp_audit` — a soft information disclosure across accounts on shared browsers. Lower-severity but still wrong: `items`, `sessions`, `sets`, `lessons`, `practice_summaries`, `account_preferences`, `last_error`/`error_muted`, `session_status`.

## Approach

1. **`Model::reset_for_sign_out()`** in `intrada-core/src/model.rs` — returns the model to `Default` while preserving `api_base_url` (set once at `StartApp`, not per-user).
2. **`Event::SignedOut`** in `intrada-core/src/app.rs` — exposes the reset to shells; handler calls `model.reset_for_sign_out()` and renders.
3. **Shell dispatch** in `intrada-web/src/app.rs` — the existing auth-state Effect already detects the `authed && initialized` → `!authed && initialized` transition; added the `Event::SignedOut` dispatch there. No new closure, no new race condition.

## Test plan

- [x] `cargo test -p intrada-core` — 288 pass (1 new test added for `Event::SignedOut`)
- [x] `cargo clippy --target wasm32-unknown-unknown -p intrada-web -- -D warnings`
- [x] `cargo clippy -p intrada-core -- -D warnings`
- [ ] Manual: sign in as user A → see items in library → sign out → sign in as user B → confirm library shows B's items (not flash of A's) before fetch completes
- [ ] Manual: settings → sign out → confirm UI flashes back to login screen without showing previous user's MCP tokens or audit list

## Out of scope

Persisting per-account preferences across sign-outs — different problem, noted in #645 already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)