### PR TITLE
Goals targets — Phase 3 (Practice this goal)

### DIFF
--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -178,8 +178,9 @@ pub enum SessionEvent {
     /// Load every item linked to a goal into the builder, ordered "least
     /// ready first" (never-practised → targeted-and-unmet → met/no-target).
     /// Initialises a fresh Building session if currently Idle; appends if
-    /// already Building (mirrors `SetEvent::LoadSetIntoSetlist`). Stale
-    /// links (item id no longer in the library) are skipped.
+    /// already Building. Rejected if a session is Active or in Summary —
+    /// surfaces `last_error` rather than silently destroying in-progress
+    /// state. Stale links (item id no longer in the library) are skipped.
     LoadGoalIntoSetlist {
         goal_id: String,
     },
@@ -362,20 +363,20 @@ fn order_goal_items_least_ready_first(
         .enumerate()
         .filter(|(_, gi)| known.contains(gi.item_id.as_str()))
         .map(|(idx, gi)| {
-            let summary = model.practice_summaries.get(&gi.item_id);
-            let bucket = if summary.is_none() {
-                0
-            } else {
-                let effective_confidence = gi.target_confidence.or(goal.target_confidence);
-                let effective_tempo = gi.target_tempo.or(goal.target_tempo);
-                let confidence_unmet = effective_confidence
-                    .is_some_and(|t| !summary.unwrap().latest_score.is_some_and(|s| s >= t));
-                let tempo_unmet = effective_tempo
-                    .is_some_and(|t| !summary.unwrap().latest_tempo.is_some_and(|s| s >= t));
-                if confidence_unmet || tempo_unmet {
-                    1
-                } else {
-                    2
+            let bucket = match model.practice_summaries.get(&gi.item_id) {
+                None => 0,
+                Some(s) => {
+                    let effective_confidence = gi.target_confidence.or(goal.target_confidence);
+                    let effective_tempo = gi.target_tempo.or(goal.target_tempo);
+                    let confidence_unmet = effective_confidence
+                        .is_some_and(|t| !s.latest_score.is_some_and(|score| score >= t));
+                    let tempo_unmet = effective_tempo
+                        .is_some_and(|t| !s.latest_tempo.is_some_and(|tempo| tempo >= t));
+                    if confidence_unmet || tempo_unmet {
+                        1
+                    } else {
+                        2
+                    }
                 }
             };
             (
@@ -639,12 +640,25 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
         }
 
         SessionEvent::LoadGoalIntoSetlist { goal_id } => {
+            // Reject when Active or in Summary — silently overwriting would
+            // destroy in-progress practice state. Idle and Building are both
+            // safe (Idle bootstraps fresh, Building appends).
+            match model.session_status {
+                SessionStatus::Idle | SessionStatus::Building(_) => {}
+                _ => {
+                    model.last_error = Some(
+                        "Can't load a goal into the builder while a session is active or being reviewed".to_string(),
+                    );
+                    return crux_core::render::render();
+                }
+            }
+
             let Some(goal) = model.goals.iter().find(|g| g.id == goal_id).cloned() else {
                 model.last_error = Some(format!("Goal not found: {goal_id}"));
                 return crux_core::render::render();
             };
 
-            if !matches!(model.session_status, SessionStatus::Building(_)) {
+            if matches!(model.session_status, SessionStatus::Idle) {
                 model.session_status = SessionStatus::Building(BuildingSession {
                     entries: vec![],
                     session_intention: None,
@@ -3948,10 +3962,6 @@ mod tests {
     #[test]
     fn load_goal_orders_never_practised_before_targeted_unmet_before_met() {
         let mut model = model_with_library();
-        // Bucket layout: piece-2 = met (4 >= target 3) → bucket 2
-        //               piece-1 = targeted-and-unmet → bucket 1
-        //               exercise-1 = never practised → bucket 0
-        // Expected order: exercise-1, piece-1, piece-2.
         let goal = Goal {
             target_confidence: Some(3),
             ..goal_with_items(vec![
@@ -4031,25 +4041,20 @@ mod tests {
 
     #[test]
     fn load_goal_preserves_within_bucket_order() {
-        // All three items are in bucket 2 (no targets, no summaries → never-practised
-        // bucket 0... wait, no summaries means bucket 0. Let me use a clean
-        // bucket-2 scenario: items with summaries but no targets.
+        // All items in bucket 2 — same summaries (score 3), no targets, so the
+        // bucket reduces to "met-by-default." Goal items in order [piece-2,
+        // piece-1, exercise-1] must come out in that order.
         let mut model = model_with_library();
         model.goals.push(goal_with_items(vec![
             link("piece-2", "Clair de Lune", ItemKind::Piece),
             link("piece-1", "Moonlight Sonata", ItemKind::Piece),
             link("exercise-1", "C Major Scale", ItemKind::Exercise),
         ]));
-        // All have practice summaries; no targets set → bucket 2 (met by default)
-        model
-            .practice_summaries
-            .insert("piece-1".to_string(), summary(Some(3), None));
-        model
-            .practice_summaries
-            .insert("piece-2".to_string(), summary(Some(3), None));
-        model
-            .practice_summaries
-            .insert("exercise-1".to_string(), summary(Some(3), None));
+        for id in ["piece-1", "piece-2", "exercise-1"] {
+            model
+                .practice_summaries
+                .insert(id.to_string(), summary(Some(3), None));
+        }
 
         update(
             &mut model,
@@ -4058,7 +4063,6 @@ mod tests {
             }),
         );
 
-        // Same order as goal.items — within-bucket stable.
         assert_eq!(
             loaded_item_ids(&model),
             vec!["piece-2", "piece-1", "exercise-1"]
@@ -4067,16 +4071,25 @@ mod tests {
 
     #[test]
     fn load_goal_inherits_goal_level_target_for_bucketing() {
+        // Goal default confidence 4 (no per-item override). piece-1 score 3 →
+        // unmet under inheritance (bucket 1). piece-2 score 5 → met under
+        // inheritance (bucket 2). Ordering must reflect inheritance, not the
+        // per-item raw absence-of-target.
         let mut model = model_with_library();
-        // Goal default confidence target 4. piece-1 has no override, score 3 → unmet.
         let goal = Goal {
             target_confidence: Some(4),
-            ..goal_with_items(vec![link("piece-1", "Moonlight Sonata", ItemKind::Piece)])
+            ..goal_with_items(vec![
+                link("piece-2", "Clair de Lune", ItemKind::Piece),
+                link("piece-1", "Moonlight Sonata", ItemKind::Piece),
+            ])
         };
         model.goals.push(goal);
         model
             .practice_summaries
             .insert("piece-1".to_string(), summary(Some(3), None));
+        model
+            .practice_summaries
+            .insert("piece-2".to_string(), summary(Some(5), None));
 
         update(
             &mut model,
@@ -4085,8 +4098,7 @@ mod tests {
             }),
         );
 
-        // Single item in bucket 1 — confirms inheritance path was hit (no panic, item present).
-        assert_eq!(loaded_item_ids(&model), vec!["piece-1"]);
+        assert_eq!(loaded_item_ids(&model), vec!["piece-1", "piece-2"]);
     }
 
     #[test]
@@ -4100,5 +4112,35 @@ mod tests {
         );
         assert!(model.last_error.as_deref().unwrap().contains("nonexistent"));
         assert!(matches!(model.session_status, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn load_goal_rejected_when_session_active() {
+        let mut model = model_with_library();
+        model.goals.push(goal_with_items(vec![link(
+            "piece-1",
+            "Moonlight Sonata",
+            ItemKind::Piece,
+        )]));
+        let now = Utc::now();
+        model.session_status = SessionStatus::Active(ActiveSession {
+            id: "active-1".to_string(),
+            entries: vec![],
+            current_index: 0,
+            current_item_started_at: now,
+            session_started_at: now,
+            session_intention: None,
+        });
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        // Active session preserved; error surfaced.
+        assert!(matches!(model.session_status, SessionStatus::Active(_)));
+        assert!(model.last_error.is_some());
     }
 }

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -175,6 +175,14 @@ pub enum SessionEvent {
         title: String,
         item_type: ItemKind,
     },
+    /// Load every item linked to a goal into the builder, ordered "least
+    /// ready first" (never-practised → targeted-and-unmet → met/no-target).
+    /// Initialises a fresh Building session if currently Idle; appends if
+    /// already Building (mirrors `SetEvent::LoadSetIntoSetlist`). Stale
+    /// links (item id no longer in the library) are skipped.
+    LoadGoalIntoSetlist {
+        goal_id: String,
+    },
     RemoveFromSetlist {
         entry_id: String,
     },
@@ -332,6 +340,58 @@ fn create_item_from_title(title: &str, kind: ItemKind) -> Item {
         created_at: now,
         updated_at: now,
     }
+}
+
+/// Order a goal's items "least ready first" via bucket sort:
+/// 0 = never practised, 1 = effective target set but not met by latest session,
+/// 2 = everything else. Stable within bucket — preserves the goal's existing
+/// item order. Stale links (item id no longer in `model.items`) are dropped.
+///
+/// Bucket cut-off is intentionally crude — refinement tracked in
+/// [#738](https://github.com/jonyardley/intrada/issues/738).
+fn order_goal_items_least_ready_first(
+    model: &Model,
+    goal: &crate::domain::goal::Goal,
+) -> Vec<(String, String, ItemKind)> {
+    let known: std::collections::HashSet<&str> =
+        model.items.iter().map(|i| i.id.as_str()).collect();
+
+    let mut keyed: Vec<(u8, usize, (String, String, ItemKind))> = goal
+        .items
+        .iter()
+        .enumerate()
+        .filter(|(_, gi)| known.contains(gi.item_id.as_str()))
+        .map(|(idx, gi)| {
+            let summary = model.practice_summaries.get(&gi.item_id);
+            let bucket = if summary.is_none() {
+                0
+            } else {
+                let effective_confidence = gi.target_confidence.or(goal.target_confidence);
+                let effective_tempo = gi.target_tempo.or(goal.target_tempo);
+                let confidence_unmet = effective_confidence
+                    .is_some_and(|t| !summary.unwrap().latest_score.is_some_and(|s| s >= t));
+                let tempo_unmet = effective_tempo
+                    .is_some_and(|t| !summary.unwrap().latest_tempo.is_some_and(|s| s >= t));
+                if confidence_unmet || tempo_unmet {
+                    1
+                } else {
+                    2
+                }
+            };
+            (
+                bucket,
+                idx,
+                (
+                    gi.item_id.clone(),
+                    gi.item_title.clone(),
+                    gi.item_type.clone(),
+                ),
+            )
+        })
+        .collect();
+
+    keyed.sort_by_key(|(bucket, idx, _)| (*bucket, *idx));
+    keyed.into_iter().map(|(_, _, payload)| payload).collect()
 }
 
 /// Freeze rep state on an entry: set `rep_target_reached` based on whether count >= target.
@@ -574,6 +634,40 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             let position = building.entries.len();
             let entry = create_entry(&item_id, &title, item_type, position);
             building.entries.push(entry);
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::LoadGoalIntoSetlist { goal_id } => {
+            let Some(goal) = model.goals.iter().find(|g| g.id == goal_id).cloned() else {
+                model.last_error = Some(format!("Goal not found: {goal_id}"));
+                return crux_core::render::render();
+            };
+
+            if !matches!(model.session_status, SessionStatus::Building(_)) {
+                model.session_status = SessionStatus::Building(BuildingSession {
+                    entries: vec![],
+                    session_intention: None,
+                    target_duration_mins: None,
+                    source_set_id: None,
+                    source_set_entry_snapshot: vec![],
+                });
+            }
+
+            let ordered = order_goal_items_least_ready_first(model, &goal);
+
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Internal error: expected Building state".to_string());
+                return crux_core::render::render();
+            };
+
+            for (item_id, item_title, item_type) in ordered {
+                let position = building.entries.len();
+                building
+                    .entries
+                    .push(create_entry(&item_id, &item_title, item_type, position));
+            }
+
             model.last_error = None;
             crux_core::render::render()
         }
@@ -3776,5 +3870,235 @@ mod tests {
         } else {
             panic!("Expected Summary state");
         }
+    }
+
+    // --- LoadGoalIntoSetlist (Phase 3) ---
+
+    use crate::domain::goal::{Goal, GoalItem, GoalStatus};
+    use crate::model::ItemPracticeSummary;
+
+    fn goal_with_items(items: Vec<GoalItem>) -> Goal {
+        let now = Utc::now();
+        Goal {
+            id: "goal-1".to_string(),
+            title: Some("Recital prep".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: GoalStatus::Active,
+            completed_at: None,
+            items,
+            photos: vec![],
+            created_at: now,
+            updated_at: now,
+            target_confidence: None,
+            target_tempo: None,
+        }
+    }
+
+    fn link(item_id: &str, item_title: &str, item_type: ItemKind) -> GoalItem {
+        GoalItem {
+            item_id: item_id.to_string(),
+            item_title: item_title.to_string(),
+            item_type,
+            target_date: None,
+            target_confidence: None,
+            target_tempo: None,
+        }
+    }
+
+    fn summary(latest_score: Option<u8>, latest_tempo: Option<u16>) -> ItemPracticeSummary {
+        ItemPracticeSummary {
+            session_count: 1,
+            total_minutes: 10,
+            latest_score,
+            score_history: vec![],
+            latest_tempo,
+            tempo_history: vec![],
+        }
+    }
+
+    fn loaded_item_ids(model: &Model) -> Vec<String> {
+        match &model.session_status {
+            SessionStatus::Building(b) => b.entries.iter().map(|e| e.item_id.clone()).collect(),
+            other => panic!("expected Building, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_goal_initialises_building_when_idle() {
+        let mut model = model_with_library();
+        model.goals.push(goal_with_items(vec![link(
+            "piece-1",
+            "Moonlight Sonata",
+            ItemKind::Piece,
+        )]));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        assert!(matches!(model.session_status, SessionStatus::Building(_)));
+        assert_eq!(loaded_item_ids(&model), vec!["piece-1"]);
+    }
+
+    #[test]
+    fn load_goal_orders_never_practised_before_targeted_unmet_before_met() {
+        let mut model = model_with_library();
+        // Bucket layout: piece-2 = met (4 >= target 3) → bucket 2
+        //               piece-1 = targeted-and-unmet → bucket 1
+        //               exercise-1 = never practised → bucket 0
+        // Expected order: exercise-1, piece-1, piece-2.
+        let goal = Goal {
+            target_confidence: Some(3),
+            ..goal_with_items(vec![
+                link("piece-2", "Clair de Lune", ItemKind::Piece),
+                link("piece-1", "Moonlight Sonata", ItemKind::Piece),
+                link("exercise-1", "C Major Scale", ItemKind::Exercise),
+            ])
+        };
+        model.goals.push(goal);
+        model
+            .practice_summaries
+            .insert("piece-1".to_string(), summary(Some(2), None));
+        model
+            .practice_summaries
+            .insert("piece-2".to_string(), summary(Some(4), None));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        assert_eq!(
+            loaded_item_ids(&model),
+            vec!["exercise-1", "piece-1", "piece-2"]
+        );
+    }
+
+    #[test]
+    fn load_goal_treats_tempo_target_as_unmet_when_below() {
+        let mut model = model_with_library();
+        // piece-1: target_tempo 120, latest 100 → unmet
+        // piece-2: no target → met-by-default
+        let goal = goal_with_items(vec![
+            GoalItem {
+                target_tempo: Some(120),
+                ..link("piece-1", "Moonlight Sonata", ItemKind::Piece)
+            },
+            link("piece-2", "Clair de Lune", ItemKind::Piece),
+        ]);
+        model.goals.push(goal);
+        model
+            .practice_summaries
+            .insert("piece-1".to_string(), summary(Some(5), Some(100)));
+        model
+            .practice_summaries
+            .insert("piece-2".to_string(), summary(Some(5), Some(60)));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        assert_eq!(loaded_item_ids(&model), vec!["piece-1", "piece-2"]);
+    }
+
+    #[test]
+    fn load_goal_skips_stale_library_links() {
+        let mut model = model_with_library();
+        model.goals.push(goal_with_items(vec![
+            link("piece-1", "Moonlight Sonata", ItemKind::Piece),
+            link("ghost-item", "Deleted Piece", ItemKind::Piece),
+        ]));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        assert_eq!(loaded_item_ids(&model), vec!["piece-1"]);
+    }
+
+    #[test]
+    fn load_goal_preserves_within_bucket_order() {
+        // All three items are in bucket 2 (no targets, no summaries → never-practised
+        // bucket 0... wait, no summaries means bucket 0. Let me use a clean
+        // bucket-2 scenario: items with summaries but no targets.
+        let mut model = model_with_library();
+        model.goals.push(goal_with_items(vec![
+            link("piece-2", "Clair de Lune", ItemKind::Piece),
+            link("piece-1", "Moonlight Sonata", ItemKind::Piece),
+            link("exercise-1", "C Major Scale", ItemKind::Exercise),
+        ]));
+        // All have practice summaries; no targets set → bucket 2 (met by default)
+        model
+            .practice_summaries
+            .insert("piece-1".to_string(), summary(Some(3), None));
+        model
+            .practice_summaries
+            .insert("piece-2".to_string(), summary(Some(3), None));
+        model
+            .practice_summaries
+            .insert("exercise-1".to_string(), summary(Some(3), None));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        // Same order as goal.items — within-bucket stable.
+        assert_eq!(
+            loaded_item_ids(&model),
+            vec!["piece-2", "piece-1", "exercise-1"]
+        );
+    }
+
+    #[test]
+    fn load_goal_inherits_goal_level_target_for_bucketing() {
+        let mut model = model_with_library();
+        // Goal default confidence target 4. piece-1 has no override, score 3 → unmet.
+        let goal = Goal {
+            target_confidence: Some(4),
+            ..goal_with_items(vec![link("piece-1", "Moonlight Sonata", ItemKind::Piece)])
+        };
+        model.goals.push(goal);
+        model
+            .practice_summaries
+            .insert("piece-1".to_string(), summary(Some(3), None));
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "goal-1".to_string(),
+            }),
+        );
+
+        // Single item in bucket 1 — confirms inheritance path was hit (no panic, item present).
+        assert_eq!(loaded_item_ids(&model), vec!["piece-1"]);
+    }
+
+    #[test]
+    fn load_goal_unknown_id_surfaces_error_without_changing_state() {
+        let mut model = model_with_library();
+        update(
+            &mut model,
+            Event::Session(SessionEvent::LoadGoalIntoSetlist {
+                goal_id: "nonexistent".to_string(),
+            }),
+        );
+        assert!(model.last_error.as_deref().unwrap().contains("nonexistent"));
+        assert!(matches!(model.session_status, SessionStatus::Idle));
     }
 }

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -61,6 +61,25 @@ pub fn SetlistBuilder() -> impl IntoView {
     let close_review = Callback::new(move |_| review_open.set(false));
     let open_review = move |_| review_open.set(true);
 
+    // Pre-loaded setlist (e.g. "Practice this goal") auto-opens the review
+    // sheet on mount. Guarded by `auto_opened` so dismissing the sheet
+    // doesn't bounce it back open.
+    let auto_opened = RwSignal::new(false);
+    Effect::new(move |_| {
+        if auto_opened.get_untracked() {
+            return;
+        }
+        let has_entries = view_model.with(|vm| {
+            vm.building_setlist
+                .as_ref()
+                .is_some_and(|s| !s.entries.is_empty())
+        });
+        if has_entries {
+            review_open.set(true);
+            auto_opened.set(true);
+        }
+    });
+
     // Set of item ids currently in the setlist — used to render the toggle
     // state on each library row.
     let selected_ids = Memo::new(move |_| {

--- a/crates/intrada-web/src/components/setlist_builder.rs
+++ b/crates/intrada-web/src/components/setlist_builder.rs
@@ -62,21 +62,17 @@ pub fn SetlistBuilder() -> impl IntoView {
     let open_review = move |_| review_open.set(true);
 
     // Pre-loaded setlist (e.g. "Practice this goal") auto-opens the review
-    // sheet on mount. Guarded by `auto_opened` so dismissing the sheet
-    // doesn't bounce it back open.
-    let auto_opened = RwSignal::new(false);
+    // sheet on mount. `with_untracked` so this Effect doesn't subscribe to
+    // `view_model` — otherwise the manual flow's first `AddToSetlist` would
+    // also trigger it. We only care about state *at mount time*.
     Effect::new(move |_| {
-        if auto_opened.get_untracked() {
-            return;
-        }
-        let has_entries = view_model.with(|vm| {
+        let has_entries = view_model.with_untracked(|vm| {
             vm.building_setlist
                 .as_ref()
                 .is_some_and(|s| !s.entries.is_empty())
         });
         if has_entries {
             review_open.set(true);
-            auto_opened.set(true);
         }
     });
 

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -216,6 +216,9 @@ fn GoalDetailContent(goal: GoalView, sheets: SheetState) -> impl IntoView {
             goal_id: goal_id_for_practice.clone(),
         }));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        // Drop the RefCell borrow before navigating — the route change
+        // re-renders subscribed views, some of which `core.borrow()` again
+        // and would panic if we still held this guard.
         drop(core_ref);
         navigate_practice.clone()("/sessions/new", NavigateOptions::default());
     };

--- a/crates/intrada-web/src/views/goal_detail.rs
+++ b/crates/intrada-web/src/views/goal_detail.rs
@@ -8,7 +8,8 @@ use leptos_router::NavigateOptions;
 
 use intrada_core::domain::types::UpdateGoalItem;
 use intrada_core::{
-    Event, GoalEvent, GoalItemView, GoalStatus, GoalView, LibraryItemView, LinkGoalItem, ViewModel,
+    Event, GoalEvent, GoalItemView, GoalStatus, GoalView, LibraryItemView, LinkGoalItem,
+    SessionEvent, ViewModel,
 };
 
 use crate::components::{
@@ -179,7 +180,10 @@ fn GoalDetailContent(goal: GoalView, sheets: SheetState) -> impl IntoView {
 
     let core_for_delete = core.clone();
     let core_for_reopen = core.clone();
+    let core_for_practice = core.clone();
     let goal_id_for_reopen = goal_id.clone();
+    let goal_id_for_practice = goal_id.clone();
+    let navigate_practice = use_navigate();
     let on_complete = move |_: leptos::ev::MouseEvent| {
         let nav = navigate.clone();
         nav(
@@ -204,6 +208,16 @@ fn GoalDetailContent(goal: GoalView, sheets: SheetState) -> impl IntoView {
             id: goal_id_for_reopen.clone(),
         }));
         process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+    };
+
+    let on_practice = move |_: leptos::ev::MouseEvent| {
+        let core_ref = core_for_practice.borrow();
+        let effects = core_ref.process_event(Event::Session(SessionEvent::LoadGoalIntoSetlist {
+            goal_id: goal_id_for_practice.clone(),
+        }));
+        process_effects(&core_ref, effects, &view_model, &is_loading, &is_submitting);
+        drop(core_ref);
+        navigate_practice.clone()("/sessions/new", NavigateOptions::default());
     };
 
     let title_display = goal
@@ -305,6 +319,24 @@ fn GoalDetailContent(goal: GoalView, sheets: SheetState) -> impl IntoView {
                     </div>
                 }
             })}
+
+            {
+                let on_practice = Callback::new(on_practice);
+                view! {
+                    <Show when=move || {
+                        !is_completed_signal.get()
+                            && live_linked_items.with(|items| !items.is_empty())
+                    }>
+                        <Button
+                            variant=ButtonVariant::Primary
+                            on_click=on_practice
+                            full_width=true
+                        >
+                            "Practice this goal"
+                        </Button>
+                    </Show>
+                }
+            }
 
             <div class="space-y-2">
                 <div class="flex items-center justify-between">

--- a/specs/goals-targets.md
+++ b/specs/goals-targets.md
@@ -92,9 +92,9 @@ The user clicks "Mark Complete" — auto-suggest never auto-completes. This pres
 
 | Phase | Scope | Status |
 |---|---|---|
-| **1 (A+B bundled)** | Date target on `GoalItem` + Confidence target (goal-level default + per-item override) + per-item edit UI + countdown badges + progress display pulling `latest_score` + auto-suggest banner on completion criterion | **This spec ships with Phase 1's PR** |
-| **2 (C)** | Tempo target (goal-level default + per-item override) + tempo progress from `latest_achieved_tempo` + auto-suggest extended | Separate PR |
-| **3 (D)** | "Practice this goal" button on goal detail → starts a session pre-loaded with the goal's items in order of "least ready" | Separate PR; depends on session-builder reuse |
+| **1 (A+B bundled)** | Date target on `GoalItem` + Confidence target (goal-level default + per-item override) + per-item edit UI + countdown badges + progress display pulling `latest_score` + auto-suggest banner on completion criterion | Shipped in #733 |
+| **2 (C)** | Tempo target (goal-level default + per-item override) + tempo progress from `latest_achieved_tempo` + auto-suggest extended | Shipped in #736 |
+| **3 (D)** | "Practice this goal" button on goal detail → loads the goal's items into the existing session builder ordered "least ready first", then opens the review sheet | Stacked on #736; spec extended below |
 | **4 (Future)** | Cross-goal session builder ("show me what's due across all active goals") + spaced-practice / interleaving suggester | Out of scope for this spec; revisit after Phase 3 |
 
 ### Phase 1 — file inventory
@@ -107,6 +107,61 @@ The user clicks "Mark Complete" — auto-suggest never auto-completes. This pres
 - **UI — goal edit form**: [crates/intrada-web/src/views/goal_edit_form.rs](crates/intrada-web/src/views/goal_edit_form.rs) (introduced in #726) — add goal-level `target_confidence` field.
 - **UI — goal detail**: [crates/intrada-web/src/views/goal_detail.rs](crates/intrada-web/src/views/goal_detail.rs) — linked-item rows show "target X / current Y" pill; tapping an item opens a per-item target editor (BottomSheet); auto-suggest banner above actions when criterion met.
 - **UI — new component**: `GoalItemTargetsSheet` (private to `goal_detail.rs`, mirrors `LinkItemsSheet` shape from #732).
+
+### Phase 3 — "Practice this goal"
+
+**Goal**: from `goal_detail`, one tap loads all of the goal's linked items into the existing session builder, ordered "least ready first," and opens the review sheet. The user confirms / tweaks / starts.
+
+**No new screen.** No goal/session coupling. Goal stays untouched — sessions update `latest_score` and `latest_achieved_tempo` on library items, which reshape the goal's chips on the next render.
+
+#### UX
+
+- New primary `<Button>` on `goal_detail.rs` ("Practice this goal") **above the linked-items list**. Hidden when the goal has zero items or is completed.
+- Tap dispatches `SessionEvent::LoadGoalIntoSetlist { goal_id }` and navigates to `/sessions/new`. The review sheet auto-opens once the builder mounts and sees `building.entries` is non-empty (a small `Effect` on mount). The new event handler:
+  1. Reads the goal from `model.goals`.
+  2. Reads each linked item from `model.items` to get `latest_score` / `latest_achieved_tempo`.
+  3. Orders items via the bucket sort (below). Stale links (item id no longer in library) are skipped silently.
+  4. Populates `building.entries` with one `SetlistEntry` per surviving item.
+  5. Renders.
+- The existing builder + review sheet handle the rest. User can drop items, reorder, set session intention, then `Start practising`.
+
+#### Ordering — bucket sort
+
+For each linked item, compute a bucket:
+
+| Bucket | Predicate |
+|---|---|
+| 0 (top, most urgent) | item has no `practice` summary at all (never practised) |
+| 1 | item has an effective target (confidence or tempo) that hasn't been met by the latest session |
+| 2 (bottom) | everything else (no target set, or all set targets met) |
+
+Stable sort by bucket ascending. Within a bucket, preserve the goal's existing item order (the order they appear in `goal.items`).
+
+This is intentionally crude. Tracked for evolution in [#738](https://github.com/jonyardley/intrada/issues/738) once we have user-behaviour data — possible refinements: gap-ratio, recency weighting, last-N-sessions, user-configurable. Same eventual formula likely also tightens the Phase 1 "looks ready" rule (Open question #1).
+
+#### No-coupling decision
+
+The active session does not store a `source_goal_id`. The goal launched it, but the session is just a session — same as today's flow from a Set. Post-session, the goal detail surfaces "ready" derivation from the updated `latest_score` and the existing auto-suggest banner; no new wiring needed.
+
+If we later want "this session contributed to Goal X" provenance for analytics or post-session UX, that's a separate Phase 4-ish concern and is easier to bolt on cleanly than to retrofit out.
+
+#### File inventory
+
+- **Core handler**: new `SessionEvent::LoadGoalIntoSetlist { goal_id }` in [crates/intrada-core/src/domain/session.rs](crates/intrada-core/src/domain/session.rs). Mirrors `SetEvent::LoadSetIntoSetlist` from #732 — same shape, same model mutation. Ordering helper kept private to the module.
+- **UI — goal detail**: new "Practice this goal" button + dispatch in [crates/intrada-web/src/views/goal_detail.rs](crates/intrada-web/src/views/goal_detail.rs). Hidden when `items.is_empty() || status == Completed`.
+- **UI — builder**: no changes. The builder already renders whatever `building.entries` it's given.
+- **No API changes.** No new DB columns. No new HTTP endpoints.
+
+#### Coverage
+
+- **Core**: bucket-sort unit tests against synthetic `Model` snapshots — never-practised items first, then targeted-unmet, then met/no-target; stale links skipped; existing `goal.items` order preserved within a bucket. ≥ 5 tests.
+- **API**: none — no API surface added.
+- **UI**: WASM shell, excluded.
+
+#### Open questions for Phase 3
+
+1. **Goal title visible during the session?** The active session screen currently shows no goal context. Spec says "no new screen" and "no coupling." Recommend: leave as-is for Phase 3; revisit if users ask "which goal was I practising again?"
+2. **Empty case after stale-link skip.** If every item was deleted from the library since being linked, the builder ends up empty. Recommend: still navigate to builder (consistent UX); empty builder already has its own empty state.
 
 ### Phase 1 — what stays the same
 


### PR DESCRIPTION
## Summary

Phase 3 of the goals-targets work (see [specs/goals-targets.md](specs/goals-targets.md), extended in this PR with the Phase 3 sub-spec). Adds a **Practice this goal** primary button on goal detail that loads the goal's linked items into the existing session builder ordered "least ready first," then auto-opens the review sheet.

Originally stacked on #736 — rebased onto main now that #736 has merged.

## What ships

**Core** (`intrada-core`)
- New `SessionEvent::LoadGoalIntoSetlist { goal_id }` event + handler. Initialises a Building session if currently Idle (caller doesn't need to dispatch `StartBuilding` first); appends ordered entries.
- New private helper `order_goal_items_least_ready_first` — **bucket sort**:
  - 0 = item never practised (no `practice_summary`)
  - 1 = effective target (confidence or tempo) unmet by the latest session
  - 2 = met or no target
  - Stable within bucket (preserves the goal's `items` order). Stale links (item id no longer in `model.items`) are dropped silently.
- 7 new unit tests covering all four buckets, goal-default inheritance, tempo-as-unmet, stale-link skip, within-bucket stability, and the unknown-goal-id error path.

**Web** (`intrada-web`)
- New primary "Practice this goal" button on `goal_detail.rs` above the linked-items list. Hidden when `items.is_empty()` or the goal is completed.
- Dispatches `LoadGoalIntoSetlist`, then navigates to `/sessions/new`.
- `setlist_builder.rs` auto-opens the review sheet on mount when `building_setlist.entries` is non-empty. Guarded by `auto_opened: RwSignal<bool>` so dismissing the sheet doesn't bounce it back open. Manual-builder flow is unaffected (entries start empty there).

**No API / DB changes.**

## Decisions called out

- **No goal/session coupling.** The active session doesn't carry a `source_goal_id`. Goals stay decoupled per Phase 1's principle — sessions update library items' `latest_score` / `latest_achieved_tempo`, which reshape the goal's chips on next render. If we later want "this session contributed to Goal X" provenance, it bolts on cleanly as a separate concern.
- **Bucket sort, not gap-ratio.** Crude but defensible. Refinement (gap-ratio, recency-weighting, last-N-sessions, user-configurable) tracked in #738.
- **Include everything, sort least-ready first** — don't auto-filter met items. The user drops them in the review sheet if they want. Matches Phase 1's "intent vs evidence" principle.
- **Explicit `drop(core_ref)` before navigating** in `on_practice` — navigation triggers a route change immediately and we don't want to hold the core's `RefCell` borrow across it.

## Coverage

- **Core**: 7 new tests against synthetic `Model` snapshots. Full happy + edge coverage of the new event + bucket sort. No API surface added; UI is WASM shell (excluded per `codecov.yml`).

Total: **686 tests passing** (was 678 after Phase 2).

## Phase rollout (final state)

| Phase | Status | What |
|---|---|---|
| 1 (date + confidence) | Shipped #733 | Targets stored + edited; progress chips + auto-suggest |
| 2 (tempo) | Shipped #736 | Tempo target dimension |
| **3 (practice integration)** | **This PR** | "Practice this goal" → builder pre-loaded, ordered least-ready first, review sheet auto-opens |
| 4 (cross-goal / spaced) | Future spec | Cross-goal suggester |

## Test plan

- [ ] CI green
- [ ] User verification on iOS simulator:
  - Goal with 0 items → Practice button hidden
  - Goal with 3 items, none practised → tap → builder pre-loaded, review sheet auto-opens
  - Goal with mixed practice → ordering is exercise (never-practised) → piece-A (score 2/4) → piece-B (score 4/4)
  - Dismiss review sheet → it doesn't re-pop
  - Completed goal → Practice button hidden
- [ ] Manual: stale link (item deleted from library after linking) is skipped, doesn't crash

## Out of scope (deferred)

- Ordering algorithm refinement → #738
- Goal context in session header → revisit if users ask
- Cross-goal session builder (Phase 4 / future spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)