### PR TITLE
chore: comment-policy section in CLAUDE.md + pre-push density hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -78,4 +78,11 @@ EOF
   exit 1
 fi
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(git rev-parse --show-toplevel)
+density_check="$repo_root/scripts/check-comment-density.sh"
+if [ -x "$density_check" ]; then
+  "$density_check" || exit $?
+fi
+
 exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,46 @@ queries alone.
 - No `unwrap()` without justification.
 - Prefer well-established libraries over custom implementations.
 
+### Comments
+
+Default to **no comments**. Self-explanatory code with well-named identifiers
+beats commented code. A reader who knows the language and framework should be
+able to answer "what does this do?" from the code alone.
+
+Add a comment only when one of these holds:
+
+- **Non-obvious WHY** — a hidden constraint, subtle invariant, workaround for a
+  specific bug, or framework quirk that would surprise a reader. Cite the
+  reason concretely: an issue number, an incident, a doc link, a `BUG:` tag.
+  Vague WHY is no better than restating WHAT.
+- **Cross-file context** — pointing at a related file, a CLAUDE.md rule, or
+  an external doc the reader could miss. One line max.
+- **Section structure** — single-line dividers like `// ── Validation ──` in a
+  long file. Never more than one line.
+
+Do **not** write a comment that:
+
+- Restates WHAT the code does (`// Filter by status` above `.filter(|g| g.status == tab)`)
+- References the current task / PR (`// Added for #719`) — rots, belongs in
+  the PR description
+- Apologises or hedges (`// quick fix`, `// TODO come back to this`) — open a
+  tracked issue instead
+- Notes that a function "Mirrors X" when the shapes already make it obvious
+- Is a `///` doc comment on a private item or a single-purpose component
+  whose signature is self-evident
+
+Two-line cap as a smell test: if a comment is more than two lines, ask "can
+this be a function name? a type? a CLAUDE.md entry?". Usually yes.
+
+The `pre-push` hook (under `.githooks/`) flags branches that push too many
+comment lines relative to code. Bypass for genuinely-justified cases
+(an incident write-up, a copy-pasted upstream notice) with
+`SKIP_COMMENT_CHECK=1 git push`.
+
+When invoking the `superpowers:code-reviewer` agent, include "comment-policy
+violations are Blockers, not Nits" in the prompt so the review treats drift
+as a merge-blocker.
+
 ## Testing
 
 **Default: ship tests with new code.** New API endpoints, DB functions, and

