### PR TITLE
fix(api): apply double_option deserializer to existing clearable fields

### DIFF
--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -773,3 +773,101 @@ async fn patch_goal_item_target_tempo_out_of_range_returns_400() {
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
+
+// ── Three-state clear-via-null tests (double_option deserializer) ─────
+//
+// JSON `null` on an `Option<Option<T>>` field must decode as `Some(None)`
+// (clear), not `None` (skip).
+
+#[tokio::test]
+async fn update_goal_clears_title_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/goals",
+        json!({ "date": "2026-05-15", "title": "Old Title" }),
+    )
+    .await;
+    let created: Goal = common::json(&body);
+    assert_eq!(created.title.as_deref(), Some("Old Title"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "title": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.title.is_none());
+}
+
+#[tokio::test]
+async fn update_goal_clears_notes_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/goals",
+        json!({ "date": "2026-05-15", "notes": "Bars 12-24" }),
+    )
+    .await;
+    let created: Goal = common::json(&body);
+    assert_eq!(created.notes.as_deref(), Some("Bars 12-24"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "notes": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.notes.is_none());
+}
+
+#[tokio::test]
+async fn update_goal_clears_deadline_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/goals",
+        json!({ "date": "2026-05-15", "deadline": "2026-06-01" }),
+    )
+    .await;
+    let created: Goal = common::json(&body);
+    assert_eq!(created.deadline.as_deref(), Some("2026-06-01"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "deadline": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert!(updated.deadline.is_none());
+}
+
+#[tokio::test]
+async fn update_goal_skip_preserves_existing_when_field_omitted() {
+    // Counterpart: omit a field → no change.
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/goals",
+        json!({ "date": "2026-05-15", "title": "Recital", "deadline": "2026-06-01" }),
+    )
+    .await;
+    let created: Goal = common::json(&body);
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/goals/{}", created.id),
+        json!({ "title": "Recital (final)" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Goal = common::json(&body);
+    assert_eq!(updated.title.as_deref(), Some("Recital (final)"));
+    assert_eq!(updated.deadline.as_deref(), Some("2026-06-01"));
+}

--- a/crates/intrada-api/tests/goals_test.rs
+++ b/crates/intrada-api/tests/goals_test.rs
@@ -850,7 +850,6 @@ async fn update_goal_clears_deadline_with_null() {
 
 #[tokio::test]
 async fn update_goal_skip_preserves_existing_when_field_omitted() {
-    // Counterpart: omit a field → no change.
     let app = common::setup_test_app().await;
     let (_, body) = common::post_json(
         app.clone(),

--- a/crates/intrada-api/tests/items_test.rs
+++ b/crates/intrada-api/tests/items_test.rs
@@ -396,3 +396,153 @@ async fn exercise_optional_composer() {
     let updated: Item = common::json(&body);
     assert_eq!(updated.composer.as_deref(), Some("Teacher"));
 }
+
+// ── Three-state clear-via-null tests (double_option deserializer) ─────
+//
+// JSON `null` on an `Option<Option<T>>` field must decode as `Some(None)`
+// (clear), not `None` (skip). Each test seeds a value, then sends `null`
+// and asserts the field cleared.
+
+#[tokio::test]
+async fn update_item_clears_composer_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Etude",
+            "kind": "piece",
+            "composer": "Chopin",
+            "tags": []
+        }),
+    )
+    .await;
+    let created: Item = common::json(&body);
+    assert_eq!(created.composer.as_deref(), Some("Chopin"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "composer": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.composer.is_none());
+}
+
+#[tokio::test]
+async fn update_item_clears_key_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Etude",
+            "kind": "piece",
+            "composer": "Chopin",
+            "key": "C# minor",
+            "tags": []
+        }),
+    )
+    .await;
+    let created: Item = common::json(&body);
+    assert_eq!(created.key.as_deref(), Some("C# minor"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "key": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.key.is_none());
+}
+
+#[tokio::test]
+async fn update_item_clears_tempo_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Etude",
+            "kind": "piece",
+            "composer": "Chopin",
+            "tempo": { "marking": "Allegro", "bpm": 120 },
+            "tags": []
+        }),
+    )
+    .await;
+    let created: Item = common::json(&body);
+    assert!(created.tempo.is_some());
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "tempo": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.tempo.is_none());
+}
+
+#[tokio::test]
+async fn update_item_clears_notes_with_null() {
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Etude",
+            "kind": "piece",
+            "composer": "Chopin",
+            "notes": "Bars 12-24",
+            "tags": []
+        }),
+    )
+    .await;
+    let created: Item = common::json(&body);
+    assert_eq!(created.notes.as_deref(), Some("Bars 12-24"));
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "notes": null }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.notes.is_none());
+}
+
+#[tokio::test]
+async fn update_item_skip_preserves_existing_when_field_omitted() {
+    // Counterpart to the above: omit the field entirely → no change.
+    let app = common::setup_test_app().await;
+    let (_, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({
+            "title": "Etude",
+            "kind": "piece",
+            "composer": "Chopin",
+            "tags": []
+        }),
+    )
+    .await;
+    let created: Item = common::json(&body);
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "title": "Etude (rev.)" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert_eq!(updated.title, "Etude (rev.)");
+    assert_eq!(updated.composer.as_deref(), Some("Chopin"));
+}

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -68,9 +68,29 @@ pub struct CreateItem {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct UpdateItem {
     pub title: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub composer: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub key: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub tempo: Option<Option<Tempo>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub notes: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
 }
@@ -165,9 +185,24 @@ pub struct CreateGoal {
 /// Uses three-state `Option<Option<T>>` for clearable fields.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct UpdateGoal {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub title: Option<Option<String>>,
     pub date: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub notes: Option<Option<String>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "double_option"
+    )]
     pub deadline: Option<Option<String>>,
     pub status: Option<super::goal::GoalStatus>,
     #[serde(


