### PR TITLE
Goals: switch link/unlink/PATCH/complete/reopen to mutate-response

### DIFF
--- a/crates/intrada-api/src/routes/goals.rs
+++ b/crates/intrada-api/src/routes/goals.rs
@@ -171,10 +171,10 @@ async fn link_item(
     AuthUser { user_id, .. }: AuthUser,
     Path(id): Path<String>,
     Json(input): Json<LinkGoalItem>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<(StatusCode, Json<Goal>), ApiError> {
     let conn = state.conn();
-    services::goals::link_item(&conn, &id, &user_id, &input).await?;
-    Ok(StatusCode::CREATED)
+    let goal = services::goals::link_item(&conn, state.r2.as_ref(), &id, &user_id, &input).await?;
+    Ok((StatusCode::CREATED, Json(goal)))
 }
 
 async fn update_item(
@@ -182,18 +182,27 @@ async fn update_item(
     AuthUser { user_id, .. }: AuthUser,
     Path((id, item_id)): Path<(String, String)>,
     Json(input): Json<UpdateGoalItem>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<Json<Goal>, ApiError> {
     let conn = state.conn();
-    services::goals::update_goal_item(&conn, &id, &item_id, &user_id, &input).await?;
-    Ok(StatusCode::NO_CONTENT)
+    let goal = services::goals::update_goal_item(
+        &conn,
+        state.r2.as_ref(),
+        &id,
+        &item_id,
+        &user_id,
+        &input,
+    )
+    .await?;
+    Ok(Json(goal))
 }
 
 async fn unlink_item(
     State(state): State<AppState>,
     AuthUser { user_id, .. }: AuthUser,
     Path((id, item_id)): Path<(String, String)>,
-) -> Result<StatusCode, ApiError> {
+) -> Result<Json<Goal>, ApiError> {
     let conn = state.conn();
-    services::goals::unlink_item(&conn, &id, &item_id, &user_id).await?;
-    Ok(StatusCode::NO_CONTENT)
+    let goal =
+        services::goals::unlink_item(&conn, state.r2.as_ref(), &id, &item_id, &user_id).await?;
+    Ok(Json(goal))
 }

--- a/crates/intrada-api/src/services/goals.rs
+++ b/crates/intrada-api/src/services/goals.rs
@@ -147,10 +147,11 @@ pub async fn delete_goal_photo(
 
 pub async fn link_item(
     conn: &Connection,
+    r2: Option<&R2Client>,
     goal_id: &str,
     user_id: &str,
     input: &LinkGoalItem,
-) -> Result<(), ApiError> {
+) -> Result<Goal, ApiError> {
     validation::validate_link_goal_item(input)?;
     db::goals::insert_goal_item(
         conn,
@@ -165,16 +166,18 @@ pub async fn link_item(
             target_tempo: input.target_tempo,
         },
     )
-    .await
+    .await?;
+    get_goal(conn, r2, goal_id, user_id).await
 }
 
 pub async fn update_goal_item(
     conn: &Connection,
+    r2: Option<&R2Client>,
     goal_id: &str,
     item_id: &str,
     user_id: &str,
     input: &UpdateGoalItem,
-) -> Result<(), ApiError> {
+) -> Result<Goal, ApiError> {
     validation::validate_update_goal_item(input)?;
     let updated = db::goals::update_goal_item(conn, goal_id, item_id, user_id, input).await?;
     if !updated {
@@ -182,20 +185,21 @@ pub async fn update_goal_item(
             "Goal item not found: {item_id}"
         )));
     }
-    Ok(())
+    get_goal(conn, r2, goal_id, user_id).await
 }
 
 pub async fn unlink_item(
     conn: &Connection,
+    r2: Option<&R2Client>,
     goal_id: &str,
     item_id: &str,
     user_id: &str,
-) -> Result<(), ApiError> {
+) -> Result<Goal, ApiError> {
     let deleted = db::goals::delete_goal_item(conn, goal_id, item_id, user_id).await?;
     if !deleted {
         return Err(ApiError::NotFound(format!(
             "Goal item not found: {item_id}"
         )));
     }
-    Ok(())
+    get_goal(conn, r2, goal_id, user_id).await
 }

--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -194,8 +194,8 @@ async fn link_and_unlink_item() {
     let created: Goal = common::json(&body);
     assert!(created.items.is_empty());
 
-    // Link an item
-    let (status, _body) = common::post_json(
+    // Link an item — response body is the updated goal (mutate-response).
+    let (status, body) = common::post_json(
         app.clone(),
         &format!("/api/goals/{}/items", created.id),
         json!({
@@ -206,28 +206,20 @@ async fn link_and_unlink_item() {
     )
     .await;
     assert_eq!(status, StatusCode::CREATED);
+    let after_link: Goal = common::json(&body);
+    assert_eq!(after_link.items.len(), 1);
+    assert_eq!(after_link.items[0].item_id, "piece-001");
+    assert_eq!(after_link.items[0].item_title, "Bach Prelude");
 
-    // Verify the item is present on the goal
-    let (status, body) = common::get(app.clone(), &format!("/api/goals/{}", created.id)).await;
-    assert_eq!(status, StatusCode::OK);
-    let fetched: Goal = common::json(&body);
-    assert_eq!(fetched.items.len(), 1);
-    assert_eq!(fetched.items[0].item_id, "piece-001");
-    assert_eq!(fetched.items[0].item_title, "Bach Prelude");
-
-    // Unlink the item
-    let (status, _body) = common::delete(
+    // Unlink the item — response body is the updated goal.
+    let (status, body) = common::delete(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", created.id),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    // Verify the item is gone
-    let (status, body) = common::get(app, &format!("/api/goals/{}", created.id)).await;
     assert_eq!(status, StatusCode::OK);
-    let fetched: Goal = common::json(&body);
-    assert!(fetched.items.is_empty());
+    let after_unlink: Goal = common::json(&body);
+    assert!(after_unlink.items.is_empty());
 }
 
 // ── Filter by status ──────────────────────────────────────────────────
@@ -423,18 +415,16 @@ async fn patch_goal_item_targets() {
     )
     .await;
 
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_date": "2026-07-01", "target_confidence": 5 }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert_eq!(fetched.items[0].target_date.as_deref(), Some("2026-07-01"));
-    assert_eq!(fetched.items[0].target_confidence, Some(5));
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert_eq!(updated.items[0].target_date.as_deref(), Some("2026-07-01"));
+    assert_eq!(updated.items[0].target_confidence, Some(5));
 }
 
 #[tokio::test]
@@ -458,18 +448,16 @@ async fn patch_goal_item_partial_update_preserves_other_fields() {
     .await;
 
     // PATCH only confidence — date should be preserved
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_confidence": 5 }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert_eq!(fetched.items[0].target_date.as_deref(), Some("2026-06-01"));
-    assert_eq!(fetched.items[0].target_confidence, Some(5));
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert_eq!(updated.items[0].target_date.as_deref(), Some("2026-06-01"));
+    assert_eq!(updated.items[0].target_confidence, Some(5));
 }
 
 #[tokio::test]
@@ -492,18 +480,16 @@ async fn patch_goal_item_clears_targets_with_null() {
     )
     .await;
 
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_date": null, "target_confidence": null }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert!(fetched.items[0].target_date.is_none());
-    assert!(fetched.items[0].target_confidence.is_none());
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.items[0].target_date.is_none());
+    assert!(updated.items[0].target_confidence.is_none());
 }
 
 #[tokio::test]
@@ -667,17 +653,15 @@ async fn patch_goal_item_target_tempo() {
     )
     .await;
 
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_tempo": 140 }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert_eq!(fetched.items[0].target_tempo, Some(140));
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert_eq!(updated.items[0].target_tempo, Some(140));
 }
 
 #[tokio::test]
@@ -699,17 +683,15 @@ async fn patch_goal_item_clears_target_tempo_with_null() {
     )
     .await;
 
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_tempo": null }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert!(fetched.items[0].target_tempo.is_none());
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.items[0].target_tempo.is_none());
 }
 
 #[tokio::test]
@@ -733,18 +715,16 @@ async fn patch_goal_item_partial_update_preserves_tempo() {
     .await;
 
     // PATCH only confidence — tempo should be preserved
-    let (status, _body) = common::patch_json(
+    let (status, body) = common::patch_json(
         app.clone(),
         &format!("/api/goals/{}/items/piece-001", goal.id),
         json!({ "target_confidence": 5 }),
     )
     .await;
-    assert_eq!(status, StatusCode::NO_CONTENT);
-
-    let (_, body) = common::get(app, &format!("/api/goals/{}", goal.id)).await;
-    let fetched: Goal = common::json(&body);
-    assert_eq!(fetched.items[0].target_tempo, Some(100));
-    assert_eq!(fetched.items[0].target_confidence, Some(5));
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert_eq!(updated.items[0].target_tempo, Some(100));
+    assert_eq!(updated.items[0].target_confidence, Some(5));
 }
 
 #[tokio::test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -51,7 +51,6 @@ pub enum Event {
     RefetchItems,
     RefetchSessions,
     RefetchSets,
-    RefetchGoals,
     /// User signed out — reset all user-scoped state so the next sign-in
     /// (possibly a different user on the same browser) doesn't inherit the
     /// previous user's items, sessions, MCP tokens/audit, errors, etc.
@@ -96,6 +95,13 @@ pub enum Event {
     },
     GoalCreated {
         temp_id: String,
+        goal: Goal,
+    },
+    /// Mutate-response confirmation for goal-item write paths (link, unlink,
+    /// per-item targets update, complete, reopen). Replaces the matching
+    /// goal in `model.goals` and `model.current_goal`. Cheaper than a list
+    /// refetch; keeps DOM stable since the `<For>` keys by goal id.
+    GoalUpdated {
         goal: Goal,
     },
     SetUpdated {
@@ -186,7 +192,6 @@ impl App for Intrada {
             Event::RefetchItems => http::fetch_items(&model.api_base_url),
             Event::RefetchSessions => http::fetch_sessions(&model.api_base_url),
             Event::RefetchSets => http::fetch_sets(&model.api_base_url),
-            Event::RefetchGoals => http::fetch_goals(&model.api_base_url),
             Event::SignedOut => {
                 model.reset_for_sign_out();
                 // Also clear the crash-recovery blob in localStorage —
@@ -259,6 +264,18 @@ impl App for Intrada {
                     *existing = goal;
                 } else {
                     model.goals.push(goal);
+                }
+                model.record_success();
+                crux_core::render::render()
+            }
+            Event::GoalUpdated { goal } => {
+                if let Some(existing) = model.goals.iter_mut().find(|g| g.id == goal.id) {
+                    *existing = goal.clone();
+                }
+                if let Some(current) = &model.current_goal {
+                    if current.id == goal.id {
+                        model.current_goal = Some(goal);
+                    }
                 }
                 model.record_success();
                 crux_core::render::render()
@@ -2675,6 +2692,101 @@ mod tests {
 
         assert_eq!(model.goals.len(), 1);
         assert_eq!(model.goals[0].id, "server_ulid");
+    }
+
+    #[test]
+    fn goal_updated_replaces_list_entry_and_current_goal() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let now = chrono::Utc::now();
+        let original = Goal {
+            id: "g1".to_string(),
+            title: Some("v1".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            target_confidence: None,
+            target_tempo: None,
+        };
+        model.goals.push(original.clone());
+        model.current_goal = Some(original);
+
+        let updated = Goal {
+            title: Some("v2".to_string()),
+            target_confidence: Some(4),
+            ..model.goals[0].clone()
+        };
+        let _cmd = app.update(
+            Event::GoalUpdated {
+                goal: updated.clone(),
+            },
+            &mut model,
+        );
+
+        assert_eq!(model.goals.len(), 1);
+        assert_eq!(model.goals[0].title.as_deref(), Some("v2"));
+        assert_eq!(model.goals[0].target_confidence, Some(4));
+        assert_eq!(
+            model.current_goal.as_ref().unwrap().title.as_deref(),
+            Some("v2")
+        );
+    }
+
+    #[test]
+    fn goal_updated_leaves_current_goal_alone_when_id_differs() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+        let now = chrono::Utc::now();
+        let other_current = Goal {
+            id: "g-other".to_string(),
+            title: Some("untouched".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            target_confidence: None,
+            target_tempo: None,
+        };
+        model.current_goal = Some(other_current);
+        model.goals.push(Goal {
+            id: "g1".to_string(),
+            title: Some("v1".to_string()),
+            date: "2026-05-19".to_string(),
+            notes: None,
+            deadline: None,
+            status: crate::domain::goal::GoalStatus::Active,
+            completed_at: None,
+            items: Vec::new(),
+            photos: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            target_confidence: None,
+            target_tempo: None,
+        });
+
+        let updated = Goal {
+            title: Some("v2".to_string()),
+            ..model.goals[0].clone()
+        };
+        let _cmd = app.update(Event::GoalUpdated { goal: updated }, &mut model);
+
+        assert_eq!(model.goals[0].title.as_deref(), Some("v2"));
+        assert_eq!(
+            model.current_goal.as_ref().unwrap().title.as_deref(),
+            Some("untouched")
+        );
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -97,10 +97,8 @@ pub enum Event {
         temp_id: String,
         goal: Goal,
     },
-    /// Mutate-response confirmation for goal-item write paths (link, unlink,
-    /// per-item targets update, complete, reopen). Replaces the matching
-    /// goal in `model.goals` and `model.current_goal`. Cheaper than a list
-    /// refetch; keeps DOM stable since the `<For>` keys by goal id.
+    /// Mutate-response confirmation for goal-item write paths. See CLAUDE.md
+    /// "Mutate response".
     GoalUpdated {
         goal: Goal,
     },

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -274,9 +274,13 @@ pub fn complete_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
     Http::put(format!("{api_base_url}/api/goals/{id}"))
         .body_json(&input)
         .expect("serialize UpdateGoal for complete")
+        .expect_json::<Goal>()
         .build()
         .then_send(|result| match result {
-            Ok(_) => Event::RefetchGoals,
+            Ok(response) => match response.body().cloned() {
+                Some(goal) => Event::GoalUpdated { goal },
+                None => Event::LoadFailed("complete_goal: server returned no body".into()),
+            },
             Err(e) => Event::LoadFailed(format!("Failed to complete goal: {e}")),
         })
 }
@@ -291,9 +295,13 @@ pub fn reopen_goal(api_base_url: &str, id: &str) -> Command<Effect, Event> {
     Http::put(format!("{api_base_url}/api/goals/{id}"))
         .body_json(&input)
         .expect("serialize UpdateGoal for reopen")
+        .expect_json::<Goal>()
         .build()
         .then_send(|result| match result {
-            Ok(_) => Event::RefetchGoals,
+            Ok(response) => match response.body().cloned() {
+                Some(goal) => Event::GoalUpdated { goal },
+                None => Event::LoadFailed("reopen_goal: server returned no body".into()),
+            },
             Err(e) => Event::LoadFailed(format!("Failed to reopen goal: {e}")),
         })
 }
@@ -315,9 +323,13 @@ pub fn link_goal_item(
     Http::post(format!("{api_base_url}/api/goals/{goal_id}/items"))
         .body_json(item)
         .expect("serialize LinkGoalItem")
+        .expect_json::<Goal>()
         .build()
         .then_send(|result| match result {
-            Ok(_) => Event::RefetchGoals,
+            Ok(response) => match response.body().cloned() {
+                Some(goal) => Event::GoalUpdated { goal },
+                None => Event::LoadFailed("link_goal_item: server returned no body".into()),
+            },
             Err(e) => Event::LoadFailed(format!("Failed to link item to goal: {e}")),
         })
 }
@@ -333,9 +345,13 @@ pub fn update_goal_item(
     ))
     .body_json(input)
     .expect("serialize UpdateGoalItem")
+    .expect_json::<Goal>()
     .build()
     .then_send(|result| match result {
-        Ok(_) => Event::RefetchGoals,
+        Ok(response) => match response.body().cloned() {
+            Some(goal) => Event::GoalUpdated { goal },
+            None => Event::LoadFailed("update_goal_item: server returned no body".into()),
+        },
         Err(e) => Event::LoadFailed(format!("Failed to update goal item targets: {e}")),
     })
 }
@@ -348,9 +364,13 @@ pub fn unlink_goal_item(
     Http::delete(format!(
         "{api_base_url}/api/goals/{goal_id}/items/{item_id}"
     ))
+    .expect_json::<Goal>()
     .build()
     .then_send(|result| match result {
-        Ok(_) => Event::RefetchGoals,
+        Ok(response) => match response.body().cloned() {
+            Some(goal) => Event::GoalUpdated { goal },
+            None => Event::LoadFailed("unlink_goal_item: server returned no body".into()),
+        },
         Err(e) => Event::LoadFailed(format!("Failed to unlink item from goal: {e}")),
     })
 }


### PR DESCRIPTION
## Summary

Drops the `RefetchGoals` round-trip on five goal write paths in favour of the mutate-response pattern documented in CLAUDE.md ("Mutate response" section). The API now returns the post-mutation `Goal` JSON; the core wrappers parse it and dispatch a new `Event::GoalUpdated { goal }` that replaces the goal in `model.goals` and `model.current_goal`.

Flagged as tech debt in #733/#736's PR descriptions; the goals-targets work is the natural forcing function.

## Why now

The visible row already keeps its DOM node (the `<For>` keys by goal id), so this isn't a flicker fix — it's correctness/consistency:
- One less network round-trip per write
- The optimistic UI no longer flickers off and back as `RefetchGoals` resets the entire list
- Brings goal-item writes in line with `ItemUpdated`/`SetUpdated`

## What ships

**Core** (`intrada-core`)
- New `Event::GoalUpdated { goal }` variant + handler. Replaces the matching goal in `model.goals`; replaces `model.current_goal` when ids match.
- 5 HTTP wrappers switched from `Event::RefetchGoals` to parsing the response body:
  - `complete_goal` (PUT /goals/:id)
  - `reopen_goal` (PUT /goals/:id)
  - `link_goal_item` (POST /goals/:id/items)
  - `update_goal_item` (PATCH /goals/:id/items/:item_id)
  - `unlink_goal_item` (DELETE /goals/:id/items/:item_id)
- `Event::RefetchGoals` removed (zero remaining callers; per CLAUDE.md "delete unused code completely").
- 2 new unit tests on the handler: list-and-current-replace; current_goal untouched when ids differ.

**API** (`intrada-api`)
- `services::goals::link_item`, `update_goal_item`, `unlink_item` now return `Goal` (via `get_goal` after the DB write). All take an `r2: Option<&R2Client>` so the returned Goal includes its photos.
- Route handlers return `Json<Goal>` (200 OK or 201 Created where appropriate) instead of empty bodies + 204.
- 7 existing PATCH/POST/DELETE integration tests updated to assert `OK`/`CREATED` + parse body directly. No new tests needed — the existing tests already verified post-mutation state via a follow-up GET; that's now collapsed into asserting the response body.

## Decisions called out

- **`Event::RefetchGoals` removed, not deprecated.** Zero remaining callers. Per CLAUDE.md "Avoid backwards-compatibility hacks... if you are certain something is unused, you can delete it completely."
- **`*Updated` mirrors `ItemUpdated`/`SetUpdated`** (not a "GoalItemLinked / GoalItemUnlinked / GoalItemTargetsUpdated" trio). All five paths converge on the same handler because the returned entity shape is identical; three event variants for one shape is noise.
- **Service signatures gained `r2: Option<&R2Client>`** so the returned `Goal` includes photo URLs. Mirrors `get_goal` / `create_goal` / `update_goal` which already pass `r2`.

## Coverage

- **Core**: 2 new unit tests; 380 → 382 core tests.
- **API**: existing 7 PATCH/POST/DELETE tests rewritten to assert body directly (same coverage; tighter assertions).
- **UI**: WASM shell, excluded per `codecov.yml`. No UI changes — the existing `goal_detail.rs` flow continues to work because `Event::GoalUpdated` replaces the goal in-place where `RefetchGoals` previously re-fetched the whole list.

Total: 687 tests passing.

## Test plan

- [ ] CI green
- [ ] Manual on iOS simulator: link an item to a goal → row appears without list flicker
- [ ] Manual: unlink an item → row vanishes without list flicker
- [ ] Manual: edit per-item targets → chip updates without list flicker
- [ ] Manual: mark a goal complete from detail → status transitions, list refreshes correctly when navigating back

## Out of scope

- `double_option` latent bug on existing `Option<Option<T>>` fields (separate PR — independent of mutate-response work)
- Web UI changes (none needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)