### PR TITLE
fix(ci): add publish = false to tauri-plugin-auth-session

### DIFF
--- a/crates/intrada-mobile/plugins/auth-session/Cargo.toml
+++ b/crates/intrada-mobile/plugins/auth-session/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tauri-plugin-auth-session"
 version = "0.0.1"
 edition = "2021"
+publish = false
 rust-version.workspace = true
 description = "Intrada-internal Tauri plugin: opens OAuth URLs in ASWebAuthenticationSession so Google doesn't reject the WKWebView user agent."
 links = "tauri-plugin-auth-session"


### PR DESCRIPTION
## Summary
- Adds missing `publish = false` to `tauri-plugin-auth-session`'s Cargo.toml
- Without it, cargo-deny (#667) flags the crate as unlicensed, failing all PR CI runs
- All other workspace crates already had `publish = false`; this was the only one missed when the plugin was added in #664

Fixes the `licenses FAILED` error on #669 and #671.

## Test plan
- [ ] `Security (cargo-deny + Gitleaks)` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)