### PR TITLE
fix(ios): native splash window for clean cold start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,14 @@ jobs:
         with:
           prefix-key: "ios-build"
           cache-on-failure: true
+      # dtolnay/rust-toolchain skips adding ~/.cargo/bin to PATH when
+      # rustup is pre-installed on the macOS image. Without this, `cargo`
+      # resolves to Apple's /usr/bin/cargo stub (rustup-init shim) and
+      # every subsequent cargo command fails.
+      - name: Ensure cargo is on PATH
+        run: |
+          echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          cargo --version
       # ── Clippy (device target) — lints #[cfg(target_os = "ios")] branches ──
       - name: Clippy iOS plugins (device target)
         run: |

--- a/crates/intrada-mobile/src-tauri/capabilities/mobile.json
+++ b/crates/intrada-mobile/src-tauri/capabilities/mobile.json
@@ -3,7 +3,7 @@
   "identifier": "mobile",
   "description": "Intrada iOS capabilities",
   "platforms": ["iOS"],
-  "windows": ["main"],
+  "windows": ["main", "splashscreen"],
   "permissions": [
     "core:default",
     "haptics:allow-selection-feedback",

--- a/crates/intrada-mobile/src-tauri/src/lib.rs
+++ b/crates/intrada-mobile/src-tauri/src/lib.rs
@@ -1,6 +1,18 @@
+use tauri::Manager;
+
 // SENTRY_DSN_MOBILE is baked at compile time. Pair with the rerun-if-env-changed
 // directive in build.rs so changing the env doesn't yield stale binaries.
 const SENTRY_DSN: Option<&str> = option_env!("SENTRY_DSN_MOBILE");
+
+#[tauri::command]
+async fn close_splashscreen(app: tauri::AppHandle) {
+    if let Some(splash) = app.get_webview_window("splashscreen") {
+        let _ = splash.close();
+    }
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.show();
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -44,6 +56,7 @@ pub fn run() {
         // real Activity<...>.request / update / end.
         .plugin(tauri_plugin_live_activity::init())
         .plugin(tauri_plugin_auth_session::init())
+        .invoke_handler(tauri::generate_handler![close_splashscreen])
         .run(tauri::generate_context!())
         .expect("error while running intrada");
 }

--- a/crates/intrada-mobile/src-tauri/tauri.conf.json
+++ b/crates/intrada-mobile/src-tauri/tauri.conf.json
@@ -11,9 +11,16 @@
       {
         "label": "main",
         "title": "Intrada",
+        "visible": false,
         "width": 375,
         "height": 812,
         "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"
+      },
+      {
+        "label": "splashscreen",
+        "url": "splashscreen.html",
+        "width": 375,
+        "height": 812
       }
     ],
     "security": {

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -52,6 +52,7 @@
     <link data-trunk rel="copy-file" href="static/sitemap.xml" />
     <link data-trunk rel="copy-file" href="static/og-image.svg" />
     <link data-trunk rel="copy-file" href="static/ios-auth.html" />
+    <link data-trunk rel="copy-file" href="static/splashscreen.html" />
 
     <!-- Release tag for Sentry. Defaults to null (PR builds, local dev) and
          is replaced by CI's deploy step with `sed` before publishing to
@@ -198,14 +199,6 @@
       // device.
       if (location.protocol === 'tauri:') {
         document.documentElement.setAttribute('data-platform', 'ios');
-        // Suppress view-transition animations during initial load so the
-        // first route change (/ → /library or /login) is instant behind
-        // the splash. Removed by dismiss_splash after the splash fades.
-        document.documentElement.classList.add('app-loading');
-        // Show the branded splash screen on iOS only — on web it feels
-        // unnecessary and adds a flash before the app renders.
-        var splash = document.getElementById('app-splash');
-        if (splash) splash.style.display = 'flex';
         // Native iOS apps don't have pinch-zoom on the page. Override the
         // viewport meta to disable it inside the Tauri WebView only —
         // regular browser users keep their accessibility zoom.
@@ -472,26 +465,5 @@
         </nav>
       </div>
     </noscript>
-    <!-- Branded splash screen — iOS only. Hidden by default (display:none);
-         the inline Tauri-detection script above sets display:flex on iOS.
-         Removed by app.rs dismiss_splash() once auth resolves.
-         Colors are hardcoded because CSS tokens aren't loaded yet —
-         keep in sync with input.css: #161926/#0f111a = surface bg,
-         #9180fa = accent, #e8e6f0 = text-primary. -->
-    <div id="app-splash" style="
-      position: fixed; inset: 0; z-index: 9999;
-      display: none; align-items: center; justify-content: center;
-      background: linear-gradient(to bottom, #161926, #0f111a);
-      transition: opacity 0.3s ease;
-    ">
-      <div style="text-align: center;">
-        <div style="display: flex; align-items: center; justify-content: center; gap: 10px; margin-bottom: 8px;">
-          <svg style="width: 28px; height: 28px; color: #9180fa;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
-          </svg>
-          <span style="font-family: 'Source Serif 4', Georgia, serif; font-size: 34px; font-weight: 700; letter-spacing: -0.02em; color: #e8e6f0;">Intrada</span>
-        </div>
-      </div>
-    </div>
   </body>
 </html>

--- a/crates/intrada-web/input.css
+++ b/crates/intrada-web/input.css
@@ -1176,15 +1176,6 @@ nav[aria-label="Mobile navigation"] {
   animation: none;
 }
 
-/* During initial load the splash covers everything. Suppress view-transition
-   animations so the first route change (/ → /library or /login) is instant —
-   no cross-fade visible when the splash later fades away. The class is set in
-   index.html and removed by dismiss_splash after the splash has fully faded. */
-html.app-loading::view-transition-old(root),
-html.app-loading::view-transition-new(root) {
-  animation: none !important;
-}
-
 html.router-outlet-0::view-transition-old(root) {
   animation: 220ms ease-in both vt-slide-out-left;
 }

--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -151,15 +151,25 @@ pub fn App() -> impl IntoView {
         closure.forget(); // leak intentionally — lives for app lifetime
     }
 
-    // ─── Splash screen dismissal ──────────────────────────────────────
-    // On iOS the splash stays visible until auth resolves and navigation
-    // Effects have settled, so the user goes directly from branded splash
-    // to the final destination (login or library) with no intermediate
-    // flicker. On web the splash element is hidden (display:none) so this
-    // is a no-op.
+    // ─── Splash screen dismissal (iOS only) ─────────────────────────
+    // On iOS the Tauri native splash window (a separate lightweight
+    // WebView defined in tauri.conf.json) shows instantly while the main
+    // WASM app loads in a hidden window. Once auth resolves we wait 300ms
+    // for the redirect Effect and view-transition animation (220ms) to
+    // complete behind the splash, then close the splash and show the
+    // main window. On web this is a no-op — there is no splash.
     Effect::new(move |_| {
         if !auth_loading.get() {
-            dismiss_splash();
+            let cb = Closure::once(move || {
+                js_bridge::close_splashscreen();
+            });
+            if let Some(w) = web_sys::window() {
+                let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
+                    cb.as_ref().unchecked_ref(),
+                    300,
+                );
+            }
+            cb.forget();
         }
     });
 
@@ -437,57 +447,6 @@ fn AuthLoadingScreen() -> impl IntoView {
             </div>
         </div>
     }
-}
-
-/// Fade out and remove the `#app-splash` overlay. The splash has already been
-/// visible since HTML load (iOS) so we skip the hold and go straight to a
-/// 400ms opacity fade, then remove the element. No-op on web where the splash
-/// is `display: none`.
-fn dismiss_splash() {
-    use leptos::web_sys;
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let Some(document) = window.document() else {
-        return;
-    };
-    let Some(el) = document.get_element_by_id("app-splash") else {
-        return;
-    };
-    // One-frame delay so navigation Effects that fire in the same reactive
-    // batch have time to update the DOM before we reveal what's underneath.
-    let raf_cb = Closure::once(move || {
-        let el_remove = el.clone();
-        let _ = el
-            .unchecked_ref::<web_sys::HtmlElement>()
-            .style()
-            .set_property("opacity", "0");
-        let remove_cb = Closure::once(move || {
-            el_remove.remove();
-            // Re-enable view-transition animations now that the splash is
-            // gone and the app is showing the correct destination view.
-            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
-                if let Some(root) = doc.document_element() {
-                    let _ = root
-                        .unchecked_ref::<web_sys::HtmlElement>()
-                        .class_list()
-                        .remove_1("app-loading");
-                }
-            }
-        });
-        // 400ms > the splash's 300ms CSS opacity transition — gives the
-        // fade a frame of headroom before removing the element and
-        // re-enabling view-transition animations.
-        if let Some(w) = web_sys::window() {
-            let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(
-                remove_cb.as_ref().unchecked_ref(),
-                400,
-            );
-        }
-        remove_cb.forget();
-    });
-    let _ = window.request_animation_frame(raf_cb.as_ref().unchecked_ref());
-    raf_cb.forget();
 }
 
 /// Design catalogue route — shows the component catalogue in debug builds,

--- a/crates/intrada-web/src/js_bridge.rs
+++ b/crates/intrada-web/src/js_bridge.rs
@@ -86,6 +86,12 @@ use wasm_bindgen::prelude::*;
             });
         }
     }
