### PR TITLE
docs(claude): require explicit "Deferred items tracked:" line in self-review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,8 +516,12 @@ guidance above.
 6. **Open a tracked issue for every deferred / out-of-scope item**, with
    appropriate labels (`horizon:now|next|later`, kind: `ux` / `architecture`
    / `bug` / `accessibility` / `ios` / `pillar:*`). PR descriptions are not
-   tracking — they get auto-collapsed after merge. Mention the issue numbers
-   in the self-review comment so the link is bidirectional.
+   tracking — they get auto-collapsed after merge. Open the issues *before*
+   posting the self-review comment, not after: phrasings like "will open a
+   follow-up if it bites" are not acceptable. Every self-review comment
+   must end with an explicit `Deferred items tracked: #N, #M` line (or
+   `none — all flagged items addressed inline`) so the question is always
+   answered. Silent omission is the failure mode.
 
 ### After completing work
 1. Update `docs/roadmap.md`, close the GitHub issue.


### PR DESCRIPTION
## Summary

Tightens [CLAUDE.md](CLAUDE.md) Workflow → Always #6 — the existing "open issues for deferred items" rule — by adding two enforcement clauses:

1. Open the issues **before** posting the self-review comment, not after. Phrasings like "will open a follow-up if it bites" are not acceptable.
2. Every self-review comment **must** end with an explicit `Deferred items tracked: #N, #M` line (or `none — all flagged items addressed inline`). Silent omission is what bit us.

## Why

Audit on 2026-05-20 found 7 deferred items from the last 3 weeks of PRs that were mentioned in PR descriptions but never tracked as issues — backfilled as [#743](https://github.com/jonyardley/intrada/issues/743)–[#749](https://github.com/jonyardley/intrada/issues/749). The rule already existed; the silent-omission failure mode wasn't called out, so the rule was easy to skip without noticing.

Forcing an explicit "Deferred items tracked:" line in every self-review makes "I forgot" structurally impossible: the question is answered every time.

## Test plan

- [x] Read your way through the new rule and check that it still makes sense alongside the surrounding workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)