### PR TITLE
fix(ios): set publishable key before loading Clerk JS

### DIFF
--- a/crates/intrada-web/static/ios-auth.html
+++ b/crates/intrada-web/static/ios-auth.html
@@ -46,6 +46,18 @@
       }
 
       try {
+        var pk = new URLSearchParams(location.search).get('pk');
+        if (pk) {
+          sessionStorage.setItem('__ios_auth_pk', pk);
+        } else {
+          pk = sessionStorage.getItem('__ios_auth_pk');
+        }
+        if (!pk) throw new Error('Missing pk parameter');
+
+        // Set the key BEFORE loading the script — the Clerk browser build
+        // auto-detects this global during execution and sets window.Clerk.
+        window.__clerk_publishable_key = pk;
+
         // Load Clerk JS (full browser build — this runs in Safari, not WKWebView)
         await new Promise(function (resolve, reject) {
           var s = document.createElement('script');
@@ -58,15 +70,6 @@
 
         var clerk = window.Clerk;
         if (!clerk) throw new Error('Clerk SDK not available');
-
-        var pk = new URLSearchParams(location.search).get('pk');
-        if (pk) {
-          sessionStorage.setItem('__ios_auth_pk', pk);
-        } else {
-          pk = sessionStorage.getItem('__ios_auth_pk');
-        }
-        if (!pk) throw new Error('Missing pk parameter');
-        window.__clerk_publishable_key = pk;
         await clerk.load();
 
         // If this is a callback from OAuth (Clerk appends status params)


### PR DESCRIPTION
## Summary

- Fix "Clerk SDK not available" error in `ios-auth.html` on device
- The Clerk browser build auto-detects `window.__clerk_publishable_key` during script execution — setting it after load means `window.Clerk` is never set

One-line fix: move the `pk` param extraction and `window.__clerk_publishable_key` assignment above the CDN script load (matching how `index.html` does it for web).

## Test plan

- [ ] iOS: tap "Sign in with Google" → Safari sheet should progress past "Signing in..." to Google OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)