### PR TITLE
fix(auth): patch jsonwebtoken v10 header bug breaking iOS auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,8 +3028,7 @@ dependencies = [
 [[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+source = "git+https://github.com/kp-timo-beyel/jsonwebtoken.git?branch=fix/header-extras-non-string-values#9bca28c470339d46a8437f03f488131d1f3a9eee"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,14 @@ ulid = "1"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 
+# jsonwebtoken v10.3.0 has a bug (#489): Header.extras is
+# HashMap<String, String> with #[serde(flatten)], so non-string header
+# fields (like Clerk's `oiat: <number>`) fail deserialization. PR #496
+# fixes this by changing extras to HashMap<String, serde_json::Value>.
+# Remove this patch once the fix lands in a released version.
+[patch.crates-io]
+jsonwebtoken = { git = "https://github.com/kp-timo-beyel/jsonwebtoken.git", branch = "fix/header-extras-non-string-values" }
+
 [profile.dev.package."*"]
 debug = false
 

--- a/crates/intrada-api/src/auth.rs
+++ b/crates/intrada-api/src/auth.rs
@@ -115,79 +115,9 @@ impl FromRequestParts<AppState> for AuthUser {
         }
 
         if let Some(e) = last_error {
-            // Decode header (first segment) + payload (middle segment) to
-            // log field names and types for diagnostics. Known bug: jsonwebtoken
-            // v10's Header has `extras: HashMap<String, String>` (#489) which
-            // rejects non-string header fields.
-            let header_info = token
-                .split('.')
-                .next()
-                .and_then(|b64| {
-                    use base64::Engine;
-                    base64::engine::general_purpose::URL_SAFE_NO_PAD
-                        .decode(b64)
-                        .ok()
-                })
-                .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-                .map(|v| {
-                    if let serde_json::Value::Object(map) = &v {
-                        map.iter()
-                            .map(|(k, v)| {
-                                let ty = match v {
-                                    serde_json::Value::String(s) => format!("str({s})"),
-                                    serde_json::Value::Number(n) => format!("num({n})"),
-                                    serde_json::Value::Bool(b) => format!("bool({b})"),
-                                    serde_json::Value::Array(_) => "array".to_string(),
-                                    serde_json::Value::Object(_) => "object".to_string(),
-                                    serde_json::Value::Null => "null".to_string(),
-                                };
-                                format!("{k}:{ty}")
-                            })
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    } else {
-                        "non-object header".to_string()
-                    }
-                })
-                .unwrap_or_else(|| "could not decode header".to_string());
-
-            let payload_info = token
-                .split('.')
-                .nth(1)
-                .and_then(|b64| {
-                    use base64::Engine;
-                    base64::engine::general_purpose::URL_SAFE_NO_PAD
-                        .decode(b64)
-                        .ok()
-                })
-                .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-                .map(|v| {
-                    if let serde_json::Value::Object(map) = &v {
-                        map.iter()
-                            .map(|(k, v)| {
-                                let ty = match v {
-                                    serde_json::Value::String(_) => "string",
-                                    serde_json::Value::Number(_) => "number",
-                                    serde_json::Value::Bool(_) => "bool",
-                                    serde_json::Value::Array(_) => "array",
-                                    serde_json::Value::Object(_) => "object",
-                                    serde_json::Value::Null => "null",
-                                };
-                                format!("{k}:{ty}")
-                            })
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    } else {
-                        "non-object payload".to_string()
-                    }
-                })
-                .unwrap_or_else(|| "could not decode payload".to_string());
-
             tracing::warn!(
                 issuer = %auth_config.issuer,
                 key_count = keys.len(),
-                header_fields = %header_info,
-                payload_fields = %payload_info,
                 "JWT validation failed after trying all keys: {e}"
             );
         } else {
@@ -401,65 +331,29 @@ mod tests {
         assert_eq!(claims.sub, "user_2abc");
     }
 
-    /// Exact field set from production Clerk JWT (from Fly.io logs).
-    /// Includes fva (array), sts (string), v (number) — Clerk-specific claims.
+    /// Regression test for jsonwebtoken v10 bug (#489): Clerk JWTs
+    /// include a numeric `oiat` field in the header, which the library's
+    /// `Header.extras: HashMap<String, String>` rejected. The patched
+    /// version (PR #496) uses `HashMap<String, serde_json::Value>`.
     #[test]
-    fn claims_deserializes_production_clerk_jwt() {
-        let payload = r#"{"azp":"pk_live_aW50cmFkYS5jbGVyay5hY2NvdW50cy5kZXYkxxxx","exp":1778695950,"fva":[19405,-1],"iat":1778695950,"iss":"https://clerk.myintrada.com","nbf":1778695940,"sid":"sess_2abc123","sts":"active","sub":"user_2abc123","v":2}"#;
-        let claims: Claims = serde_json::from_str(payload).expect("should parse");
-        assert_eq!(claims.sub, "user_2abc123");
-    }
-
-    /// Use `insecure_decode` (no signature check, no validation) to
-    /// confirm Claims deserialization works in isolation. If this passes
-    /// but full `decode()` fails, the bug is in jsonwebtoken's internal
-    /// `ClaimsForValidation` deserialization.
-    #[test]
-    fn insecure_decode_clerk_jwt_succeeds() {
-        use base64::Engine;
-        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(r#"{"alg":"RS256","typ":"JWT"}"#);
-        let payload_json = r#"{"azp":"pk_live_aW50cmFkYS5jbGVyay5hY2NvdW50cy5kZXYkxxxx","exp":1778695950,"fva":[19405,-1],"iat":1778695950,"iss":"https://clerk.myintrada.com","nbf":1778695940,"sid":"sess_2abc123","sts":"active","sub":"user_2abc123","v":2}"#;
-        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload_json);
-        let fake_sig = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("fake");
-        let token = format!("{header}.{payload}.{fake_sig}");
-
-        // insecure_decode: base64 → deserialize Claims only (no validate)
-        let result = jsonwebtoken::dangerous::insecure_decode::<Claims>(&token);
-        match &result {
-            Ok(data) => assert_eq!(data.claims.sub, "user_2abc123"),
-            Err(e) => panic!("insecure_decode failed: {e}"),
-        }
-    }
-
-    /// Deserialize the same payload into jsonwebtoken's internal
-    /// ClaimsForValidation-equivalent to isolate where the "expected a
-    /// string" error comes from. We can't import the private type, so
-    /// we replicate the relevant fields.
-    #[test]
-    fn validate_path_clerk_jwt() {
+    fn decode_header_accepts_non_string_extras() {
         use base64::Engine;
 
-        let payload_json = r#"{"azp":"pk_live_aW50cmFkYS5jbGVyay5hY2NvdW50cy5kZXYkxxxx","exp":1778695950,"fva":[19405,-1],"iat":1778695950,"iss":"https://clerk.myintrada.com","nbf":1778695940,"sid":"sess_2abc123","sts":"active","sub":"user_2abc123","v":2}"#;
+        // Clerk production header contains `oiat` (numeric) and `cat` (string)
+        let header_json =
+            r#"{"alg":"RS256","cat":"cl_abc","kid":"ins_abc","oiat":1778699272,"typ":"JWT"}"#;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(header_json);
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"sub":"user_123"}"#);
+        let sig = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("fake");
+        let token = format!("{header}.{payload}.{sig}");
 
-        // Deserialize as serde_json::Value to confirm the JSON is valid
-        let val: serde_json::Value =
-            serde_json::from_str(payload_json).expect("payload should be valid JSON");
-        let obj = val.as_object().unwrap();
-        assert_eq!(obj["sub"].as_str(), Some("user_2abc123"));
-        assert_eq!(obj["iat"].as_u64(), Some(1778695950));
-
-        // Mimic ClaimsForValidation: struct with only known fields
-        #[derive(Deserialize)]
-        struct FakeValidation {
-            exp: Option<u64>,
-            nbf: Option<u64>,
-            sub: Option<String>,
-            iss: Option<String>,
-        }
-        let fv: FakeValidation =
-            serde_json::from_str(payload_json).expect("FakeValidation should parse");
-        assert_eq!(fv.sub.as_deref(), Some("user_2abc123"));
-        assert_eq!(fv.iss.as_deref(), Some("https://clerk.myintrada.com"));
+        // Before the patch this returned Err("expected a string")
+        let result = jsonwebtoken::decode_header(&token);
+        assert!(
+            result.is_ok(),
+            "decode_header should accept non-string extras: {:?}",
+            result
+        );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -81,4 +81,8 @@ wildcards = "allow"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# jsonwebtoken v10.3.0 has a bug (#489): Header.extras is
+# HashMap<String, String>, so non-string header fields (like Clerk's
+# `oiat: <number>`) fail deserialization. PR #496 fixes this.
+# Remove this entry once the fix lands in a released version.
+allow-git = ["https://github.com/kp-timo-beyel/jsonwebtoken.git"]


### PR DESCRIPTION
## Summary
- **Root cause found**: Clerk JWTs include `oiat` (numeric) in the JWT header. jsonwebtoken v10.3.0's `Header.extras: HashMap<String, String>` with `#[serde(flatten)]` rejects non-string header values, causing the iOS auth 401.
- **Fix**: Cargo `[patch]` pointing at [upstream PR #496](https://github.com/Keats/jsonwebtoken/pull/496) which changes `extras` to `HashMap<String, serde_json::Value>`
- **Cleanup**: Removes the temporary diagnostic logging from #675/#678/#681. Keeps the useful warn-level "JWT validation failed" message.
- Adds a regression test `decode_header_accepts_non_string_extras`

## Upstream
- Bug: https://github.com/Keats/jsonwebtoken/issues/489
- Fix PR: https://github.com/Keats/jsonwebtoken/pull/496
- Remove the `[patch]` once the fix lands in a released version

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p intrada-api -- -D warnings` passes
- [x] 166 tests pass (including new regression test)
- [ ] Deploy and retry iOS sign-in — should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)