### PR TITLE
fix(ios): three-layer splash for flicker-free cold start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,17 +73,12 @@ cargo install tauri-cli --version "^2" --locked   # Tauri CLI
 brew install cocoapods                             # CocoaPods (required by Tauri iOS)
 brew install xcodegen                              # xcodegen (required by Tauri iOS)
 # Also requires: iOS Simulator runtime (Xcode → Settings → Platforms → iOS Simulator)
-cd crates/intrada-mobile/src-tauri
-cargo tauri ios init       # generates the Xcode project under src-tauri/gen/apple/
-
-# Run the post-init scripts to (a) fix the libapp.a duplicate-output bug
-# (#476) and (b) add the Live Activity widget extension target (#474).
-# Both mutate gen/apple/project.yml and re-run xcodegen. Idempotent —
-# re-run after every `cargo tauri ios init`.
-cd ..   # back to crates/intrada-mobile/
-ruby scripts/fix-ios-build-config.rb
-ruby scripts/add-live-activity-target.rb
+just ios-init   # generates Xcode project + applies post-init patches
 ```
+
+`just ios-init` runs `cargo tauri ios init` then the two post-init Ruby scripts
+(`fix-ios-build-config.rb`, `add-live-activity-target.rb`) that patch the
+generated `project.yml`. Re-run it after any `cargo tauri ios init` regeneration.
 
 If you're forking this repo, update `bundle.iOS.developmentTeam` in
 `crates/intrada-mobile/src-tauri/tauri.conf.json` to your own Apple Team ID

--- a/crates/intrada-mobile/scripts/fix-ios-build-config.rb
+++ b/crates/intrada-mobile/scripts/fix-ios-build-config.rb
@@ -88,6 +88,7 @@ REQUIRED_PLIST = {
   'UIBackgroundModes'              => ['audio'],
   'NSCameraUsageDescription'       => 'Intrada uses your camera to take photos of your music.',
   'NSPhotoLibraryUsageDescription' => 'Intrada accesses your photo library to add images to your pieces.',
+  'UILaunchScreen'                 => {},
 }.freeze
 
 (project['targets'] || {}).each do |name, target|

--- a/crates/intrada-mobile/src-tauri/tauri.conf.json
+++ b/crates/intrada-mobile/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
       {
         "label": "main",
         "title": "Intrada",
+        "backgroundColor": [15, 17, 26, 255],
         "width": 375,
         "height": 812,
         "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1"

--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -190,6 +190,14 @@
     <!-- Self-hosted Sentry browser SDK — see comment on the <script> tag
          in <head>. Re-vendor with scripts/vendor-sentry-sdk.sh. -->
     <link data-trunk rel="copy-dir" href="static/sentry" />
+    <style>
+      /* iOS splash: CSS activates the overlay the instant #app-splash
+         enters the DOM during body parse. data-platform="ios" is set
+         on <html> in the script below, so this rule matches before
+         first paint. Web never gets data-platform, so the overlay
+         stays display:none. */
+      [data-platform="ios"] #app-splash { display: flex !important; }
+    </style>
     <script>
       // Set data-platform="ios" early so [data-platform="ios"] CSS applies
       // before first paint — no flicker. Tauri WebView always serves pages
@@ -198,11 +206,6 @@
       // device.
       if (location.protocol === 'tauri:') {
         document.documentElement.setAttribute('data-platform', 'ios');
-        // Show the branded splash overlay on iOS. The dark html background
-        // (#0f111a) is already visible from first paint — this adds the
-        // logo on top. Dismissed by app.rs once auth resolves.
-        var splash = document.getElementById('app-splash');
-        if (splash) splash.style.display = 'flex';
         // Native iOS apps don't have pinch-zoom on the page. Override the
         // viewport meta to disable it inside the Tauri WebView only —
         // regular browser users keep their accessibility zoom.
@@ -477,10 +480,10 @@
         </nav>
       </div>
     </noscript>
-    <!-- Branded splash overlay — iOS only. Hidden by default; the
-         platform-detection script above sets display:flex on iOS.
-         Dismissed by app.rs once auth resolves. The dark html background
-         (#0f111a) fills the gap before this element even parses. -->
+    <!-- Branded splash overlay — iOS only. Hidden by default (inline
+         display:none); the CSS rule in <head> activates it via
+         [data-platform="ios"] #app-splash { display: flex !important }.
+         Dismissed by app.rs once auth resolves. -->
     <div id="app-splash" style="
       position: fixed; inset: 0; z-index: 9999;
       display: none; align-items: center; justify-content: center;

--- a/justfile
+++ b/justfile
@@ -94,7 +94,19 @@ e2e: build
 # First-time setup:
 #   cargo install tauri-cli --version "^2" --locked
 #   brew install cocoapods
-#   cd crates/intrada-mobile/src-tauri && cargo tauri ios init
+#   just ios-init
+
+# Generate the Xcode project and apply post-init patches.
+# Run once after cloning, or after `cargo tauri ios init` regenerates gen/apple/.
+ios-init:
+    #!/usr/bin/env bash
+    set -e
+    cd crates/intrada-mobile/src-tauri && cargo tauri ios init
+    cd crates/intrada-mobile
+    echo "Applying post-init patches..."
+    ruby scripts/fix-ios-build-config.rb
+    ruby scripts/add-live-activity-target.rb
+    echo "✓ iOS project ready. Run: just ios-dev"
 
 # Runs trunk serve (web) in background, then tauri ios dev.
 # Pre-boots the simulator before handing off to tauri so `simctl install`


### PR DESCRIPTION
## Summary

Fixes the iOS cold start experience with a three-layer seamless dark chain:

- **Layer 1 — CSS-driven HTML splash**: The `<head>` script was calling
  `getElementById('app-splash')` before the element existed in `<body>`, so
  the splash never showed. Replaced with a CSS rule
  `[data-platform="ios"] #app-splash { display: flex !important }` which
  activates the overlay the instant it enters the DOM during body parse.
- **Layer 2 — Dark native launch screen**: Added `UILaunchScreen = {}` to
  plist properties in `fix-ios-build-config.rb`. Combined with the existing
  `UIUserInterfaceStyle = Dark`, iOS shows a dark system launch screen
  instead of the default white one.
- **Layer 3 — WKWebView background color**: Set `backgroundColor` in
  `tauri.conf.json` to `#0f111a` so the WebView is dark from creation,
  closing the gap between native launch and HTML first paint.

Result: `dark native launch → dark WebView → dark+logo overlay → fade to app`.
No white flash at any point. Web is completely unaffected — no splash, marketing
page renders immediately.

**Coverage**: All changes are in the WASM shell (`intrada-web`) and Tauri host
(`intrada-mobile`), both excluded from coverage.

## Test plan

- [ ] `just ios-dev` — dark native launch screen, branded splash visible, smooth fade to app
- [ ] Verify no white frame at any point during iOS cold start
- [ ] Web dev server — no splash, marketing page renders immediately
- [ ] Re-run `ruby scripts/fix-ios-build-config.rb` after `cargo tauri ios init` — verify `UILaunchScreen` appears in plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)