### PR TITLE
fix(web): restore lazy Clerk SDK load to fix login (INTRADA-WEB-N)

### DIFF
--- a/crates/intrada-web/index.html
+++ b/crates/intrada-web/index.html
@@ -263,18 +263,6 @@
       }
     </script>
     <script>
-      // Parallel-with-WASM SDK load (#580); Tauri shell uses PATs, skipped.
-      if (location.protocol !== 'tauri:') {
-        var s = document.createElement('script');
-        s.src = '/clerk/clerk.browser.js';
-        window.__clerkLoadPromise = new Promise(function (resolve, reject) {
-          s.onload = resolve;
-          s.onerror = function () { reject(new Error('Clerk SDK load failed')); };
-        });
-        document.head.appendChild(s);
-      }
-    </script>
-    <script>
       // Auth helper bridge — used by WASM via wasm_bindgen(inline_js)
       // Skip if already defined (E2E tests inject a mock via addInitScript)
       //
@@ -301,11 +289,21 @@
           }
 
           // ── Web: standard Clerk JS flow ──
+          // Set the publishable key BEFORE injecting the script: the Clerk
+          // bundle auto-runs `new Clerk(window.__clerk_publishable_key || "")`
+          // at script-load time, which throws synchronously if the key is
+          // empty. See INTRADA-WEB-N.
           try {
             window.__clerk_publishable_key = publishableKey;
             if (!window.Clerk) {
               try {
-                await window.__clerkLoadPromise;
+                await new Promise((resolve, reject) => {
+                  const s = document.createElement('script');
+                  s.src = '/clerk/clerk.browser.js';
+                  s.onload = resolve;
+                  s.onerror = () => reject(new Error('Clerk SDK load failed'));
+                  document.head.appendChild(s);
+                });
               } catch (e) {
                 this._lastError = 'script_load: ' + e.message;
                 this._initFailed = true;


### PR DESCRIPTION
## Summary

- Production web login has been broken since #741 merged (2026-05-20 20:01 UTC). Sentry: [INTRADA-WEB-N](https://jon-yardley.sentry.io/issues/INTRADA-WEB-N) — `@clerk/clerk-js: Missing publishableKey` on `/` cold load.
- Root cause: #741 moved the self-hosted Clerk SDK from a lazy in-body load to an eager `<head>` `<script>`. The minified bundle auto-runs `new Clerk(window.__clerk_publishable_key || "", ...)` at script-load time, which throws synchronously when the key is empty. Eager load fires before WASM sets the global → crash on every cold page load.
- Minimal fix: re-inject the Clerk `<script>` from inside `__intrada_auth.init()` after the publishable key is set, restoring the pre-#741 ordering. Loses #741's parallel-load perf win as a deliberate tradeoff.

## Tradeoff & follow-up

This intentionally undoes the parallelisation in #741. The proper fix is to inject the (public) publishable key into `index.html` at build time via a trunk `pre_build` hook, then restore the eager load — tracked in #752, which also covers the broader fragility of inline JS in `index.html` and a possible Leptos SSR direction.

## Test plan

- [ ] `cargo fmt --check && cargo clippy -- -D warnings && cargo test` (no Rust changes — should be a no-op verify)
- [ ] Deploy to staging Cloudflare Worker, sign in with Google in a fresh browser — should succeed
- [ ] Verify INTRADA-WEB-N stops producing new events after deploy
- [ ] iOS: `just ios-dev` and sign in — unaffected (tauri shell skipped this path entirely, just-confirm via smoke)
- [ ] Existing E2E auth tests pass

## Coverage

Coverage: HTML-only change, no Rust patch coverage delta expected. WASM/HTML shell is on the Codecov ignore list per CLAUDE.md.

Fixes INTRADA-WEB-N
Follow-up: #752

https://claude.ai/code/session_01XtESWPNGkC7W5eXwXunB4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtESWPNGkC7W5eXwXunB4S)_