### PR TITLE
fix(api): wrap remaining read endpoints in with_transient_retry (#611)

### DIFF
--- a/crates/intrada-api/src/routes/account.rs
+++ b/crates/intrada-api/src/routes/account.rs
@@ -33,10 +33,13 @@ async fn get_audit_log(
     AuthUser { user_id, .. }: AuthUser,
     Query(q): Query<AuditQuery>,
 ) -> Result<Json<Vec<AuditLogEntry>>, ApiError> {
-    let conn = state.conn();
-    let entries =
-        services::audit::list_audit(&conn, &user_id, q.limit.unwrap_or(DEFAULT_AUDIT_LIMIT))
-            .await?;
+    let limit = q.limit.unwrap_or(DEFAULT_AUDIT_LIMIT);
+    let entries = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::audit::list_audit(&conn, &user_id, limit).await }
+        })
+        .await?;
     Ok(Json(entries))
 }
 
@@ -44,8 +47,12 @@ async fn get_preferences(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<AccountPreferences>, ApiError> {
-    let conn = state.conn();
-    let prefs = services::account::get_preferences(&conn, &user_id).await?;
+    let prefs = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::account::get_preferences(&conn, &user_id).await }
+        })
+        .await?;
     Ok(Json(prefs))
 }
 

--- a/crates/intrada-api/src/routes/items.rs
+++ b/crates/intrada-api/src/routes/items.rs
@@ -21,8 +21,12 @@ async fn list_items(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Item>>, ApiError> {
-    let conn = state.conn();
-    let items = services::items::list_items(&conn, &user_id).await?;
+    let items = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::items::list_items(&conn, &user_id).await }
+        })
+        .await?;
     Ok(Json(items))
 }
 
@@ -31,8 +35,13 @@ async fn get_item(
     AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Item>, ApiError> {
-    let conn = state.conn();
-    let item = services::items::get_item(&conn, &id, &user_id).await?;
+    let item = state
+        .with_transient_retry(|conn| {
+            let id = id.clone();
+            let user_id = user_id.clone();
+            async move { services::items::get_item(&conn, &id, &user_id).await }
+        })
+        .await?;
     Ok(Json(item))
 }
 

--- a/crates/intrada-api/src/routes/lessons.rs
+++ b/crates/intrada-api/src/routes/lessons.rs
@@ -38,9 +38,13 @@ async fn list_lessons(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Lesson>>, ApiError> {
-    let conn = state.conn();
     let r2 = state.r2()?;
-    let lessons = services::lessons::list_lessons(&conn, r2, &user_id).await?;
+    let lessons = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::lessons::list_lessons(&conn, r2, &user_id).await }
+        })
+        .await?;
     Ok(Json(lessons))
 }
 
@@ -49,9 +53,14 @@ async fn get_lesson(
     AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Lesson>, ApiError> {
-    let conn = state.conn();
     let r2 = state.r2()?;
-    let lesson = services::lessons::get_lesson(&conn, r2, &id, &user_id).await?;
+    let lesson = state
+        .with_transient_retry(|conn| {
+            let id = id.clone();
+            let user_id = user_id.clone();
+            async move { services::lessons::get_lesson(&conn, r2, &id, &user_id).await }
+        })
+        .await?;
     Ok(Json(lesson))
 }
 

--- a/crates/intrada-api/src/routes/oauth.rs
+++ b/crates/intrada-api/src/routes/oauth.rs
@@ -98,12 +98,16 @@ async fn authorize(
     State(state): State<AppState>,
     Query(params): Query<AuthorizeParams>,
 ) -> Result<Response, ApiError> {
-    let conn = state.conn();
     // Validate up-front so an invalid client_id / redirect_uri / response_type
     // surfaces an error here rather than after the user has signed in. We
     // don't redirect errors back to the (possibly attacker-controlled)
     // redirect_uri until we've validated it's the registered one — RFC 6749 §4.1.2.1.
-    services::oauth::validate_authorize_request(&conn, &params).await?;
+    state
+        .with_transient_retry(|conn| {
+            let params = params.clone();
+            async move { services::oauth::validate_authorize_request(&conn, &params).await }
+        })
+        .await?;
 
     // Redirect to the web app's consent page. The web app gates on
     // Clerk auth (existing flow), shows consent UI, and on Allow calls

--- a/crates/intrada-api/src/routes/sessions.rs
+++ b/crates/intrada-api/src/routes/sessions.rs
@@ -21,8 +21,12 @@ async fn list_sessions(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<PracticeSession>>, ApiError> {
-    let conn = state.conn();
-    let sessions = services::sessions::list_sessions(&conn, &user_id).await?;
+    let sessions = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::sessions::list_sessions(&conn, &user_id).await }
+        })
+        .await?;
     Ok(Json(sessions))
 }
 