### PR DESCRIPTION
## Summary

Before this fix, JSON \`null\` on \`UpdateItem.{composer, key, tempo, notes}\` and \`UpdateGoal.{title, notes, deadline}\` decoded as \`None\` (skip) rather than \`Some(None)\` (clear) — so a client trying to clear a field by sending \`null\` got silently no-op'd. Only the newer Phase 1/2 fields (\`UpdateGoal.target_*\`, \`UpdateGoalItem.target_*\`) had the correct three-state deserializer; this brings the older fields in line.

Flagged as a latent bug in #733/#736's PR descriptions; the goals-targets cleanup sweep is the natural moment to retire it.

## Why this is latent rather than visible

The current Web UI clears fields by sending the empty string (\`""\`) for text fields and omitting them otherwise — the DB write layer treats empty-string-after-trim as NULL in some places, so users haven't noticed. But:

- Any client expecting standard \`null\`-means-clear semantics (e.g. the MCP server, a future mobile or third-party client) would silently fail.
- \`UpdateItem.tempo\` is an object, not a string — there's no "empty value" workaround. Pre-fix, there was no way to clear tempo at all.
- The newer goal-target fields already use \`double_option\`; the inconsistency was a footgun.

## Diff

- \`crates/intrada-core/src/domain/types.rs\` — add \`#[serde(default, skip_serializing_if = "Option::is_none", deserialize_with = "double_option")]\` to the seven affected fields.

The DB write layer already handles \`Some(None)\` correctly (\`match &input.field { None => current.field, Some(opt) => opt }\`) — it was just unreachable because the deserializer collapsed both \`null\` and absent into \`None\`. No DB or service changes needed.

## Coverage (+9 tests)

**\`items_test.rs\`** — five new tests:
- \`update_item_clears_composer_with_null\`
- \`update_item_clears_key_with_null\`
- \`update_item_clears_tempo_with_null\` ← previously had no clear path at all
- \`update_item_clears_notes_with_null\`
- \`update_item_skip_preserves_existing_when_field_omitted\` (counterpart proving the omitted-field path still works)

**\`goals_test.rs\`** — four new tests:
- \`update_goal_clears_title_with_null\`
- \`update_goal_clears_notes_with_null\`
- \`update_goal_clears_deadline_with_null\`
- \`update_goal_skip_preserves_existing_when_field_omitted\`

Total: 696 tests passing (was 687).

## Out of scope

- Web UI changes — the current "empty string" workaround keeps working; the UI doesn't need to switch to \`null\` immediately, this just unblocks future clients (MCP, mobile, etc.).
- Investigating whether any DB write layer has subtle handling of empty-string-vs-null that the UI relies on — those layers haven't changed and continue to work.

## Test plan

- [ ] CI green
- [ ] No further manual verification needed — pure data-layer fix, fully covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)