### PR TITLE
fix(auth): upgrade JWT validation failure logging

### DIFF
--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -95,6 +95,7 @@ impl FromRequestParts<AppState> for AuthUser {
         validation.validate_aud = false;
 
         let keys = auth_config.decoding_keys.read().await;
+        let mut last_error = None;
         for key in keys.iter() {
             match decode::<Claims>(token, key, &validation) {
                 Ok(data) => {
@@ -107,11 +108,21 @@ impl FromRequestParts<AppState> for AuthUser {
                 }
                 Err(e) => {
                     tracing::debug!("JWT decode error: {e}");
+                    last_error = Some(e);
                     continue;
                 }
             }
         }
 
+        if let Some(e) = last_error {
+            tracing::warn!(
+                issuer = %auth_config.issuer,
+                key_count = keys.len(),
+                "JWT validation failed after trying all keys: {e}"
+            );
+        } else {
+            tracing::warn!("JWT validation failed: no decoding keys loaded");
+        }
         Err(ApiError::Unauthorized("Unauthorized".to_string()))
     }
 }


### PR DESCRIPTION
## Summary
- JWT decode errors were logged at `debug` level, invisible in production Fly.io logs
- Upgraded to `warn` level when all JWKS keys fail, including the actual error message, issuer URL, and key count
- Needed to diagnose the iOS auth 401 — we can't see why the Clerk JWT fails validation without this

## Context
The iOS OAuth flow completes successfully through Safari (Clerk JS → Google → callback), but the `POST /api/auth/ios/exchange` endpoint returns 401. The auth extractor's JWT decode error was silently swallowed at `debug` level. This change surfaces it so we can identify the root cause (likely expired token or issuer mismatch).

## Test plan
- [x] `cargo clippy -p intrada-api -- -D warnings` passes
- [x] All 164 tests pass
- [ ] Deploy to Fly.io, retry iOS sign-in, check logs for the warn-level message

🤖 Generated with [Claude Code](https://claude.com/claude-code)