### PR TITLE
fix(ios): native cold start — splash fades to reveal ready app

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -198,6 +198,10 @@
       // device.
       if (location.protocol === 'tauri:') {
         document.documentElement.setAttribute('data-platform', 'ios');
+        // Suppress view-transition animations during initial load so the
+        // first route change (/ → /library or /login) is instant behind
+        // the splash. Removed by dismiss_splash after the splash fades.
+        document.documentElement.classList.add('app-loading');
         // Show the branded splash screen on iOS only — on web it feels
         // unnecessary and adds a flash before the app renders.
         var splash = document.getElementById('app-splash');

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1176,6 +1176,15 @@ nav[aria-label="Mobile navigation"] {
   animation: none;
 }
 
+/* During initial load the splash covers everything. Suppress view-transition
+   animations so the first route change (/ → /library or /login) is instant —
+   no cross-fade visible when the splash later fades away. The class is set in
+   index.html and removed by dismiss_splash after the splash has fully faded. */
+html.app-loading::view-transition-old(root),
+html.app-loading::view-transition-new(root) {
+  animation: none !important;
+}
+
 html.router-outlet-0::view-transition-old(root) {
   animation: 220ms ease-in both vt-slide-out-left;
 }

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -475,6 +475,9 @@ fn dismiss_splash() {
                 }
             }
         });
+        // 400ms > the splash's 300ms CSS opacity transition — gives the
+        // fade a frame of headroom before removing the element and
+        // re-enabling view-transition animations.
         if let Some(w) = web_sys::window() {
             let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
                 remove_cb.as_ref().unchecked_ref(),

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -464,6 +464,16 @@ fn dismiss_splash() {
             .set_property("opacity", "0");
         let remove_cb = Closure::once(move || {
             el_remove.remove();
+            // Re-enable view-transition animations now that the splash is
+            // gone and the app is showing the correct destination view.
+            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+                if let Some(root) = doc.document_element() {
+                    let _ = root
+                        .unchecked_ref::<web_sys::HtmlElement>()
+                        .class_list()
+                        .remove_1("app-loading");
+                }
+            }
         });
         if let Some(w) = web_sys::window() {
             let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -12,12 +12,12 @@ use intrada_web::platform::is_ios;
 ///
 /// Pencil ref: `fWsUw` (desktop) and `vFOGv` (mobile-web).
 ///
-/// Shows a branded loading screen while Clerk initialises, then either
-/// redirects or renders the marketing page:
-/// - Authed users → redirect to /library.
-/// - Unauthed iOS users (Tauri WebView) → redirect to /login. They already
-///   downloaded the app; the marketing pitch is redundant.
-/// - Anyone else → render the marketing page.
+/// On iOS the splash screen covers the viewport until auth resolves, so
+/// this component renders nothing — the redirect Effect fires behind the
+/// splash and the user goes straight from splash → fade → destination.
+///
+/// On web, shows a branded loading screen while Clerk initialises, then
+/// either redirects (authed → /library) or renders the marketing page.
 ///
 /// Sub-sections live as private components in this file. Phone-frame
 /// graphics in the hero use a small reusable `PhoneFrame` shell with
@@ -49,7 +49,11 @@ pub fn WelcomeView() -> impl IntoView {
         }
     });
 
-    move || {
+    if on_ios {
+        return view! { <div></div> }.into_any();
+    }
+
+    (move || {
         if auth.auth_loading.get() {
             view! {
                 <div class="relative z-0 min-h-screen text-primary flex items-center justify-center">
@@ -109,7 +113,8 @@ pub fn WelcomeView() -> impl IntoView {
                 </div>
             }.into_any()
         }
-    }
+    })
+    .into_any()
 }
 
 // ════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Builds on #687 (splash holds until auth resolves). That PR eliminated premature splash dismissal but the view transition cross-fade between `/` → `/library` was still visible, producing the ugly overlap seen in the video.

- **CSS**: `html.app-loading` suppresses `::view-transition` animations so the initial route change is instant (no cross-fade behind the splash)
- **WelcomeView**: renders nothing on iOS — the splash covers everything, so marketing content underneath is wasteful and risks a flash
- **dismiss_splash**: removes `app-loading` class after splash fade completes, re-enabling view transitions for subsequent navigation

### iOS cold start (before → after)

**Before:** splash → marketing page visible → cross-fade overlap → library  
**After:** splash (logo) → smooth 400ms fade → library (or login)

## Coverage

UI-only change in `intrada-web` (WASM shell, excluded from coverage). CSS rule and class toggle have no testable logic.

## Test plan

- [ ] iOS (authenticated): cold launch → splash holds, fades smoothly to library. No marketing page or cross-fade visible
- [ ] iOS (unauthenticated): cold launch → splash holds, fades smoothly to login
- [ ] Web (unauthenticated): visit `/` → branded loading screen, then marketing page (no splash, no `app-loading` class)
- [ ] Web (authenticated): visit `/` → branded loading screen, then redirects to `/library`
- [ ] After splash dismisses on iOS, navigate between tabs → view transitions animate normally (220ms slide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)