### PR TITLE
fix(sentry,ux): filter binding import noise + session saved toast (#435, #440, #446)

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -120,7 +120,8 @@
           beforeSend: function (event) {
             // Drop benign errors that can't be fixed in code:
             // - View transition skipped when app is backgrounded mid-nav
-            // - WASM LinkError from transient cache coherence mismatch
+            // - WASM LinkError / SyntaxError from transient cache coherence
+            //   mismatch during deployment (stale JS glue vs new WASM)
             try {
               var msg = (event.message || '');
               if (event.exception && Array.isArray(event.exception.values)) {
@@ -128,6 +129,7 @@
               }
               if (msg.indexOf('View transition was skipped') !== -1) return null;
               if (msg.indexOf('must be callable') !== -1 && msg.indexOf('LinkError') !== -1) return null;
+              if (msg.indexOf('Importing binding name') !== -1) return null;
             } catch(e) {}
             try {
               var EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -4,7 +4,8 @@ use intrada_core::{CompletionStatus, EntryStatus, Event, SessionEvent, SetEvent,
 use intrada_web::validation::validate_achieved_tempo_input;
 
 use crate::components::{
-    AccentBar, Button, ButtonVariant, Icon, IconName, RatingChips, SetSaveForm, StatCard, StatTone,
+    use_toast, AccentBar, Button, ButtonVariant, Icon, IconName, RatingChips, SetSaveForm,
+    StatCard, StatTone,
 };
 use intrada_web::core_bridge::process_effects;
 use intrada_web::js_bridge;
@@ -18,6 +19,7 @@ pub fn SessionSummary() -> impl IntoView {
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
 
+    let toast = use_toast();
     let session_notes = RwSignal::new(String::new());
 
     let core_save = core.clone();
@@ -349,6 +351,7 @@ pub fn SessionSummary() -> impl IntoView {
                                             let core_ref = core_save.borrow();
                                             let effects = core_ref.process_event(event);
                                             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                                            toast.show("Session saved");
                                         })
                                     >
                                         "Save Session"


### PR DESCRIPTION
## Summary
- Filter `Importing binding name` SyntaxErrors in Sentry `beforeSend` — transient cache coherence artifacts during deployment, not code bugs (#435, #440)
- Wire "Session saved" toast into the session summary save flow (#446), matching the existing pattern in add_form, edit_form, set_edit

## Changes
- Add `Importing binding name` string check to `beforeSend` noise filter in `index.html`
- Add `use_toast()` + `toast.show("Session saved")` to `SessionSummary` save handler

## Test plan
- [ ] Save a session from the summary screen — "Session saved" toast appears
- [ ] No `Importing binding name` events appear in Sentry after next deployment

Closes #435
Closes #440
Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)