@@ -31,8 +35,13 @@ async fn get_session(
     AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<PracticeSession>, ApiError> {
-    let conn = state.conn();
-    let session = services::sessions::get_session(&conn, &id, &user_id).await?;
+    let session = state
+        .with_transient_retry(|conn| {
+            let id = id.clone();
+            let user_id = user_id.clone();
+            async move { services::sessions::get_session(&conn, &id, &user_id).await }
+        })
+        .await?;
     Ok(Json(session))
 }
 

--- a/crates/intrada-api/src/routes/sets.rs
+++ b/crates/intrada-api/src/routes/sets.rs
@@ -21,10 +21,6 @@ async fn list_sets(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<Set>>, ApiError> {
-    // Wrapped in `with_transient_retry` because INTRADA-API-36 surfaces
-    // here: Hrana streams occasionally drop mid-request between heartbeat
-    // ticks, returning "stream not found". The per-request retry covers
-    // the gap by reconnecting and re-running the whole list_sets call.
     let sets = state
         .with_transient_retry(|conn| {
             let user_id = user_id.clone();
@@ -39,8 +35,13 @@ async fn get_set(
     AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
 ) -> Result<Json<Set>, ApiError> {
-    let conn = state.conn();
-    let set = services::sets::get_set(&conn, &id, &user_id).await?;
+    let set = state
+        .with_transient_retry(|conn| {
+            let id = id.clone();
+            let user_id = user_id.clone();
+            async move { services::sets::get_set(&conn, &id, &user_id).await }
+        })
+        .await?;
     Ok(Json(set))
 }
 

--- a/crates/intrada-api/src/routes/tokens.rs
+++ b/crates/intrada-api/src/routes/tokens.rs
@@ -19,8 +19,12 @@ async fn list_tokens(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
 ) -> Result<Json<Vec<TokenListItem>>, ApiError> {
-    let conn = state.conn();
-    let tokens = services::tokens::list_tokens(&conn, &user_id).await?;
+    let tokens = state
+        .with_transient_retry(|conn| {
+            let user_id = user_id.clone();
+            async move { services::tokens::list_tokens(&conn, &user_id).await }
+        })
+        .await?;
     Ok(Json(tokens))
 }
 


### PR DESCRIPTION
Closes #611.

## Summary

INTRADA-API-36 (Hrana stream-not-found) re-surfaced 8h ago on `GET /api/account/preferences` — same bug-shape as the original, just on an endpoint that hadn't been wrapped yet. Original fix only covered `list_sets`; this PR rolls the same per-request reconnect+retry across every `async fn list_*` / `async fn get_*` handler in `crates/intrada-api/src/routes/`:

- **account**: `get_preferences`, `get_audit_log`
- **items**: `list_items`, `get_item`
- **sessions**: `list_sessions`, `get_session`
- **sets**: `get_set` (`list_sets` already wrapped)
- **lessons**: `list_lessons`, `get_lesson`
- **tokens**: `list_tokens`
- **oauth**: `authorize` (validate call only; `finalize` is a write)

Writes stay unwrapped per #611's rationale — naive retry on a `POST` could double-create. That's deferred until specific endpoints prove flaky AND have request-id idempotency keys.

Also drops the rationale comment from `list_sets` — `with_transient_retry`'s helper docs already explain the WHY, and repeating it on every call site is noise.

## Out of scope

- **MCP read tools** (`src/mcp/handlers.rs::{list_items, get_item, list_sets, get_set, list_sessions, get_session, get_practice_summary}`) — #611's acceptance criterion explicitly scopes to `src/routes/`. The MCP dispatch path in `src/mcp/server.rs` takes a different shape (JSON-RPC `parse_and_run` wrapper around each tool); wiring `with_transient_retry` through it deserves its own pass. Worth tracking as a follow-up if MCP tool calls show up in Sentry — none have yet.

## Coverage

Coverage: existing tests cover the happy/sad paths of each handler. No new tests — the retry behaviour itself is tested via the helper, and the test harness uses SQLite (not Hrana) so transient-stream paths aren't reachable here. If we need integration coverage for the retry, that's a separate piece of work that would need a mock libsql layer.

## Test plan

- [x] `cargo check -p intrada-api`
- [x] `cargo test -p intrada-api` — all 157 existing tests pass
- [x] `cargo fmt --check`
- [x] `cargo clippy -p intrada-api -- -D warnings` (library only — test-harness `dead_code` warnings are pre-existing on `main`)
- [ ] Monitor Sentry for INTRADA-API-36 recurrence on any wrapped endpoint after deploy

## Related

- Closes #611
- Sentry: [INTRADA-API-36](https://jon-yardley.sentry.io/issues/INTRADA-API-36) — the recurrence on `/api/account/preferences` that prompted this

---
_Generated by [Claude Code](https://claude.ai/code/session_015QSKJSMj7AWrJ2tdZ9jogW)_