### PR TITLE
fix(ios): splash never dismissed — inline style guard mismatch

### DIFF
--- a/crates/intrada-web/src/js_bridge.rs
+++ b/crates/intrada-web/src/js_bridge.rs
@@ -89,7 +89,7 @@ use wasm_bindgen::prelude::*;
     }
     export function js_dismiss_splash() {
         var el = document.getElementById('app-splash');
-        if (!el || el.style.display === 'none') return;
+        if (!el) return;
         requestAnimationFrame(function() {
             requestAnimationFrame(function() {
                 el.style.opacity = '0';


### PR DESCRIPTION
## Summary

- The CSS-driven splash uses `!important` to override the inline `display: none`,
  but `dismiss_splash()` was checking `el.style.display === 'none'` which reads
  the **inline** attribute, not the computed style. The guard always returned early
  — splash was never dismissed.
- Fix: remove the display guard. The null-check on the element is sufficient.

## Test plan

- [ ] `just ios-dev` — splash shows on cold start, fades out when auth resolves
- [ ] Web — no splash visible, marketing page renders immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)