### PR TITLE
Goals targets — Phase 1 (date + confidence)

### DIFF
--- a/crates/intrada-api/src/db/goals.rs
+++ b/crates/intrada-api/src/db/goals.rs
@@ -47,7 +47,7 @@ fn row_to_goal(
     let created_at_str: String = col!(row, 8)?;
     let updated_at_str: String = col!(row, 9)?;
     let target_confidence: Option<i64> = col!(row, 10)?;
-    let target_confidence: Option<u8> = target_confidence.map(|n| n as u8);
+    let target_confidence: Option<u8> = target_confidence.and_then(|n| u8::try_from(n).ok());
 
     let status = goal_status_from_str(&status_str);
 
@@ -109,7 +109,7 @@ fn row_to_goal_item(row: &libsql::Row) -> Result<GoalItem, ApiError> {
     let item_type: ItemKind = item_kind_from_str(&item_type_str)?;
     let target_date: Option<String> = col!(row, 4)?;
     let target_confidence: Option<i64> = col!(row, 5)?;
-    let target_confidence: Option<u8> = target_confidence.map(|n| n as u8);
+    let target_confidence: Option<u8> = target_confidence.and_then(|n| u8::try_from(n).ok());
 
     Ok(GoalItem {
         item_id,

--- a/crates/intrada-api/src/db/goals.rs
+++ b/crates/intrada-api/src/db/goals.rs
@@ -3,18 +3,19 @@ use libsql::Connection;
 
 use intrada_core::domain::goal::{Goal, GoalItem, GoalPhoto, GoalStatus};
 use intrada_core::domain::item::ItemKind;
-use intrada_core::domain::types::{CreateGoal, UpdateGoal};
+use intrada_core::domain::types::{CreateGoal, UpdateGoal, UpdateGoalItem};
 
 use super::{col, item_kind_from_str, item_kind_to_str};
 use crate::error::ApiError;
 use crate::storage::R2Client;
 
 const SELECT_COLUMNS: &str =
-    "id, user_id, title, date, notes, deadline, status, completed_at, created_at, updated_at";
+    "id, user_id, title, date, notes, deadline, status, completed_at, created_at, updated_at, target_confidence";
 
 const PHOTO_SELECT_COLUMNS: &str = "id, goal_id, user_id, storage_key, created_at";
 
-const GOAL_ITEMS_SELECT_COLUMNS: &str = "goal_id, item_id, item_title, item_type";
+const GOAL_ITEMS_SELECT_COLUMNS: &str =
+    "goal_id, item_id, item_title, item_type, target_date, target_confidence";
 
 fn goal_status_from_str(s: &str) -> GoalStatus {
     match s {
@@ -45,6 +46,8 @@ fn row_to_goal(
     let completed_at_str: Option<String> = col!(row, 7)?;
     let created_at_str: String = col!(row, 8)?;
     let updated_at_str: String = col!(row, 9)?;
+    let target_confidence: Option<i64> = col!(row, 10)?;
+    let target_confidence: Option<u8> = target_confidence.map(|n| n as u8);
 
     let status = goal_status_from_str(&status_str);
 
@@ -74,6 +77,7 @@ fn row_to_goal(
         photos,
         created_at,
         updated_at,
+        target_confidence,
     })
 }
 
@@ -103,11 +107,16 @@ fn row_to_goal_item(row: &libsql::Row) -> Result<GoalItem, ApiError> {
     let item_title: String = col!(row, 2)?;
     let item_type_str: String = col!(row, 3)?;
     let item_type: ItemKind = item_kind_from_str(&item_type_str)?;
+    let target_date: Option<String> = col!(row, 4)?;
+    let target_confidence: Option<i64> = col!(row, 5)?;
+    let target_confidence: Option<u8> = target_confidence.map(|n| n as u8);
 
     Ok(GoalItem {
         item_id,
         item_title,
         item_type,
+        target_date,
+        target_confidence,
     })
 }
 
@@ -239,8 +248,9 @@ pub async fn insert_goal(
     let now = Utc::now();
     let now_str = now.to_rfc3339();
 
+    let target_confidence_val: Option<i64> = input.target_confidence.map(|c| c as i64);
     conn.execute(
-        "INSERT INTO goals (id, user_id, title, date, notes, deadline, status, completed_at, created_at, updated_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO goals (id, user_id, title, date, notes, deadline, status, completed_at, created_at, updated_at, target_confidence) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         libsql::params![
             id.as_str(),
             user_id,
@@ -251,7 +261,8 @@ pub async fn insert_goal(
             "active",
             Option::<String>::None,
             now_str.as_str(),
-            now_str.as_str()
+            now_str.as_str(),
+            target_confidence_val
         ],
     )
     .await?;
@@ -302,12 +313,17 @@ pub async fn update_goal(
         GoalStatus::Active => None,
     };
 
+    let target_confidence: Option<i64> = match &input.target_confidence {
+        None => current.target_confidence.map(|c| c as i64),
+        Some(opt) => opt.map(|c| c as i64),
+    };
+
     let now = Utc::now();
     let now_str = now.to_rfc3339();
 
     conn.execute(
-        "UPDATE goals SET title = ?1, date = ?2, notes = ?3, deadline = ?4, status = ?5, completed_at = ?6, updated_at = ?7 WHERE id = ?8 AND user_id = ?9",
-        libsql::params![title, date, notes, deadline, status_str, completed_at_str.as_deref(), now_str.as_str(), id, user_id],
+        "UPDATE goals SET title = ?1, date = ?2, notes = ?3, deadline = ?4, status = ?5, completed_at = ?6, updated_at = ?7, target_confidence = ?8 WHERE id = ?9 AND user_id = ?10",
+        libsql::params![title, date, notes, deadline, status_str, completed_at_str.as_deref(), now_str.as_str(), target_confidence, id, user_id],
     )
     .await?;
 
@@ -447,6 +463,7 @@ pub async fn list_photo_storage_keys(
 
 // ── Goal item DB operations ────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_goal_item(
     conn: &Connection,
     goal_id: &str,
@@ -454,14 +471,59 @@ pub async fn insert_goal_item(
     item_id: &str,
     item_title: &str,
     item_type: &ItemKind,
+    target_date: Option<&str>,
+    target_confidence: Option<u8>,
 ) -> Result<(), ApiError> {
     let now = chrono::Utc::now().to_rfc3339();
+    let target_confidence_val: Option<i64> = target_confidence.map(|c| c as i64);
     conn.execute(
-        "INSERT OR IGNORE INTO goal_items (goal_id, item_id, user_id, item_title, item_type, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        libsql::params![goal_id, item_id, user_id, item_title, item_kind_to_str(item_type), now],
+        "INSERT OR IGNORE INTO goal_items (goal_id, item_id, user_id, item_title, item_type, created_at, target_date, target_confidence) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        libsql::params![
+            goal_id,
+            item_id,
+            user_id,
+            item_title,
+            item_kind_to_str(item_type),
+            now,
+            target_date,
+            target_confidence_val
+        ],
     )
     .await?;
     Ok(())
+}
+
+pub async fn update_goal_item(
+    conn: &Connection,
+    goal_id: &str,
+    item_id: &str,
+    user_id: &str,
+    input: &UpdateGoalItem,
+) -> Result<bool, ApiError> {
+    let current = list_items_for_goal(conn, goal_id)
+        .await?
+        .into_iter()
+        .find(|i| i.item_id == item_id);
+    let Some(current) = current else {
+        return Ok(false);
+    };
+
+    let target_date: Option<String> = match &input.target_date {
+        None => current.target_date.clone(),
+        Some(opt) => opt.clone(),
+    };
+    let target_confidence: Option<i64> = match &input.target_confidence {
+        None => current.target_confidence.map(|c| c as i64),
+        Some(opt) => opt.map(|c| c as i64),
+    };
+
+    let rows_affected = conn
+        .execute(
+            "UPDATE goal_items SET target_date = ?1, target_confidence = ?2 WHERE goal_id = ?3 AND item_id = ?4 AND user_id = ?5",
+            libsql::params![target_date, target_confidence, goal_id, item_id, user_id],
+        )
+        .await?;
+    Ok(rows_affected > 0)
 }
 
 pub async fn delete_goal_item(

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -526,6 +526,22 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0074_index_goal_items_goal",
         "CREATE INDEX IF NOT EXISTS idx_goal_items_goal ON goal_items(goal_id);",
     ),
+    (
+        "0075_goals_target_confidence",
+        "ALTER TABLE goals ADD COLUMN target_confidence INTEGER;",
+    ),
+    (
+        "0076_goal_items_targets",
+        "ALTER TABLE goal_items ADD COLUMN target_date TEXT;",
+    ),
+    (
+        "0077_goal_items_target_confidence",
+        "ALTER TABLE goal_items ADD COLUMN target_confidence INTEGER;",
+    ),
+    (
+        "0078_goal_items_target_tempo",
+        "ALTER TABLE goal_items ADD COLUMN target_tempo INTEGER;",
+    ),
 ];
 
 /// Backoff schedule for transient-error retries during migration: try

--- a/crates/intrada-api/src/routes/goals.rs
+++ b/crates/intrada-api/src/routes/goals.rs
@@ -1,11 +1,11 @@
 use axum::extract::{DefaultBodyLimit, Multipart, Path, Query, State};
 use axum::http::StatusCode;
-use axum::routing::{delete, get, post};
+use axum::routing::{delete, get, patch, post};
 use axum::{Json, Router};
 use tower_http::limit::RequestBodyLimitLayer;
 
 use intrada_core::domain::goal::Goal;
-use intrada_core::domain::types::{CreateGoal, LinkGoalItem, UpdateGoal};
+use intrada_core::domain::types::{CreateGoal, LinkGoalItem, UpdateGoal, UpdateGoalItem};
 
 use crate::auth::AuthUser;
 use crate::error::ApiError;
@@ -34,7 +34,10 @@ pub fn router() -> Router<AppState> {
         .route("/{id}", get(get_goal).put(update_goal).delete(delete_goal))
         .route("/{id}/photos/{photo_id}", delete(delete_photo))
         .route("/{id}/items", post(link_item))
-        .route("/{id}/items/{item_id}", delete(unlink_item))
+        .route(
+            "/{id}/items/{item_id}",
+            patch(update_item).delete(unlink_item),
+        )
         .merge(photo_upload)
 }
 
@@ -172,6 +175,17 @@ async fn link_item(
     let conn = state.conn();
     services::goals::link_item(&conn, &id, &user_id, &input).await?;
     Ok(StatusCode::CREATED)
+}
+
+async fn update_item(
+    State(state): State<AppState>,
+    AuthUser { user_id, .. }: AuthUser,
+    Path((id, item_id)): Path<(String, String)>,
+    Json(input): Json<UpdateGoalItem>,
+) -> Result<StatusCode, ApiError> {
+    let conn = state.conn();
+    services::goals::update_goal_item(&conn, &id, &item_id, &user_id, &input).await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 async fn unlink_item(

--- a/crates/intrada-api/src/services/goals.rs
+++ b/crates/intrada-api/src/services/goals.rs
@@ -1,7 +1,7 @@
 use libsql::Connection;
 
 use intrada_core::domain::goal::{Goal, GoalPhoto};
-use intrada_core::domain::types::{CreateGoal, LinkGoalItem, UpdateGoal};
+use intrada_core::domain::types::{CreateGoal, LinkGoalItem, UpdateGoal, UpdateGoalItem};
 use intrada_core::validation;
 
 use crate::db;
@@ -151,6 +151,7 @@ pub async fn link_item(
     user_id: &str,
     input: &LinkGoalItem,
 ) -> Result<(), ApiError> {
+    validation::validate_link_goal_item(input)?;
     db::goals::insert_goal_item(
         conn,
         goal_id,
@@ -158,8 +159,27 @@ pub async fn link_item(
         &input.item_id,
         &input.item_title,
         &input.item_type,
+        input.target_date.as_deref(),
+        input.target_confidence,
     )
     .await
+}
+
+pub async fn update_goal_item(
+    conn: &Connection,
+    goal_id: &str,
+    item_id: &str,
+    user_id: &str,
+    input: &UpdateGoalItem,
+) -> Result<(), ApiError> {
+    validation::validate_update_goal_item(input)?;
+    let updated = db::goals::update_goal_item(conn, goal_id, item_id, user_id, input).await?;
+    if !updated {
+        return Err(ApiError::NotFound(format!(
+            "Goal item not found: {item_id}"
+        )));
+    }
+    Ok(())
 }
 
 pub async fn unlink_item(

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -228,6 +228,32 @@ pub async fn put_json(
     (status, body)
 }
 
+/// Send a PATCH request with a JSON body and return the response.
+pub async fn patch_json(
+    router: Router,
+    uri: &str,
+    body: impl serde::Serialize,
+) -> (StatusCode, Vec<u8>) {
+    let json = serde_json::to_string(&body).unwrap();
+    let request = Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(json))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .unwrap()
+        .to_bytes()
+        .to_vec();
+    (status, body)
+}
+
 /// Send a DELETE request and return the response.
 pub async fn delete(router: Router, uri: &str) -> (StatusCode, Vec<u8>) {
     let request = Request::builder()

--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -289,3 +289,227 @@ async fn filter_goals_by_status() {
     let goals: Vec<Goal> = common::json(&body);
     assert_eq!(goals.len(), 2);
 }
+
+// ── Targets (Phase 1) ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn create_goal_with_target_confidence() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/goals",
+        json!({ "date": "2026-05-15", "target_confidence": 4 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let goal: Goal = common::json(&body);
+    assert_eq!(goal.target_confidence, Some(4));
+}
+
+#[tokio::test]
+async fn create_goal_target_confidence_out_of_range_returns_400() {
+    let app = common::setup_test_app().await;
+    let (status, _body) = common::post_json(
+        app,
+        "/api/goals",
+        json!({ "date": "2026-05-15", "target_confidence": 9 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn update_goal_clears_target_confidence() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/goals",
+        json!({ "date": "2026-05-15", "target_confidence": 3 }),
+    )
+    .await;
+    let created: Goal = common::json(&body);
+    assert_eq!(created.target_confidence, Some(3));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "target_confidence": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.target_confidence.is_none());
+}
+
+#[tokio::test]
+async fn link_item_with_targets() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    let (status, _body) = common::post_json(
+        app.clone(),
+        &format!("/api/goals/{}/items", goal.id),
+        json!({
+            "item_id": "piece-001",
+            "item_title": "Bach Prelude",
+            "item_type": "piece",
+            "target_date": "2026-06-01",
+            "target_confidence": 4
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
+    assert_eq!(status, StatusCode::OK);
+    let fetched: Goal = common::json(&body);
+    assert_eq!(fetched.items.len(), 1);
+    assert_eq!(fetched.items[0].target_date.as_deref(), Some("2026-06-01"));
+    assert_eq!(fetched.items[0].target_confidence, Some(4));
+}
+
+#[tokio::test]
+async fn patch_goal_item_targets() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    common::post_json(
+        app.clone(),
+        &format!("/api/goals/{}/items", goal.id),
+        json!({
+            "item_id": "piece-001",
+            "item_title": "Bach",
+            "item_type": "piece"
+        }),
+    )
+    .await;
+
+    let (status, _body) = common::patch_json(
+        app.clone(),
+        &format!("/api/goals/{}/items/piece-001", goal.id),
+        json!({ "target_date": "2026-07-01", "target_confidence": 5 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
+    let fetched: Goal = common::json(&body);
+    assert_eq!(fetched.items[0].target_date.as_deref(), Some("2026-07-01"));
+    assert_eq!(fetched.items[0].target_confidence, Some(5));
+}
+
+#[tokio::test]
+async fn patch_goal_item_partial_update_preserves_other_fields() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    common::post_json(
+        app.clone(),
+        &format!("/api/goals/{}/items", goal.id),
+        json!({
+            "item_id": "piece-001",
+            "item_title": "Bach",
+            "item_type": "piece",
+            "target_date": "2026-06-01",
+            "target_confidence": 3
+        }),
+    )
+    .await;
+
+    // PATCH only confidence — date should be preserved
+    let (status, _body) = common::patch_json(
+        app.clone(),
+        &format!("/api/goals/{}/items/piece-001", goal.id),
+        json!({ "target_confidence": 5 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
+    let fetched: Goal = common::json(&body);
+    assert_eq!(fetched.items[0].target_date.as_deref(), Some("2026-06-01"));
+    assert_eq!(fetched.items[0].target_confidence, Some(5));
+}
+
+#[tokio::test]
+async fn patch_goal_item_clears_targets_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    common::post_json(
+        app.clone(),
+        &format!("/api/goals/{}/items", goal.id),
+        json!({
+            "item_id": "piece-001",
+            "item_title": "Bach",
+            "item_type": "piece",
+            "target_date": "2026-06-01",
+            "target_confidence": 3
+        }),
+    )
+    .await;
+
+    let (status, _body) = common::patch_json(
+        app.clone(),
+        &format!("/api/goals/{}/items/piece-001", goal.id),
+        json!({ "target_date": null, "target_confidence": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
+    let fetched: Goal = common::json(&body);
+    assert!(fetched.items[0].target_date.is_none());
+    assert!(fetched.items[0].target_confidence.is_none());
+}
+
+#[tokio::test]
+async fn patch_goal_item_target_confidence_out_of_range_returns_400() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    common::post_json(
+        app.clone(),
+        &format!("/api/goals/{}/items", goal.id),
+        json!({
+            "item_id": "piece-001",
+            "item_title": "Bach",
+            "item_type": "piece"
+        }),
+    )
+    .await;
+
+    let (status, _body) = common::patch_json(
+        app,
+        &format!("/api/goals/{}/items/piece-001", goal.id),
+        json!({ "target_confidence": 9 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn patch_goal_item_not_found_returns_404() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let goal: Goal = common::json(&body);
+
+    let (status, _body) = common::patch_json(
+        app,
+        &format!("/api/goals/{}/items/nonexistent", goal.id),
+        json!({ "target_confidence": 4 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -290,6 +290,41 @@ async fn filter_goals_by_status() {
     assert_eq!(goals.len(), 2);
 }
 
+#[tokio::test]
+async fn reopen_goal_clears_completed_at() {
+    let app = common::setup_test_app().await;
+    let (_, body) =
+        common::post_json(app.clone(), "/api/goals", json!({ "date": "2026-05-15" })).await;
+    let created: Goal = common::json(&body);
+
+    // Mark as completed
+    let (_, body) = common::put_json(
+        app.clone(),
+        &format!("/api/goals/{}", created.id),
+        json!({ "status": "completed" }),
+    )
+    .await;
+    let completed: Goal = common::json(&body);
+    assert_eq!(completed.status, GoalStatus::Completed);
+    assert!(completed.completed_at.is_some());
+
+    // Reopen by flipping status back to active
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "status": "active" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let reopened: Goal = common::json(&body);
+    assert_eq!(reopened.status, GoalStatus::Active);
+    assert!(
+        reopened.completed_at.is_none(),
+        "completed_at should be cleared on reopen, was {:?}",
+        reopened.completed_at
+    );
+}
+
 // ── Targets (Phase 1) ─────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -2472,6 +2472,7 @@ mod tests {
             photos: Vec::new(),
             created_at: now,
             updated_at: now,
+            target_confidence: None,
         };
         model.goals.push(goal.clone());
         model.current_goal = Some(goal);
@@ -2584,6 +2585,7 @@ mod tests {
             photos: Vec::new(),
             created_at: now,
             updated_at: now,
+            target_confidence: None,
         };
 
         // No optimistic entry — caller may have navigated away and back.
@@ -2618,6 +2620,7 @@ mod tests {
             photos: Vec::new(),
             created_at: now,
             updated_at: now,
+            target_confidence: None,
         });
 
         let server_goal = Goal {
@@ -2632,6 +2635,7 @@ mod tests {
             photos: Vec::new(),
             created_at: now,
             updated_at: now,
+            target_confidence: None,
         };
 
         let _cmd = app.update(
@@ -2664,6 +2668,7 @@ mod tests {
             photos: Vec::new(),
             created_at: now,
             updated_at: now,
+            target_confidence: None,
         };
         let other = Goal {
             id: "other".to_string(),

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -459,7 +459,11 @@ impl App for Intrada {
         // first, no-deadline last) then created_at descending; completed goals
         // by completed_at descending. Active goals come before completed so
         // both tabs render in the right order from a single sorted vec.
-        let mut goals: Vec<_> = model.goals.iter().map(goal_to_view).collect();
+        let mut goals: Vec<_> = model
+            .goals
+            .iter()
+            .map(|g| goal_to_view(g, &items))
+            .collect();
         goals.sort_by(|a, b| {
             use crate::domain::goal::GoalStatus;
             let status_ord = |s: &GoalStatus| match s {
@@ -488,7 +492,7 @@ impl App for Intrada {
             }
         });
 
-        let current_goal = model.current_goal.as_ref().map(goal_to_view);
+        let current_goal = model.current_goal.as_ref().map(|g| goal_to_view(g, &items));
 
         ViewModel {
             items,

--- a/crates/intrada-core/src/domain/goal.rs
+++ b/crates/intrada-core/src/domain/goal.rs
@@ -3,7 +3,7 @@ use crux_core::Command;
 use serde::{Deserialize, Serialize};
 
 use super::item::ItemKind;
-use super::types::{CreateGoal, LinkGoalItem, UpdateGoal};
+use super::types::{CreateGoal, LinkGoalItem, UpdateGoal, UpdateGoalItem};
 use crate::app::{Effect, Event};
 use crate::model::Model;
 use crate::validation;
@@ -31,6 +31,8 @@ pub struct Goal {
     pub photos: Vec<GoalPhoto>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_confidence: Option<u8>,
 }
 
 /// Photo metadata for a goal. Binary data lives in R2; core only sees metadata.
@@ -47,18 +49,42 @@ pub struct GoalItem {
     pub item_id: String,
     pub item_title: String,
     pub item_type: ItemKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_confidence: Option<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum GoalEvent {
     FetchGoals,
-    FetchGoal { id: String },
+    FetchGoal {
+        id: String,
+    },
     Add(CreateGoal),
-    Update { id: String, input: UpdateGoal },
-    Complete { id: String },
-    Delete { id: String },
-    LinkItem { goal_id: String, item: LinkGoalItem },
-    UnlinkItem { goal_id: String, item_id: String },
+    Update {
+        id: String,
+        input: UpdateGoal,
+    },
+    Complete {
+        id: String,
+    },
+    Delete {
+        id: String,
+    },
+    LinkItem {
+        goal_id: String,
+        item: LinkGoalItem,
+    },
+    UnlinkItem {
+        goal_id: String,
+        item_id: String,
+    },
+    UpdateGoalItemTargets {
+        goal_id: String,
+        item_id: String,
+        input: UpdateGoalItem,
+    },
 }
 
 pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect, Event> {
@@ -84,6 +110,7 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
                 photos: Vec::new(),
                 created_at: now,
                 updated_at: now,
+                target_confidence: input.target_confidence,
             };
 
             let temp_id = goal.id.clone();
@@ -120,6 +147,9 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
             }
             if let Some(status) = &input.status {
                 goal.status = status.clone();
+            }
+            if let Some(target_confidence) = &input.target_confidence {
+                goal.target_confidence = *target_confidence;
             }
             goal.updated_at = chrono::Utc::now();
             model.last_error = None;
@@ -164,13 +194,18 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
             ])
         }
         GoalEvent::LinkItem { goal_id, item } => {
+            if let Err(e) = validation::validate_link_goal_item(&item) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
             if let Some(goal) = model.goals.iter_mut().find(|g| g.id == goal_id) {
                 let goal_item = GoalItem {
                     item_id: item.item_id.clone(),
                     item_title: item.item_title.clone(),
                     item_type: item.item_type.clone(),
+                    target_date: item.target_date.clone(),
+                    target_confidence: item.target_confidence,
                 };
-                // Avoid duplicates
                 if !goal.items.iter().any(|i| i.item_id == goal_item.item_id) {
                     goal.items.push(goal_item);
                 }
@@ -180,6 +215,33 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
 
             Command::all([
                 crate::http::link_goal_item(&model.api_base_url, &goal_id, &item),
+                crux_core::render::render(),
+            ])
+        }
+        GoalEvent::UpdateGoalItemTargets {
+            goal_id,
+            item_id,
+            input,
+        } => {
+            if let Err(e) = validation::validate_update_goal_item(&input) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+            if let Some(goal) = model.goals.iter_mut().find(|g| g.id == goal_id) {
+                if let Some(gi) = goal.items.iter_mut().find(|i| i.item_id == item_id) {
+                    if let Some(d) = &input.target_date {
+                        gi.target_date = d.clone();
+                    }
+                    if let Some(c) = &input.target_confidence {
+                        gi.target_confidence = *c;
+                    }
+                    goal.updated_at = chrono::Utc::now();
+                }
+            }
+            model.last_error = None;
+
+            Command::all([
+                crate::http::update_goal_item(&model.api_base_url, &goal_id, &item_id, &input),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/domain/goal.rs
+++ b/crates/intrada-core/src/domain/goal.rs
@@ -69,6 +69,9 @@ pub enum GoalEvent {
     Complete {
         id: String,
     },
+    Reopen {
+        id: String,
+    },
     Delete {
         id: String,
     },
@@ -173,6 +176,22 @@ pub fn handle_goal_event(event: GoalEvent, model: &mut Model) -> Command<Effect,
 
             Command::all([
                 crate::http::complete_goal(&model.api_base_url, &id),
+                crux_core::render::render(),
+            ])
+        }
+        GoalEvent::Reopen { id } => {
+            let Some(goal) = model.goals.iter_mut().find(|g| g.id == id) else {
+                model.last_error = Some(format!("Goal not found: {id}"));
+                return crux_core::render::render();
+            };
+
+            goal.status = GoalStatus::Active;
+            goal.completed_at = None;
+            goal.updated_at = chrono::Utc::now();
+            model.last_error = None;
+
+            Command::all([
+                crate::http::reopen_goal(&model.api_base_url, &id),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -1,6 +1,17 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::item::{Item, ItemKind};
+
+/// Deserialize an `Option<Option<T>>` field with three-state semantics:
+/// absent → `None` (skip), `null` → `Some(None)` (clear), `v` → `Some(Some(v))` (set).
+/// Pair with `#[serde(default, deserialize_with = "double_option")]`.
+fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
+}
 
 /// Top-level serialisation unit for library data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -144,6 +155,8 @@ pub struct CreateGoal {
     pub title: Option<String>,
     pub notes: Option<String>,
     pub deadline: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_confidence: Option<u8>,
 }
 
 /// Request body for updating a goal via the REST API.
@@ -155,6 +168,12 @@ pub struct UpdateGoal {
     pub notes: Option<Option<String>>,
     pub deadline: Option<Option<String>>,
     pub status: Option<super::goal::GoalStatus>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
+    pub target_confidence: Option<Option<u8>>,
 }
 
 /// Request body for linking a library item to a goal.
@@ -163,6 +182,28 @@ pub struct LinkGoalItem {
     pub item_id: String,
     pub item_title: String,
     pub item_type: ItemKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_confidence: Option<u8>,
+}
+
+/// Request body for updating the targets on a goal/item link.
+/// Three-state options: None = skip, Some(None) = clear, Some(Some(v)) = set.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct UpdateGoalItem {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
+    pub target_date: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
+    pub target_confidence: Option<Option<u8>>,
 }
 
 /// Filters for listing/searching library items.

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -15,7 +15,7 @@ use crate::domain::mcp_tokens::{CreatedMcpToken, McpToken, McpTokenEvent};
 use crate::domain::oauth::{OAuthEvent, OAuthFinalizeParams};
 use crate::domain::session::PracticeSession;
 use crate::domain::types::{
-    CreateGoal, CreateItem, CreateSetRequest, LinkGoalItem, UpdateGoal, UpdateItem,
+    CreateGoal, CreateItem, CreateSetRequest, LinkGoalItem, UpdateGoal, UpdateGoalItem, UpdateItem,
     UpdateSetRequest,
 };
 
@@ -302,6 +302,24 @@ pub fn link_goal_item(
             Ok(_) => Event::RefetchGoals,
             Err(e) => Event::LoadFailed(format!("Failed to link item to goal: {e}")),
         })
+}
+
+pub fn update_goal_item(
+    api_base_url: &str,
+    goal_id: &str,
+    item_id: &str,
+    input: &UpdateGoalItem,
+) -> Command<Effect, Event> {
+    Http::patch(format!(
+        "{api_base_url}/api/goals/{goal_id}/items/{item_id}"
+    ))
+    .body_json(input)
+    .expect("serialize UpdateGoalItem")
+    .build()
+    .then_send(|result| match result {
+        Ok(_) => Event::RefetchGoals,
+        Err(e) => Event::LoadFailed(format!("Failed to update goal item targets: {e}")),
+    })
 }
 
 pub fn unlink_goal_item(
@@ -721,6 +739,7 @@ mod tests {
             title: Some("learn Etude".into()),
             notes: None,
             deadline: Some("2026-06-19".into()),
+            target_confidence: None,
         };
         let req = take_http(&mut create_goal(BASE, &input, "temp-goal"));
         assert_eq!(req.method, "POST");
@@ -777,6 +796,8 @@ mod tests {
             item_id: "01HX0000000000000000000000".into(),
             item_title: "Etude".into(),
             item_type: ItemKind::Piece,
+            target_date: None,
+            target_confidence: None,
         };
         let req = take_http(&mut link_goal_item(
             BASE,
@@ -805,6 +826,29 @@ mod tests {
             req.url,
             "https://api.example.com/api/goals/01HG0000000000000000000000/items/01HX0000000000000000000000"
         );
+    }
+
+    #[test]
+    fn update_goal_item_patches_targets() {
+        use crate::domain::types::UpdateGoalItem;
+        let input = UpdateGoalItem {
+            target_date: Some(Some("2026-06-01".into())),
+            target_confidence: Some(Some(4)),
+        };
+        let req = take_http(&mut update_goal_item(
+            BASE,
+            "01HG0000000000000000000000",
+            "01HX0000000000000000000000",
+            &input,
+        ));
+        assert_eq!(req.method, "PATCH");
+        assert_eq!(
+            req.url,
+            "https://api.example.com/api/goals/01HG0000000000000000000000/items/01HX0000000000000000000000"
+        );
+        let body = body_as_json(&req);
+        assert_eq!(body["target_date"], "2026-06-01");
+        assert_eq!(body["target_confidence"], 4);
     }
 
     // ── Account / MCP / OAuth endpoints ──────────────────────────────

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -280,6 +280,23 @@ pub fn complete_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         })
 }
 
+pub fn reopen_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
+    use crate::domain::goal::GoalStatus;
+    use crate::domain::types::UpdateGoal;
+    let input = UpdateGoal {
+        status: Some(GoalStatus::Active),
+        ..Default::default()
+    };
+    Http::put(format!("{api_base_url}/api/goals/{id}"))
+        .body_json(&input)
+        .expect("serialize UpdateGoal for reopen")
+        .build()
+        .then_send(|result| match result {
+            Ok(_) => Event::RefetchGoals,
+            Err(e) => Event::LoadFailed(format!("Failed to reopen goal: {e}")),
+        })
+}
+
 pub fn delete_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
     Http::delete(format!("{api_base_url}/api/goals/{id}"))
         .build()
@@ -778,6 +795,18 @@ mod tests {
         );
         let body = body_as_json(&req);
         assert_eq!(body["status"], "completed");
+    }
+
+    #[test]
+    fn reopen_goal_sends_status_active() {
+        let req = take_http(&mut reopen_goal(BASE, "01HG0000000000000000000000"));
+        assert_eq!(req.method, "PUT");
+        assert_eq!(
+            req.url,
+            "https://api.example.com/api/goals/01HG0000000000000000000000"
+        );
+        let body = body_as_json(&req);
+        assert_eq!(body["status"], "active");
     }
 
     #[test]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -712,6 +712,7 @@ mod tests {
             photos: vec![],
             created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: None,
         };
         let view = goal_to_view(&goal);
         assert_eq!(view.notes_preview.len(), 100);
@@ -735,6 +736,7 @@ mod tests {
             }],
             created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: None,
         };
         let view = goal_to_view(&goal);
         assert!(view.has_photos);
@@ -758,6 +760,7 @@ mod tests {
             photos: vec![],
             created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: None,
         };
         let view = goal_to_view(&goal);
         assert!(view.is_overdue);
@@ -780,6 +783,7 @@ mod tests {
             photos: vec![],
             created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: None,
         };
         let view = goal_to_view(&goal);
         assert!(!view.is_overdue);
@@ -799,10 +803,13 @@ mod tests {
                 item_id: "item-1".to_string(),
                 item_title: "Moonlight Sonata".to_string(),
                 item_type: ItemKind::Piece,
+                target_date: None,
+                target_confidence: None,
             }],
             photos: vec![],
             created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: None,
         };
         let view = goal_to_view(&goal);
         assert_eq!(view.items.len(), 1);

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -209,8 +209,6 @@ pub struct GoalView {
     pub has_photos: bool,
     pub created_at: String,
     pub updated_at: String,
-    /// Goal-level default confidence target (1-5). Items inherit this
-    /// unless they specify their own `target_confidence` override.
     pub target_confidence: Option<u8>,
 }
 
@@ -221,12 +219,6 @@ pub struct GoalPhotoView {
     pub url: String,
 }
 
-/// A linked library item for display in the UI.
-///
-/// `effective_target_confidence` is the inherited target — item override
-/// if set, otherwise the goal-level default. `latest_score` and
-/// `latest_achieved_tempo` are pulled from the library item's session
-/// history so progress is always derived, never stored on the goal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GoalItemView {
     pub item_id: String,
@@ -843,5 +835,87 @@ mod tests {
         let view = goal_to_view(&goal, &[]);
         assert_eq!(view.items.len(), 1);
         assert_eq!(view.items[0].item_title, "Moonlight Sonata");
+    }
+
+    #[test]
+    fn goal_item_view_derives_progress_and_inheritance_from_library() {
+        // Item override beats goal default; latest_score / tempo flow through.
+        let goal = Goal {
+            id: "g1".to_string(),
+            title: None,
+            date: "2026-01-15".to_string(),
+            notes: None,
+            deadline: None,
+            status: GoalStatus::Active,
+            completed_at: None,
+            items: vec![
+                GoalItem {
+                    item_id: "item-a".to_string(),
+                    item_title: "Bach".to_string(),
+                    item_type: ItemKind::Piece,
+                    target_date: None,
+                    target_confidence: Some(5),
+                },
+                GoalItem {
+                    item_id: "item-b".to_string(),
+                    item_title: "Chromatic".to_string(),
+                    item_type: ItemKind::Exercise,
+                    target_date: None,
+                    target_confidence: None,
+                },
+            ],
+            photos: vec![],
+            created_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
+            target_confidence: Some(3),
+        };
+
+        let items = vec![
+            LibraryItemView {
+                id: "item-a".to_string(),
+                item_type: ItemKind::Piece,
+                title: "Bach".to_string(),
+                subtitle: String::new(),
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+                created_at: String::new(),
+                updated_at: String::new(),
+                practice: Some(ItemPracticeSummary {
+                    session_count: 2,
+                    total_minutes: 30,
+                    latest_score: Some(4),
+                    score_history: vec![],
+                    latest_tempo: None,
+                    tempo_history: vec![],
+                }),
+                latest_achieved_tempo: Some(120),
+            },
+            LibraryItemView {
+                id: "item-b".to_string(),
+                item_type: ItemKind::Exercise,
+                title: "Chromatic".to_string(),
+                subtitle: String::new(),
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+                created_at: String::new(),
+                updated_at: String::new(),
+                practice: None,
+                latest_achieved_tempo: None,
+            },
+        ];
+
+        let view = goal_to_view(&goal, &items);
+
+        // Item A: per-item override wins (5), latest_score reflects session data
+        assert_eq!(view.items[0].effective_target_confidence, Some(5));
+        assert_eq!(view.items[0].latest_score, Some(4));
+        assert_eq!(view.items[0].latest_achieved_tempo, Some(120));
+        // Item B: inherits goal-level default (3), no practice yet
+        assert_eq!(view.items[1].effective_target_confidence, Some(3));
+        assert_eq!(view.items[1].latest_score, None);
     }
 }

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -209,6 +209,9 @@ pub struct GoalView {
     pub has_photos: bool,
     pub created_at: String,
     pub updated_at: String,
+    /// Goal-level default confidence target (1-5). Items inherit this
+    /// unless they specify their own `target_confidence` override.
+    pub target_confidence: Option<u8>,
 }
 
 /// Photo metadata for display in the UI.
@@ -219,14 +222,24 @@ pub struct GoalPhotoView {
 }
 
 /// A linked library item for display in the UI.
+///
+/// `effective_target_confidence` is the inherited target — item override
+/// if set, otherwise the goal-level default. `latest_score` and
+/// `latest_achieved_tempo` are pulled from the library item's session
+/// history so progress is always derived, never stored on the goal.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GoalItemView {
     pub item_id: String,
     pub item_title: String,
     pub item_type: ItemKind,
+    pub target_date: Option<String>,
+    pub target_confidence: Option<u8>,
+    pub effective_target_confidence: Option<u8>,
+    pub latest_score: Option<u8>,
+    pub latest_achieved_tempo: Option<u16>,
 }
 
-pub fn goal_to_view(goal: &Goal) -> GoalView {
+pub fn goal_to_view(goal: &Goal, items: &[LibraryItemView]) -> GoalView {
     let notes_preview = goal
         .notes
         .as_deref()
@@ -242,6 +255,8 @@ pub fn goal_to_view(goal: &Goal) -> GoalView {
                 .unwrap_or(false)
         });
 
+    let goal_target_confidence = goal.target_confidence;
+
     GoalView {
         id: goal.id.clone(),
         title: goal.title.clone(),
@@ -255,10 +270,23 @@ pub fn goal_to_view(goal: &Goal) -> GoalView {
         items: goal
             .items
             .iter()
-            .map(|i| GoalItemView {
-                item_id: i.item_id.clone(),
-                item_title: i.item_title.clone(),
-                item_type: i.item_type.clone(),
+            .map(|gi| {
+                let library_item = items.iter().find(|i| i.id == gi.item_id);
+                let latest_score = library_item
+                    .and_then(|li| li.practice.as_ref())
+                    .and_then(|p| p.latest_score);
+                let latest_achieved_tempo = library_item.and_then(|li| li.latest_achieved_tempo);
+                let effective_target_confidence = gi.target_confidence.or(goal_target_confidence);
+                GoalItemView {
+                    item_id: gi.item_id.clone(),
+                    item_title: gi.item_title.clone(),
+                    item_type: gi.item_type.clone(),
+                    target_date: gi.target_date.clone(),
+                    target_confidence: gi.target_confidence,
+                    effective_target_confidence,
+                    latest_score,
+                    latest_achieved_tempo,
+                }
             })
             .collect(),
         photos: goal
@@ -272,6 +300,7 @@ pub fn goal_to_view(goal: &Goal) -> GoalView {
         has_photos: !goal.photos.is_empty(),
         created_at: goal.created_at.to_rfc3339(),
         updated_at: goal.updated_at.to_rfc3339(),
+        target_confidence: goal.target_confidence,
     }
 }
 
@@ -714,7 +743,7 @@ mod tests {
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             target_confidence: None,
         };
-        let view = goal_to_view(&goal);
+        let view = goal_to_view(&goal, &[]);
         assert_eq!(view.notes_preview.len(), 100);
     }
 
@@ -738,7 +767,7 @@ mod tests {
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             target_confidence: None,
         };
-        let view = goal_to_view(&goal);
+        let view = goal_to_view(&goal, &[]);
         assert!(view.has_photos);
         assert_eq!(view.photos.len(), 1);
     }
@@ -762,7 +791,7 @@ mod tests {
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             target_confidence: None,
         };
-        let view = goal_to_view(&goal);
+        let view = goal_to_view(&goal, &[]);
         assert!(view.is_overdue);
     }
 
@@ -785,7 +814,7 @@ mod tests {
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             target_confidence: None,
         };
-        let view = goal_to_view(&goal);
+        let view = goal_to_view(&goal, &[]);
         assert!(!view.is_overdue);
     }
 
@@ -811,7 +840,7 @@ mod tests {
             updated_at: Utc.with_ymd_and_hms(2026, 1, 15, 10, 0, 0).unwrap(),
             target_confidence: None,
         };
-        let view = goal_to_view(&goal);
+        let view = goal_to_view(&goal, &[]);
         assert_eq!(view.items.len(), 1);
         assert_eq!(view.items[0].item_title, "Moonlight Sonata");
     }

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -1,5 +1,7 @@
 use crate::domain::item::ItemKind;
-use crate::domain::types::{CreateGoal, CreateItem, Tempo, UpdateGoal, UpdateItem};
+use crate::domain::types::{
+    CreateGoal, CreateItem, LinkGoalItem, Tempo, UpdateGoal, UpdateGoalItem, UpdateItem,
+};
 use crate::error::LibraryError;
 
 /// Validation limits shared across shells (web, CLI).
@@ -368,11 +370,32 @@ fn validate_goal_deadline(deadline: Option<&str>) -> Result<(), LibraryError> {
     Ok(())
 }
 
+fn validate_target_confidence(value: u8) -> Result<(), LibraryError> {
+    if !(MIN_SCORE..=MAX_SCORE).contains(&value) {
+        return Err(LibraryError::Validation {
+            field: "target_confidence".to_string(),
+            message: format!("Target confidence must be between {MIN_SCORE} and {MAX_SCORE}"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_target_date(date: &str) -> Result<(), LibraryError> {
+    chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| LibraryError::Validation {
+        field: "target_date".to_string(),
+        message: "Target date must be in YYYY-MM-DD format".to_string(),
+    })?;
+    Ok(())
+}
+
 pub fn validate_create_goal(input: &CreateGoal) -> Result<(), LibraryError> {
     validate_goal_date(&input.date)?;
     validate_goal_title(input.title.as_deref())?;
     validate_goal_notes(input.notes.as_deref())?;
     validate_goal_deadline(input.deadline.as_deref())?;
+    if let Some(c) = input.target_confidence {
+        validate_target_confidence(c)?;
+    }
     Ok(())
 }
 
@@ -388,6 +411,30 @@ pub fn validate_update_goal(input: &UpdateGoal) -> Result<(), LibraryError> {
     }
     if let Some(ref deadline) = input.deadline {
         validate_goal_deadline(deadline.as_deref())?;
+    }
+    if let Some(Some(c)) = input.target_confidence {
+        validate_target_confidence(c)?;
+    }
+    Ok(())
+}
+
+pub fn validate_link_goal_item(input: &LinkGoalItem) -> Result<(), LibraryError> {
+    validate_set_entry_fields(&input.item_id, &input.item_title)?;
+    if let Some(ref d) = input.target_date {
+        validate_target_date(d)?;
+    }
+    if let Some(c) = input.target_confidence {
+        validate_target_confidence(c)?;
+    }
+    Ok(())
+}
+
+pub fn validate_update_goal_item(input: &UpdateGoalItem) -> Result<(), LibraryError> {
+    if let Some(Some(ref d)) = input.target_date {
+        validate_target_date(d)?;
+    }
+    if let Some(Some(c)) = input.target_confidence {
+        validate_target_confidence(c)?;
     }
     Ok(())
 }
@@ -1293,5 +1340,142 @@ mod tests {
             }
             _ => panic!("Expected Validation error"),
         }
+    }
+
+    // --- Goal target validation ---
+
+    #[test]
+    fn test_create_goal_with_target_confidence_in_range() {
+        let input = CreateGoal {
+            date: "2026-05-19".to_string(),
+            title: Some("recital prep".to_string()),
+            notes: None,
+            deadline: None,
+            target_confidence: Some(4),
+        };
+        assert!(validate_create_goal(&input).is_ok());
+    }
+
+    #[test]
+    fn test_create_goal_target_confidence_zero_rejected() {
+        let input = CreateGoal {
+            date: "2026-05-19".to_string(),
+            title: None,
+            notes: None,
+            deadline: None,
+            target_confidence: Some(0),
+        };
+        let err = validate_create_goal(&input).unwrap_err();
+        match err {
+            LibraryError::Validation { field, .. } => {
+                assert_eq!(field, "target_confidence");
+            }
+            _ => panic!("Expected Validation error"),
+        }
+    }
+
+    #[test]
+    fn test_create_goal_target_confidence_too_high_rejected() {
+        let input = CreateGoal {
+            date: "2026-05-19".to_string(),
+            title: None,
+            notes: None,
+            deadline: None,
+            target_confidence: Some(6),
+        };
+        assert!(validate_create_goal(&input).is_err());
+    }
+
+    #[test]
+    fn test_update_goal_target_confidence_clear_is_ok() {
+        let input = UpdateGoal {
+            target_confidence: Some(None),
+            ..Default::default()
+        };
+        assert!(validate_update_goal(&input).is_ok());
+    }
+
+    #[test]
+    fn test_update_goal_target_confidence_out_of_range_rejected() {
+        let input = UpdateGoal {
+            target_confidence: Some(Some(7)),
+            ..Default::default()
+        };
+        assert!(validate_update_goal(&input).is_err());
+    }
+
+    #[test]
+    fn test_link_goal_item_with_targets() {
+        let input = LinkGoalItem {
+            item_id: "item-1".to_string(),
+            item_title: "Bach".to_string(),
+            item_type: ItemKind::Piece,
+            target_date: Some("2026-06-01".to_string()),
+            target_confidence: Some(4),
+        };
+        assert!(validate_link_goal_item(&input).is_ok());
+    }
+
+    #[test]
+    fn test_link_goal_item_bad_target_date_rejected() {
+        let input = LinkGoalItem {
+            item_id: "item-1".to_string(),
+            item_title: "Bach".to_string(),
+            item_type: ItemKind::Piece,
+            target_date: Some("not-a-date".to_string()),
+            target_confidence: None,
+        };
+        let err = validate_link_goal_item(&input).unwrap_err();
+        match err {
+            LibraryError::Validation { field, .. } => {
+                assert_eq!(field, "target_date");
+            }
+            _ => panic!("Expected Validation error"),
+        }
+    }
+
+    #[test]
+    fn test_link_goal_item_still_requires_item_fields() {
+        let input = LinkGoalItem {
+            item_id: "".to_string(),
+            item_title: "Bach".to_string(),
+            item_type: ItemKind::Piece,
+            target_date: None,
+            target_confidence: None,
+        };
+        assert!(validate_link_goal_item(&input).is_err());
+    }
+
+    #[test]
+    fn test_update_goal_item_clear_targets_ok() {
+        let input = UpdateGoalItem {
+            target_date: Some(None),
+            target_confidence: Some(None),
+        };
+        assert!(validate_update_goal_item(&input).is_ok());
+    }
+
+    #[test]
+    fn test_update_goal_item_bad_date_rejected() {
+        let input = UpdateGoalItem {
+            target_date: Some(Some("2026/06/01".to_string())),
+            target_confidence: None,
+        };
+        assert!(validate_update_goal_item(&input).is_err());
+    }
+
+    #[test]
+    fn test_update_goal_item_bad_confidence_rejected() {
+        let input = UpdateGoalItem {
+            target_date: None,
+            target_confidence: Some(Some(0)),
+        };
+        assert!(validate_update_goal_item(&input).is_err());
+    }
+
+    #[test]
+    fn test_update_goal_item_empty_skip_is_ok() {
+        let input = UpdateGoalItem::default();
+        assert!(validate_update_goal_item(&input).is_ok());
     }
 }

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -5,7 +5,8 @@ use leptos::prelude::*;
 use leptos_router::hooks::{use_navigate, use_params_map};
 use leptos_router::NavigateOptions;
 
-use intrada_core::{Event, GoalEvent, GoalStatus, GoalView, LinkGoalItem, ViewModel};
+use intrada_core::domain::types::UpdateGoalItem;
+use intrada_core::{Event, GoalEvent, GoalItemView, GoalStatus, GoalView, LinkGoalItem, ViewModel};
 
 use crate::components::{
     AccentBar, AccentRow, BackLink, BottomSheet, BuilderItemRow, Button, ButtonVariant,
@@ -113,6 +114,8 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
     let close_edit_sheet = Callback::new(move |_| edit_sheet_open.set(false));
     let link_sheet_open = RwSignal::new(false);
     let close_link_sheet = Callback::new(move |_| link_sheet_open.set(false));
+    let targets_sheet_item_id: RwSignal<Option<String>> = RwSignal::new(None);
+    let close_targets_sheet = Callback::new(move |_| targets_sheet_item_id.set(None));
     let show_delete_confirm = RwSignal::new(false);
 
     let live_linked_items = {
@@ -265,19 +268,26 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
                     } else {
                         view! {
                             <ul class="space-y-2 list-none p-0" role="list">
-                                {items.into_iter().map(|item| view! {
-                                    <li>
-                                        <a
-                                            href=format!("/library/{}", item.item_id)
-                                            class="no-underline"
-                                        >
-                                            <AccentRow bar=AccentBar::None>
-                                                <div class="flex-1 min-w-0 text-sm text-primary truncate">
-                                                    {item.item_title}
-                                                </div>
-                                            </AccentRow>
-                                        </a>
-                                    </li>
+                                {items.into_iter().map(|item| {
+                                    let item_id_for_tap = item.item_id.clone();
+                                    view! {
+                                        <li>
+                                            <button
+                                                type="button"
+                                                class="w-full text-left no-underline appearance-none bg-transparent p-0"
+                                                on:click=move |_| targets_sheet_item_id.set(Some(item_id_for_tap.clone()))
+                                            >
+                                                <AccentRow bar=AccentBar::None>
+                                                    <div class="flex-1 min-w-0">
+                                                        <div class="text-sm text-primary truncate">
+                                                            {item.item_title.clone()}
+                                                        </div>
+                                                        <GoalItemTargetChips item=item.clone() />
+                                                    </div>
+                                                </AccentRow>
+                                            </button>
+                                        </li>
+                                    }
                                 }).collect::<Vec<_>>()}
                             </ul>
                         }.into_any()
@@ -287,6 +297,11 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
 
             // Actions
             <div class="space-y-3 pt-4 border-t border-border-default">
+                {move || (!is_completed && goal_looks_ready(&live_linked_items.get())).then(|| view! {
+                    <div class="rounded-lg p-card-compact bg-surface-secondary text-sm text-accent-text">
+                        "🎯 All targeted items meet their confidence target. Looks ready — mark complete?"
+                    </div>
+                })}
                 {(!is_completed).then(|| view! {
                     <Button
                         variant=ButtonVariant::Primary
@@ -317,6 +332,208 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
             open=link_sheet_open
             on_close=close_link_sheet
         />
+        <GoalItemTargetsSheet
+            goal_id=goal.id.clone()
+            item_id=targets_sheet_item_id
+            on_close=close_targets_sheet
+        />
+    }
+}
+
+/// Returns true if the goal has at least one targeted item AND every
+/// targeted item's `latest_score` meets its `effective_target_confidence`.
+/// Untargeted items don't gate the suggestion (see spec, decision #5).
+fn goal_looks_ready(items: &[GoalItemView]) -> bool {
+    let targeted: Vec<&GoalItemView> = items
+        .iter()
+        .filter(|i| i.effective_target_confidence.is_some())
+        .collect();
+    if targeted.is_empty() {
+        return false;
+    }
+    targeted.iter().all(|i| {
+        let target = i.effective_target_confidence.unwrap();
+        i.latest_score.is_some_and(|s| s >= target)
+    })
+}
+
+#[component]
+fn GoalItemTargetChips(item: GoalItemView) -> impl IntoView {
+    let target_date = item.target_date.clone();
+    let effective_confidence = item.effective_target_confidence;
+    let latest_score = item.latest_score;
+    let has_any = target_date.is_some() || effective_confidence.is_some();
+
+    if !has_any {
+        return view! {
+            <div class="text-xs text-muted mt-0.5 italic">"No targets set"</div>
+        }
+        .into_any();
+    }
+
+    view! {
+        <div class="flex flex-wrap gap-1 mt-1">
+            {target_date.map(|d| view! {
+                <span class="badge badge--muted">{format!("📅 {d}")}</span>
+            })}
+            {effective_confidence.map(|target| {
+                let met = latest_score.is_some_and(|s| s >= target);
+                let badge_class = if met { "badge badge--accent" } else { "badge badge--muted" };
+                let label = match latest_score {
+                    Some(score) => format!("Confidence {score}/{target}"),
+                    None => format!("Confidence —/{target}"),
+                };
+                view! { <span class=badge_class>{label}</span> }
+            })}
+        </div>
+    }
+    .into_any()
+}
+
+#[component]
+fn GoalItemTargetsSheet(
+    goal_id: String,
+    item_id: RwSignal<Option<String>>,
+    on_close: Callback<()>,
+) -> impl IntoView {
+    let view_model = expect_context::<RwSignal<ViewModel>>();
+    let core = expect_context::<SharedCore>();
+    let is_loading = expect_context::<IsLoading>();
+    let is_submitting = expect_context::<IsSubmitting>();
+
+    let open = RwSignal::new(false);
+    Effect::new(move |_| {
+        open.set(item_id.with(|i| i.is_some()));
+    });
+
+    let target_date = RwSignal::new(String::new());
+    let target_confidence = RwSignal::new(String::new());
+
+    let goal_id_for_effect = goal_id.clone();
+    Effect::new(move |_| {
+        let id = item_id.with(|i| i.clone());
+        let Some(id) = id else {
+            return;
+        };
+        let item = view_model.with_untracked(|vm| {
+            vm.goals
+                .iter()
+                .find(|g| g.id == goal_id_for_effect)
+                .and_then(|g| g.items.iter().find(|i| i.item_id == id).cloned())
+        });
+        if let Some(item) = item {
+            target_date.set(item.target_date.clone().unwrap_or_default());
+            target_confidence.set(
+                item.target_confidence
+                    .map(|c| c.to_string())
+                    .unwrap_or_default(),
+            );
+        }
+    });
+
+    let goal_id_for_view = goal_id.clone();
+    let item_view = Signal::derive(move || {
+        let id = item_id.with(|i| i.clone())?;
+        view_model.with(|vm| {
+            vm.goals
+                .iter()
+                .find(|g| g.id == goal_id_for_view)
+                .and_then(|g| g.items.iter().find(|i| i.item_id == id).cloned())
+        })
+    });
+
+    let goal_id_for_save = goal_id;
+    let on_save = Callback::new(move |_| {
+        let Some(id) = item_id.with_untracked(|i| i.clone()) else {
+            return;
+        };
+        let td = target_date.get_untracked();
+        let tc = target_confidence.get_untracked();
+
+        let target_date_val = if td.is_empty() { None } else { Some(td) };
+        let target_confidence_val: Option<u8> = if tc.is_empty() { None } else { tc.parse().ok() };
+
+        let input = UpdateGoalItem {
+            target_date: Some(target_date_val),
+            target_confidence: Some(target_confidence_val),
+        };
+
+        let core_ref = core.borrow();
+        let effects = core_ref.process_event(Event::Goal(GoalEvent::UpdateGoalItemTargets {
+            goal_id: goal_id_for_save.clone(),
+            item_id: id,
+            input,
+        }));
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        on_close.run(());
+    });
+
+    let submitting_signal = Signal::derive(move || is_submitting.get());
+
+    view! {
+        <BottomSheet
+            open=open
+            on_close=on_close
+            nav_title="Item Targets".to_string()
+            nav_action_label="Save".to_string()
+            on_nav_action=on_save
+            nav_action_disabled=submitting_signal
+        >
+            {move || {
+                let item = item_view.get();
+                match item {
+                    None => view! { <div></div> }.into_any(),
+                    Some(item) => view! {
+                        <div class="space-y-4">
+                            <div>
+                                <p class="field-label">"Item"</p>
+                                <p class="text-base text-primary">{item.item_title.clone()}</p>
+                                <a
+                                    href=format!("/library/{}", item.item_id)
+                                    class="text-sm text-accent-text"
+                                >
+                                    "Open in library →"
+                                </a>
+                            </div>
+
+                            <div class="space-y-1">
+                                <label for="goal-item-target-date" class="form-label">
+                                    "Target date"
+                                </label>
+                                <input
+                                    id="goal-item-target-date"
+                                    type="date"
+                                    class="input-base"
+                                    bind:value=target_date
+                                />
+                                <p class="text-xs text-muted">
+                                    "When you want this piece ready. Overrides the goal's deadline for this item."
+                                </p>
+                            </div>
+
+                            <div class="space-y-1">
+                                <label for="goal-item-target-confidence" class="form-label">
+                                    "Target confidence"
+                                </label>
+                                <select
+                                    id="goal-item-target-confidence"
+                                    class="input-base"
+                                    prop:value=move || target_confidence.get()
+                                    on:change=move |ev| target_confidence.set(leptos::prelude::event_target_value(&ev))
+                                >
+                                    <option value="">"(use goal default)"</option>
+                                    <option value="1">"1 — Just starting"</option>
+                                    <option value="2">"2"</option>
+                                    <option value="3">"3 — Comfortable"</option>
+                                    <option value="4">"4"</option>
+                                    <option value="5">"5 — Performance ready"</option>
+                                </select>
+                            </div>
+                        </div>
+                    }.into_any()
+                }
+            }}
+        </BottomSheet>
     }
 }
 

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -2,11 +2,14 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use leptos::prelude::*;
+use leptos_router::components::A;
 use leptos_router::hooks::{use_navigate, use_params_map};
 use leptos_router::NavigateOptions;
 
 use intrada_core::domain::types::UpdateGoalItem;
-use intrada_core::{Event, GoalEvent, GoalItemView, GoalStatus, GoalView, LinkGoalItem, ViewModel};
+use intrada_core::{
+    Event, GoalEvent, GoalItemView, GoalStatus, GoalView, LibraryItemView, LinkGoalItem, ViewModel,
+};
 
 use crate::components::{
     AccentBar, AccentRow, BackLink, BottomSheet, BuilderItemRow, Button, ButtonVariant,
@@ -15,6 +18,19 @@ use crate::components::{
 use crate::views::GoalEditFormView;
 use intrada_web::core_bridge::process_effects;
 use intrada_web::types::{IsLoading, IsSubmitting, SharedCore};
+
+/// Sheet-state signals owned by `GoalDetailView`, not `GoalDetailContent`.
+/// The inner content component is rebuilt on every view-model update
+/// (its prop changes when the goal mutates); local signals there would
+/// reset mid-interaction. Hoisting them to the outer component keeps
+/// in-flight sheets open across optimistic updates.
+#[derive(Clone, Copy)]
+struct SheetState {
+    edit_open: RwSignal<bool>,
+    link_open: RwSignal<bool>,
+    targets_item_id: RwSignal<Option<String>>,
+    show_delete_confirm: RwSignal<bool>,
+}
 
 #[component]
 pub fn GoalDetailView() -> impl IntoView {
@@ -28,6 +44,27 @@ pub fn GoalDetailView() -> impl IntoView {
     // Sticky so a Delete that wipes the goal from the model doesn't flash
     // "not found" before the route transition unmounts the view.
     let goal_snapshot = RwSignal::new(None::<GoalView>);
+
+    let sheets = SheetState {
+        edit_open: RwSignal::new(false),
+        link_open: RwSignal::new(false),
+        targets_item_id: RwSignal::new(None),
+        show_delete_confirm: RwSignal::new(false),
+    };
+
+    // Reset sheets when the route id changes (navigating between goals).
+    let last_route_id = RwSignal::new(String::new());
+    Effect::new(move |_| {
+        let route_id = params.with(|p| p.get("id").unwrap_or_default().to_string());
+        let prev = last_route_id.get_untracked();
+        if !prev.is_empty() && prev != route_id {
+            sheets.edit_open.set(false);
+            sheets.link_open.set(false);
+            sheets.targets_item_id.set(None);
+            sheets.show_delete_confirm.set(false);
+        }
+        last_route_id.set(route_id);
+    });
 
     // Untracked view-model read: only `params` should re-fire this Effect,
     // otherwise the route transition out of the view re-triggers FetchGoal
@@ -82,7 +119,7 @@ pub fn GoalDetailView() -> impl IntoView {
             <Show when=move || !is_loading.get()>
                 {move || {
                     match goal.get() {
-                        Some(g) => view! { <GoalDetailContent goal=g /> }.into_any(),
+                        Some(g) => view! { <GoalDetailContent goal=g sheets=sheets /> }.into_any(),
                         None => view! {
                             <BackLink label="Back to Goals" href="/goals".to_string() />
                             <p class="text-muted text-sm">"Goal not found."</p>
@@ -95,7 +132,7 @@ pub fn GoalDetailView() -> impl IntoView {
 }
 
 #[component]
-fn GoalDetailContent(goal: GoalView) -> impl IntoView {
+fn GoalDetailContent(goal: GoalView, sheets: SheetState) -> impl IntoView {
     let core = expect_context::<SharedCore>();
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let is_loading = expect_context::<IsLoading>();
@@ -108,15 +145,24 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
     let goal_id_for_section = goal.id.clone();
     let goal_id_for_edit_sheet = goal.id.clone();
     let goal_id_for_link_sheet = goal.id.clone();
-    let is_completed = goal.status == GoalStatus::Completed;
+    let goal_id_for_status = goal.id.clone();
+    let is_completed_signal = Signal::derive(move || {
+        view_model.with(|vm| {
+            vm.goals
+                .iter()
+                .find(|g| g.id == goal_id_for_status)
+                .map(|g| g.status == GoalStatus::Completed)
+                .unwrap_or(false)
+        })
+    });
 
-    let edit_sheet_open = RwSignal::new(false);
+    let edit_sheet_open = sheets.edit_open;
     let close_edit_sheet = Callback::new(move |_| edit_sheet_open.set(false));
-    let link_sheet_open = RwSignal::new(false);
+    let link_sheet_open = sheets.link_open;
     let close_link_sheet = Callback::new(move |_| link_sheet_open.set(false));
-    let targets_sheet_item_id: RwSignal<Option<String>> = RwSignal::new(None);
+    let targets_sheet_item_id = sheets.targets_item_id;
     let close_targets_sheet = Callback::new(move |_| targets_sheet_item_id.set(None));
-    let show_delete_confirm = RwSignal::new(false);
+    let show_delete_confirm = sheets.show_delete_confirm;
 
     let live_linked_items = {
         let goal_id_for_section = goal_id_for_section.clone();
@@ -132,6 +178,8 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
     };
 
     let core_for_delete = core.clone();
+    let core_for_reopen = core.clone();
+    let goal_id_for_reopen = goal_id.clone();
     let on_complete = move |_: leptos::ev::MouseEvent| {
         let nav = navigate.clone();
         nav(
@@ -144,6 +192,16 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
         let core_ref = core.borrow();
         let effects = core_ref.process_event(Event::Goal(GoalEvent::Complete {
             id: goal_id.clone(),
+        }));
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+    };
+
+    // Reopen stays on the goal detail — user is reverting a decision, not
+    // finishing a flow, so no nav back to /goals.
+    let on_reopen = move |_: leptos::ev::MouseEvent| {
+        let core_ref = core_for_reopen.borrow();
+        let effects = core_ref.process_event(Event::Goal(GoalEvent::Reopen {
+            id: goal_id_for_reopen.clone(),
         }));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
     };
@@ -205,8 +263,8 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
             <div class="space-y-2">
                 <h2 class="page-title">{title_display}</h2>
                 <div class="flex items-center gap-2 flex-wrap">
-                    <span class=if is_completed { "badge badge--accent" } else { "badge badge--warm" }>
-                        {if is_completed { "Completed" } else { "Active" }}
+                    <span class=move || if is_completed_signal.get() { "badge badge--accent" } else { "badge badge--warm" }>
+                        {move || if is_completed_signal.get() { "Completed" } else { "Active" }}
                     </span>
                     {goal.deadline.clone().map(|d| {
                         let badge_class = if goal.is_overdue {
@@ -270,22 +328,28 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
                             <ul class="space-y-2 list-none p-0" role="list">
                                 {items.into_iter().map(|item| {
                                     let item_id_for_tap = item.item_id.clone();
+                                    let item_id_for_library = item.item_id.clone();
                                     view! {
                                         <li>
-                                            <button
-                                                type="button"
-                                                class="w-full text-left no-underline appearance-none bg-transparent p-0"
-                                                on:click=move |_| targets_sheet_item_id.set(Some(item_id_for_tap.clone()))
-                                            >
-                                                <AccentRow bar=AccentBar::None>
-                                                    <div class="flex-1 min-w-0">
-                                                        <div class="text-sm text-primary truncate">
-                                                            {item.item_title.clone()}
-                                                        </div>
-                                                        <GoalItemTargetChips item=item.clone() />
+                                            <AccentRow bar=AccentBar::None>
+                                                <button
+                                                    type="button"
+                                                    class="flex-1 min-w-0 text-left appearance-none bg-transparent p-0"
+                                                    on:click=move |_| targets_sheet_item_id.set(Some(item_id_for_tap.clone()))
+                                                >
+                                                    <div class="text-sm text-primary truncate">
+                                                        {item.item_title.clone()}
                                                     </div>
-                                                </AccentRow>
-                                            </button>
+                                                    <GoalItemTargetChips item=item.clone() />
+                                                </button>
+                                                <A
+                                                    href=format!("/library/{}", item_id_for_library)
+                                                    attr:class="ml-2 px-2 py-1 text-muted hover:text-accent-text no-underline"
+                                                    attr:aria-label="Open in library"
+                                                >
+                                                    "›"
+                                                </A>
+                                            </AccentRow>
                                         </li>
                                     }
                                 }).collect::<Vec<_>>()}
@@ -297,20 +361,37 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
 
             // Actions
             <div class="space-y-3 pt-4 border-t border-border-default">
-                {move || (!is_completed && goal_looks_ready(&live_linked_items.get())).then(|| view! {
+                {move || (!is_completed_signal.get() && goal_looks_ready(&live_linked_items.get())).then(|| view! {
                     <div class="rounded-lg p-card-compact bg-surface-secondary text-sm text-accent-text">
                         "🎯 All targeted items meet their confidence target. Looks ready — mark complete?"
                     </div>
                 })}
-                {(!is_completed).then(|| view! {
-                    <Button
-                        variant=ButtonVariant::Primary
-                        on_click=Callback::new(on_complete)
-                        full_width=true
-                    >
-                        "Mark Complete"
-                    </Button>
-                })}
+                {
+                    let on_complete = Callback::new(on_complete);
+                    let on_reopen = Callback::new(on_reopen);
+                    view! {
+                        <Show
+                            when=move || is_completed_signal.get()
+                            fallback=move || view! {
+                                <Button
+                                    variant=ButtonVariant::Primary
+                                    on_click=on_complete
+                                    full_width=true
+                                >
+                                    "Mark Complete"
+                                </Button>
+                            }
+                        >
+                            <Button
+                                variant=ButtonVariant::Primary
+                                on_click=on_reopen
+                                full_width=true
+                            >
+                                "Reopen Goal"
+                            </Button>
+                        </Show>
+                    }
+                }
                 <Button
                     variant=ButtonVariant::Danger
                     on_click=Callback::new(move |_| { show_delete_confirm.set(true); })
@@ -353,6 +434,41 @@ fn goal_looks_ready(items: &[GoalItemView]) -> bool {
         }
     }
     any_targeted
+}
+
+#[component]
+fn ItemPracticeInfo(library: Signal<Option<LibraryItemView>>) -> impl IntoView {
+    view! {
+        {move || library.get().map(|item| {
+            let composer = (!item.subtitle.is_empty()).then(|| item.subtitle.clone());
+            let practice = item.practice.clone();
+            let latest_tempo = item.latest_achieved_tempo;
+            view! {
+                <div class="space-y-1 text-sm text-muted">
+                    {composer.map(|c| view! { <div>{c}</div> })}
+                    {practice.as_ref().map(|p| {
+                        let count = p.session_count;
+                        let score = p.latest_score;
+                        view! {
+                            <div>
+                                {format!("{count} session{} • ", if count == 1 { "" } else { "s" })}
+                                {match score {
+                                    Some(s) => format!("last score {s}/5"),
+                                    None => "no score yet".to_string(),
+                                }}
+                            </div>
+                        }
+                    })}
+                    {latest_tempo.map(|bpm| view! {
+                        <div>{format!("Last achieved tempo: {bpm} bpm")}</div>
+                    })}
+                    {(practice.is_none() && latest_tempo.is_none() && item.subtitle.is_empty()).then(|| view! {
+                        <div class="italic">"No practice yet for this item."</div>
+                    })}
+                </div>
+            }
+        })}
+    }
 }
 
 #[component]
@@ -440,6 +556,11 @@ fn GoalItemTargetsSheet(
         })
     });
 
+    let library_item = Signal::derive(move || {
+        let id = item_id.with(|i| i.clone())?;
+        view_model.with(|vm| vm.items.iter().find(|i| i.id == id).cloned())
+    });
+
     let goal_id_for_save = goal_id;
     // Full overwrite on Save: both fields are initialised from the item on
     // open, so wrapping each in Some(_) sends the form's current state
@@ -487,15 +608,10 @@ fn GoalItemTargetsSheet(
                     None => view! { <div></div> }.into_any(),
                     Some(item) => view! {
                         <div class="space-y-4">
-                            <div>
+                            <div class="space-y-1">
                                 <p class="field-label">"Item"</p>
                                 <p class="text-base text-primary">{item.item_title.clone()}</p>
-                                <a
-                                    href=format!("/library/{}", item.item_id)
-                                    class="text-sm text-accent-text"
-                                >
-                                    "Open in library →"
-                                </a>
+                                <ItemPracticeInfo library=library_item />
                             </div>
 
                             <div class="space-y-1">

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -363,6 +363,8 @@ fn LinkItemsSheet(goal_id: String, open: RwSignal<bool>, on_close: Callback<()>)
                         item_id: item.id.clone(),
                         item_title: item.title.clone(),
                         item_type: item.item_type,
+                        target_date: None,
+                        target_confidence: None,
                     },
                 })
             };

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -340,21 +340,19 @@ fn GoalDetailContent(goal: GoalView) -> impl IntoView {
     }
 }
 
-/// Returns true if the goal has at least one targeted item AND every
-/// targeted item's `latest_score` meets its `effective_target_confidence`.
-/// Untargeted items don't gate the suggestion (see spec, decision #5).
+// Untargeted items don't gate the suggestion — see specs/goals-targets.md decision #5.
 fn goal_looks_ready(items: &[GoalItemView]) -> bool {
-    let targeted: Vec<&GoalItemView> = items
-        .iter()
-        .filter(|i| i.effective_target_confidence.is_some())
-        .collect();
-    if targeted.is_empty() {
-        return false;
+    let mut any_targeted = false;
+    for item in items {
+        let Some(target) = item.effective_target_confidence else {
+            continue;
+        };
+        any_targeted = true;
+        if !item.latest_score.is_some_and(|s| s >= target) {
+            return false;
+        }
     }
-    targeted.iter().all(|i| {
-        let target = i.effective_target_confidence.unwrap();
-        i.latest_score.is_some_and(|s| s >= target)
-    })
+    any_targeted
 }
 
 #[component]
@@ -443,6 +441,10 @@ fn GoalItemTargetsSheet(
     });
 
     let goal_id_for_save = goal_id;
+    // Full overwrite on Save: both fields are initialised from the item on
+    // open, so wrapping each in Some(_) sends the form's current state
+    // (including explicit clears as Some(None)). No per-field dirty
+    // tracking — form is the single source of truth.
     let on_save = Callback::new(move |_| {
         let Some(id) = item_id.with_untracked(|i| i.clone()) else {
             return;

--- a/crates/intrada-web/src/views/goal_edit_form.rs
+++ b/crates/intrada-web/src/views/goal_edit_form.rs
@@ -106,6 +106,11 @@ pub fn GoalEditFormView(
     let title = RwSignal::new(goal.title.clone().unwrap_or_default());
     let notes = RwSignal::new(goal.notes.clone().unwrap_or_default());
     let deadline = RwSignal::new(goal.deadline.clone().unwrap_or_default());
+    let target_confidence = RwSignal::new(
+        goal.target_confidence
+            .map(|c| c.to_string())
+            .unwrap_or_default(),
+    );
     let errors: RwSignal<HashMap<String, String>> = RwSignal::new(HashMap::new());
 
     let navigate_cancel = navigate.clone();
@@ -128,13 +133,20 @@ pub fn GoalEditFormView(
                     let notes_val = notes.get().trim().to_string();
                     let deadline_val = deadline.get().trim().to_string();
 
+                    let tc_str = target_confidence.get();
+                    let tc_parsed: Option<u8> = if tc_str.is_empty() {
+                        None
+                    } else {
+                        tc_str.parse().ok()
+                    };
+
                     let input = UpdateGoal {
                         title: Some(if title_val.is_empty() { None } else { Some(title_val) }),
                         date: None,
                         notes: Some(if notes_val.is_empty() { None } else { Some(notes_val) }),
                         deadline: Some(if deadline_val.is_empty() { None } else { Some(deadline_val) }),
                         status: None,
-                        target_confidence: None,
+                        target_confidence: Some(tc_parsed),
                     };
 
                     let core_ref = core.borrow();
@@ -186,6 +198,28 @@ pub fn GoalEditFormView(
                 errors=errors
                 input_type="date"
             />
+
+            <div class="space-y-1">
+                <label for="goal-edit-target-confidence" class="form-label">
+                    "Target confidence"
+                </label>
+                <select
+                    id="goal-edit-target-confidence"
+                    class="input-base"
+                    prop:value=move || target_confidence.get()
+                    on:change=move |ev| target_confidence.set(leptos::prelude::event_target_value(&ev))
+                >
+                    <option value="">"(no target)"</option>
+                    <option value="1">"1 — Just starting"</option>
+                    <option value="2">"2"</option>
+                    <option value="3">"3 — Comfortable"</option>
+                    <option value="4">"4"</option>
+                    <option value="5">"5 — Performance ready"</option>
+                </select>
+                <p class="text-xs text-muted">
+                    "Default target for items in this goal. Individual items can override."
+                </p>
+            </div>
 
             <div class="flex flex-col pt-2">
                 <Button

--- a/crates/intrada-web/src/views/goal_edit_form.rs
+++ b/crates/intrada-web/src/views/goal_edit_form.rs
@@ -134,6 +134,7 @@ pub fn GoalEditFormView(
                         notes: Some(if notes_val.is_empty() { None } else { Some(notes_val) }),
                         deadline: Some(if deadline_val.is_empty() { None } else { Some(deadline_val) }),
                         status: None,
+                        target_confidence: None,
                     };
 
                     let core_ref = core.borrow();

--- a/crates/intrada-web/src/views/goal_form.rs
+++ b/crates/intrada-web/src/views/goal_form.rs
@@ -61,6 +61,7 @@ pub fn GoalFormView(
                     title: if title_val.is_empty() { None } else { Some(title_val) },
                     notes: if notes_val.is_empty() { None } else { Some(notes_val) },
                     deadline: if deadline_val.is_empty() { None } else { Some(deadline_val) },
+                    target_confidence: None,
                 };
 
                 let core_ref = core.borrow();

--- a/crates/intrada-web/src/views/goal_form.rs
+++ b/crates/intrada-web/src/views/goal_form.rs
@@ -30,6 +30,7 @@ pub fn GoalFormView(
     let title = RwSignal::new(String::new());
     let notes = RwSignal::new(String::new());
     let deadline = RwSignal::new(String::new());
+    let target_confidence = RwSignal::new(String::new());
     let errors: RwSignal<HashMap<String, String>> = RwSignal::new(HashMap::new());
 
     let dismiss_save = on_dismiss;
@@ -56,12 +57,15 @@ pub fn GoalFormView(
                 let notes_val = notes.get();
                 let deadline_val = deadline.get();
 
+                let tc_str = target_confidence.get();
+                let tc_parsed: Option<u8> = if tc_str.is_empty() { None } else { tc_str.parse().ok() };
+
                 let input = CreateGoal {
                     date,
                     title: if title_val.is_empty() { None } else { Some(title_val) },
                     notes: if notes_val.is_empty() { None } else { Some(notes_val) },
                     deadline: if deadline_val.is_empty() { None } else { Some(deadline_val) },
-                    target_confidence: None,
+                    target_confidence: tc_parsed,
                 };
 
                 let core_ref = core.borrow();
@@ -109,6 +113,28 @@ pub fn GoalFormView(
                 errors=errors
                 input_type="date"
             />
+
+            <div class="space-y-1">
+                <label for="goal-target-confidence" class="form-label">
+                    "Target confidence"
+                </label>
+                <select
+                    id="goal-target-confidence"
+                    class="input-base"
+                    prop:value=move || target_confidence.get()
+                    on:change=move |ev| target_confidence.set(leptos::prelude::event_target_value(&ev))
+                >
+                    <option value="">"(no target)"</option>
+                    <option value="1">"1 — Just starting"</option>
+                    <option value="2">"2"</option>
+                    <option value="3">"3 — Comfortable"</option>
+                    <option value="4">"4"</option>
+                    <option value="5">"5 — Performance ready"</option>
+                </select>
+                <p class="text-xs text-muted">
+                    "Default target for items in this goal. Individual items can override."
+                </p>
+            </div>
 
             <div class="flex flex-col pt-2">
                 <Button

--- a/specs/goals-targets.md
+++ b/specs/goals-targets.md
@@ -1,0 +1,137 @@
+# Goals targets — per-item commitments with derived progress
+
+> Tier 3 follow-on spec. Builds on [specs/goals.md](goals.md) (the Plan-pillar spine from #711). This spec turns Goals from "a bag of linked items with a deadline" into "a commitment with measurable targets, progress derived from session data."
+
+## Problem
+
+After #711, #719, #726, and #732, a Goal can be created, linked to library items, edited, completed, and deleted. But it's a write-only diary — a user can say "I want to play these pieces" but can't say *how well* or *by when* per piece, and the app has no way to show progress against the commitment.
+
+The hard part of practising isn't picking what to play — it's knowing whether you're on track. The current model has the *what* (linked items) and the *when* (a goal-wide deadline) but is missing the *how well* (tempo, confidence) and the *per-item when* (different pieces ready at different points before the goal date). And nothing in the goal connects to the rich session data the app already collects.
+
+This spec adds **per-item targets** to Goals, with **progress derived from existing session data** (not stored). Targets are date, confidence, and tempo. Targets inherit from goal-level defaults and can be overridden per item.
+
+## Approach
+
+### Data model — additive only, optional everywhere
+
+```text
+Goal {
+  // existing
+  id, user_id, title, notes, deadline, status, completed_at, items, photos, ...
+
+  // new (goal-level defaults — items inherit unless overridden)
+  target_confidence: Option<u8>   // 1..=5
+  target_tempo:      Option<u32>  // bpm  [Phase C — deferred]
+  // note: no `target_date` at goal level — `deadline` IS the goal-level date
+}
+
+GoalItem {
+  // existing
+  item_id, item_title, item_type
+
+  // new (overrides goal-level defaults)
+  target_date:       Option<String>  // ISO date "YYYY-MM-DD"
+  target_confidence: Option<u8>      // 1..=5
+  target_tempo:      Option<u32>     // bpm  [Phase C — deferred]
+}
+```
+
+All new fields are nullable in DB, optional in API request bodies, optional in core types. No existing data is invalidated; un-targeted items remain valid forever.
+
+### Inheritance — effective target is `item.foo.or(goal.foo)`
+
+A goal-level `target_confidence = 4` means "every item targets 4 unless I say otherwise on the item." Override semantics are read-only — clearing `goal.target_confidence` doesn't cascade to clear item overrides; clearing `item.target_confidence` causes that item to fall back to the goal-level default (or to having no confidence target if the goal-level is also None).
+
+Date is *not* inherited. `Goal.deadline` is the urgency frame for the whole goal; `GoalItem.target_date`, when set, is a per-item earlier deadline ("Bach must be ready 2 weeks before the recital"). An item without `target_date` shows the goal's `deadline` as its countdown context.
+
+### Progress — derived, not stored
+
+Goals store *intent*. Sessions store *evidence*. The view-model projection derives progress:
+
+- **current_confidence** for an item = `vm.items.find(id).practice.latest_score` (already exists, see [session.rs:1892](crates/intrada-core/src/domain/session.rs)).
+- **current_tempo** for an item = `vm.items.find(id).practice.latest_achieved_tempo` (already exists, see [LibraryItemView](crates/intrada-core/src/lib.rs)).
+- **date status** for an item = simple comparison of `today` to `item.target_date.or(goal.deadline)`. No storage, no compute.
+
+There is no goal/session coupling — a session is just a session. It updates `latest_score` and `latest_achieved_tempo` on each library item it touches, which in turn moves the needle on *every* goal containing that item. This is what enables cross-goal practice in a future phase without any data-model gymnastics.
+
+### Completion — auto-suggest, manual confirm
+
+The "looks ready" prompt fires when:
+
+```
+goal.items
+  .filter(|i| i.has_any_target())   // un-targeted items are ignored
+  .all(|i| effective_target_met_by_latest_session(i))
+```
+
+Where "effective target met" means:
+- if `effective_target_confidence` is set: `latest_score ≥ target`
+- if `effective_target_tempo` is set (Phase C): `latest_achieved_tempo ≥ target`
+- if neither is set on the item: item doesn't gate the prompt
+
+**Date is informational only** — it drives countdowns and overdue badges; it does not gate the prompt. A goal can be "ready" before its deadline; a goal past its deadline with unmet confidence targets is *overdue* not *complete*.
+
+**Goals with no targets at all never auto-suggest.** User taps Mark Complete manually, same as today.
+
+The user clicks "Mark Complete" — auto-suggest never auto-completes. This preserves the current handler (`GoalEvent::Complete`) unchanged.
+
+## Key decisions
+
+| # | Decision | Reason |
+|---|---|---|
+| 1 | Targets live on the `GoalItem` link, not the library item | Same piece can have different targets in different goals (Bach for the lesson at 80bpm, Bach for the recital at 120bpm) |
+| 2 | Inheritance via `item.foo.or(goal.foo)` | One place to set "performance tempo for the whole recital"; cheap escape valve per piece |
+| 3 | Progress derived from session data; goals store no progress fields | Goals stay as views over evidence; sessions are the single source of truth for what actually happened |
+| 4 | Date is informational, not a completion gate | Date = urgency; readiness = confidence/tempo. Confusing these would mean a goal could be "complete" just by waiting |
+| 5 | Un-targeted items don't gate the auto-suggest | Otherwise adding a piece with no target would silently block completion. Make absence-of-target mean absence-of-opinion |
+| 6 | Latest-session-meets-target is the "looks ready" rule | Simplest defensible rule. Risks false-positives from a single good day — flagged as the **#1 open question** to revisit |
+| 7 | Manual completion only — auto-suggest never auto-completes | User decides when "embedded enough to count." Removes a class of "why did my goal disappear?" surprises |
+| 8 | Single migration adds all new columns | Phase B uses confidence; Phase C uses tempo; one migration is cheaper than two and won't break ordering invariants |
+
+## Phase rollout
+
+| Phase | Scope | Status |
+|---|---|---|
+| **1 (A+B bundled)** | Date target on `GoalItem` + Confidence target (goal-level default + per-item override) + per-item edit UI + countdown badges + progress display pulling `latest_score` + auto-suggest banner on completion criterion | **This spec ships with Phase 1's PR** |
+| **2 (C)** | Tempo target (goal-level default + per-item override) + tempo progress from `latest_achieved_tempo` + auto-suggest extended | Separate PR |
+| **3 (D)** | "Practice this goal" button on goal detail → starts a session pre-loaded with the goal's items in order of "least ready" | Separate PR; depends on session-builder reuse |
+| **4 (Future)** | Cross-goal session builder ("show me what's due across all active goals") + spaced-practice / interleaving suggester | Out of scope for this spec; revisit after Phase 3 |
+
+### Phase 1 — file inventory
+
+- **Migration**: new sequential migration in [crates/intrada-api/src/migrations.rs](crates/intrada-api/src/migrations.rs). Adds `target_confidence INTEGER` to `goals`, adds `target_date TEXT, target_confidence INTEGER, target_tempo INTEGER` to `goal_items`. (Tempo column added now; left unused until Phase 2 — single migration is cheaper than two.)
+- **Core types**: [crates/intrada-core/src/domain/types.rs](crates/intrada-core/src/domain/types.rs) — extend `Goal`, `GoalItem`, `CreateGoal`, `UpdateGoal`, `LinkGoalItem`, plus a new `UpdateGoalItem { goal_id, item_id, target_date?, target_confidence? }` request type. Add `effective_target_*` helpers on the view-model projection.
+- **API endpoints**: extend `POST /goals` and `PATCH /goals/:id` to accept `target_confidence`. Extend `POST /goals/:id/items` to accept `target_date?` and `target_confidence?`. New `PATCH /goals/:id/items/:item_id` for editing a link's targets without unlinking+relinking.
+- **HTTP wrapper**: [crates/intrada-core/src/http.rs](crates/intrada-core/src/http.rs) — `update_goal_item(...)` builder.
+- **Validation**: [crates/intrada-core/src/validation.rs](crates/intrada-core/src/validation.rs) — `validate_target_confidence` (1..=5), `validate_target_date` (ISO-parsable).
+- **UI — goal edit form**: [crates/intrada-web/src/views/goal_edit_form.rs](crates/intrada-web/src/views/goal_edit_form.rs) (introduced in #726) — add goal-level `target_confidence` field.
+- **UI — goal detail**: [crates/intrada-web/src/views/goal_detail.rs](crates/intrada-web/src/views/goal_detail.rs) — linked-item rows show "target X / current Y" pill; tapping an item opens a per-item target editor (BottomSheet); auto-suggest banner above actions when criterion met.
+- **UI — new component**: `GoalItemTargetsSheet` (private to `goal_detail.rs`, mirrors `LinkItemsSheet` shape from #732).
+
+### Phase 1 — what stays the same
+
+- `#732`'s `LinkItemsSheet` (link/unlink picker). Adding an item still creates a target-less link; targets are set in the new per-item editor.
+- `#726`'s edit form. We add fields to it; we don't change its shape.
+- The `goal_snapshot` flicker-prevention pattern. Untouched.
+
+## Open questions — for later, not for Phase 1
+
+1. **Consolidation rule for "looks ready."** The latest-session rule is intentionally simplistic. Revisit once we have user behaviour to learn from. Candidate refinements: last-N-sessions, N-sessions-over-M-days, weighted-by-recency. (User flagged wanting to think more on this.)
+2. **Sets and Goals overlap.** Sets stay separate for now. Worth revisiting once Phase 3 ("Practice this goal") exists — at that point a Set and a Goal both become "things you can launch a practice session from," and the conceptual cost of having both gets clearer.
+3. **What happens when the user re-records a piece (e.g. changes BPM)?** Currently the goal's `target_tempo` refers to a bpm number, not a percentage of the piece's "natural" tempo. If the user updates the library item's tempo marking from Allegro to Presto, the goal target doesn't auto-adjust. That's probably correct (the goal target is an absolute commitment) but worth a follow-up if it surprises users.
+4. **Cross-goal practice suggester.** The "show me what's due" / interleaving / spaced-practice feature. Depends on Phase 3 existing and on enough goal data flowing through sessions to be useful. Out of scope here; flagged to anchor future spec work.
+
+## Coverage expectations (per PR)
+
+Phase 1 PR description should include:
+
+> **Coverage: full on core + API; UI is shell-only (excluded).** New core handlers `UpdateGoalItem`, the `effective_target_*` projection helpers, and `validate_target_*` get unit tests. New API endpoints get happy-path + auth-rejection tests in `intrada-api/tests/`. Goal-detail and goal-edit-form changes are WASM shell code, excluded from coverage per `codecov.yml`.
+
+## Out of scope (this spec)
+
+- Tempo targets (Phase 2)
+- Practice integration (Phase 3)
+- Cross-goal suggesters (Phase 4 / future spec)
+- Goal templates / cloning ("save this goal shape to reuse next term")
+- Notification / reminder when a target's date is approaching
+- Tasks (the non-instrument work concept from the original Goals+Tasks design memory) — not in scope; this spec keeps Goals as collections of *library items* with targets, not arbitrary tasks. Revisit only if user research surfaces it as a gap.


### PR DESCRIPTION
## Summary

First phase of the goals-as-commitments work. Adds **per-item targets** to Goals with **progress derived from session data** — see [\`specs/goals-targets.md\`](specs/goals-targets.md) (rides with this PR per CLAUDE.md Tier 3 guidance).

Phase 1 scope (bundled A + B from the spec): **date** and **confidence** target dimensions. Tempo deferred to Phase 2; practice-session integration to Phase 3.

## What ships

**Data model** (additive, optional everywhere):
- \`Goal.target_confidence: Option<u8>\` — goal-level default (1-5), inherited by items
- \`GoalItem.target_date: Option<String>\` — ISO date, overrides goal deadline for the item
- \`GoalItem.target_confidence: Option<u8>\` — per-item override of the goal default

**API**: new \`PATCH /api/goals/:id/items/:item_id\` with three-state \`UpdateGoalItem { target_date, target_confidence }\` body. \`POST /api/goals\` and \`POST /api/goals/:id/items\` extended to accept the new fields on create.

**Migration**: adds \`target_confidence\` on \`goals\`; \`target_date\`, \`target_confidence\`, **and \`target_tempo\`** on \`goal_items\`. Tempo column is intentionally added now and unused — Phase 2 becomes pure UI/types changes without another migration.

**UI**:
- Goal create/edit forms gain a "Target confidence" select (1-5 or "no target")
- Goal detail rows show target chips: 📅 target date + "Confidence X/Y" pill (X = latest session score, Y = effective target). Pill is accent when met, muted otherwise. Tap a row to open the per-item targets editor.
- New \`GoalItemTargetsSheet\` BottomSheet (Cancel · Item Targets · Save) with date + confidence inputs
- Auto-suggest banner appears above Mark Complete when all targeted items meet their target via latest session

**Derived progress** is computed in \`goal_to_view\` from \`LibraryItemView.practice.latest_score\` and \`latest_achieved_tempo\` — goals store *intent*, sessions store *evidence*. This means a single session can move the needle on multiple goals (no goal/session coupling), which unblocks the future cross-goal practice work cleanly.

## Decisions called out

- **Inheritance** via \`item.target_confidence.or(goal.target_confidence)\`. Items override; goal sets default.
- **Date is informational only**, not a completion gate (spec decision #4).
- **Un-targeted items don't gate the auto-suggest** (spec decision #5).
- **\`double_option\` serde deserializer** added only to the new \`Option<Option<T>>\` fields — the existing \`UpdateGoal.notes\` / \`UpdateItem.composer\` / etc. fields have a latent bug where JSON \`null\` is decoded as "skip" rather than "clear". Out of scope for this PR; flagged for a separate dedicated fix.
- **\`as u8\` narrowing** on SQLite \`i64\` → \`u8\` reads uses \`u8::try_from(n).ok()\` to fail loudly on stale out-of-range values.
- **PATCH still triggers \`RefetchGoals\`** for consistency with the existing \`link_goal_item\` / \`unlink_goal_item\` pattern. Switching to mutate-response semantics across all goal-item endpoints is its own follow-up (matches the "Creates still re-fetch" line in CLAUDE.md tech debt).

## Coverage

- **Core**: 9 new validation tests, 1 new projection-path test (\`goal_item_view_derives_progress_and_inheritance_from_library\`) exercises the items-slice → \`effective_target_confidence\` / \`latest_score\` derivation. 1 new HTTP wrapper test.
- **API**: 9 new integration tests in \`goals_test.rs\` covering happy path, null-clear, out-of-range, 404, and partial-update preservation.
- **UI**: WASM shell — excluded from coverage per \`codecov.yml\`. Preview-driven verification end-to-end: created a goal with \`target_confidence=4\` via the form, linked Chromatic Scale, opened per-item editor, set date \`2026-07-01\` + confidence \`4\`, saved → DB persisted, page renders correct chips.

Total: **660 tests passing**.

## Phase rollout

| Phase | Status | What |
|---|---|---|
| **1 (date + confidence)** | **This PR** | Targets stored + edited; progress chips + auto-suggest |
| 2 (tempo) | Follow-up | Same shape, adds \`target_tempo\` to UI/types; migration already in place |
| 3 (practice integration) | Follow-up | "Practice this goal" launches session pre-loaded with items |
| 4 (cross-goal / spaced) | Future spec | Suggester pulls from multiple goals using session data |

## Out of scope (deferred)

- Tempo target UI (Phase 2)
- Practice integration (Phase 3)
- Cross-goal suggester (Phase 4)
- Fixing the \`double_option\` latent bug on existing \`Option<Option<T>>\` fields (separate PR)
- Switching goal-item PATCH from \`RefetchGoals\` to mutate-response (separate PR alongside the same change for link/unlink)
- Refactor \`insert_goal_item\` 8-arg signature → \`GoalItemInsert\` struct (Phase 2 forcing function)

## Test plan

- [ ] CI green
- [ ] User verification on iOS simulator: per-item targets editor sheet animation + selection haptic, date picker, confidence dropdown
- [ ] Manual: set goal target_confidence=4 → link an item with no per-item override → confirm chip shows "Confidence —/4" inheriting from goal default

🤖 Generated with [Claude Code](https://claude.com/claude-code)