### PR TITLE
fix(web): gate WelcomeView on auth_loading to prevent marketing page flash

### DIFF
--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -4,7 +4,7 @@ use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
 use crate::app::AuthState;
-use crate::components::{BrandMark, Button, ButtonVariant};
+use crate::components::{BrandMark, BrandMarkSize, Button, ButtonVariant};
 use intrada_web::js_bridge;
 use intrada_web::platform::is_ios;
 
@@ -52,51 +52,66 @@ pub fn WelcomeView() -> impl IntoView {
         }
     });
 
-    view! {
-        <div class="relative z-0 min-h-screen text-primary">
-            <WelcomeNav />
-            <WelcomeHero />
-            <WelcomePillars />
-            <WelcomeDifferentiators />
-            <WelcomeFeature
-                kicker="PLAN".to_string()
-                title="The library that\nremembers for you.".to_string()
-                description="Half of what your teacher gives you disappears within a week. Intrada catches it — tag by composer, key, or tempo, group what you actually run into reusable routines, and connect everything to the goals you're working towards.".to_string()
-                bullets=vec![
-                    "Pieces, exercises, and patterns in one place".to_string(),
-                    "Reusable routines for the warm-ups and blocks you run every week".to_string(),
-                    "Goals that turn the library into a path".to_string(),
-                ]
-                reverse=false
-                mock=Box::new(|| view! { <LibraryMock /> }.into_any())
-            />
-            <WelcomeFeature
-                kicker="PRACTICE".to_string()
-                title="One decision:\nstart.".to_string()
-                description="Choosing what to practise is the silent killer of a session. Intrada plans the work for the time you've got — you tap start and play. Each item gets a timer and a quick rating, then on to the next. Big numbers, big buttons, no chrome.".to_string()
-                bullets=vec![
-                    "A session ready every time you sit down".to_string(),
-                    "Resume right where you left off".to_string(),
-                    "Adjust duration and focus mid-session without losing your place".to_string(),
-                ]
-                reverse=true
-                mock=Box::new(|| view! { <PracticeMock /> }.into_any())
-            />
-            <WelcomeFeature
-                kicker="TRACK".to_string()
-                title="Progress you\ncan't yet feel.".to_string()
-                description="Music improves between sessions, not within them — so the work feels invisible while it's happening. Intrada turns weeks of mastery ratings, time, and tempo into evidence you can see today, before your ears catch up.".to_string()
-                bullets=vec![
-                    "Mastery per piece, per key, across weeks".to_string(),
-                    "Time, sessions, and where your attention actually went".to_string(),
-                    "A welcome back when life happens — not a guilt trip".to_string(),
-                ]
-                reverse=false
-                mock=Box::new(|| view! { <AnalyticsMock /> }.into_any())
-            />
-            <WelcomeFinalCta />
-            <WelcomeFooter />
-        </div>
+    move || {
+        if auth.auth_loading.get() {
+            view! {
+                <div class="relative z-0 min-h-screen text-primary flex items-center justify-center">
+                    <div class="text-center">
+                        <div class="mb-2">
+                            <BrandMark size=BrandMarkSize::Lg />
+                        </div>
+                        <p class="text-muted">"Loading..."</p>
+                    </div>
+                </div>
+            }.into_any()
+        } else {
+            view! {
+                <div class="relative z-0 min-h-screen text-primary">
+                    <WelcomeNav />
+                    <WelcomeHero />
+                    <WelcomePillars />
+                    <WelcomeDifferentiators />
+                    <WelcomeFeature
+                        kicker="PLAN".to_string()
+                        title="The library that\nremembers for you.".to_string()
+                        description="Half of what your teacher gives you disappears within a week. Intrada catches it — tag by composer, key, or tempo, group what you actually run into reusable routines, and connect everything to the goals you're working towards.".to_string()
+                        bullets=vec![
+                            "Pieces, exercises, and patterns in one place".to_string(),
+                            "Reusable routines for the warm-ups and blocks you run every week".to_string(),
+                            "Goals that turn the library into a path".to_string(),
+                        ]
+                        reverse=false
+                        mock=Box::new(|| view! { <LibraryMock /> }.into_any())
+                    />
+                    <WelcomeFeature
+                        kicker="PRACTICE".to_string()
+                        title="One decision:\nstart.".to_string()
+                        description="Choosing what to practise is the silent killer of a session. Intrada plans the work for the time you've got — you tap start and play. Each item gets a timer and a quick rating, then on to the next. Big numbers, big buttons, no chrome.".to_string()
+                        bullets=vec![
+                            "A session ready every time you sit down".to_string(),
+                            "Resume right where you left off".to_string(),
+                            "Adjust duration and focus mid-session without losing your place".to_string(),
+                        ]
+                        reverse=true
+                        mock=Box::new(|| view! { <PracticeMock /> }.into_any())
+                    />
+                    <WelcomeFeature
+                        kicker="TRACK".to_string()
+                        title="Progress you\ncan't yet feel.".to_string()
+                        description="Music improves between sessions, not within them — so the work feels invisible while it's happening. Intrada turns weeks of mastery ratings, time, and tempo into evidence you can see today, before your ears catch up.".to_string()
+                        bullets=vec![
+                            "Mastery per piece, per key, across weeks".to_string(),
+                            "Time, sessions, and where your attention actually went".to_string(),
+                            "A welcome back when life happens — not a guilt trip".to_string(),
+                        ]
+                        reverse=false
+                        mock=Box::new(|| view! { <AnalyticsMock /> }.into_any())
+                    />
+                    <WelcomeFinalCta />
+                    <WelcomeFooter />
+                </div>
+            }.into_any()
+        }
     }
 }
 

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -12,14 +12,11 @@ use intrada_web::platform::is_ios;
 ///
 /// Pencil ref: `fWsUw` (desktop) and `vFOGv` (mobile-web).
 ///
