### PR TITLE
fix(auth): show Google account picker and hide iOS tokens from MCP list

### DIFF
--- a/crates/intrada-api/src/db/tokens.rs
+++ b/crates/intrada-api/src/db/tokens.rs
@@ -11,6 +11,11 @@ use crate::error::ApiError;
 /// generating new tokens.
 pub const TOKEN_PREFIX: &str = "intrada_pat_";
 
+/// Token name used for iOS app authentication. These are internal tokens
+/// created by the `/api/auth/ios/exchange` endpoint and should not appear
+/// in the user-facing MCP tokens list.
+pub const IOS_APP_TOKEN_NAME: &str = "iOS App";
+
 /// Request payload for `POST /api/account/tokens`.
 #[derive(Debug, Deserialize)]
 pub struct CreateTokenRequest {
@@ -75,8 +80,9 @@ pub async fn list(conn: &Connection, user_id: &str) -> Result<Vec<TokenListItem>
     let mut rows = conn
         .query(
             "SELECT id, name, prefix, last_used_at, created_at, revoked_at
-             FROM mcp_tokens WHERE user_id = ?1 ORDER BY created_at DESC",
-            libsql::params![user_id],
+             FROM mcp_tokens WHERE user_id = ?1 AND name != ?2
+             ORDER BY created_at DESC",
+            libsql::params![user_id, IOS_APP_TOKEN_NAME],
         )
         .await?;
 

--- a/crates/intrada-api/src/routes/auth_ios.rs
+++ b/crates/intrada-api/src/routes/auth_ios.rs
@@ -5,6 +5,7 @@ use axum::{Json, Router};
 use serde::Serialize;
 
 use crate::auth::{AuthSource, AuthUser};
+use crate::db::tokens::IOS_APP_TOKEN_NAME;
 use crate::error::ApiError;
 use crate::services;
 use crate::state::AppState;
@@ -40,8 +41,8 @@ async fn exchange(
     };
 
     let conn = state.conn();
-    services::tokens::revoke_tokens_by_name(&conn, &user_id, "iOS App").await?;
-    let created = services::tokens::create_token(&conn, &user_id, "iOS App").await?;
+    services::tokens::revoke_tokens_by_name(&conn, &user_id, IOS_APP_TOKEN_NAME).await?;
+    let created = services::tokens::create_token(&conn, &user_id, IOS_APP_TOKEN_NAME).await?;
 
     Ok((
         StatusCode::CREATED,

--- a/crates/intrada-api/tests/auth_ios_test.rs
+++ b/crates/intrada-api/tests/auth_ios_test.rs
@@ -114,27 +114,20 @@ async fn revoke_by_name_revokes_prior_tokens() {
     .expect("revoke_by_name should succeed");
     assert_eq!(revoked, 2, "should revoke exactly the 2 'iOS App' tokens");
 
-    // List tokens and verify state.
+    // List tokens via the API. "iOS App" tokens are internal and should
+    // be hidden from the MCP tokens list — only the "Other" token appears.
     let (_, body) = common::get(app2, "/api/account/tokens").await;
     let tokens: Vec<Value> = common::json(&body);
-    assert_eq!(tokens.len(), 3);
-
-    for t in &tokens {
-        let name = t["name"].as_str().unwrap();
-        if name == "iOS App" {
-            assert!(
-                t["revoked_at"].is_string(),
-                "iOS App token {} should be revoked",
-                t["id"]
-            );
-        } else {
-            assert!(
-                t["revoked_at"].is_null(),
-                "Non-iOS token {} should NOT be revoked",
-                t["id"]
-            );
-        }
-    }
+    assert_eq!(
+        tokens.len(),
+        1,
+        "only the non-iOS token should appear in the list"
+    );
+    assert_eq!(tokens[0]["name"].as_str().unwrap(), "Other");
+    assert!(
+        tokens[0]["revoked_at"].is_null(),
+        "Non-iOS token should NOT be revoked"
+    );
 
     // Calling revoke_by_name again should return 0 (already revoked).
     let revoked_again = intrada_api::db::tokens::revoke_by_name(&conn, "", "iOS App")

--- a/crates/intrada-web/static/ios-auth.html
+++ b/crates/intrada-web/static/ios-auth.html
@@ -72,40 +72,52 @@
         if (!clerk) throw new Error('Clerk SDK not available');
         await clerk.load();
 
-        // If this is a callback from OAuth (Clerk appends status params)
-        if (location.search.includes('__clerk_status') ||
-            location.hash.includes('__clerk_status')) {
+        // Check if this is a callback from OAuth (Clerk appends status params)
+        var isCallback = location.search.includes('__clerk_status') ||
+            location.hash.includes('__clerk_status');
+
+        // Check if the URL includes the "completing" flag we set before
+        // redirecting to Google. This distinguishes a post-OAuth return
+        // (should grab token) from a fresh page load (should show picker).
+        var isCompleting = new URLSearchParams(location.search).get('completing') === '1';
+
+        if (isCallback) {
           statusEl.textContent = 'Completing sign-in...';
           await clerk.handleRedirectCallback({
-            redirectUrl: location.origin + '/ios-auth.html',
+            redirectUrl: location.origin + '/ios-auth.html?completing=1&pk=' + encodeURIComponent(pk),
           });
           // handleRedirectCallback navigates away; if we reach here, wait
           return;
         }
 
-        // User is already signed in (e.g. returning after OAuth completed)
-        if (clerk.user && clerk.session) {
+        // Post-OAuth: user is signed in after the redirect completed.
+        // Grab the session token and redirect back to the app.
+        if (isCompleting && clerk.user && clerk.session) {
           statusEl.textContent = 'Getting session token...';
           var token = await clerk.session.getToken();
           if (!token) throw new Error('No session token');
-          // The Clerk session persists in Safari cookies. This means
-          // re-auth reuses the same Google account silently (no picker).
-          // Acceptable for beta — switching accounts requires signing out
-          // of Google in Safari first.
           window.location.href = 'com.intrada.app://oauth-callback?token=' + encodeURIComponent(token);
           return;
         }
 
-        // Not signed in — trigger Google OAuth. The redirect chain stays
-        // on this page: Google → Clerk verify → /ios-auth.html (callback)
-        // → /ios-auth.html (complete, now signed in) → app scheme.
+        // Fresh sign-in attempt from the iOS app. If a previous Clerk
+        // session exists in Safari cookies, sign out first so the user
+        // always gets the Google account picker.
+        if (clerk.user) {
+          statusEl.textContent = 'Preparing sign-in...';
+          await clerk.signOut();
+        }
+
+        // Trigger Google OAuth. The redirect chain stays on this page:
+        // Google → Clerk verify → /ios-auth.html?__clerk_status (callback)
+        // → /ios-auth.html?completing=1 (signed in) → app scheme.
         statusEl.textContent = 'Redirecting to Google...';
         var signIn = clerk.client && clerk.client.signIn;
         if (signIn && typeof signIn.authenticateWithRedirect === 'function') {
           await signIn.authenticateWithRedirect({
             strategy: 'oauth_google',
-            redirectUrl: location.origin + '/ios-auth.html',
-            redirectUrlComplete: location.origin + '/ios-auth.html',
+            redirectUrl: location.origin + '/ios-auth.html?pk=' + encodeURIComponent(pk),
+            redirectUrlComplete: location.origin + '/ios-auth.html?completing=1&pk=' + encodeURIComponent(pk),
           });
         } else {
           await clerk.redirectToSignIn();


### PR DESCRIPTION
## Summary

- **Google account picker not showing**: When a previous Clerk session existed in Safari cookies, `ios-auth.html` skipped straight to getting a token and redirecting back — the Safari popup opened and closed instantly with no chance to pick an account. Fix: sign out of Clerk before triggering OAuth on fresh sign-in attempts (distinguished from post-OAuth returns via a `completing` URL parameter).

- **iOS App tokens visible in MCP tokens list**: The `/api/auth/ios/exchange` endpoint creates PATs named "iOS App" in the `mcp_tokens` table, which then appeared in the user-facing Settings → MCP tokens page. Fix: filter them out of the list query using a shared `IOS_APP_TOKEN_NAME` constant.

## Test plan

- [x] `cargo test -p intrada-api` — all 166 tests pass
- [x] `cargo clippy -p intrada-api -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] iOS: tap "Sign in" → Safari sheet should show Google account picker (not auto-close)
- [ ] iOS: after sign-in, check Settings → MCP tokens — no "iOS App" entries
- [ ] Web: sign in unchanged — no regression

## Coverage

iOS auth flow not reachable from unit tests (requires real Clerk JWT + Safari). Token list filtering tested via updated `revoke_by_name_revokes_prior_tokens` integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)