### PR TITLE
feat(ci): add cargo-deny and Gitleaks security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,25 +457,24 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  audit:
-    name: Cargo Audit
+  security:
+    name: Security (cargo-deny + Gitleaks)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Cache the RustSec advisory database to avoid re-cloning ~50MB on
-      # every run. Stale-OK: cargo-audit fetches incrementally on top.
-      - name: Cache advisory database
-        uses: actions/cache@v5
         with:
-          path: ~/.cargo/advisory-db
-          key: advisory-db-${{ github.run_id }}
-          restore-keys: advisory-db-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-audit
-      # Reads ignore list from .cargo/audit.toml — each entry must have a
-      # tracking issue and rationale comment. Anything new fails CI.
-      - run: cargo audit
+          fetch-depth: 0
+      # ── cargo-deny ─────────────────────────────────────────────────────
+      # Replaces cargo-audit. Checks advisories (same RustSec DB), license
+      # compliance, crate bans, and source restrictions in one pass.
+      # Config: deny.toml. Ignore list migrated from .cargo/audit.toml.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+      # ── Gitleaks ───────────────────────────────────────────────────────
+      # Scans for leaked secrets (API keys, tokens, credentials) in the
+      # diff. ~150 built-in regex patterns, runs in seconds.
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   api-docker-build:
     # Catches Dockerfile / workspace-scoping bugs on PRs that would otherwise

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-api"
 version = "0.1.0"
 edition = "2021"
+publish = false
 rust-version = "1.78"
 
 [lib]

--- a/crates/intrada-core/Cargo.toml
+++ b/crates/intrada-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-core"
 version = "0.1.0"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/intrada-mobile/plugins/background-audio/Cargo.toml
+++ b/crates/intrada-mobile/plugins/background-audio/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tauri-plugin-background-audio"
 version = "0.0.1"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 description = "Intrada-internal Tauri plugin: keeps the practice timer running while the app is backgrounded / the device is locked. Bridges to Swift on iOS for AVAudioSession + lock-screen Now Playing."
 # Required by tauri-plugin's build script (must match package.name).

--- a/crates/intrada-mobile/plugins/live-activity/Cargo.toml
+++ b/crates/intrada-mobile/plugins/live-activity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tauri-plugin-live-activity"
 version = "0.0.1"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 description = "Intrada-internal Tauri plugin: ActivityKit Live Activity for the active practice session — Lock Screen card + Dynamic Island compact / expanded views. iOS-only; layered alongside the background-audio plugin."
 # Required by tauri-plugin's build script (must match package.name).

--- a/crates/intrada-mobile/src-tauri/Cargo.toml
+++ b/crates/intrada-mobile/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-mobile"
 version = "0.1.0"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 
 # Tauri requires both staticlib (iOS) and cdylib (desktop) targets.

--- a/crates/intrada-web/Cargo.toml
+++ b/crates/intrada-web/Cargo.toml
@@ -2,6 +2,7 @@
 name = "intrada-web"
 version = "0.1.0"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,84 @@
+# cargo-deny configuration.
+# https://embarkstudios.github.io/cargo-deny/
+#
+# Replaces the standalone cargo-audit job. Checks four categories:
+# advisories, licenses, bans, sources.
+
+[graph]
+targets = []
+all-features = false
+no-default-features = false
+
+# ── Advisories ───────────────────────────────────────────────────────────
+# Same RustSec database as cargo-audit. Migrated from .cargo/audit.toml.
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Unmaintained crates are informational, not vulnerabilities — warn, don't fail.
+unmaintained = "workspace"
+
+ignore = [
+    # rsa 0.9.x Marvin Attack (timing side-channel on RSA key recovery).
+    # No upstream fix. jsonwebtoken's `rust_crypto` feature pulls in the rsa
+    # crate for RSA math, but we only perform RS256 *signature verification*
+    # (public-key operation) — the Marvin attack targets RSA *decryption*
+    # (PKCS#1v1.5 padding oracle), which is never exercised in the JWT path.
+    # Re-evaluate when rsa 0.10 drops or if advisory scope broadens.
+    { id = "RUSTSEC-2023-0071", reason = "only public-key verification, Marvin attack targets decryption" },
+
+    # rustls-webpki advisories pulled in transitively by libsql 0.9.30 →
+    # tonic 0.11.0. Cleared by upgrading libsql to ≥0.10. Tracked in
+    # https://github.com/jonyardley/intrada/issues/568.
+    { id = "RUSTSEC-2026-0049", reason = "transitive via libsql; tracked in #568" },
+    { id = "RUSTSEC-2026-0098", reason = "transitive via libsql; tracked in #568" },
+    { id = "RUSTSEC-2026-0099", reason = "transitive via libsql; tracked in #568" },
+    { id = "RUSTSEC-2026-0104", reason = "transitive via libsql; tracked in #568" },
+]
+
+# ── Licenses ─────────────────────────────────────────────────────────────
+# Allowlist of acceptable SPDX license expressions. Anything not listed
+# here fails CI — catches unexpected copyleft or proprietary deps early.
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "BSL-1.0",
+]
+confidence-threshold = 0.8
+
+# Our own workspace crates are private / unlicensed.
+exceptions = [
+    { allow = ["CDLA-Permissive-2.0"], crate = "webpki-roots" },
+]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# Private workspace crates — no license field needed.
+[licenses.private]
+ignore = true
+registries = []
+
+# ── Bans ─────────────────────────────────────────────────────────────────
+# Block specific crates or detect duplicates.
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+# ── Sources ──────────────────────────────────────────────────────────────
+# Restrict where crates can be fetched from.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

- **Replace `cargo-audit` with `cargo-deny`** — same RustSec advisory database, plus license compliance (SPDX allowlist), crate bans (duplicate detection), and source restrictions (registry pinning). Existing ignore list migrated from `.cargo/audit.toml` into `deny.toml`.
- **Add Gitleaks** secret detection — scans every PR for leaked API keys, tokens, and credentials (~150 built-in regex patterns, runs in seconds).
- **Mark all 6 workspace crates `publish = false`** — required for cargo-deny to recognise them as private and skip license field checks. Also a good practice since none of these should ever go to crates.io.

## Test plan

- [ ] `security` job passes on this PR (cargo-deny + Gitleaks both green)
- [ ] No regressions in other CI jobs (the old `audit` job is fully replaced)
- [ ] Verify cargo-deny catches a bad license locally: temporarily add a crate with GPL license and confirm `cargo deny check licenses` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)