### PR TITLE
Goals polish: design parity, BottomSheet add, flicker fixes, mutate-response creates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,16 @@ data in shell-local state. UI-only state stays in Leptos signals.
 - **Validation**: `intrada-core/src/validation.rs` is the single source of truth
 - **DB**: Positional column indexing with `SELECT_COLUMNS` const
 - **Migrations**: Sequential in `intrada-api/src/migrations.rs`, one SQL statement each
-- **Mutate response**: Updates/deletes use API response directly (no re-fetch).
-  Session creates use optimistic push (no re-fetch). Item creates re-fetch the
-  full list (server assigns ID).
+- **Mutate response**: Writes reconcile with the server response directly — no
+  full-list refetch. Creates use a temp-id pattern: the domain handler pushes
+  an optimistic entry with a client-generated ulid, the HTTP wrapper carries
+  that ulid into the response handler, and the `*Created { temp_id, … }` event
+  replaces the optimistic entry with the server's authoritative version
+  (different ulid). Applies to `Item` and `Goal` creates today; `Session`
+  creates already keep the client ulid (no server reassignment); `Set` creates
+  still use the `set_saves_committed` counter + refetch (separate flow tied to
+  the save-form's confirm UI). Updates use `*Updated { entity }` (server echoes
+  the row), deletes use `DeleteConfirmed` (model already mutated optimistically).
 
 ## Authentication
 
@@ -450,4 +457,13 @@ Colours must reference Pencil variables, not raw hex.
 
 ## Known Tech Debt
 
-- Creates still re-fetch the full collection (server assigns ID)
+- `Set` creates still bump `set_saves_committed` + refetch instead of using
+  the temp-id mutate-response pattern (see "Mutate response" under Other
+  patterns). The counter drives the save-form's optimistic→confirmed flip;
+  reworking it needs to keep that affordance.
+- `Goal` write ops other than `Add`/`Update`/`Delete` (Complete, LinkItem,
+  UnlinkItem) still dispatch `RefetchGoals` from the HTTP success handler.
+  Each is a candidate for the mutate-response treatment (e.g.
+  `GoalCompleted { goal }` / `GoalItemLinked { goal }`) — currently they're
+  cheap because the list `<For>` keys by goal id, so the visible row keeps
+  its DOM node.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,15 +127,23 @@ data in shell-local state. UI-only state stays in Leptos signals.
 - **DB**: Positional column indexing with `SELECT_COLUMNS` const
 - **Migrations**: Sequential in `intrada-api/src/migrations.rs`, one SQL statement each
 - **Mutate response**: Writes reconcile with the server response directly — no
-  full-list refetch. Creates use a temp-id pattern: the domain handler pushes
-  an optimistic entry with a client-generated ulid, the HTTP wrapper carries
-  that ulid into the response handler, and the `*Created { temp_id, … }` event
-  replaces the optimistic entry with the server's authoritative version
-  (different ulid). Applies to `Item` and `Goal` creates today; `Session`
-  creates already keep the client ulid (no server reassignment); `Set` creates
-  still use the `set_saves_committed` counter + refetch (separate flow tied to
-  the save-form's confirm UI). Updates use `*Updated { entity }` (server echoes
-  the row), deletes use `DeleteConfirmed` (model already mutated optimistically).
+  full-list refetch. Three create variants live in the codebase; pick the one
+  that matches the entity's shape:
+  - **Temp-id mutate-response** (`Item`, `Goal`): domain handler pushes the
+    optimistic entry with a client-generated ulid; HTTP wrapper carries that
+    ulid; `*Created { temp_id, entity }` event replaces the optimistic entry
+    (server-assigned ulid differs from the client one). Default for new
+    entities — use this unless one of the others applies.
+  - **Client-owned ulid** (`Session`): client ulid is the canonical id. POST
+    is fire-and-forget — `SessionSaved` just clears the error state and the
+    model keeps the optimistic write.
+  - **Save-counter + refetch** (`Set`): optimistic push + bump
+    `set_saves_committed` + full refetch via `SetSaveSucceeded`. The counter
+    drives the save-form's optimistic→confirmed UI flip; tracked as tech debt
+    to migrate to temp-id once the counter is decoupled from the UI state.
+
+  Updates use `*Updated { entity }` (server echoes the row); deletes use
+  `DeleteConfirmed` (model already mutated optimistically).
 
 ## Authentication
 

--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -71,13 +71,17 @@ async fn create_goal_invalid_date_returns_400() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
+// `validate_goal_date` previously rejected future dates, but that produced
+// false rejections for users east of UTC near midnight (the client form
+// fills `date` from local time and the server compares against UTC). The
+// restriction was dropped; we now accept any valid YYYY-MM-DD.
 #[tokio::test]
-async fn create_goal_future_date_returns_400() {
+async fn create_goal_far_future_date_accepted() {
     let app = common::setup_test_app().await;
     let (status, _body) =
         common::post_json(app, "/api/goals", json!({ "date": "2099-01-01" })).await;
 
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::CREATED);
 }
 
 // ── Get by ID ──────────────────────────────────────────────────────────

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -86,25 +86,18 @@ pub enum Event {
     },
 
     // ── Write-confirmation callbacks ────────────────────────────────
-    /// Server confirmed an item create. `temp_id` is the optimistic ulid the
-    /// core generated locally on `ItemEvent::Add`; the handler replaces that
-    /// entry in `model.items` with the server's authoritative version (which
-    /// uses a different ulid). Mutate-response pattern, parallels
-    /// [`Event::GoalCreated`] and [`Event::ItemUpdated`].
+    // Temp-id mutate-response: see CLAUDE.md "Mutate response".
     ItemCreated {
         temp_id: String,
         item: Item,
     },
-    /// Server confirmed an item update — replace the optimistic copy.
     ItemUpdated {
         item: Item,
     },
-    /// Server confirmed a goal create. See [`Event::ItemCreated`].
     GoalCreated {
         temp_id: String,
         goal: Goal,
     },
-    /// Server confirmed a set update — replace the optimistic copy.
     SetUpdated {
         set: Set,
     },
@@ -250,9 +243,6 @@ impl App for Intrada {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == temp_id) {
                     *existing = item;
                 } else {
-                    // Optimistic entry not found (e.g. user navigated away
-                    // and back before the server response). Push fresh so
-                    // the item still ends up in the model.
                     model.items.push(item);
                 }
                 model.record_success();

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -252,7 +252,7 @@ impl App for Intrada {
                 } else {
                     // Optimistic entry not found (e.g. user navigated away
                     // and back before the server response). Push fresh so
-                    // the goal still ends up in the model.
+                    // the item still ends up in the model.
                     model.items.push(item);
                 }
                 model.record_success();
