### PR TITLE
fix(ios): use ephemeral auth session so Google shows account picker

### DIFF
--- a/crates/intrada-mobile/plugins/auth-session/ios/Sources/AuthSessionPlugin/AuthSessionPlugin.swift
+++ b/crates/intrada-mobile/plugins/auth-session/ios/Sources/AuthSessionPlugin/AuthSessionPlugin.swift
@@ -63,7 +63,10 @@ class AuthSessionPlugin: Plugin {
       }
 
       session.presentationContextProvider = contextProvider
-      session.prefersEphemeralWebBrowserSession = false
+      // Ephemeral = true gives a clean cookie jar each time, so Google
+      // always shows the account picker instead of auto-selecting the
+      // previously used account from Safari's shared cookies.
+      session.prefersEphemeralWebBrowserSession = true
 
       self?.activeSession = session
 


### PR DESCRIPTION
## Summary

- `ASWebAuthenticationSession.prefersEphemeralWebBrowserSession` was `false`, meaning the Safari auth sheet shared cookies with the user's main Safari browser. Google's OAuth auto-selected the previously used account — the sheet opened and closed instantly with no account picker shown.
- Setting it to `true` gives each auth session a clean cookie jar. Google always shows the account picker.

## Test plan

- [ ] iOS: tap "Sign in" → Safari sheet opens → **Google account picker is shown**
- [ ] iOS: select account → OAuth completes → signed in successfully
- [ ] iOS: sign out, sign back in → picker shown again (not auto-selected)

## Coverage

Swift plugin change — not reachable from Rust unit tests. Manual iOS testing required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)