### PR TITLE
fix(auth): eliminate sign-in error flicker on all platforms

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -384,7 +384,7 @@
               window.__TAURI_INTERNALS__?.invoke;
             if (!tauriInvoke) {
               this._lastError = 'ios_auth: Tauri invoke not available';
-              return;
+              return null;
             }
             try {
               // Open ios-auth.html in ASWebAuthenticationSession (Safari).
@@ -428,15 +428,22 @@
 
               // Notify the Leptos app that auth state changed
               if (this._authListener) this._authListener();
+              return 'ok';
             } catch (e) {
               console.error('iOS auth flow failed:', e);
+              if (e && typeof e.message === 'string' && e.message.includes('user cancelled')) {
+                return 'cancelled';
+              }
               this._lastError = 'ios_auth: ' + (e.message || String(e));
+              return null;
             }
-            return;
           }
 
           // ── Web: standard Clerk redirect flow ──
-          if (!this._clerk) return;
+          // authenticateWithRedirect resolves its Promise, then the browser
+          // starts navigating to Google. Return "redirect" so the caller
+          // knows not to show an error in the brief window before unload.
+          if (!this._clerk) return null;
           const signIn = this._clerk.client?.signIn;
           if (signIn && typeof signIn.authenticateWithRedirect === 'function') {
             await signIn.authenticateWithRedirect({
@@ -447,6 +454,7 @@
           } else {
             await this._clerk.redirectToSignIn();
           }
+          return 'redirect';
         },
         addListener(callback) {
           if (!this._ready) return;

--- a/crates/intrada-web/src/js_bridge.rs
+++ b/crates/intrada-web/src/js_bridge.rs
@@ -57,8 +57,9 @@ use wasm_bindgen::prelude::*;
     }
     export async function js_sign_in_with_google() {
         if (window.__intrada_auth) {
-            await window.__intrada_auth.signInWithGoogle();
+            return await window.__intrada_auth.signInWithGoogle();
         }
+        return null;
     }
     export function js_add_auth_listener(callback) {
         if (window.__intrada_auth) {
@@ -97,7 +98,7 @@ extern "C" {
     fn js_get_user_id() -> JsValue;
     fn js_get_user_email() -> JsValue;
     async fn js_sign_out();
-    async fn js_sign_in_with_google();
+    async fn js_sign_in_with_google() -> JsValue;
     fn js_add_auth_listener(callback: &Closure<dyn Fn()>);
     fn js_sentry_set_user(id: &str);
     fn js_sentry_clear_user();
@@ -159,9 +160,13 @@ pub async fn sign_out() {
     js_sign_out().await;
 }
 
-/// Redirect to Google OAuth sign-in.
-pub async fn sign_in_with_google() {
-    js_sign_in_with_google().await;
+/// Start the Google OAuth sign-in flow. Returns a result string:
+/// - `"ok"` — sign-in completed (iOS: PAT stored, listener fired)
+/// - `"redirect"` — page is navigating to Google (web)
+/// - `"cancelled"` — user dismissed the sign-in sheet (iOS)
+/// - `None` — bridge not available or error (check `init_error()`)
+pub async fn sign_in_with_google() -> Option<String> {
+    js_sign_in_with_google().await.as_string()
 }
 
 /// Register a listener for auth state changes (sign-in/sign-out).

--- a/crates/intrada-web/src/views/login.rs
+++ b/crates/intrada-web/src/views/login.rs
@@ -44,24 +44,31 @@ pub fn LoginView() -> impl IntoView {
         signing_in.set(true);
         sign_in_error.set(None);
         leptos::task::spawn_local(async move {
-            js_bridge::sign_in_with_google().await;
-            // Web: on success the page navigates away (Clerk redirect) and
-            // this code never runs. If we reach here, something failed.
-            //
-            // iOS: signInWithGoogle() completes in-process (Safari sheet →
-            // PAT exchange → auth listener fires). The user is already
-            // signed in when we get here — don't show an error.
-            if js_bridge::is_signed_in() {
-                // Auth listener already fired; the Effect above will
-                // redirect to /library. Just clear the spinner.
-                signing_in.set(false);
-                return;
-            }
-            signing_in.set(false);
-            if let Some(err) = js_bridge::init_error() {
-                sign_in_error.set(Some(err));
-            } else {
-                sign_in_error.set(Some("Sign-in failed. Please try again.".into()));
+            let result = js_bridge::sign_in_with_google().await;
+            match result.as_deref() {
+                // iOS: flow completed, PAT stored, auth listener fired.
+                // The Effect above will redirect to /library.
+                Some("ok") => {
+                    signing_in.set(false);
+                }
+                // Web: page is navigating to Google for OAuth. Keep the
+                // spinner visible — don't flash an error in the brief
+                // window before the browser unloads this page.
+                Some("redirect") => {}
+                // iOS: user dismissed the Safari sign-in sheet.
+                // Not an error — just reset to the initial state.
+                Some("cancelled") => {
+                    signing_in.set(false);
+                }
+                // Actual failure — show the error.
+                _ => {
+                    signing_in.set(false);
+                    if let Some(err) = js_bridge::init_error() {
+                        sign_in_error.set(Some(err));
+                    } else {
+                        sign_in_error.set(Some("Sign-in failed. Please try again.".into()));
+                    }
+                }
             }
         });
     });


### PR DESCRIPTION
## Summary

Supersedes the approach from #690. The login view assumed that if `signInWithGoogle()` returned, sign-in had failed. This was wrong in two cases:

- **iOS**: the flow completes in-process (Safari sheet → PAT exchange → auth listener) and returns normally on success. The `is_signed_in()` check from #690 sometimes lost the race.
- **Web**: `authenticateWithRedirect` resolves its Promise *before* the browser starts navigating to Google. In the brief window before page unload, the error flashed.

**Fix**: `signInWithGoogle()` now returns a result string so the caller knows exactly what happened:
- `"ok"` — sign-in completed (iOS), clear spinner, let redirect Effect handle navigation
- `"redirect"` — page is navigating to Google (web), keep spinner visible, don't show error
- `"cancelled"` — user dismissed the Safari sheet (iOS), reset to initial state
- `null` — actual failure, show the error message

## Test plan

- [ ] **Web**: click "Sign in with Google" → spinner shows → redirects to Google → no error flicker at any point
- [ ] **iOS**: tap "Sign in" → Safari sheet → complete OAuth → goes to library, no error flicker
- [ ] **iOS**: tap "Sign in" → dismiss Safari sheet → button resets, no error shown
- [ ] **Both**: when auth genuinely fails, error message still displays correctly

## Coverage

UI interaction flow — manual testing required on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)