@@ -292,9 +292,10 @@ impl App for Intrada {
                 // Bump the monotonic counter so `SetSaveForm` can promote its
                 // optimistic state to confirmed. Also refetch sets — the
                 // optimistic push used a client-side ulid that the server
-                // may have replaced (mutate-response pattern is the standard
-                // for updates, but creates still rely on a follow-up
-                // refetch — known tech debt per CLAUDE.md).
+                // may have replaced. `Item` and `Goal` creates use the temp-id
+                // mutate-response pattern instead; `Set` still refetches
+                // because the counter is wired into the save-form's UI state
+                // — known tech debt per CLAUDE.md.
                 model.set_saves_committed = model.set_saves_committed.wrapping_add(1);
                 model.record_success();
                 crate::http::fetch_sets(&model.api_base_url)
@@ -2573,6 +2574,39 @@ mod tests {
 
         assert_eq!(model.items.len(), 1);
         assert_eq!(model.items[0].id, "server_ulid");
+    }
+
+    #[test]
+    fn goal_created_pushes_when_temp_id_absent() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let server_goal = Goal {
+            id: "server_ulid".to_string(),
+            title: Some("Late confirmation".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        // No optimistic entry — caller may have navigated away and back.
+        let _cmd = app.update(
+            Event::GoalCreated {
+                temp_id: "missing_temp".into(),
+                goal: server_goal,
+            },
+            &mut model,
+        );
+
+        assert_eq!(model.goals.len(), 1);
+        assert_eq!(model.goals[0].id, "server_ulid");
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -86,9 +86,23 @@ pub enum Event {
     },
 
     // ── Write-confirmation callbacks ────────────────────────────────
+    /// Server confirmed an item create. `temp_id` is the optimistic ulid the
+    /// core generated locally on `ItemEvent::Add`; the handler replaces that
+    /// entry in `model.items` with the server's authoritative version (which
+    /// uses a different ulid). Mutate-response pattern, parallels
+    /// [`Event::GoalCreated`] and [`Event::ItemUpdated`].
+    ItemCreated {
+        temp_id: String,
+        item: Item,
+    },
     /// Server confirmed an item update — replace the optimistic copy.
     ItemUpdated {
         item: Item,
+    },
+    /// Server confirmed a goal create. See [`Event::ItemCreated`].
+    GoalCreated {
+        temp_id: String,
+        goal: Goal,
     },
     /// Server confirmed a set update — replace the optimistic copy.
     SetUpdated {
@@ -232,9 +246,30 @@ impl App for Intrada {
             }
 
             // ── Write-confirmation callbacks ─────────────────────────
+            Event::ItemCreated { temp_id, item } => {
+                if let Some(existing) = model.items.iter_mut().find(|i| i.id == temp_id) {
+                    *existing = item;
+                } else {
+                    // Optimistic entry not found (e.g. user navigated away
+                    // and back before the server response). Push fresh so
+                    // the goal still ends up in the model.
+                    model.items.push(item);
+                }
+                model.record_success();
+                crux_core::render::render()
+            }
             Event::ItemUpdated { item } => {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == item.id) {
                     *existing = item;
+                }
+                model.record_success();
+                crux_core::render::render()
+            }
+            Event::GoalCreated { temp_id, goal } => {
+                if let Some(existing) = model.goals.iter_mut().find(|g| g.id == temp_id) {
+                    *existing = goal;
+                } else {
+                    model.goals.push(goal);
                 }
                 model.record_success();
                 crux_core::render::render()
@@ -2426,5 +2461,206 @@ mod tests {
         model.set_saves_committed = 42;
         let vm = app.view(&model);
         assert_eq!(vm.set_saves_committed, 42);
+    }
+
+    #[test]
+    fn goal_delete_clears_current_goal_when_id_matches() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let goal = Goal {
+            id: "g1".to_string(),
+            title: Some("Test".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        model.goals.push(goal.clone());
+        model.current_goal = Some(goal);
+
+        let _cmd = app.update(
+            Event::Goal(GoalEvent::Delete {
+                id: "g1".to_string(),
+            }),
+            &mut model,
+        );
+
+        assert!(model.goals.is_empty());
+        assert!(
+            model.current_goal.is_none(),
+            "current_goal should be cleared when the deleted goal matches"
+        );
+    }
+
+    #[test]
+    fn item_created_replaces_optimistic_by_temp_id() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let temp_id = "temp_ulid".to_string();
+        model.items.push(Item {
+            id: temp_id.clone(),
+            title: "Optimistic".to_string(),
+            kind: ItemKind::Piece,
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        });
+
+        let server_item = Item {
+            id: "server_ulid".to_string(),
+            title: "Optimistic".to_string(),
+            kind: ItemKind::Piece,
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        };
+        let _cmd = app.update(
+            Event::ItemCreated {
+                temp_id: temp_id.clone(),
+                item: server_item.clone(),
+            },
+            &mut model,
+        );
+
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(model.items[0].id, "server_ulid");
+    }
+
+    #[test]
+    fn item_created_pushes_when_temp_id_absent() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let server_item = Item {
+            id: "server_ulid".to_string(),
+            title: "Late confirmation".to_string(),
+            kind: ItemKind::Piece,
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+        };
+
+        // No optimistic entry — caller may have navigated away and back.
+        let _cmd = app.update(
+            Event::ItemCreated {
+                temp_id: "missing_temp".into(),
+                item: server_item,
+            },
+            &mut model,
+        );
+
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(model.items[0].id, "server_ulid");
+    }
+
+    #[test]
+    fn goal_created_replaces_optimistic_by_temp_id() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let temp_id = "temp_ulid".to_string();
+        model.goals.push(Goal {
+            id: temp_id.clone(),
+            title: Some("Optimistic".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        });
+
+        let server_goal = Goal {
+            id: "server_ulid".to_string(),
+            title: Some("Optimistic".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let _cmd = app.update(
+            Event::GoalCreated {
+                temp_id,
+                goal: server_goal,
+            },
+            &mut model,
+        );
+
+        assert_eq!(model.goals.len(), 1);
+        assert_eq!(model.goals[0].id, "server_ulid");
+    }
+
+    #[test]
+    fn goal_delete_preserves_current_goal_when_id_differs() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let viewing = Goal {
+            id: "viewing".to_string(),
+            title: Some("Viewing".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let other = Goal {
+            id: "other".to_string(),
+            ..viewing.clone()
+        };
+        model.goals.push(viewing.clone());
+        model.goals.push(other);
+        model.current_goal = Some(viewing);
+
+        let _cmd = app.update(
+            Event::Goal(GoalEvent::Delete {
+                id: "other".to_string(),
+            }),
+            &mut model,
+        );
+
+        assert_eq!(model.goals.len(), 1);
+        assert_eq!(
+            model.current_goal.as_ref().map(|g| g.id.as_str()),
+            Some("viewing"),
+            "current_goal should be untouched when a different goal is deleted"
+        );
     }
 }

--- a/crates/intrada-core/src/domain/goal.rs
+++ b/crates/intrada-core/src/domain/goal.rs
@@ -86,11 +86,12 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
                 updated_at: now,
             };
 
+            let temp_id = goal.id.clone();
             model.goals.push(goal);
             model.last_error = None;
 
             Command::all([
-                crate::http::create_goal(&model.api_base_url, &input),
+                crate::http::create_goal(&model.api_base_url, &input, &temp_id),
                 crux_core::render::render(),
             ])
         }
@@ -151,6 +152,9 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
             if model.goals.len() == len_before {
                 model.last_error = Some(format!("Goal not found: {id}"));
                 return crux_core::render::render();
+            }
+            if model.current_goal.as_ref().is_some_and(|g| g.id == id) {
+                model.current_goal = None;
             }
             model.last_error = None;
 

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -71,11 +71,12 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
                 updated_at: now,
             };
 
+            let temp_id = item.id.clone();
             model.items.push(item.clone());
             model.last_error = None;
 
             Command::all([
-                crate::http::create_item(&model.api_base_url, &item),
+                crate::http::create_item(&model.api_base_url, &item, &temp_id),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -599,7 +599,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.last_error = None;
 
             Command::all([
-                crate::http::create_item(&model.api_base_url, &item),
+                crate::http::create_item(&model.api_base_url, &item, &new_item_id),
                 crux_core::render::render(),
             ])
         }
@@ -825,7 +825,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
 
             let save_effect_session = AppEffect::SaveSessionInProgress(active.clone());
             Command::all([
-                crate::http::create_item(&model.api_base_url, &item),
+                crate::http::create_item(&model.api_base_url, &item, &new_item_id),
                 Command::notify_shell(save_effect_session).into(),
                 crux_core::render::render(),
             ])

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -66,7 +66,11 @@ pub fn fetch_sets(api_base_url: &str) -> Command<Effect, Event> {
 
 // ── Item operations ─────────────────────────────────────────────────────
 
-pub fn create_item(api_base_url: &str, item: &Item) -> Command<Effect, Event> {
+/// `temp_id` is the optimistic client-generated ulid the caller pushed into
+/// `model.items` before sending the request. The server assigns its own id;
+/// the response replaces the optimistic entry by `temp_id` so the list keeps
+/// the same row position and avoids a full refetch / re-render flash.
+pub fn create_item(api_base_url: &str, item: &Item, temp_id: &str) -> Command<Effect, Event> {
     let create = CreateItem {
         title: item.title.clone(),
         kind: item.kind.clone(),
@@ -76,12 +80,20 @@ pub fn create_item(api_base_url: &str, item: &Item) -> Command<Effect, Event> {
         notes: item.notes.clone(),
         tags: item.tags.clone(),
     };
+    let temp_id = temp_id.to_string();
     Http::post(format!("{api_base_url}/api/items"))
         .body_json(&create)
         .expect("serialize CreateItem")
+        .expect_json::<Item>()
         .build()
-        .then_send(|result| match result {
-            Ok(_) => Event::RefetchItems,
+        .then_send(move |result| match result {
+            Ok(response) => match response.body().cloned() {
+                Some(item) => Event::ItemCreated {
+                    temp_id: temp_id.clone(),
+                    item,
+                },
+                None => Event::LoadFailed("create_item: server returned no body".into()),
+            },
             Err(e) => Event::LoadFailed(format!("Failed to save item: {e}")),
         })
 }
@@ -217,13 +229,29 @@ pub fn fetch_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         })
 }
 
-pub fn create_goal(api_base_url: &str, input: &CreateGoal) -> Command<Effect, Event> {
+/// `temp_id` is the optimistic client-generated ulid the caller pushed into
+/// `model.goals`. The server assigns its own id and returns the created goal;
+/// the response replaces the optimistic entry by `temp_id` (mutate-response,
+/// same pattern as `create_item`).
+pub fn create_goal(
+    api_base_url: &str,
+    input: &CreateGoal,
+    temp_id: &str,
+) -> Command<Effect, Event> {
+    let temp_id = temp_id.to_string();
     Http::post(format!("{api_base_url}/api/goals"))
         .body_json(input)
         .expect("serialize CreateGoal")
+        .expect_json::<Goal>()
         .build()
-        .then_send(|result| match result {
-            Ok(_) => Event::RefetchGoals,
+        .then_send(move |result| match result {
+            Ok(response) => match response.body().cloned() {
+                Some(goal) => Event::GoalCreated {
+                    temp_id: temp_id.clone(),
+                    goal,
+                },
+                None => Event::LoadFailed("create_goal: server returned no body".into()),
+            },
             Err(e) => Event::LoadFailed(format!("Failed to save goal: {e}")),
         })
 }

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -66,10 +66,6 @@ pub fn fetch_sets(api_base_url: &str) -> Command<Effect, Event> {
 
 // ── Item operations ─────────────────────────────────────────────────────
 
-/// `temp_id` is the optimistic client-generated ulid the caller pushed into
-/// `model.items` before sending the request. The server assigns its own id;
-/// the response replaces the optimistic entry by `temp_id` so the list keeps
-/// the same row position and avoids a full refetch / re-render flash.
 pub fn create_item(api_base_url: &str, item: &Item, temp_id: &str) -> Command<Effect, Event> {
     let create = CreateItem {
         title: item.title.clone(),
@@ -229,10 +225,6 @@ pub fn fetch_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         })
 }
 
-/// `temp_id` is the optimistic client-generated ulid the caller pushed into
-/// `model.goals`. The server assigns its own id and returns the created goal;
-/// the response replaces the optimistic entry by `temp_id` (mutate-response,
-/// same pattern as `create_item`).
 pub fn create_goal(
     api_base_url: &str,
     input: &CreateGoal,

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -319,20 +319,16 @@ pub fn validate_set_entry_fields(item_id: &str, item_title: &str) -> Result<(), 
 // ── Goal validation ───────────────────────────────────────────────
 
 fn validate_goal_date(date: &str) -> Result<(), LibraryError> {
-    let parsed = chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| {
-        LibraryError::Validation {
-            field: "date".to_string(),
-            message: "Date must be in YYYY-MM-DD format".to_string(),
-        }
+    // No past-only restriction: the form fills this from the client's local
+    // date, but the server compares against UTC. Around midnight UTC the
+    // two diverge, so a strict past-or-today check would reject legitimate
+    // "today" submissions from users east of UTC. The `date` field is a
+    // semantic creation date for the goal (server also tracks `created_at`
+    // independently) so allowing any valid date is fine.
+    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| LibraryError::Validation {
+        field: "date".to_string(),
+        message: "Date must be in YYYY-MM-DD format".to_string(),
     })?;
-
-    let today = chrono::Utc::now().date_naive();
-    if parsed > today {
-        return Err(LibraryError::Validation {
-            field: "date".to_string(),
-            message: "Date cannot be in the future".to_string(),
-        });
-    }
     Ok(())
 }
 

--- a/crates/intrada-web/src/components/app_header.rs
+++ b/crates/intrada-web/src/components/app_header.rs
@@ -14,6 +14,11 @@ pub fn AppHeader() -> impl IntoView {
     let location = use_location();
     let view_model = expect_context::<RwSignal<ViewModel>>();
 
+    let is_goals_active = move || {
+        let path = location.pathname.get();
+        path.starts_with("/goals")
+    };
+
     let is_library_active = move || {
         let path = location.pathname.get();
         path.starts_with("/library")
@@ -54,6 +59,19 @@ pub fn AppHeader() -> impl IntoView {
                 </div>
                 <div class="hidden sm:flex items-center gap-4">
                     <nav class="flex items-center gap-4">
+                        <A
+                            href="/goals"
+                            attr:class=move || {
+                                if is_goals_active() {
+                                    "text-sm font-medium text-accent-text motion-safe:transition-colors"
+                                } else {
+                                    "text-sm font-medium text-secondary hover:text-primary motion-safe:transition-colors"
+                                }
+                            }
+                            attr:aria-current=move || if is_goals_active() { Some("page") } else { None }
+                        >
+                            "Goals"
+                        </A>
                         <A
                             href="/library"
                             attr:class=move || {

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -8,10 +8,6 @@ use crate::components::{AccentBar, AccentRow, BackLink, Button, ButtonVariant, S
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-/// Detail view for a single goal.
-///
-/// Reached via `/goals/:id`. Shows full goal info including notes, photos,
-/// linked items, and actions (complete, delete).
 #[component]
 pub fn GoalDetailView() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -21,22 +17,13 @@ pub fn GoalDetailView() -> impl IntoView {
 
     let params = use_params_map();
 
-    // Sticky snapshot of the displayed goal. Updated whenever a matching
-    // goal appears in the view model (current_goal or goals list), but
-    // never cleared by the view model — so a Delete that wipes the goal
-    // from the model doesn't trigger a "Goal not found" flash before the
-    // route transition unmounts the view. Same trick keeps the row stable
-    // when an optimistic-create's client ulid is replaced by the server's
-    // ulid (the row disappears from `vm.goals` for one frame).
+    // Sticky so a Delete that wipes the goal from the model doesn't flash
+    // "not found" before the route transition unmounts the view.
     let goal_snapshot = RwSignal::new(None::<GoalView>);
 
-    // Fetch the goal when the route id changes. Untracked-read the view
-    // model so the Effect's only reactive dependency is `params` — that
-    // way the route transition out of this view (e.g. after Delete) can't
-    // re-fire FetchGoal for the just-deleted id. Also skip the fetch when
-    // the goal is already loaded — either as `current_goal` from a prior
-    // fetch, or in the `goals` list from the initial app-load fetch (or
-    // an optimistic create the server hasn't acknowledged yet).
+    // Untracked view-model read: only `params` should re-fire this Effect,
+    // otherwise the route transition out of the view re-triggers FetchGoal
+    // for the just-deleted id.
     Effect::new(move |_| {
         let id = params.with(|p| p.get("id").unwrap_or_default().to_string());
         if id.is_empty() {
@@ -54,13 +41,6 @@ pub fn GoalDetailView() -> impl IntoView {
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
     });
 
-    // Watch the view model for a matching goal and keep `goal_snapshot`
-    // updated. Update when a matching goal appears; keep the existing
-    // snapshot when its id still matches the route (Delete / refetch
-    // briefly remove the goal — let the route transition dismiss the
-    // view, don't flash "not found"); clear when the route id moves on
-    // to a different goal so we don't render stale content from the
-    // previous route.
     Effect::new(move |_| {
         let route_id = params.with(|p| p.get("id").unwrap_or_default().to_string());
         let candidate = view_model.with(|vm| {
@@ -106,7 +86,6 @@ pub fn GoalDetailView() -> impl IntoView {
     }
 }
 
-/// Inner content for a loaded goal.
 #[component]
 fn GoalDetailContent(goal: GoalView) -> impl IntoView {
     let core = expect_context::<SharedCore>();

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -4,7 +4,7 @@ use leptos_router::NavigateOptions;
 
 use intrada_core::{Event, GoalEvent, GoalStatus, GoalView, ViewModel};
 
-use crate::components::{BackLink, Button, ButtonVariant, SkeletonCardList};
+use crate::components::{AccentBar, AccentRow, BackLink, Button, ButtonVariant, SkeletonCardList};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
@@ -21,18 +21,68 @@ pub fn GoalDetailView() -> impl IntoView {
 
     let params = use_params_map();
 
-    // Fetch goal on mount
+    // Sticky snapshot of the displayed goal. Updated whenever a matching
+    // goal appears in the view model (current_goal or goals list), but
+    // never cleared by the view model — so a Delete that wipes the goal
+    // from the model doesn't trigger a "Goal not found" flash before the
+    // route transition unmounts the view. Same trick keeps the row stable
+    // when an optimistic-create's client ulid is replaced by the server's
+    // ulid (the row disappears from `vm.goals` for one frame).
+    let goal_snapshot = RwSignal::new(None::<GoalView>);
+
+    // Fetch the goal when the route id changes. Untracked-read the view
+    // model so the Effect's only reactive dependency is `params` — that
+    // way the route transition out of this view (e.g. after Delete) can't
+    // re-fire FetchGoal for the just-deleted id. Also skip the fetch when
+    // the goal is already loaded — either as `current_goal` from a prior
+    // fetch, or in the `goals` list from the initial app-load fetch (or
+    // an optimistic create the server hasn't acknowledged yet).
     Effect::new(move |_| {
         let id = params.with(|p| p.get("id").unwrap_or_default().to_string());
-        if !id.is_empty() {
-            let core_ref = core.borrow();
-            let effects = core_ref.process_event(Event::Goal(GoalEvent::FetchGoal { id }));
-            process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        if id.is_empty() {
+            return;
+        }
+        let already_loaded = view_model.with_untracked(|vm| {
+            vm.current_goal.as_ref().is_some_and(|g| g.id == id)
+                || vm.goals.iter().any(|g| g.id == id)
+        });
+        if already_loaded {
+            return;
+        }
+        let core_ref = core.borrow();
+        let effects = core_ref.process_event(Event::Goal(GoalEvent::FetchGoal { id }));
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+    });
+
+    // Watch the view model for a matching goal and keep `goal_snapshot`
+    // updated. Update when a matching goal appears; keep the existing
+    // snapshot when its id still matches the route (Delete / refetch
+    // briefly remove the goal — let the route transition dismiss the
+    // view, don't flash "not found"); clear when the route id moves on
+    // to a different goal so we don't render stale content from the
+    // previous route.
+    Effect::new(move |_| {
+        let route_id = params.with(|p| p.get("id").unwrap_or_default().to_string());
+        let candidate = view_model.with(|vm| {
+            if let Some(g) = vm.current_goal.as_ref() {
+                if g.id == route_id {
+                    return Some(g.clone());
+                }
+            }
+            vm.goals.iter().find(|g| g.id == route_id).cloned()
+        });
+        if candidate.is_some() {
+            goal_snapshot.set(candidate);
+            return;
+        }
+        let stale_for_other_route =
+            goal_snapshot.with_untracked(|s| s.as_ref().is_some_and(|g| g.id != route_id));
+        if stale_for_other_route {
+            goal_snapshot.set(None);
         }
     });
 
-    // Read current_goal from ViewModel
-    let goal = Signal::derive(move || view_model.with(|vm| vm.current_goal.clone()));
+    let goal = Signal::derive(move || goal_snapshot.get());
 
     view! {
         <div class="space-y-4">
@@ -72,23 +122,35 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
 
     let core_for_delete = core.clone();
     let on_complete = move |_: leptos::ev::MouseEvent| {
+        let nav = navigate.clone();
+        nav(
+            "/goals",
+            NavigateOptions {
+                replace: true,
+                ..Default::default()
+            },
+        );
         let core_ref = core.borrow();
         let effects = core_ref.process_event(Event::Goal(GoalEvent::Complete {
             id: goal_id.clone(),
         }));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-        let nav = navigate.clone();
-        nav("/goals", NavigateOptions::default());
     };
 
     let on_delete = move |_: leptos::ev::MouseEvent| {
+        let nav = navigate_delete.clone();
+        nav(
+            "/goals",
+            NavigateOptions {
+                replace: true,
+                ..Default::default()
+            },
+        );
         let core_ref = core_for_delete.borrow();
         let effects = core_ref.process_event(Event::Goal(GoalEvent::Delete {
             id: goal_id_delete.clone(),
         }));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
-        let nav = navigate_delete.clone();
-        nav("/goals", NavigateOptions::default());
     };
 
     let title_display = goal
@@ -102,25 +164,17 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
             <div class="space-y-2">
                 <h2 class="page-title">{title_display}</h2>
                 <div class="flex items-center gap-2 flex-wrap">
-                    // Status badge
-                    <span class=if is_completed {
-                        "text-xs px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-400 font-medium"
-                    } else {
-                        "text-xs px-2 py-0.5 rounded bg-amber-500/15 text-amber-500 font-medium"
-                    }>
+                    <span class=if is_completed { "badge badge--accent" } else { "badge badge--warm" }>
                         {if is_completed { "Completed" } else { "Active" }}
                     </span>
-                    // Deadline badge
                     {goal.deadline.clone().map(|d| {
                         let badge_class = if goal.is_overdue {
-                            "text-xs px-2 py-0.5 rounded bg-red-500/15 text-red-400"
+                            "badge badge--warning"
                         } else {
-                            "text-xs px-2 py-0.5 rounded bg-surface-secondary text-muted"
+                            "badge badge--muted"
                         };
                         view! {
-                            <span class=badge_class>
-                                {d}
-                            </span>
+                            <span class=badge_class>{d}</span>
                         }
                     })}
                 </div>
@@ -159,16 +213,22 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
                 view! {
                     <div class="space-y-2">
                         <p class="field-label">"Linked items"</p>
-                        <div class="space-y-1">
+                        <ul class="space-y-2 list-none p-0" role="list">
                             {items.into_iter().map(|item| view! {
-                                <a
-                                    href=format!("/library/{}", item.item_id)
-                                    class="block rounded-lg bg-surface-secondary p-card-compact text-sm text-secondary hover:text-primary transition-colors"
-                                >
-                                    {item.item_title}
-                                </a>
+                                <li>
+                                    <a
+                                        href=format!("/library/{}", item.item_id)
+                                        class="no-underline"
+                                    >
+                                        <AccentRow bar=AccentBar::None>
+                                            <div class="flex-1 min-w-0 text-sm text-primary truncate">
+                                                {item.item_title}
+                                            </div>
+                                        </AccentRow>
+                                    </a>
+                                </li>
                             }).collect::<Vec<_>>()}
-                        </div>
+                        </ul>
                     </div>
                 }
             })}

--- a/crates/intrada-web/src/views/goal_form.rs
+++ b/crates/intrada-web/src/views/goal_form.rs
@@ -13,27 +13,11 @@ use crate::components::{
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
-/// Goal creation form.
-///
-/// Mirrors `AddLibraryItemForm`: renders the same body in both a standalone
-/// `/goals/new` route (with back-link + page heading + card chrome) and
-/// inside a `BottomSheet` from the goals list (the sheet supplies its own
-/// nav chrome).
 #[component]
 pub fn GoalFormView(
-    /// When rendered inside a BottomSheet (vs as a standalone route), drop
-    /// the back-link / page heading / card chrome — the sheet provides its
-    /// own. Cancel + Save call `on_dismiss` instead of navigating.
-    #[prop(optional)]
-    in_sheet: bool,
-    /// Fired when the user successfully saves or cancels. Required when
-    /// `in_sheet` is true; ignored otherwise (route mode navigates instead).
-    #[prop(optional, into)]
-    on_dismiss: Option<Callback<()>>,
-    /// Optional ref to the underlying `<form>` element so the sheet's
-    /// nav-bar Save can trigger `requestSubmit()` on it.
-    #[prop(optional, into)]
-    form_ref: Option<NodeRef<leptos::html::Form>>,
+    #[prop(optional)] in_sheet: bool,
+    #[prop(optional, into)] on_dismiss: Option<Callback<()>>,
+    #[prop(optional, into)] form_ref: Option<NodeRef<leptos::html::Form>>,
 ) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();

--- a/crates/intrada-web/src/views/goal_form.rs
+++ b/crates/intrada-web/src/views/goal_form.rs
@@ -1,124 +1,165 @@
 use std::collections::HashMap;
 
+use leptos::ev;
 use leptos::prelude::*;
 use leptos_router::hooks::use_navigate;
 use leptos_router::NavigateOptions;
 
 use intrada_core::{CreateGoal, Event, GoalEvent, ViewModel};
 
-use crate::components::{BackLink, Button, ButtonVariant, PageHeading, TextArea, TextField};
+use crate::components::{
+    use_toast, BackLink, Button, ButtonSize, ButtonVariant, Card, PageHeading, TextArea, TextField,
+};
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
 
 /// Goal creation form.
 ///
-/// Renders fields for title (optional), notes, and deadline, then dispatches
-/// `GoalEvent::Add` on submit. Navigates back to `/goals` on success.
+/// Mirrors `AddLibraryItemForm`: renders the same body in both a standalone
+/// `/goals/new` route (with back-link + page heading + card chrome) and
+/// inside a `BottomSheet` from the goals list (the sheet supplies its own
+/// nav chrome).
 #[component]
-pub fn GoalFormView() -> impl IntoView {
+pub fn GoalFormView(
+    /// When rendered inside a BottomSheet (vs as a standalone route), drop
+    /// the back-link / page heading / card chrome — the sheet provides its
+    /// own. Cancel + Save call `on_dismiss` instead of navigating.
+    #[prop(optional)]
+    in_sheet: bool,
+    /// Fired when the user successfully saves or cancels. Required when
+    /// `in_sheet` is true; ignored otherwise (route mode navigates instead).
+    #[prop(optional, into)]
+    on_dismiss: Option<Callback<()>>,
+    /// Optional ref to the underlying `<form>` element so the sheet's
+    /// nav-bar Save can trigger `requestSubmit()` on it.
+    #[prop(optional, into)]
+    form_ref: Option<NodeRef<leptos::html::Form>>,
+) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let core = expect_context::<SharedCore>();
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
+    let toast = use_toast();
     let navigate = use_navigate();
+    let navigate_cancel = navigate.clone();
 
-    // Form state
     let title = RwSignal::new(String::new());
     let notes = RwSignal::new(String::new());
     let deadline = RwSignal::new(String::new());
     let errors: RwSignal<HashMap<String, String>> = RwSignal::new(HashMap::new());
 
-    let on_submit = move |ev: leptos::ev::SubmitEvent| {
-        ev.prevent_default();
+    let dismiss_save = on_dismiss;
+    let dismiss_cancel = on_dismiss;
 
-        // Build today's date for the `date` field
-        let today = js_sys::Date::new_0();
-        let date = format!(
-            "{}-{:02}-{:02}",
-            today.get_full_year(),
-            today.get_month() + 1,
-            today.get_date()
-        );
+    let form_ref = form_ref.unwrap_or_default();
 
-        let title_val = title.get();
-        let notes_val = notes.get();
-        let deadline_val = deadline.get();
+    let form_body = view! {
+        <form
+            node_ref=form_ref
+            class="space-y-4"
+            on:submit=move |ev: ev::SubmitEvent| {
+                ev.prevent_default();
 
-        let input = CreateGoal {
-            date,
-            title: if title_val.is_empty() {
-                None
-            } else {
-                Some(title_val)
-            },
-            notes: if notes_val.is_empty() {
-                None
-            } else {
-                Some(notes_val)
-            },
-            deadline: if deadline_val.is_empty() {
-                None
-            } else {
-                Some(deadline_val)
-            },
-        };
+                let today = js_sys::Date::new_0();
+                let date = format!(
+                    "{}-{:02}-{:02}",
+                    today.get_full_year(),
+                    today.get_month() + 1,
+                    today.get_date()
+                );
 
-        let core_ref = core.borrow();
-        let effects = core_ref.process_event(Event::Goal(GoalEvent::Add(input)));
-        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+                let title_val = title.get();
+                let notes_val = notes.get();
+                let deadline_val = deadline.get();
 
-        // Check for errors from validation
-        let vm = view_model.get_untracked();
-        if let Some(err) = vm.error {
-            errors.set(HashMap::from([("title".to_string(), err)]));
-        } else {
-            let nav = navigate.clone();
-            nav("/goals", NavigateOptions::default());
-        }
-    };
+                let input = CreateGoal {
+                    date,
+                    title: if title_val.is_empty() { None } else { Some(title_val) },
+                    notes: if notes_val.is_empty() { None } else { Some(notes_val) },
+                    deadline: if deadline_val.is_empty() { None } else { Some(deadline_val) },
+                };
 
-    view! {
-        <div class="space-y-4">
-            <BackLink label="Back to Goals" href="/goals".to_string() />
-            <PageHeading text="New Goal" />
+                let core_ref = core.borrow();
+                let effects = core_ref.process_event(Event::Goal(GoalEvent::Add(input)));
+                process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
 
-            <form class="space-y-4" on:submit=on_submit>
-                <TextField
-                    id="goal-title"
-                    label="Title"
-                    value=title
-                    field_name="title"
-                    errors=errors
-                    placeholder="e.g. Prep for Tuesday lesson"
-                    input_type="text"
-                />
+                let vm = view_model.get_untracked();
+                if let Some(err) = vm.error {
+                    errors.set(HashMap::from([("title".to_string(), err)]));
+                    return;
+                }
+                errors.set(HashMap::new());
+                toast.show("Goal added");
+                if let Some(cb) = dismiss_save {
+                    cb.run(());
+                } else {
+                    navigate("/goals", NavigateOptions { replace: true, ..Default::default() });
+                }
+            }
+        >
+            <TextField
+                id="goal-title"
+                label="Title"
+                value=title
+                field_name="title"
+                errors=errors
+                placeholder="e.g. Prep for Tuesday lesson"
+                input_type="text"
+            />
 
-                <TextArea
-                    id="goal-notes"
-                    label="Notes"
-                    value=notes
-                    rows=4
-                    field_name="notes"
-                    errors=errors
-                />
+            <TextArea
+                id="goal-notes"
+                label="Notes"
+                value=notes
+                rows=4
+                field_name="notes"
+                errors=errors
+            />
 
-                <TextField
-                    id="goal-deadline"
-                    label="Deadline"
-                    value=deadline
-                    field_name="deadline"
-                    errors=errors
-                    input_type="date"
-                />
+            <TextField
+                id="goal-deadline"
+                label="Deadline"
+                value=deadline
+                field_name="deadline"
+                errors=errors
+                input_type="date"
+            />
 
+            <div class="flex flex-col pt-2">
                 <Button
                     variant=ButtonVariant::Primary
-                    full_width=true
                     button_type="submit"
+                    size=ButtonSize::Hero
+                    full_width=true
+                    loading=Signal::derive(move || is_submitting.get())
                 >
-                    "Save Goal"
+                    {move || if is_submitting.get() { "Saving\u{2026}" } else { "Save Goal" }}
                 </Button>
-            </form>
-        </div>
+                {(!in_sheet).then(|| view! {
+                    <div class="mt-3">
+                        <Button variant=ButtonVariant::Secondary full_width=true on_click=Callback::new(move |_| {
+                            if let Some(cb) = dismiss_cancel {
+                                cb.run(());
+                            } else {
+                                navigate_cancel("/goals", NavigateOptions::default());
+                            }
+                        })>"Cancel"</Button>
+                    </div>
+                })}
+            </div>
+        </form>
+    };
+
+    if in_sheet {
+        form_body.into_any()
+    } else {
+        view! {
+            <div class="sm:max-w-2xl sm:mx-auto">
+                <BackLink label="Cancel" href="/goals".to_string() />
+                <PageHeading text="New Goal" />
+                <Card>{form_body}</Card>
+            </div>
+        }
+        .into_any()
     }
 }

--- a/crates/intrada-web/src/views/goals_list.rs
+++ b/crates/intrada-web/src/views/goals_list.rs
@@ -11,9 +11,6 @@ use crate::views::GoalFormView;
 use intrada_web::haptics::haptic_selection;
 use intrada_web::types::{IsLoading, IsSubmitting};
 
-/// Goals list view with Active/Completed toggle tabs.
-///
-/// Fetches goals on mount and displays them filtered by status.
 #[component]
 pub fn GoalsListView() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
@@ -24,10 +21,6 @@ pub fn GoalsListView() -> impl IntoView {
     let add_sheet_open = RwSignal::new(false);
     let open_add_sheet = Callback::new(move |_| add_sheet_open.set(true));
     let close_add_sheet = Callback::new(move |_| add_sheet_open.set(false));
-
-    // Goals are fetched as part of `init_core` at app start (alongside items,
-    // sessions, sets) — no per-mount refetch needed. Matches the Library
-    // pattern; pull-to-refresh is a separate future affordance.
 
     let filtered_goals = Memo::new(move |_| {
         let vm = view_model.get();
@@ -80,7 +73,6 @@ pub fn GoalsListView() -> impl IntoView {
                 }.into_any())
             />
 
-            // Active / Completed tabs — same `.tabs-underline` pattern as Library.
             <div
                 class="tabs-underline"
                 role="tablist"
@@ -158,9 +150,6 @@ pub fn GoalsListView() -> impl IntoView {
     }
 }
 
-/// Wraps `<GoalFormView>` inside a `<BottomSheet>` configured for the
-/// iOS Mail-compose pattern: Cancel on the left of the nav bar, Save on
-/// the right (triggers form submission via the form's NodeRef).
 #[component]
 fn AddGoalSheet(
     open: RwSignal<bool>,
@@ -188,7 +177,6 @@ fn AddGoalSheet(
     }
 }
 
-/// Individual goal card — uses the shared `AccentRow` primitive.
 #[component]
 fn GoalCard(goal: GoalView) -> impl IntoView {
     let href = format!("/goals/{}", goal.id);
@@ -234,7 +222,6 @@ fn GoalCard(goal: GoalView) -> impl IntoView {
     }
 }
 
-/// Format a deadline date string (YYYY-MM-DD) for display.
 fn format_deadline(deadline: &str) -> String {
     if let Ok(date) = chrono::NaiveDate::parse_from_str(deadline, "%Y-%m-%d") {
         let today = chrono::Utc::now().date_naive();

--- a/crates/intrada-web/src/views/goals_list.rs
+++ b/crates/intrada-web/src/views/goals_list.rs
@@ -1,35 +1,34 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 
-use intrada_core::{Event, GoalEvent, GoalStatus, GoalView, ViewModel};
+use intrada_core::{GoalStatus, GoalView, ViewModel};
 
-use crate::components::{EmptyState, IconName, PageHeading, SkeletonCardList};
-use intrada_web::core_bridge::process_effects_with_core;
-use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
+use crate::components::{
+    AccentBar, AccentRow, BottomSheet, EmptyState, IconName, PageAddButton, PageHeading,
+    SkeletonCardList,
+};
+use crate::views::GoalFormView;
+use intrada_web::haptics::haptic_selection;
+use intrada_web::types::{IsLoading, IsSubmitting};
 
 /// Goals list view with Active/Completed toggle tabs.
 ///
-/// Fetches goals on mount and displays them filtered by status. A floating
-/// action button links to the goal creation form.
+/// Fetches goals on mount and displays them filtered by status.
 #[component]
 pub fn GoalsListView() -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let is_loading = expect_context::<IsLoading>();
     let is_submitting = expect_context::<IsSubmitting>();
-    let core = expect_context::<SharedCore>();
 
-    // Active/Completed filter tab state
     let active_tab = RwSignal::new(GoalStatus::Active);
+    let add_sheet_open = RwSignal::new(false);
+    let open_add_sheet = Callback::new(move |_| add_sheet_open.set(true));
+    let close_add_sheet = Callback::new(move |_| add_sheet_open.set(false));
 
-    // Fetch goals on mount
-    Effect::new(move |_| {
-        let effects = {
-            let core_ref = core.borrow();
-            core_ref.process_event(Event::Goal(GoalEvent::FetchGoals))
-        };
-        process_effects_with_core(&core, effects, &view_model, &is_loading, &is_submitting);
-    });
+    // Goals are fetched as part of `init_core` at app start (alongside items,
+    // sessions, sets) — no per-mount refetch needed. Matches the Library
+    // pattern; pull-to-refresh is a separate future affordance.
 
-    // Filtered goals memo
     let filtered_goals = Memo::new(move |_| {
         let vm = view_model.get();
         let tab = active_tab.get();
@@ -41,86 +40,160 @@ pub fn GoalsListView() -> impl IntoView {
 
     let is_active_tab = move || active_tab.get() == GoalStatus::Active;
 
+    let set_tab = move |status: GoalStatus| {
+        if active_tab.get_untracked() == status {
+            return;
+        }
+        haptic_selection();
+        active_tab.set(status);
+    };
+
+    let active_tab_class = move || {
+        if is_active_tab() {
+            "tabs-underline-btn tabs-underline-btn--active"
+        } else {
+            "tabs-underline-btn"
+        }
+    };
+    let completed_tab_class = move || {
+        if !is_active_tab() {
+            "tabs-underline-btn tabs-underline-btn--active"
+        } else {
+            "tabs-underline-btn"
+        }
+    };
+
+    let indicator_style = move || {
+        let pct = if is_active_tab() { 0 } else { 100 };
+        format!("--tab-count: 2; --thumb-x: {pct}%")
+    };
+
     view! {
         <div class="space-y-4">
-            <PageHeading text="Goals" />
+            <PageHeading
+                text="Goals"
+                trailing=Box::new(move || view! {
+                    <PageAddButton
+                        aria_label="New Goal"
+                        on_click=Callback::new(move |_| open_add_sheet.run(()))
+                    />
+                }.into_any())
+            />
 
-            // Active / Completed toggle tabs
-            <div class="flex gap-2">
+            // Active / Completed tabs — same `.tabs-underline` pattern as Library.
+            <div
+                class="tabs-underline"
+                role="tablist"
+                aria-label="Filter goals by status"
+                style=indicator_style
+            >
+                <div class="tabs-underline-indicator" aria-hidden="true" />
                 <button
-                    class=move || if is_active_tab() {
-                        "px-4 py-2 rounded-lg text-sm font-medium bg-amber-500/15 text-amber-500"
-                    } else {
-                        "px-4 py-2 rounded-lg text-sm font-medium text-muted hover:text-secondary"
-                    }
-                    on:click=move |_| active_tab.set(GoalStatus::Active)
+                    type="button"
+                    role="tab"
+                    aria-selected=move || if is_active_tab() { "true" } else { "false" }
+                    aria-controls="goals-list"
+                    tabindex=move || if is_active_tab() { "0" } else { "-1" }
+                    class=active_tab_class
+                    on:click=move |_| set_tab(GoalStatus::Active)
                 >
                     "Active"
                 </button>
                 <button
-                    class=move || if !is_active_tab() {
-                        "px-4 py-2 rounded-lg text-sm font-medium bg-amber-500/15 text-amber-500"
-                    } else {
-                        "px-4 py-2 rounded-lg text-sm font-medium text-muted hover:text-secondary"
-                    }
-                    on:click=move |_| active_tab.set(GoalStatus::Completed)
+                    type="button"
+                    role="tab"
+                    aria-selected=move || if !is_active_tab() { "true" } else { "false" }
+                    aria-controls="goals-list"
+                    tabindex=move || if !is_active_tab() { "0" } else { "-1" }
+                    class=completed_tab_class
+                    on:click=move |_| set_tab(GoalStatus::Completed)
                 >
                     "Completed"
                 </button>
             </div>
 
-            // Loading skeleton
-            <Show when=move || is_loading.get()>
-                <SkeletonCardList />
-            </Show>
+            <section id="goals-list" aria-label="Goals">
+                <Show when=move || is_loading.get()>
+                    <SkeletonCardList />
+                </Show>
 
-            // Goal cards
-            <Show when=move || !is_loading.get()>
-                {move || {
-                    let goals = filtered_goals.get();
-                    if goals.is_empty() {
-                        let (title, body) = if is_active_tab() {
-                            ("No active goals yet", "Set a goal to focus your practice")
+                <Show when=move || !is_loading.get()>
+                    {move || {
+                        if filtered_goals.with(|g| g.is_empty()) {
+                            let (title, body) = if is_active_tab() {
+                                ("No active goals yet", "Set a goal to focus your practice")
+                            } else {
+                                ("No completed goals", "Goals you complete will appear here")
+                            };
+                            view! {
+                                <EmptyState
+                                    icon=IconName::Star
+                                    title=title
+                                    body=body
+                                />
+                            }.into_any()
                         } else {
-                            ("No completed goals", "Goals you complete will appear here")
-                        };
-                        view! {
-                            <EmptyState
-                                icon=IconName::Star
-                                title=title
-                                body=body
-                            />
-                        }.into_any()
-                    } else {
-                        view! {
-                            <div class="space-y-3">
-                                {goals.into_iter().map(|goal| {
-                                    view! { <GoalCard goal=goal /> }
-                                }).collect::<Vec<_>>()}
-                            </div>
-                        }.into_any()
-                    }
-                }}
-            </Show>
-
-            // FAB — create new goal
-            <a
-                href="/goals/new"
-                class="fixed bottom-20 right-4 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-amber-500 to-amber-600 text-black text-2xl font-light shadow-lg sm:bottom-6"
-            >
-                "+"
-            </a>
+                            view! {
+                                <ul class="space-y-2 list-none p-0" role="list">
+                                    <For
+                                        each=move || filtered_goals.get()
+                                        key=|g| g.id.clone()
+                                        let:goal
+                                    >
+                                        <li><GoalCard goal=goal /></li>
+                                    </For>
+                                </ul>
+                            }.into_any()
+                        }
+                    }}
+                </Show>
+            </section>
         </div>
+
+        <AddGoalSheet
+            open=add_sheet_open
+            on_close=close_add_sheet
+            is_submitting=is_submitting
+        />
     }
 }
 
-/// Individual goal card.
+/// Wraps `<GoalFormView>` inside a `<BottomSheet>` configured for the
+/// iOS Mail-compose pattern: Cancel on the left of the nav bar, Save on
+/// the right (triggers form submission via the form's NodeRef).
+#[component]
+fn AddGoalSheet(
+    open: RwSignal<bool>,
+    on_close: Callback<()>,
+    is_submitting: IsSubmitting,
+) -> impl IntoView {
+    let form_ref = NodeRef::<leptos::html::Form>::new();
+    let on_save = Callback::new(move |_| {
+        if let Some(form) = form_ref.get() {
+            let _ = form.request_submit();
+        }
+    });
+    let submitting_signal = Signal::derive(move || is_submitting.get());
+    view! {
+        <BottomSheet
+            open=open
+            on_close=on_close
+            nav_title="New Goal".to_string()
+            nav_action_label="Save".to_string()
+            on_nav_action=on_save
+            nav_action_disabled=submitting_signal
+        >
+            <GoalFormView in_sheet=true on_dismiss=on_close form_ref=form_ref />
+        </BottomSheet>
+    }
+}
+
+/// Individual goal card — uses the shared `AccentRow` primitive.
 #[component]
 fn GoalCard(goal: GoalView) -> impl IntoView {
     let href = format!("/goals/{}", goal.id);
     let is_completed = goal.status == GoalStatus::Completed;
 
-    // Title or notes preview
     let display_title = if let Some(ref title) = goal.title {
         title.clone()
     } else if !goal.notes_preview.is_empty() {
@@ -128,98 +201,36 @@ fn GoalCard(goal: GoalView) -> impl IntoView {
     } else {
         "Untitled goal".to_string()
     };
-
     let has_title = goal.title.is_some();
     let deadline = goal.deadline.clone();
     let is_overdue = goal.is_overdue;
-    let has_photos = goal.has_photos;
-    let completed_at = goal.completed_at.clone();
+
+    let title_class = if is_completed {
+        "text-sm font-medium text-muted line-through truncate"
+    } else if has_title {
+        "text-sm font-semibold text-primary truncate"
+    } else {
+        "text-sm italic text-secondary truncate"
+    };
 
     view! {
-        <a
-            href=href
-            class="block rounded-lg bg-surface-secondary p-card hover:bg-surface-secondary/80 transition-colors"
-        >
-            <div class="flex items-center justify-between gap-3">
-                // Left: title/preview
-                <div class="flex-1 min-w-0">
-                    <p class=move || {
-                        if is_completed {
-                            "text-sm font-medium text-muted line-through"
-                        } else if has_title {
-                            "text-sm font-semibold text-primary"
-                        } else {
-                            "text-sm italic text-secondary"
-                        }
-                    }>
-                        {display_title.clone()}
-                    </p>
-                    // Photo count indicator
-                    {has_photos.then(|| view! {
-                        <span class="text-xs text-muted mt-0.5 inline-flex items-center gap-1">
-                            <PhotoIcon />
-                        </span>
-                    })}
-                    // Completed date
-                    {completed_at.clone().map(|date| view! {
-                        <span class="text-xs text-emerald-500 mt-0.5 inline-flex items-center gap-1">
-                            <CheckIcon />
-                            {format_completed_date(&date)}
-                        </span>
-                    })}
+        <A href=href attr:class="no-underline">
+            <AccentRow bar=AccentBar::None>
+                <div class="flex-1 min-w-0 text-left">
+                    <div class=title_class>{display_title}</div>
                 </div>
-
-                // Right: deadline badge
-                {deadline.clone().map(|d| {
+                {deadline.map(|d| {
                     let badge_class = if is_overdue {
-                        "text-xs px-2 py-0.5 rounded bg-red-500/15 text-red-400"
+                        "badge badge--warning"
                     } else {
-                        "text-xs px-2 py-0.5 rounded bg-amber-500/15 text-amber-500"
+                        "badge badge--muted"
                     };
                     view! {
-                        <span class=badge_class>
-                            {format_deadline(&d)}
-                        </span>
+                        <span class=badge_class>{format_deadline(&d)}</span>
                     }
                 })}
-            </div>
-        </a>
-    }
-}
-
-/// Small check icon for completed goals.
-#[component]
-fn CheckIcon() -> impl IntoView {
-    view! {
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-3 w-3"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2".to_string()
-            aria-hidden="true"
-        >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-        </svg>
-    }
-}
-
-/// Small photo icon.
-#[component]
-fn PhotoIcon() -> impl IntoView {
-    view! {
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-3 w-3"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2".to_string()
-            aria-hidden="true"
-        >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" />
-        </svg>
+            </AccentRow>
+        </A>
     }
 }
 
@@ -239,14 +250,5 @@ fn format_deadline(deadline: &str) -> String {
         }
     } else {
         deadline.to_string()
-    }
-}
-
-/// Format a completed_at date (RFC3339) for display.
-fn format_completed_date(date_str: &str) -> String {
-    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(date_str) {
-        dt.format("%b %d").to_string()
-    } else {
-        "Completed".to_string()
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #711. Brings Goals up to the design-system parity and behavioural patterns established for Library, fixes two correctness bugs surfaced during testing, and aligns create flows for `Item` + `Goal` on the mutate-response pattern so the codebase has one consistent shape for writes.

## UI consistency
- Goals link added to the desktop top-nav
- `/goals` list: `PageAddButton` in the heading trailing slot (matches Library); removed the floating gradient FAB
- Active / Completed toggles use the shared `.tabs-underline` CSS pattern (matches `LibraryFilterTabs`)
- Goal rows use `AccentRow`; deadline pills use the `.badge` utility
- Goal detail status / deadline pills use `.badge` utilities; linked-item rows use `AccentRow`
- "Add Goal" opens in a `BottomSheet` (iOS Mail-compose pattern: Cancel left, Save right) — same shape as `AddLibraryItemForm`. `/goals/new` route still works as a standalone fallback with BackLink + PageHeading + Card chrome
- Removed bespoke `GoalCard` / `CheckIcon` / `PhotoIcon` SVGs

## Bug fixes
- **Delete 404**: route transitions kept the detail view briefly mounted; its Effect could re-fire `FetchGoal` for the just-deleted id. Effect now short-circuits when the goal is already loaded (current_goal or in goals); the core also clears `model.current_goal` on `GoalEvent::Delete` when its id matches. Navigation uses `replace: true`
- **Timezone-driven validation rejection**: `validate_goal_date` enforced past-or-today in UTC, but the form fills `date` from the client's local time. East-of-UTC users near midnight saw "Date cannot be in the future" on legitimate Save. Dropped the past-only restriction (server still tracks `created_at` independently)

## Flicker fixes
- List uses `<For each= key=|g| g.id …>` instead of `.map().collect()` — reconciles by id, avoids re-creating rows on every model update
- Detail view reads from a sticky `goal_snapshot` `RwSignal`. Updates when a matching goal appears in the view model; keeps the existing snapshot when the route id still matches (Delete / refetch briefly remove the goal — the route transition is what should dismiss the view, not a "not found" flash); clears when the route id moves on. Also falls back to `vm.goals` so a freshly-created optimistic goal renders without waiting on `FetchGoal`

## Mutate-response creates (cross-entity consistency)
- `Item` and `Goal` create flows now use the temp-id mutate-response pattern. Domain handler pushes the optimistic entry with a client-generated ulid; HTTP wrapper carries the ulid into the response handler; `*Created { temp_id, … }` event replaces the optimistic entry with the server's authoritative version (or pushes if missing — defensive). No more full-list refetch on create
- `RefetchItems` / `RefetchGoals` events kept — still useful for pull-to-refresh
- `Set` creates and goal Complete / LinkItem / UnlinkItem still refetch — flagged in CLAUDE.md "Known Tech Debt" as candidates for the same treatment

## Coverage

5 new core unit tests cover the changed write paths (delete clears `current_goal`, item/goal `*Created` replace by temp_id, item `ItemCreated` push-on-missing). `goals_test::create_goal_future_date_returns_400` (which asserted the buggy timezone-aware behaviour) was replaced by `create_goal_far_future_date_accepted` documenting the relaxed validation. `goal_form` / `goal_detail` / `goals_list` are WASM shell code (excluded from coverage per `codecov.yml`).

## Test plan

- [ ] `cargo test` — workspace
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Manual: tap `+` on `/goals` — sheet slides up; type + tap Save; sheet closes, new goal appears in list without a flicker
- [ ] Manual: tap a goal → detail loads; tap Delete → returns to list without "Goal not found" flash
- [ ] Manual: desktop view shows Goals in the top nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)