### PR TITLE
fix(set): isolate SetSaveForm via per-dispatch request_id (#663)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -278,9 +278,6 @@ impl App for Intrada {
                 crux_core::render::render()
             }
             Event::SetSaveSucceeded { request_id } => {
-                // Refetch reconciles the optimistic push's client-side ulid
-                // with whatever the server assigned (save-counter+refetch
-                // pattern; tech debt to migrate to temp-id per CLAUDE.md).
                 model.last_set_save_request_id = Some(request_id);
                 model.record_success();
                 crate::http::fetch_sets(&model.api_base_url)
@@ -693,10 +690,8 @@ mod tests {
 
     #[test]
     fn test_load_failed_does_not_set_last_set_save_request_id() {
-        // The request_id is the shell's signal for "save round-trip confirmed".
-        // A LoadFailed (the failure path from create_set's HTTP handler) must
-        // NOT touch it — otherwise SetSaveForm would flip to "Saved" on
-        // failure (#449).
+        // Failure must not surface a request_id — would flip "Saved" on a
+        // failed save (#449).
         let app = Intrada;
         let mut model = Model {
             api_base_url: "http://localhost:3001".to_string(),
@@ -738,22 +733,16 @@ mod tests {
             &mut model,
         );
 
-        // Latest confirmed request_id is recorded so shells can detect it.
         assert_eq!(model.last_set_save_request_id.as_deref(), Some("req-new"));
-        // Stale error cleared + dismiss-mute lifted (record_success contract).
         assert!(model.last_error.is_none());
         assert!(!model.error_muted);
-        // ViewModel mirror picks it up.
         let vm = app.view(&model);
         assert_eq!(vm.last_set_save_request_id.as_deref(), Some("req-new"));
     }
 
     #[test]
     fn test_concurrent_set_saves_only_promote_matching_form() {
-        // Two SetSaveForm instances dispatch with distinct request_ids. Each
-        // success event must overwrite the field with that specific id, so
-        // only the matching form sees its own confirmation — this is the
-        // core invariant behind the fix for #663.
+        // The invariant behind #663: each success overwrites with its own id.
         let app = Intrada;
         let mut model = Model {
             api_base_url: "http://localhost:3001".to_string(),

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -101,12 +101,11 @@ pub enum Event {
     SetUpdated {
         set: Set,
     },
-    /// Server confirmed a set creation (SaveBuildingAsSet / SaveSummaryAsSet).
-    /// Increments `model.set_saves_committed` so shells can flip an optimistic
-    /// "saved" UI state to a confirmed one only after the round-trip succeeds.
-    /// Without this, a failed save leaves the button stuck on "Saved" while
-    /// the error toast contradicts it (#449).
-    SetSaveSucceeded,
+    /// Server confirmed `Save{Building,Summary}AsSet`. `request_id` echoes
+    /// the shell's dispatch tag so per-form promotion stays isolated (#663).
+    SetSaveSucceeded {
+        request_id: String,
+    },
     /// Server confirmed a delete — model already updated optimistically.
     DeleteConfirmed,
     /// Server confirmed session creation — model already updated optimistically.
@@ -278,15 +277,11 @@ impl App for Intrada {
                 model.record_success();
                 crux_core::render::render()
             }
-            Event::SetSaveSucceeded => {
-                // Bump the monotonic counter so `SetSaveForm` can promote its
-                // optimistic state to confirmed. Also refetch sets — the
-                // optimistic push used a client-side ulid that the server
-                // may have replaced. `Item` and `Goal` creates use the temp-id
-                // mutate-response pattern instead; `Set` still refetches
-                // because the counter is wired into the save-form's UI state
-                // — known tech debt per CLAUDE.md.
-                model.set_saves_committed = model.set_saves_committed.wrapping_add(1);
+            Event::SetSaveSucceeded { request_id } => {
+                // Refetch reconciles the optimistic push's client-side ulid
+                // with whatever the server assigned (save-counter+refetch
+                // pattern; tech debt to migrate to temp-id per CLAUDE.md).
+                model.last_set_save_request_id = Some(request_id);
                 model.record_success();
                 crate::http::fetch_sets(&model.api_base_url)
             }
@@ -518,7 +513,7 @@ impl App for Intrada {
             just_created_token: model.just_created_token.clone(),
             oauth_in_flight: model.oauth_in_flight,
             oauth_redirect_url: model.oauth_redirect_url.clone(),
-            set_saves_committed: model.set_saves_committed,
+            last_set_save_request_id: model.last_set_save_request_id.clone(),
         }
     }
 }
@@ -697,15 +692,15 @@ mod tests {
     }
 
     #[test]
-    fn test_load_failed_does_not_bump_set_saves_counter() {
-        // The counter is the shell's signal for "save round-trip confirmed".
+    fn test_load_failed_does_not_set_last_set_save_request_id() {
+        // The request_id is the shell's signal for "save round-trip confirmed".
         // A LoadFailed (the failure path from create_set's HTTP handler) must
-        // NOT bump it — otherwise SetSaveForm would flip to "Saved" on
-        // failure, the exact bug we're fixing (#449).
+        // NOT touch it — otherwise SetSaveForm would flip to "Saved" on
+        // failure (#449).
         let app = Intrada;
         let mut model = Model {
             api_base_url: "http://localhost:3001".to_string(),
-            set_saves_committed: 3,
+            last_set_save_request_id: Some("req-old".to_string()),
             ..Default::default()
         };
 
@@ -715,8 +710,9 @@ mod tests {
         );
 
         assert_eq!(
-            model.set_saves_committed, 3,
-            "counter must not bump on failure"
+            model.last_set_save_request_id.as_deref(),
+            Some("req-old"),
+            "request_id must not change on failure"
         );
         assert_eq!(
             model.last_error.as_deref(),
@@ -725,26 +721,60 @@ mod tests {
     }
 
     #[test]
-    fn test_set_save_succeeded_bumps_counter_and_clears_error() {
+    fn test_set_save_succeeded_records_request_id_and_clears_error() {
         let app = Intrada;
         let mut model = Model {
             api_base_url: "http://localhost:3001".to_string(),
-            set_saves_committed: 7,
+            last_set_save_request_id: Some("req-old".to_string()),
             last_error: Some("Failed to save set: timeout".to_string()),
             error_muted: true,
             ..Default::default()
         };
 
-        let _cmd = app.update(Event::SetSaveSucceeded, &mut model);
+        let _cmd = app.update(
+            Event::SetSaveSucceeded {
+                request_id: "req-new".to_string(),
+            },
+            &mut model,
+        );
 
-        // Counter bumped so shells can detect the confirmed save.
-        assert_eq!(model.set_saves_committed, 8);
+        // Latest confirmed request_id is recorded so shells can detect it.
+        assert_eq!(model.last_set_save_request_id.as_deref(), Some("req-new"));
         // Stale error cleared + dismiss-mute lifted (record_success contract).
         assert!(model.last_error.is_none());
         assert!(!model.error_muted);
         // ViewModel mirror picks it up.
         let vm = app.view(&model);
-        assert_eq!(vm.set_saves_committed, 8);
+        assert_eq!(vm.last_set_save_request_id.as_deref(), Some("req-new"));
+    }
+
+    #[test]
+    fn test_concurrent_set_saves_only_promote_matching_form() {
+        // Two SetSaveForm instances dispatch with distinct request_ids. Each
+        // success event must overwrite the field with that specific id, so
+        // only the matching form sees its own confirmation — this is the
+        // core invariant behind the fix for #663.
+        let app = Intrada;
+        let mut model = Model {
+            api_base_url: "http://localhost:3001".to_string(),
+            ..Default::default()
+        };
+
+        let _cmd = app.update(
+            Event::SetSaveSucceeded {
+                request_id: "req-A".to_string(),
+            },
+            &mut model,
+        );
+        assert_eq!(model.last_set_save_request_id.as_deref(), Some("req-A"));
+
+        let _cmd = app.update(
+            Event::SetSaveSucceeded {
+                request_id: "req-B".to_string(),
+            },
+            &mut model,
+        );
+        assert_eq!(model.last_set_save_request_id.as_deref(), Some("req-B"));
     }
 
     #[test]
@@ -2450,12 +2480,12 @@ mod tests {
     }
 
     #[test]
-    fn view_set_saves_committed_mirrors_model() {
+    fn view_last_set_save_request_id_mirrors_model() {
         let app = Intrada;
         let mut model = Model::test_default();
-        model.set_saves_committed = 42;
+        model.last_set_save_request_id = Some("req-42".to_string());
         let vm = app.view(&model);
-        assert_eq!(vm.set_saves_committed, 42);
+        assert_eq!(vm.last_set_save_request_id.as_deref(), Some("req-42"));
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -36,9 +36,12 @@ pub struct SetEntry {
 pub enum SetEvent {
     SaveBuildingAsSet {
         name: String,
+        /// Shell-generated ulid echoed back via `SetSaveSucceeded` (#663).
+        request_id: String,
     },
     SaveSummaryAsSet {
         name: String,
+        request_id: String,
     },
     LoadSetIntoSetlist {
         set_id: String,
@@ -58,7 +61,7 @@ pub enum SetEvent {
 
 pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, Event> {
     match event {
-        SetEvent::SaveBuildingAsSet { name } => {
+        SetEvent::SaveBuildingAsSet { name, request_id } => {
             // Precondition: must be in Building status
             let building = match &model.session_status {
                 SessionStatus::Building(b) => b,
@@ -104,12 +107,12 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
             model.last_error = None;
 
             Command::all([
-                crate::http::create_set(&model.api_base_url, &set),
+                crate::http::create_set(&model.api_base_url, &set, request_id),
                 crux_core::render::render(),
             ])
         }
 
-        SetEvent::SaveSummaryAsSet { name } => {
+        SetEvent::SaveSummaryAsSet { name, request_id } => {
             // Precondition: must be in Summary status
             let summary = match &model.session_status {
                 SessionStatus::Summary(s) => s,
@@ -155,7 +158,7 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
             model.last_error = None;
 
             Command::all([
-                crate::http::create_set(&model.api_base_url, &set),
+                crate::http::create_set(&model.api_base_url, &set, request_id),
                 crux_core::render::render(),
             ])
         }
@@ -435,6 +438,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "Morning Warm-up".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -454,6 +458,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "Test".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -472,6 +477,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -486,6 +492,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "   ".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -500,6 +507,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "x".repeat(201),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -514,6 +522,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "x".repeat(200),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -528,6 +537,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "Test".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -542,6 +552,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveBuildingAsSet {
                 name: "Test".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -571,6 +582,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveSummaryAsSet {
                 name: "Post-Session Set".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );
@@ -587,6 +599,7 @@ mod tests {
         let _cmd = handle_set_event(
             SetEvent::SaveSummaryAsSet {
                 name: "Test".to_string(),
+                request_id: "req-test".to_string(),
             },
             &mut model,
         );

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -155,17 +155,18 @@ pub fn delete_session(api_base_url: &str, id: &str) -> Command<Effect, Event> {
 
 // ── Set operations ──────────────────────────────────────────────────
 
-pub fn create_set(api_base_url: &str, set: &crate::domain::set::Set) -> Command<Effect, Event> {
+pub fn create_set(
+    api_base_url: &str,
+    set: &crate::domain::set::Set,
+    request_id: String,
+) -> Command<Effect, Event> {
     let create = CreateSetRequest::from_set(set);
     Http::post(format!("{api_base_url}/api/sets"))
         .body_json(&create)
         .expect("serialize CreateSetRequest")
         .build()
-        .then_send(|result| match result {
-            // Success bumps the set_saves_committed counter (so SetSaveForm
-            // can flip from optimistic→confirmed) AND triggers a refetch via
-            // the SetSaveSucceeded handler — see app.rs (#449).
-            Ok(_) => Event::SetSaveSucceeded,
+        .then_send(move |result| match result {
+            Ok(_) => Event::SetSaveSucceeded { request_id },
             Err(e) => Event::LoadFailed(format!("Failed to save set: {e}")),
         })
 }
@@ -710,7 +711,7 @@ mod tests {
     #[test]
     fn create_set_posts_create_dto_shape() {
         let set = sample_set();
-        let req = take_http(&mut create_set(BASE, &set));
+        let req = take_http(&mut create_set(BASE, &set, "req-test".to_string()));
         assert_eq!(req.method, "POST");
         assert_eq!(req.url, "https://api.example.com/api/sets");
 

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -70,14 +70,9 @@ pub struct Model {
     /// reacts by navigating the browser to this URL (which contains the
     /// auth code + state for the OAuth client).
     pub oauth_redirect_url: Option<String>,
-    /// Monotonic counter that increments each time the server confirms a
-    /// `SaveBuildingAsSet` / `SaveSummaryAsSet` write. `SetSaveForm` reads
-    /// the value at dispatch time and flips its "Saved" state only after
-    /// it observes the counter rise — turning the optimistic-success UX
-    /// into a confirmed-success UX. Without this, a failed save would
-    /// leave the button stuck on "Saved" while an error toast contradicted
-    /// it (#449).
-    pub set_saves_committed: u64,
+    /// Set from the confirmed `SetSaveSucceeded { request_id }`; per-form
+    /// id-matching isolates concurrent `SetSaveForm` instances (#663).
+    pub last_set_save_request_id: Option<String>,
 }
 
 impl Model {
@@ -185,8 +180,7 @@ pub struct ViewModel {
     pub mcp_audit_loading: bool,
     pub oauth_in_flight: bool,
     pub oauth_redirect_url: Option<String>,
-    /// Mirrors `Model::set_saves_committed`. See that field for the contract.
-    pub set_saves_committed: u64,
+    pub last_set_save_request_id: Option<String>,
 }
 
 // Sanity-check that ViewModel field names mirror Model where applicable.
@@ -625,11 +619,11 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         });
-        model.set_saves_committed = 5;
+        model.last_set_save_request_id = Some("req-1".to_string());
         model.reset_for_sign_out();
         assert_eq!(model.api_base_url, "https://api.example.com");
         assert!(model.items.is_empty());
-        assert_eq!(model.set_saves_committed, 0);
+        assert!(model.last_set_save_request_id.is_none());
     }
 
     // ── entry_to_view ──────────────────────────────────────────────────

--- a/crates/intrada-web/src/components/session_review_sheet.rs
+++ b/crates/intrada-web/src/components/session_review_sheet.rs
@@ -307,8 +307,8 @@ fn ReviewSheetBody(
                                         </Button>
                                         <SetSaveForm
                                             sheet_open=sheet_open
-                                            on_save=Callback::new(move |name: String| {
-                                                let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
+                                            on_save=Callback::new(move |(name, request_id): (String, String)| {
+                                                let event = Event::Set(SetEvent::SaveBuildingAsSet { name, request_id });
                                                 let core_ref = core_s.borrow();
                                                 let effects = core_ref.process_event(event);
                                                 process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
@@ -321,8 +321,8 @@ fn ReviewSheetBody(
                                 view! {
                                     <SetSaveForm
                                         sheet_open=sheet_open
-                                        on_save=Callback::new(move |name: String| {
-                                            let event = Event::Set(SetEvent::SaveBuildingAsSet { name });
+                                        on_save=Callback::new(move |(name, request_id): (String, String)| {
+                                            let event = Event::Set(SetEvent::SaveBuildingAsSet { name, request_id });
                                             let core_ref = core_save_inner.borrow();
                                             let effects = core_ref.process_event(event);
                                             process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);

--- a/crates/intrada-web/src/components/session_summary.rs
+++ b/crates/intrada-web/src/components/session_summary.rs
@@ -315,8 +315,8 @@ pub fn SessionSummary() -> impl IntoView {
                             {
                                 let core_save_set = core_set_save.clone();
                                 view! {
-                                    <SetSaveForm on_save=Callback::new(move |name: String| {
-                                        let event = Event::Set(SetEvent::SaveSummaryAsSet { name });
+                                    <SetSaveForm on_save=Callback::new(move |(name, request_id): (String, String)| {
+                                        let event = Event::Set(SetEvent::SaveSummaryAsSet { name, request_id });
                                         let core_ref = core_save_set.borrow();
                                         let effects = core_ref.process_event(event);
                                         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);

--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -4,12 +4,9 @@ use intrada_core::ViewModel;
 
 use crate::components::{use_toast, Button, ButtonVariant, Card, Icon};
 
-/// Inline form for saving a setlist or summary as a named set. Generates a
-/// `request_id` ulid per dispatch and only promotes its own "Saved" state when
-/// that id surfaces on `ViewModel::last_set_save_request_id` — isolating
-/// concurrent instances (#663). On failure the form re-expands; bottom-sheet
-/// mounts must pass `sheet_open` so a close/reopen resets state (sheets keep
-/// children mounted off-screen).
+/// Inline "Save as Set" form. Per-dispatch `request_id` isolates concurrent
+/// instances (#663); `sheet_open` is required for bottom-sheet mounts since
+/// sheets keep children mounted off-screen.
 #[component]
 pub fn SetSaveForm(
     on_save: Callback<(String, String)>,
@@ -22,8 +19,7 @@ pub fn SetSaveForm(
     let saved = RwSignal::new(false);
     let pending = RwSignal::new(false);
     let my_request_id = RwSignal::new(Option::<String>::None);
-    // Snapshot pre-dispatch error so a dismissed-but-not-cleared earlier
-    // failure doesn't immediately trigger our failure path (#449).
+    // Avoid a dismissed earlier failure tripping our failure path (#449).
     let error_before_dispatch = RwSignal::new(Option::<String>::None);
     let toast = use_toast();
 
@@ -64,9 +60,7 @@ pub fn SetSaveForm(
         error.set(None);
         let vm = view_model.get_untracked();
         let request_id = ulid::Ulid::new().to_string();
-        // Order matters: set `my_request_id` BEFORE `pending` so the
-        // tracked-Effect's early-return guard never sees a pending state
-        // without an id to match against.
+        // Must precede `pending.set(true)` — Effect guards on `my_id.is_some()`.
         my_request_id.set(Some(request_id.clone()));
         error_before_dispatch.set(vm.error.clone());
         pending.set(true);

--- a/crates/intrada-web/src/components/set_save_form.rs
+++ b/crates/intrada-web/src/components/set_save_form.rs
@@ -4,48 +4,27 @@ use intrada_core::ViewModel;
 
 use crate::components::{use_toast, Button, ButtonVariant, Card, Icon};
 
-/// Inline form for saving a setlist or summary as a named set.
-///
-/// When collapsed, shows a "Save as Set" button. When expanded, shows a
-/// name input, Save, and Cancel buttons. Calls `on_save` with the entered name.
-/// After the **server confirms** the save (via the `set_saves_committed`
-/// counter rising on the ViewModel), the button switches to a disabled
-/// "Saved" state. If the save fails, the form stays expanded so the user
-/// can retry — no false-success feedback (#449).
-///
-/// When mounted inside a [`BottomSheet`], pass the sheet's `open` signal as
-/// `sheet_open` — the "Saved" state will reset when the sheet closes, so a
-/// close→reopen cycle starts fresh. Bottom sheets keep their children
-/// mounted (translated off-screen), so without this the button would stay
-/// stuck in the "Saved" state forever. Full-screen mounts (e.g. session
-/// summary) can omit it.
+/// Inline form for saving a setlist or summary as a named set. Generates a
+/// `request_id` ulid per dispatch and only promotes its own "Saved" state when
+/// that id surfaces on `ViewModel::last_set_save_request_id` — isolating
+/// concurrent instances (#663). On failure the form re-expands; bottom-sheet
+/// mounts must pass `sheet_open` so a close/reopen resets state (sheets keep
+/// children mounted off-screen).
 #[component]
 pub fn SetSaveForm(
-    /// Callback invoked with the set name when the user taps Save.
-    on_save: Callback<String>,
-    /// Optional parent-sheet open signal. If provided, the "Saved" state
-    /// resets when this transitions to false.
-    #[prop(optional, into)]
-    sheet_open: Option<Signal<bool>>,
+    on_save: Callback<(String, String)>,
+    #[prop(optional, into)] sheet_open: Option<Signal<bool>>,
 ) -> impl IntoView {
     let view_model = expect_context::<RwSignal<ViewModel>>();
     let expanded = RwSignal::new(false);
     let name = RwSignal::new(String::new());
     let error = RwSignal::new(Option::<String>::None);
     let saved = RwSignal::new(false);
-    // Pending = a save was dispatched and we're waiting for server confirmation
-    // (counter increment) OR an error to surface. Stops users double-dispatching
-    // while the request is in flight.
     let pending = RwSignal::new(false);
-    // Snapshot of the success-counter at dispatch time. We promote `saved=true`
-    // only when the live counter > this baseline.
-    let baseline_counter = RwSignal::new(0u64);
-    // Snapshot of `view_model.error` at dispatch time. A pre-existing error
-    // (e.g. dismissed-but-not-cleared from an unrelated earlier failure)
-    // would otherwise immediately trigger the failure path on the first
-    // render after dispatch. We only count a NEW error (post-dispatch) as
-    // our save's failure signal.
-    let baseline_error = RwSignal::new(Option::<String>::None);
+    let my_request_id = RwSignal::new(Option::<String>::None);
+    // Snapshot pre-dispatch error so a dismissed-but-not-cleared earlier
+    // failure doesn't immediately trigger our failure path (#449).
+    let error_before_dispatch = RwSignal::new(Option::<String>::None);
     let toast = use_toast();
 
     if let Some(open) = sheet_open {
@@ -53,29 +32,25 @@ pub fn SetSaveForm(
             if !open.get() {
                 saved.set(false);
                 pending.set(false);
+                my_request_id.set(None);
             }
         });
     }
 
-    // Reactive bridge: pending → confirmed (success) or pending → expanded
-    // (failure). Driven by either the counter rising or a NEW
-    // `view_model.error` appearing post-dispatch (distinguished from a
-    // pre-existing one via `baseline_error`).
     Effect::new(move |_| {
         let vm = view_model.get();
         if !pending.get_untracked() {
             return;
         }
-        if vm.set_saves_committed > baseline_counter.get_untracked() {
-            // Confirmed: the round-trip succeeded.
+        let my_id = my_request_id.get_untracked();
+        if my_id.is_some() && vm.last_set_save_request_id == my_id {
             pending.set(false);
+            my_request_id.set(None);
             saved.set(true);
             toast.show("Saved as Set");
-        } else if vm.error.is_some() && vm.error != baseline_error.get_untracked() {
-            // A new error surfaced after dispatch — treat as our save's
-            // failure. Re-expand the form so the user can retry; the error
-            // banner shows the message.
+        } else if vm.error.is_some() && vm.error != error_before_dispatch.get_untracked() {
             pending.set(false);
+            my_request_id.set(None);
             expanded.set(true);
         }
     });
@@ -88,10 +63,14 @@ pub fn SetSaveForm(
         }
         error.set(None);
         let vm = view_model.get_untracked();
-        baseline_counter.set(vm.set_saves_committed);
-        baseline_error.set(vm.error.clone());
+        let request_id = ulid::Ulid::new().to_string();
+        // Order matters: set `my_request_id` BEFORE `pending` so the
+        // tracked-Effect's early-return guard never sees a pending state
+        // without an id to match against.
+        my_request_id.set(Some(request_id.clone()));
+        error_before_dispatch.set(vm.error.clone());
         pending.set(true);
-        on_save.run(trimmed);
+        on_save.run((trimmed, request_id));
         name.set(String::new());
         expanded.set(false);
     };
@@ -147,8 +126,6 @@ pub fn SetSaveForm(
                     </Card>
                 }.into_any()
             } else if pending.get() {
-                // Awaiting server confirmation. Show a disabled "Saving…" so
-                // users see feedback but can't double-dispatch (#449).
                 view! {
                     <button
                         class="w-full rounded-lg border border-dashed border-border-default bg-surface-secondary px-4 py-3 text-sm font-medium text-muted inline-flex items-center justify-center gap-2 cursor-default"

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -1597,7 +1597,7 @@ pub fn DesignCatalogue() -> impl IntoView {
             <section id="set-save">
                 <h3 class="text-lg font-semibold text-primary mb-4 font-heading">"Set Save Form"</h3>
                 <p class="text-xs text-faint mb-3">"Click the dashed button to expand the form. Interactive — try saving without a name."</p>
-                <SetSaveForm on_save=Callback::new(|_name: String| {}) />
+                <SetSaveForm on_save=Callback::new(|_: (String, String)| {}) />
             </section>
 
             // ── Loading States ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes [#663](https://github.com/jonyardley/intrada/issues/663). Two concurrently-pending `SetSaveForm` instances both promoted to "Saved" on the first save confirmation, because the shell used a global monotonic `Model::set_saves_committed` counter that didn't carry origin information.

Replaces the counter with a per-dispatch ulid that round-trips through the Crux event flow:

- Shell generates `request_id: ulid` at dispatch time
- `Event::Set(SaveBuildingAsSet { name, request_id })` carries it into the core
- `crate::http::create_set` echoes it back via `Event::SetSaveSucceeded { request_id }`
- Core handler stores it on `Model::last_set_save_request_id` (mirrored to `ViewModel`)
- Each `SetSaveForm` instance only promotes itself when `vm.last_set_save_request_id == Some(my_id)`; siblings' confirmations carry different ids and are ignored

Same fix applies to `SaveSummaryAsSet`.

Today's mount sites (`session_review_sheet.rs`, `session_summary.rs`) are on distinct routes so concurrent pending isn't reachable in normal flow — this is a defensive fix against future second mount sites, as the issue's "Scope" section calls out.

## Coverage

Full — added `test_concurrent_set_saves_only_promote_matching_form` to encode the per-id invariant; updated existing `test_set_save_succeeded_*` and `test_load_failed_does_not_*` tests for the new field shape. The HTTP-closure round-trip (`create_set` success path producing `SetSaveSucceeded { request_id }`) is not unit-tested — the codebase has no precedent for driving crux_http response completion through `then_send` closures, and the closure body is a single-line `Ok(_) => Event::SetSaveSucceeded { request_id }` enforced by the type system. Adding that test infra is out of scope.

## Test plan

- [x] `cargo test --workspace --exclude tauri-plugin-background-audio` — 663 passed
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --exclude tauri-plugin-background-audio -- -D warnings` clean
- [x] Pre-push comment-density hook passes
- [ ] UI verification — manual cross-talk repro not possible without a second mount site; the encoded core invariant is the regression guard

## Self-review

Ran `superpowers:code-reviewer`. Verdict: READY-WITH-NITS. Comment-policy violations (Blockers per CLAUDE.md) were trimmed before push; rename `pending_request_id` → `my_request_id` and the `Order matters` Effect-ordering invariant were both applied. Posted summary as PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)