+    export function js_close_splashscreen() {
+        var invoke = window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke;
+        if (invoke) {
+            invoke('close_splashscreen');
+        }
+    }
 ")]
 extern "C" {
     fn js_init_clerk(key: &str);
@@ -102,6 +108,7 @@ extern "C" {
     fn js_sentry_set_user(id: &str);
     fn js_sentry_clear_user();
     fn js_sentry_breadcrumb(category: &str, message: &str, level: &str);
+    fn js_close_splashscreen();
 }
 
 /// Initialize Clerk with the publishable key.
@@ -190,4 +197,10 @@ pub fn sentry_clear_user() {
 /// No-op if Sentry isn't loaded.
 pub fn sentry_breadcrumb(category: &str, message: &str, level: &str) {
     js_sentry_breadcrumb(category, message, level);
+}
+
+/// Close the Tauri native splash screen window and show the main window.
+/// No-op on web where `__TAURI__` doesn't exist.
+pub fn close_splashscreen() {
+    js_close_splashscreen();
 }

--- a/crates/intrada-web/src/views/welcome.rs
+++ b/crates/intrada-web/src/views/welcome.rs
@@ -4,7 +4,7 @@ use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
 use crate::app::AuthState;
-use crate::components::{BrandMark, BrandMarkSize, Button, ButtonVariant};
+use crate::components::{BrandMark, Button, ButtonVariant};
 use intrada_web::js_bridge;
 use intrada_web::platform::is_ios;
 
@@ -12,12 +12,13 @@ use intrada_web::platform::is_ios;
 ///
 /// Pencil ref: `fWsUw` (desktop) and `vFOGv` (mobile-web).
 ///
-/// On iOS the splash screen covers the viewport until auth resolves, so
-/// this component renders nothing — the redirect Effect fires behind the
-/// splash and the user goes straight from splash → fade → destination.
+/// On iOS the native Tauri splash window covers the viewport until auth
+/// resolves, so this component renders nothing — the redirect Effect
+/// fires behind the splash and the user goes straight from splash →
+/// fade → destination.
 ///
-/// On web, shows a branded loading screen while Clerk initialises, then
-/// either redirects (authed → /library) or renders the marketing page.
+/// On web, the marketing page renders immediately (no loading gate).
+/// When auth finishes, authed users redirect to /library.
 ///
 /// Sub-sections live as private components in this file. Phone-frame
 /// graphics in the hero use a small reusable `PhoneFrame` shell with
@@ -53,67 +54,52 @@ pub fn WelcomeView() -> impl IntoView {
         return view! { <div></div> }.into_any();
     }
 
-    (move || {
-        if auth.auth_loading.get() {
-            view! {
-                <div class="relative z-0 min-h-screen text-primary flex items-center justify-center">
-                    <div class="text-center">
-                        <div class="mb-2">
-                            <BrandMark size=BrandMarkSize::Lg />
-                        </div>
-                        <p class="text-muted">"Loading..."</p>
-                    </div>
-                </div>
-            }.into_any()
-        } else {
-            view! {
-                <div class="relative z-0 min-h-screen text-primary">
-                    <WelcomeNav />
-                    <WelcomeHero />
-                    <WelcomePillars />
-                    <WelcomeDifferentiators />
-                    <WelcomeFeature
-                        kicker="PLAN".to_string()
-                        title="The library that\nremembers for you.".to_string()
-                        description="Half of what your teacher gives you disappears within a week. Intrada catches it — tag by composer, key, or tempo, group what you actually run into reusable routines, and connect everything to the goals you're working towards.".to_string()
-                        bullets=vec![
-                            "Pieces, exercises, and patterns in one place".to_string(),
-                            "Reusable routines for the warm-ups and blocks you run every week".to_string(),
-                            "Goals that turn the library into a path".to_string(),
-                        ]
-                        reverse=false
-                        mock=Box::new(|| view! { <LibraryMock /> }.into_any())
-                    />
-                    <WelcomeFeature
-                        kicker="PRACTICE".to_string()
-                        title="One decision:\nstart.".to_string()
-                        description="Choosing what to practise is the silent killer of a session. Intrada plans the work for the time you've got — you tap start and play. Each item gets a timer and a quick rating, then on to the next. Big numbers, big buttons, no chrome.".to_string()
-                        bullets=vec![
-                            "A session ready every time you sit down".to_string(),
-                            "Resume right where you left off".to_string(),
-                            "Adjust duration and focus mid-session without losing your place".to_string(),
-                        ]
-                        reverse=true
-                        mock=Box::new(|| view! { <PracticeMock /> }.into_any())
-                    />
-                    <WelcomeFeature
-                        kicker="TRACK".to_string()
-                        title="Progress you\ncan't yet feel.".to_string()
-                        description="Music improves between sessions, not within them — so the work feels invisible while it's happening. Intrada turns weeks of mastery ratings, time, and tempo into evidence you can see today, before your ears catch up.".to_string()
-                        bullets=vec![
-                            "Mastery per piece, per key, across weeks".to_string(),
-                            "Time, sessions, and where your attention actually went".to_string(),
-                            "A welcome back when life happens — not a guilt trip".to_string(),
-                        ]
-                        reverse=false
-                        mock=Box::new(|| view! { <AnalyticsMock /> }.into_any())
-                    />
-                    <WelcomeFinalCta />
-                    <WelcomeFooter />
-                </div>
-            }.into_any()
-        }
-    })
+    view! {
+        <div class="relative z-0 min-h-screen text-primary">
+            <WelcomeNav />
+            <WelcomeHero />
+            <WelcomePillars />
+            <WelcomeDifferentiators />
+            <WelcomeFeature
+                kicker="PLAN".to_string()
+                title="The library that\nremembers for you.".to_string()
+                description="Half of what your teacher gives you disappears within a week. Intrada catches it — tag by composer, key, or tempo, group what you actually run into reusable routines, and connect everything to the goals you're working towards.".to_string()
+                bullets=vec![
+                    "Pieces, exercises, and patterns in one place".to_string(),
+                    "Reusable routines for the warm-ups and blocks you run every week".to_string(),
+                    "Goals that turn the library into a path".to_string(),
+                ]
+                reverse=false
+                mock=Box::new(|| view! { <LibraryMock /> }.into_any())
+            />
+            <WelcomeFeature
+                kicker="PRACTICE".to_string()
+                title="One decision:\nstart.".to_string()
+                description="Choosing what to practise is the silent killer of a session. Intrada plans the work for the time you've got — you tap start and play. Each item gets a timer and a quick rating, then on to the next. Big numbers, big buttons, no chrome.".to_string()
+                bullets=vec![
+                    "A session ready every time you sit down".to_string(),
+                    "Resume right where you left off".to_string(),
+                    "Adjust duration and focus mid-session without losing your place".to_string(),
+                ]
+                reverse=true
+                mock=Box::new(|| view! { <PracticeMock /> }.into_any())
+            />
+            <WelcomeFeature
+                kicker="TRACK".to_string()
+                title="Progress you\ncan't yet feel.".to_string()
+                description="Music improves between sessions, not within them — so the work feels invisible while it's happening. Intrada turns weeks of mastery ratings, time, and tempo into evidence you can see today, before your ears catch up.".to_string()
+                bullets=vec![
+                    "Mastery per piece, per key, across weeks".to_string(),
+                    "Time, sessions, and where your attention actually went".to_string(),
+                    "A welcome back when life happens — not a guilt trip".to_string(),
+                ]
+                reverse=false
+                mock=Box::new(|| view! { <AnalyticsMock /> }.into_any())
+            />
+            <WelcomeFinalCta />
+            <WelcomeFooter />
+        </div>
+    }
     .into_any()
 }
 

--- a/crates/intrada-web/static/splashscreen.html
+++ b/crates/intrada-web/static/splashscreen.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Intrada</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body {
+      height: 100%;
+      overflow: hidden;
+      background: linear-gradient(to bottom, #161926, #0f111a);
+      -webkit-user-select: none;
+      user-select: none;
+    }
+    .splash {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      width: 100%;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      animation: fadeIn 0.4s ease-out;
+    }
+    .brand svg {
+      width: 28px;
+      height: 28px;
+      color: #9180fa;
+    }
+    .brand span {
+      font-family: 'Source Serif 4', Georgia, serif;
+      font-size: 34px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      color: #e8e6f0;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: scale(0.96); }
+      to { opacity: 1; transform: scale(1); }
+    }
+  </style>
+</head>
+<body>
+  <div class="splash">
+    <div class="brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+      </svg>
+      <span>Intrada</span>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **iOS**: Replace the layered HTML-overlay splash with a Tauri 2 native splash window (`splashscreen.html`) that shows the branded logo instantly — before WASM loads. The main window stays hidden until auth resolves and the destination view has painted (300ms delay), then `close_splashscreen` swaps them.
- **Web**: Remove the splash/loading gate entirely. Marketing page at `/` renders immediately; private routes still show `AuthLoadingScreen` while Clerk loads.
- **Cleanup**: Remove `#app-splash` HTML overlay, `app-loading` CSS class + rule, `dismiss_splash()` function (46 lines), and the `auth_loading` gate on WelcomeView web path. Net -59 lines.

Follows on from #691, #687, #685 which iteratively reduced iOS cold-start flicker. This PR consolidates those fixes into a single clean mechanism per platform.

### Design

| Platform | Mechanism | Flow |
|----------|-----------|------|
| iOS | Tauri native splash window | Splash → WASM loads (hidden) → auth resolves → 300ms delay → main window appears |
| Web | None | Marketing page renders immediately, auth redirect happens when ready |

### iOS verification needed

The Tauri 2 two-window pattern needs testing on the iOS simulator to confirm `get_webview_window("splashscreen")` works on mobile. Error handling is graceful (`if let Some(...)`) so if it doesn't, the app still loads — just without the splash benefit.

## Coverage

No new testable logic — the `close_splashscreen` command is a Tauri window-management shim, and the splash Effect is a 300ms timer calling a JS bridge no-op on web.

## Test plan

- [ ] `cargo fmt --check` + `cargo clippy` pass
- [ ] `just ios-dev` — confirm branded splash shows instantly, no blank white screen, app appears after auth
- [ ] Web: visit `/` unauthenticated — marketing page renders immediately (no loading screen)
- [ ] Web: visit `/library` unauthenticated — AuthLoadingScreen shows briefly, then redirect to `/login`
- [ ] Web: visit `/` authenticated — marketing page shows then redirects to `/library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)