### PR TITLE
fix(sentry,web): silence View Transitions noise + fix timer disposal (#581, #479)

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -119,7 +119,9 @@
           // and return the event unchanged on any failure.
           beforeSend: function (event) {
             // Drop benign errors that can't be fixed in code:
-            // - View transition skipped when app is backgrounded mid-nav
+            // - View Transitions API: AbortError / InvalidStateError when a
+            //   new nav fires before the previous transition settles. Leptos
+            //   calls startViewTransition internally; we can't catch there.
             // - WASM LinkError / SyntaxError from transient cache coherence
             //   mismatch during deployment (stale JS glue vs new WASM)
             try {
@@ -128,6 +130,8 @@
                 msg += ' ' + event.exception.values.map(function(v){ return v.value || ''; }).join(' ');
               }
               if (msg.indexOf('View transition was skipped') !== -1) return null;
+              if (msg.indexOf('Transition was skipped') !== -1) return null;
+              if (msg.indexOf('Transition was aborted') !== -1) return null;
               if (msg.indexOf('must be callable') !== -1 && msg.indexOf('LinkError') !== -1) return null;
               if (msg.indexOf('Importing binding name') !== -1) return null;
             } catch(e) {}

--- a/crates/intrada-web/src/components/week_strip.rs
+++ b/crates/intrada-web/src/components/week_strip.rs
@@ -165,11 +165,15 @@ pub fn WeekStrip(
     // transition_disabled / snap_target) fires after the parent owner is
     // disposed and panics with "reactive value already disposed".
     let snap_timeout_handle: RwSignal<Option<i32>> = RwSignal::new(None);
+    let raf_handle: RwSignal<Option<i32>> = RwSignal::new(None);
 
     on_cleanup(move || {
-        if let Some(id) = snap_timeout_handle.get_untracked() {
-            if let Some(window) = web_sys::window() {
+        if let Some(window) = web_sys::window() {
+            if let Some(id) = snap_timeout_handle.get_untracked() {
                 window.clear_timeout_with_handle(id);
+            }
+            if let Some(id) = raf_handle.get_untracked() {
+                let _ = window.cancel_animation_frame(id);
             }
         }
     });
@@ -357,7 +361,11 @@ pub fn WeekStrip(
                     transition_disabled.set(false);
                 });
                 if let Some(window) = web_sys::window() {
-                    let _ = window.request_animation_frame(cb_re_enable.as_ref().unchecked_ref());
+                    if let Ok(id) =
+                        window.request_animation_frame(cb_re_enable.as_ref().unchecked_ref())
+                    {
+                        raf_handle.set(Some(id));
+                    }
                 }
                 cb_re_enable.forget();
             });

--- a/crates/intrada-web/src/components/welcome_carousel.rs
+++ b/crates/intrada-web/src/components/welcome_carousel.rs
@@ -209,11 +209,11 @@ pub fn WelcomeCarousel(
                                 card_index.set(current + 1);
                             } else {
                                 transitioning.set(true);
-                                gloo_timers::callback::Timeout::new(50, move || {
+                                leptos::task::spawn_local(async move {
+                                    gloo_timers::future::TimeoutFuture::new(50).await;
                                     card_index.set(current + 1);
                                     transitioning.set(false);
-                                })
-                                .forget();
+                                });
                             }
                         }
                     } else {
@@ -224,11 +224,11 @@ pub fn WelcomeCarousel(
                                 card_index.set(current - 1);
                             } else {
                                 transitioning.set(true);
-                                gloo_timers::callback::Timeout::new(50, move || {
+                                leptos::task::spawn_local(async move {
+                                    gloo_timers::future::TimeoutFuture::new(50).await;
                                     card_index.set(current - 1);
                                     transitioning.set(false);
-                                })
-                                .forget();
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- **#581**: Adds two Sentry `beforeSend` filters for View Transitions API `AbortError` ("Transition was skipped") and `InvalidStateError` ("Transition was aborted") — benign rejections from Leptos's internal `startViewTransition()` when navigations overlap
- **#479**: Fixes two disposal-unsafe timer call sites:
  - `week_strip.rs`: rAF handle now stored and cancelled via `on_cleanup` (was `.forget()`)
  - `welcome_carousel.rs`: swipe timeouts switched from `callback::Timeout.forget()` to `spawn_local` + `TimeoutFuture` (matches the existing `transition_to` pattern; signal `.set()` is a no-op if owner is disposed)

Closes #581, closes #479.

## Test plan
- [ ] CI passes (fmt, clippy, wasm build, tests)
- [ ] Swipe carousel on iOS — transition still animates
- [ ] Week strip swipe on iOS — snap-back still springs
- [ ] Sentry dashboard: no new View Transitions errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)