### PR TITLE
fix(ios): suppress view transitions while splash is visible

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -197,6 +197,12 @@
          first paint. Web never gets data-platform, so the overlay
          stays display:none. */
       [data-platform="ios"] #app-splash { display: flex !important; }
+      /* Suppress view-transition slide animations while the splash is present.
+         Once dismiss_splash() removes #app-splash, normal transitions resume. */
+      html:has(#app-splash) ::view-transition-old(*),
+      html:has(#app-splash) ::view-transition-new(*) {
+        animation-duration: 0s !important;
+      }
     </style>
     <script>
       // Set data-platform="ios" early so [data-platform="ios"] CSS applies


### PR DESCRIPTION
## Summary
- Adds a CSS rule using `:has(#app-splash)` to make view transitions instant while the splash overlay is in the DOM
- The initial WelcomeView → `/library` redirect triggers a 220ms slide animation via `<Routes transition=true>` — this was visible as a sideways "flicker" during the splash fade-out
- Once `dismiss_splash()` removes `#app-splash`, normal route transitions resume automatically

Follows #698 (300ms hold). Together: dark native launch → branded splash (opaque through all redirects) → smooth fade to settled app.

**Coverage**: CSS-only change in `index.html`, no Rust code affected.

## Test plan
- [ ] `just ios-dev` — cold start shows smooth fade, no sideways slide visible
- [ ] After splash dismissed, navigating between routes still has normal slide transitions
- [ ] Web — no splash, no impact on route transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)