### PR TITLE
fix(ios): hold splash until auth resolves to eliminate startup flicker

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -470,7 +470,7 @@
     </noscript>
     <!-- Branded splash screen — iOS only. Hidden by default (display:none);
          the inline Tauri-detection script above sets display:flex on iOS.
-         Removed by main.rs dismiss_splash() once the Leptos app mounts.
+         Removed by app.rs dismiss_splash() once auth resolves.
          Colors are hardcoded because CSS tokens aren't loaded yet —
          keep in sync with input.css: #161926/#0f111a = surface bg,
          #9180fa = accent, #e8e6f0 = text-primary. -->

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -9,6 +9,7 @@ use leptos_router::path;
 use leptos_router::NavigateOptions;
 use send_wrapper::SendWrapper;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 use intrada_core::{Event, Intrada, SessionEvent, ViewModel};
 
@@ -119,8 +120,13 @@ pub fn App() -> impl IntoView {
                     auth_loading.set(false);
                     return;
                 }
+                // Auth bridge is ready but user isn't signed in — no point
+                // polling for 5 more seconds. On iOS this fires on the first
+                // tick (PAT check is synchronous).
+                if js_bridge::is_ready() {
+                    break;
+                }
             }
-            // After 5 seconds, Clerk has loaded but user is not signed in
             auth_loading.set(false);
         });
     }
@@ -144,6 +150,18 @@ pub fn App() -> impl IntoView {
         js_bridge::add_auth_listener(&closure);
         closure.forget(); // leak intentionally — lives for app lifetime
     }
+
+    // ─── Splash screen dismissal ──────────────────────────────────────
+    // On iOS the splash stays visible until auth resolves and navigation
+    // Effects have settled, so the user goes directly from branded splash
+    // to the final destination (login or library) with no intermediate
+    // flicker. On web the splash element is hidden (display:none) so this
+    // is a no-op.
+    Effect::new(move |_| {
+        if !auth_loading.get() {
+            dismiss_splash();
+        }
+    });
 
     // ─── Crux core + app-level reactive state ─────────────────────────
     // Mounted once at the App level (was previously inside the
@@ -419,6 +437,44 @@ fn AuthLoadingScreen() -> impl IntoView {
             </div>
         </div>
     }
+}
+
+/// Fade out and remove the `#app-splash` overlay. The splash has already been
+/// visible since HTML load (iOS) so we skip the hold and go straight to a
+/// 400ms opacity fade, then remove the element. No-op on web where the splash
+/// is `display: none`.
+fn dismiss_splash() {
+    use leptos::web_sys;
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let Some(document) = window.document() else {
+        return;
+    };
+    let Some(el) = document.get_element_by_id("app-splash") else {
+        return;
+    };
+    // One-frame delay so navigation Effects that fire in the same reactive
+    // batch have time to update the DOM before we reveal what's underneath.
+    let raf_cb = Closure::once(move || {
+        let el_remove = el.clone();
+        let _ = el
+            .unchecked_ref::<web_sys::HtmlElement>()
+            .style()
+            .set_property("opacity", "0");
+        let remove_cb = Closure::once(move || {
+            el_remove.remove();
+        });
+        if let Some(w) = web_sys::window() {
+            let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
+                remove_cb.as_ref().unchecked_ref(),
+                400,
+            );
+        }
+        remove_cb.forget();
+    });
+    let _ = window.request_animation_frame(raf_cb.as_ref().unchecked_ref());
+    raf_cb.forget();
 }
 
 /// Design catalogue route — shows the component catalogue in debug builds,

--- a/crates/intrada-web/src/js_bridge.rs
+++ b/crates/intrada-web/src/js_bridge.rs
@@ -23,6 +23,9 @@ use wasm_bindgen::prelude::*;
         }
         return false;
     }