--- a/scripts/check-comment-density.sh
+++ b/scripts/check-comment-density.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Flag pushes that add too many comments relative to code.
+# See CLAUDE.md "Comments" — code should be self-explanatory; comments are
+# for non-obvious WHY, not narration. Bypass with `SKIP_COMMENT_CHECK=1`.
+
+set -euo pipefail
+
+if [ "${SKIP_COMMENT_CHECK:-}" = "1" ]; then
+  exit 0
+fi
+
+branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+if [ -z "$branch" ]; then
+  exit 0
+fi
+case "$branch" in
+  main|master) exit 0 ;;
+esac
+
+if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+  exit 0
+fi
+
+range="origin/main...HEAD"
+
+files=$(git diff --name-only "$range" -- \
+  '*.rs' '*.css' '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null || true)
+if [ -z "$files" ]; then
+  exit 0
+fi
+
+diff_out=$(git diff "$range" -- $files 2>/dev/null || true)
+if [ -z "$diff_out" ]; then
+  exit 0
+fi
+
+added=$(printf '%s\n' "$diff_out" | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+if [ -z "$added" ]; then
+  exit 0
+fi
+
+# Heuristic: a line is "comment" if its first non-whitespace is //, ///, /*,
+# * (block continuation), or # (shell/python).
+added_comments=$(printf '%s\n' "$added" \
+  | grep -cE '^\+[[:space:]]*(//|/\*|\*[^/]|\*$|#[[:space:]])' || true)
+added_blank=$(printf '%s\n' "$added" | grep -cE '^\+[[:space:]]*$' || true)
+added_total=$(printf '%s\n' "$added" | grep -cE '^\+' || true)
+added_code=$((added_total - added_comments - added_blank))
+
+if [ "$added_code" -le 0 ]; then
+  exit 0
+fi
+
+threshold="0.15"
+ratio=$(awk -v c="$added_comments" -v k="$added_code" \
+  'BEGIN { printf "%.2f", c / k }')
+over=$(awk -v r="$ratio" -v t="$threshold" 'BEGIN { print (r > t) }')
+
+if [ "$over" = "1" ]; then
+  cat <<EOF >&2
+
+❌ Pre-push blocked: comment density on this branch is ${ratio} (threshold ${threshold}).
+
+   Added comment lines: ${added_comments}
+   Added code lines:    ${added_code}
+
+   CLAUDE.md asks for self-explanatory code with minimal comments. Add a
+   comment only for non-obvious WHY (bug ref, framework quirk, hidden
+   invariant) — never to restate WHAT.
+
+   Inspect what tripped the check:
+
+     git diff origin/main...HEAD -- '*.rs' '*.ts' '*.tsx' \\
+       | grep -E '^\+[[:space:]]*(//|/\*|\*)'
+
+   If the comments are genuinely justified (incident write-up, vendored
+   notice, etc.), bypass with:
+
+     SKIP_COMMENT_CHECK=1 git push
+
+EOF
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Why

Soft guidance in CLAUDE.md hasn't been sufficient — recent PRs (notably #719) shipped with significant amounts of comments that restate WHAT the code does, mirror a sibling comment, or narrate the implementation in multi-paragraph docstrings. The system prompt and CLAUDE.md both already say "minimal comments" but the rule is easy to drift from when pattern-matching against surrounding code.

This PR adds two layered defences so drift fails fast instead of landing on `main` and getting cleaned up after review.

## What

### CLAUDE.md "Comments" section under Code Style

Names the rule explicitly: default to none, only non-obvious WHY justifies one. Lists concrete anti-patterns the rule is trying to prevent — restating WHAT, `// Added for #X`, hedges like `// quick fix`, `Mirrors X` cross-references when the shape is obvious from props. Two-line cap as a smell test. Also notes that `superpowers:code-reviewer` invocations should mark comment-policy violations as **Blockers**, not Nits.

### `scripts/check-comment-density.sh` + `.githooks/pre-push` integration

Pre-push hook fails the push when `comment_lines_added / code_lines_added > 0.15` in the branch's diff against `origin/main`, restricted to source files (`*.rs *.ts *.tsx *.js *.jsx *.css`). Bypass via `SKIP_COMMENT_CHECK=1 git push` for genuinely-justified edge cases (incident write-up, vendored notice).

Threshold is conservative — I'd like to observe a few PRs before tightening. The script doesn't pretend to be a literary critic; it catches the egregious cases that fixed thresholds reliably surface. The reviewer agent's standing instruction (now per CLAUDE.md) catches the cases that pass the density check but still drift.

## Coverage

No code changes — docs + script + hook only. Manually verified the script:

- Runs cleanly against a branch with zero source-file changes (this PR's own state)
- Will trip on a branch with high comment ratio against `origin/main`
- Has a `SKIP_COMMENT_CHECK=1` escape hatch documented in the hook's failure message

The pre-push hook is opt-in per the existing `scripts/install-git-hooks.sh` flow (sets `core.hooksPath = .githooks`).

## Test plan

- [ ] Read the new CLAUDE.md "Comments" section — does it match what you'd want to point a contributor at?
- [ ] Try `SKIP_COMMENT_CHECK=1` is mentioned in the failure message
- [ ] Verify the script is executable (`ls -l scripts/check-comment-density.sh`)
- [ ] Decide whether 0.15 is the right starting threshold (see "Discussion" below)

## Discussion / open questions

- **Threshold**: 0.15 was a guess based on what would have caught PR #719's density (~0.10-0.13). Could be tightened to 0.10 if we want it to bite harder. Looser if the false-positive rate is high.
- **Block on max-comment-block-size?** Not implemented here. Could add: "any consecutive `+//` block > 5 lines without a `// BUG:` / issue-ref tag fails." More aggressive but catches the specific 7-line-Effect-comment shape that triggered this work.
- **Pre-commit instead of pre-push?** Pre-commit is more immediate but requires installing a second hook. Pre-push catches the cumulative diff which is what reviewers see anyway. Sticking with pre-push for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)