### PR TITLE
fix(web): guard ev.key() against undefined on Android IME events

### DIFF
--- a/crates/intrada-web/src/components/autocomplete.rs
+++ b/crates/intrada-web/src/components/autocomplete.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
 use leptos::prelude::*;
-use wasm_bindgen::JsValue;
 
 use crate::components::FormFieldError;
-use intrada_web::helpers::filter_suggestions;
+use intrada_web::helpers::{filter_suggestions, keyboard_event_key};
 
 /// Reusable autocomplete dropdown component.
 ///
@@ -76,12 +75,7 @@ pub fn Autocomplete(
 
     // Handle keyboard navigation
     let on_keydown = move |ev: web_sys::KeyboardEvent| {
-        // Android IME events can have event.key === undefined, which panics
-        // in wasm-bindgen's passStringToWasm0. Safely extract via Reflect.
-        let Some(key) = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
-            .ok()
-            .and_then(|v| v.as_string())
-        else {
+        let Some(key) = keyboard_event_key(ev.as_ref()) else {
             return;
         };
         let items = filtered.get();

--- a/crates/intrada-web/src/components/autocomplete.rs
+++ b/crates/intrada-web/src/components/autocomplete.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use leptos::prelude::*;
+use wasm_bindgen::JsValue;
 
 use crate::components::FormFieldError;
 use intrada_web::helpers::filter_suggestions;
@@ -75,7 +76,14 @@ pub fn Autocomplete(
 
     // Handle keyboard navigation
     let on_keydown = move |ev: web_sys::KeyboardEvent| {
-        let key = ev.key();
+        // Android IME events can have event.key === undefined, which panics
+        // in wasm-bindgen's passStringToWasm0. Safely extract via Reflect.
+        let Some(key) = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
+            .ok()
+            .and_then(|v| v.as_string())
+        else {
+            return;
+        };
         let items = filtered.get();
         let len = items.len();
 

--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -2,7 +2,7 @@ use leptos::portal::Portal;
 use leptos::prelude::*;
 use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
 
 use intrada_web::haptics::haptic_light;
@@ -97,7 +97,10 @@ pub fn BottomSheet(
             return;
         };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
-            if ev.key() == "Escape" {
+            let key = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
+                .ok()
+                .and_then(|v| v.as_string());
+            if key.as_deref() == Some("Escape") {
                 close.run(());
             }
         });

--- a/crates/intrada-web/src/components/bottom_sheet.rs
+++ b/crates/intrada-web/src/components/bottom_sheet.rs
@@ -2,7 +2,7 @@ use leptos::portal::Portal;
 use leptos::prelude::*;
 use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
 
 use intrada_web::haptics::haptic_light;
@@ -97,10 +97,7 @@ pub fn BottomSheet(
             return;
         };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
-            let key = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
-                .ok()
-                .and_then(|v| v.as_string());
-            if key.as_deref() == Some("Escape") {
+            if intrada_web::helpers::keyboard_event_key(ev.as_ref()).as_deref() == Some("Escape") {
                 close.run(());
             }
         });

--- a/crates/intrada-web/src/components/context_menu.rs
+++ b/crates/intrada-web/src/components/context_menu.rs
@@ -2,7 +2,7 @@ use leptos::portal::Portal;
 use leptos::prelude::*;
 use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
 
 use intrada_web::haptics::haptic_medium;
@@ -74,10 +74,7 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
             return;
         };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
-            let key = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
-                .ok()
-                .and_then(|v| v.as_string());
-            if key.as_deref() == Some("Escape") {
+            if intrada_web::helpers::keyboard_event_key(ev.as_ref()).as_deref() == Some("Escape") {
                 close.run(());
             }
         });

--- a/crates/intrada-web/src/components/context_menu.rs
+++ b/crates/intrada-web/src/components/context_menu.rs
@@ -2,7 +2,7 @@ use leptos::portal::Portal;
 use leptos::prelude::*;
 use send_wrapper::SendWrapper;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{AddEventListenerOptions, KeyboardEvent, TouchEvent};
 
 use intrada_web::haptics::haptic_medium;
@@ -74,7 +74,10 @@ pub fn ContextMenu(actions: Vec<ContextMenuAction>, children: Children) -> impl 
             return;
         };
         let on_keydown: Closure<dyn Fn(KeyboardEvent)> = Closure::new(move |ev: KeyboardEvent| {
-            if ev.key() == "Escape" {
+            let key = js_sys::Reflect::get(ev.as_ref(), &JsValue::from_str("key"))
+                .ok()
+                .and_then(|v| v.as_string());
+            if key.as_deref() == Some("Escape") {
                 close.run(());
             }
         });

--- a/crates/intrada-web/src/components/library_filter_tabs.rs
+++ b/crates/intrada-web/src/components/library_filter_tabs.rs
@@ -91,8 +91,11 @@ pub fn LibraryFilterTabs(
     };
 
     let handle_keydown = move |ev: ev::KeyboardEvent| {
+        let Some(key) = intrada_web::helpers::keyboard_event_key(ev.as_ref()) else {
+            return;
+        };
         let current = active_index();
-        let target_index = match ev.key().as_str() {
+        let target_index = match key.as_str() {
             "ArrowLeft" if current > 0 => current - 1,
             "ArrowRight" if current + 1 < N_TABS => current + 1,
             "Home" => 0,

--- a/crates/intrada-web/src/components/library_type_tabs.rs
+++ b/crates/intrada-web/src/components/library_type_tabs.rs
@@ -70,8 +70,11 @@ pub fn LibraryTypeTabs(
     };
 
     let handle_keydown = move |ev: ev::KeyboardEvent| {
+        let Some(key) = intrada_web::helpers::keyboard_event_key(ev.as_ref()) else {
+            return;
+        };
         let current = active_index();
-        let target_index = match ev.key().as_str() {
+        let target_index = match key.as_str() {
             "ArrowLeft" if current > 0 => current - 1,
             "ArrowRight" if current + 1 < N_TABS => current + 1,
             // Home/End jump to the first/last tab. Per WAI-ARIA tabs

--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -114,7 +114,10 @@ pub fn SetSaveForm(
                                     placeholder="e.g. Morning Warm-up"
                                     bind:value=name
                                     on:keydown=move |ev: leptos::ev::KeyboardEvent| {
-                                        if ev.key() == "Enter" {
+                                        let key = js_sys::Reflect::get(ev.as_ref(), &wasm_bindgen::JsValue::from_str("key"))
+                                            .ok()
+                                            .and_then(|v| v.as_string());
+                                        if key.as_deref() == Some("Enter") {
                                             try_save_enter();
                                         }
                                     }

--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -114,10 +114,7 @@ pub fn SetSaveForm(
                                     placeholder="e.g. Morning Warm-up"
                                     bind:value=name
                                     on:keydown=move |ev: leptos::ev::KeyboardEvent| {
-                                        let key = js_sys::Reflect::get(ev.as_ref(), &wasm_bindgen::JsValue::from_str("key"))
-                                            .ok()
-                                            .and_then(|v| v.as_string());
-                                        if key.as_deref() == Some("Enter") {
+                                        if intrada_web::helpers::keyboard_event_key(ev.as_ref()).as_deref() == Some("Enter") {
                                             try_save_enter();
                                         }
                                     }

--- a/crates/intrada-web/src/components/type_tabs.rs
+++ b/crates/intrada-web/src/components/type_tabs.rs
@@ -56,7 +56,9 @@ pub fn TypeTabs(
         if !is_interactive {
             return;
         }
-        let key = ev.key();
+        let Some(key) = intrada_web::helpers::keyboard_event_key(ev.as_ref()) else {
+            return;
+        };
         match key.as_str() {
             "ArrowLeft" | "ArrowRight" => {
                 ev.prevent_default();

--- a/crates/intrada-web/src/helpers.rs
+++ b/crates/intrada-web/src/helpers.rs
@@ -2,6 +2,18 @@ use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Datelike, Duration, NaiveDate, Weekday};
 use intrada_core::{LibraryItemView, PracticeSessionView, Tempo};
+use wasm_bindgen::JsValue;
+
+/// Safely extract the `key` property from a KeyboardEvent.
+///
+/// Android IME events can have `event.key === undefined`, which panics
+/// in wasm-bindgen's `passStringToWasm0`. This uses `Reflect::get` to
+/// return `None` instead. Pass `ev.as_ref()` from any `web_sys` event type.
+pub fn keyboard_event_key(ev: &JsValue) -> Option<String> {
+    js_sys::Reflect::get(ev, &JsValue::from_str("key"))
+        .ok()
+        .and_then(|v| v.as_string())
+}
 
 /// Format an ISO 8601 / RFC 3339 date string to "d Mon YYYY" (e.g. "4 Mar 2026").
 pub fn format_date_short(iso: &str) -> String {


### PR DESCRIPTION
## Summary

- Android IME keyboard events can return `undefined` for `event.key`, which panics in wasm-bindgen's `passStringToWasm0` (reads `.length` on `undefined`)
- Extracted a shared `keyboard_event_key()` helper in `intrada_web::helpers` that safely reads the key via `js_sys::Reflect::get`
- Replaced all 7 `ev.key()` call sites with the safe helper
- Fixes [INTRADA-WEB-M](https://jon-yardley.sentry.io/issues/INTRADA-WEB-M) (TypeError, 6 events) and [INTRADA-WEB-3](https://jon-yardley.sentry.io/issues/INTRADA-WEB-3) (RuntimeError: unreachable, 3 events)

## Files changed

- `crates/intrada-web/src/helpers.rs` — new `keyboard_event_key()` helper
- `crates/intrada-web/src/components/autocomplete.rs` — the crashing site (tags input keydown)
- `crates/intrada-web/src/components/set_save_form.rs` — Enter key check
- `crates/intrada-web/src/components/context_menu.rs` — Escape key check
- `crates/intrada-web/src/components/bottom_sheet.rs` — Escape key check
- `crates/intrada-web/src/components/library_filter_tabs.rs` — arrow/Home/End key navigation
- `crates/intrada-web/src/components/type_tabs.rs` — arrow key navigation
- `crates/intrada-web/src/components/library_type_tabs.rs` — arrow/Home/End key navigation

## Coverage

No new test coverage — the bug is in wasm-bindgen's JS↔WASM boundary when `KeyboardEvent.key` is undefined, which only manifests in a real browser on Android. Not reproducible in unit tests.

## Test plan

- [ ] Verify tags input works on Android Chrome (the reporter's device)
- [ ] Verify Enter/Escape still work normally on desktop browsers
- [ ] Verify tab keyboard navigation (arrow keys) still works
- [ ] Confirm no new Sentry events for INTRADA-WEB-M or INTRADA-WEB-3 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)