### PR TITLE
fix(ios): hold splash 300ms before fade to mask view transitions

### DIFF
--- a/crates/intrada-web/src/app.rs
+++ b/crates/intrada-web/src/app.rs
@@ -153,10 +153,10 @@ pub fn App() -> impl IntoView {
     // ─── Splash screen dismissal (iOS only) ─────────────────────────
     // On iOS the #app-splash overlay covers the viewport from first
     // paint (dark html background eliminates any white flash before the
-    // overlay parses). Once auth resolves we fade it out. Two rAF
-    // cycles let the redirect Effect fire and the destination view
-    // paint before the fade begins — the 300ms CSS transition then
-    // reveals the fully-rendered app underneath. On web the overlay is
+    // overlay parses). Once auth resolves we fade it out. The 300ms
+    // hold lets the route redirect + view transition (220ms) complete
+    // underneath the still-opaque splash, then the 400ms opacity fade
+    // reveals the fully-rendered destination. On web the overlay is
     // display:none so this is a no-op.
     Effect::new(move |_| {
         if !auth_loading.get() {

--- a/crates/intrada-web/src/js_bridge.rs
+++ b/crates/intrada-web/src/js_bridge.rs
@@ -90,12 +90,10 @@ use wasm_bindgen::prelude::*;
     export function js_dismiss_splash() {
         var el = document.getElementById('app-splash');
         if (!el) return;
-        requestAnimationFrame(function() {
-            requestAnimationFrame(function() {
-                el.style.opacity = '0';
-                setTimeout(function() { el.remove(); }, 400);
-            });
-        });
+        setTimeout(function() {
+            el.style.opacity = '0';
+            setTimeout(function() { el.remove(); }, 400);
+        }, 300);
     }
 ")]
 extern "C" {
@@ -209,8 +207,8 @@ pub fn sentry_breadcrumb(category: &str, message: &str, level: &str) {
 }
 
 /// Fade out and remove the `#app-splash` HTML overlay.
-/// Two rAF cycles let the destination view paint before the fade begins.
-/// No-op on web where the overlay is `display:none`.
+/// 300ms hold lets route redirects and view transitions settle, then
+/// 400ms opacity fade reveals the destination. No-op on web (`display:none`).
 pub fn dismiss_splash() {
     js_dismiss_splash();
 }


### PR DESCRIPTION
## Summary
- Replaces the 2-rAF delay (~33ms) in `dismiss_splash()` with a 300ms `setTimeout`, so the splash stays fully opaque while route redirects and view transitions (220ms) complete underneath
- The 400ms opacity fade then reveals the fully-settled destination view — no more visible "flicker" from transition animations leaking through a semi-transparent overlay

Follows up on #697 (dismiss guard fix). Same three-layer chain: dark native launch → dark WebView → branded overlay → fade to app.

**Coverage**: no new logic paths; JS timing change in inline wasm_bindgen string.

## Test plan
- [ ] `just ios-dev` — cold start: dark launch → branded splash → smooth fade to library (no flicker)
- [ ] Web dev server — no splash, marketing page renders immediately
- [ ] Sign out → sign in: splash does not reappear (element already removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)