-/// Renders immediately — does not wait for Clerk to initialise. Auth-state-
-/// based redirects fire reactively via the Effect below as soon as Clerk
-/// resolves:
+/// Shows a branded loading screen while Clerk initialises, then either
+/// redirects or renders the marketing page:
 /// - Authed users → redirect to /library.
 /// - Unauthed iOS users (Tauri WebView) → redirect to /login. They already
-///   downloaded the app; the marketing pitch is redundant. Held until
-///   `auth_loading=false` so we know they're really unauthed (vs. Clerk
-///   still loading their session).
+///   downloaded the app; the marketing pitch is redundant.
 /// - Anyone else → render the marketing page.
 ///
 /// Sub-sections live as private components in this file. Phone-frame


### PR DESCRIPTION
## Summary

- Authenticated web users visiting `/` saw the full marketing page flash for 1-3s while Clerk loaded from CDN, then got redirected to `/library`
- `WelcomeView` now shows a branded loading screen (`BrandMark` + "Loading...") while `auth_loading` is true, matching the `AuthenticatedShell` pattern used by private routes
- Once auth resolves: authenticated users redirect to `/library`, unauthenticated users see the marketing page — no flash either way

## Coverage

Single-file UI change in `intrada-web` (WASM shell, excluded from coverage). No new logic branches that are testable from the API harness.

## Test plan

- [ ] Visit `/` as an authenticated web user — should see branded loading screen, then redirect to `/library` (no marketing page flash)
- [ ] Visit `/` as an unauthenticated web user — should see branded loading screen briefly, then the marketing page
- [ ] Visit `/` on iOS (Tauri) — splash screen covers the loading state; after auth resolves, redirects to `/login` (unauthenticated) or `/library` (authenticated)
- [ ] Verify the loading screen matches the `AuthLoadingScreen` style (centred BrandMark + "Loading..." text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)