### PR TITLE
fix(web): don't flash sign-in error when auth succeeded

### DIFF
--- a/crates/intrada-web/src/views/login.rs
+++ b/crates/intrada-web/src/views/login.rs
@@ -45,8 +45,18 @@ pub fn LoginView() -> impl IntoView {
         sign_in_error.set(None);
         leptos::task::spawn_local(async move {
             js_bridge::sign_in_with_google().await;
-            // If we reach here, the redirect didn't happen — something failed.
-            // On success the page navigates away and this code never runs.
+            // Web: on success the page navigates away (Clerk redirect) and
+            // this code never runs. If we reach here, something failed.
+            //
+            // iOS: signInWithGoogle() completes in-process (Safari sheet →
+            // PAT exchange → auth listener fires). The user is already
+            // signed in when we get here — don't show an error.
+            if js_bridge::is_signed_in() {
+                // Auth listener already fired; the Effect above will
+                // redirect to /library. Just clear the spinner.
+                signing_in.set(false);
+                return;
+            }
             signing_in.set(false);
             if let Some(err) = js_bridge::init_error() {
                 sign_in_error.set(Some(err));


### PR DESCRIPTION
## Summary

- On iOS, `signInWithGoogle()` completes in-process (Safari sheet → PAT exchange → auth listener fires) and the await resolves normally. The login view assumed that if the await resolved without a page redirect, sign-in had failed — showing "Sign-in failed. Please try again." briefly before the auth listener redirect kicked in to `/library`.
- Fix: check `is_signed_in()` after the await returns. If the user is already authenticated, clear the spinner and let the existing redirect Effect handle navigation without flashing an error.
- This also covers an edge case on web where the redirect hasn't started yet but auth state has already been set.

## Test plan

- [ ] iOS: sign in → no "Sign-in failed" flicker, goes straight to library
- [ ] Web: sign in → normal redirect flow, no regression
- [ ] Both: actual sign-in failure still shows the error message

## Coverage

UI interaction — not reachable from unit tests. Manual testing required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)