### PR TITLE
chore: configure Codecov with informational patch target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,12 @@ When skipping tests, say so explicitly in the PR description with the reason
 "All 157 tests pass" is not coverage — those are existing tests, not tests
 for new code.
 
+**Codecov**: PRs get an automated patch-coverage comment (70% target,
+informational — not blocking). Before declaring a PR ready, check the
+Codecov comment: if new lines are uncovered, either add tests or note
+why in the PR description (e.g. "temporary diagnostic code", "UI glue
+not reachable from unit tests"). Config lives in `codecov.yml`.
+
 ## Project-specific gotchas
 
 Bear-traps that have caught us at least once. Skim before you start; the cost

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+# Codecov configuration — informational, not blocking.
+# Coverage data helps spot gaps; it doesn't gate merges.
+
+coverage:
+  status:
+    # Project-level coverage (overall %) — off. Too noisy at this stage
+    # and penalises PRs that touch uncovered legacy code.
+    project: false
+
+    # Patch coverage (new/changed lines) — informational only.
+    # Target 70%: low enough to not block diagnostic/glue code,
+    # high enough to flag PRs that ship zero tests for real logic.
+    patch:
+      default:
+        target: 70%
+        informational: true
+
+comment:
+  # Show the Codecov PR comment but keep it compact.
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true      # only comment when coverage data changes
+  require_base: false        # don't fail if base commit has no coverage
+  require_head: true
+
+ignore:
+  # Leptos web shell — UI code compiled to WASM, not covered by
+  # cargo-llvm-cov (excluded from the coverage job entirely).
+  - "crates/intrada-web/**"
+
+  # Tauri iOS host + plugins — excluded from coverage job (needs
+  # macOS + iOS target, not available on ubuntu runners).
+  - "crates/intrada-mobile/**"
+
+  # Migrations — pure SQL strings, validated by integration tests
+  # but the Rust wrapper lines are just string constants.
+  - "crates/intrada-api/src/migrations.rs"


### PR DESCRIPTION
## Summary
- Add `codecov.yml` with sensible defaults so Codecov PR comments are useful, not noise
- Update `CLAUDE.md` testing section with coverage guidance

## What's configured
| Setting | Value | Why |
|---------|-------|-----|
| Patch coverage target | 70% | Low enough for glue code, high enough to flag missing tests |
| Patch status | **Informational** | Visible on PR, doesn't block merge |
| Project coverage | **Off** | Overall % is meaningless at this stage |
| Ignore: `intrada-web` | ✓ | WASM shell, excluded from coverage job |
| Ignore: `intrada-mobile` | ✓ | iOS/Tauri, excluded from coverage job |
| Ignore: `migrations.rs` | ✓ | SQL strings, not unit-testable logic |

## Process change
CLAUDE.md now says: check the Codecov comment before declaring a PR ready. If lines are uncovered, either add tests or explain why in the PR description.

## Test plan
- [ ] Next PR with Rust changes gets a Codecov comment with the new config
- [ ] Ignored paths don't appear in the coverage diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)