+    export function js_is_ready() {
+        return !!(window.__intrada_auth && window.__intrada_auth._ready);
+    }
     export function js_init_error() {
         if (window.__intrada_auth) {
             return window.__intrada_auth._lastError || null;
@@ -88,6 +91,7 @@ extern "C" {
     fn js_init_clerk(key: &str);
     fn js_is_signed_in() -> bool;
     fn js_init_failed() -> bool;
+    fn js_is_ready() -> bool;
     fn js_init_error() -> JsValue;
     async fn js_get_token() -> JsValue;
     fn js_get_user_id() -> JsValue;
@@ -116,6 +120,13 @@ pub fn is_signed_in() -> bool {
 /// Check whether Clerk initialization failed (bad key, wrong domain, network error).
 pub fn init_failed() -> bool {
     js_init_failed()
+}
+
+/// Check whether the auth bridge is ready (Clerk loaded on web, or PAT
+/// check possible on iOS). When ready and `is_signed_in()` is false, the
+/// user is genuinely unauthenticated — no need to keep polling.
+pub fn is_ready() -> bool {
+    js_is_ready()
 }
 
 /// Get the Clerk initialization error message, if any.

--- a/crates/intrada-web/src/main.rs
+++ b/crates/intrada-web/src/main.rs
@@ -3,46 +3,8 @@ mod components;
 mod views;
 
 use app::App;
-use wasm_bindgen::JsCast;
 
 fn main() {
     console_error_panic_hook::set_once();
     leptos::mount::mount_to_body(App);
-    dismiss_splash();
-}
-
-fn dismiss_splash() {
-    use leptos::web_sys;
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let Some(document) = window.document() else {
-        return;
-    };
-    let Some(el) = document.get_element_by_id("app-splash") else {
-        return;
-    };
-    // Hold the splash for a minimum duration so it reads as intentional
-    // branding rather than a flicker. The fade-out starts after the hold,
-    // then the element is removed after the CSS transition completes.
-    let fade = wasm_bindgen::closure::Closure::once(move || {
-        let el_remove = el.clone();
-        let _ = el
-            .unchecked_ref::<web_sys::HtmlElement>()
-            .style()
-            .set_property("opacity", "0");
-        let remove_cb = wasm_bindgen::closure::Closure::once(move || {
-            el_remove.remove();
-        });
-        if let Some(w) = web_sys::window() {
-            let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
-                remove_cb.as_ref().unchecked_ref(),
-                400,
-            );
-        }
-        remove_cb.forget();
-    });
-    let _ = window
-        .set_timeout_with_callback_and_timeout_and_arguments_0(fade.as_ref().unchecked_ref(), 600);
-    fade.forget();
 }


### PR DESCRIPTION
## Summary

- On iOS, the splash screen dismissed on WASM mount (600ms hold) regardless of auth state, revealing 2-3 intermediate states (loading screen, marketing page, view transition) before landing on login — causing multiple rapid flickers
- Splash dismissal now tied to `auth_loading` becoming false via a reactive Effect in `app.rs`, so the splash covers the entire auth window and fades directly to the final destination (login or library)
- Added `is_ready()` to the JS auth bridge so the polling loop exits early when auth is resolved but the user isn't signed in — on iOS this fires on the first tick (PAT check is synchronous) instead of waiting the full 5-second timeout
- `dismiss_splash` uses `requestAnimationFrame` instead of a 600ms hold, giving navigation Effects one frame to settle before revealing the view underneath

### iOS startup sequence (before → after)

**Before:** splash (1s) → loading screen → marketing page → view transition → login  
**After:** splash → fade → login (or library)

## Coverage

UI-only change in `intrada-web` (WASM shell, excluded from coverage). `is_ready()` is a thin JS bridge wrapper — no testable logic.

## Test plan

- [ ] iOS (unauthenticated): launch app → splash holds, fades directly to login screen. No intermediate marketing page or loading screen visible
- [ ] iOS (authenticated, has PAT): launch app → splash holds, fades directly to library
- [ ] Web (unauthenticated): visit `/` → branded loading screen briefly, then marketing page (splash is not shown on web)
- [ ] Web (authenticated): visit `/` → branded loading screen briefly, then redirects to `/library`
- [ ] Verify splash fade animation is smooth (400ms opacity transition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)