### PR TITLE
perf(ci): narrow API Docker Build path filter (~8 min skip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,7 @@ jobs:
               - '.github/workflows/ci.yml'
             api:
               - 'Dockerfile'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
               - 'crates/intrada-api/**'
-              - 'crates/intrada-core/**'
               - '.github/workflows/ci.yml'
             web:
               - 'Cargo.toml'
@@ -583,10 +580,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   api-docker-build:
-    # Catches Dockerfile / workspace-scoping bugs on PRs that would otherwise
-    # only surface when the Deploy API job runs on main. Only runs when paths
-    # that could affect the build change — most PRs (frontend/iOS only) skip
-    # this and stay fast. Always runs on main pushes (gates deploy).
+    # Catches Dockerfile / API-specific build bugs on PRs. Narrowly filtered
+    # to Dockerfile + intrada-api crate only — Cargo.toml, Cargo.lock, and
+    # intrada-core changes are already validated by test/clippy jobs, so they
+    # don't need an ~8 min Docker build. Always runs on main pushes (gates
+    # deploy).
     #
     # On main pushes the resulting image is pushed to Fly's registry tagged
     # with the commit SHA, and `deploy-api` deploys that image instead of


### PR DESCRIPTION
## Summary
- Narrow the `api` path filter to only `Dockerfile` + `crates/intrada-api/**` + workflow file
- Removes `Cargo.toml`, `Cargo.lock`, and `crates/intrada-core/**` which triggered an ~8 min Docker build on every PR touching shared deps or core logic
- Test/clippy jobs already validate Rust compilation — the Docker build only adds value for Dockerfile-specific issues
- Still runs on every main push (gates deploy)

## Impact
Most PRs (frontend, iOS, core-only) will skip the Docker build entirely, saving ~8 min from the critical path when it was the longest-running job.

## Test plan
- [ ] PR CI skips the API Docker Build job (this PR only touches the workflow file, not Dockerfile or intrada-api)
- [ ] A PR touching `crates/intrada-api/` still triggers the Docker build
- [ ] Main push still runs the full Docker build + deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)