### PR TITLE
Priority items — Phase A: per-item priority foundation (core + API + DB)

### DIFF
--- a/crates/intrada-api/src/db/items.rs
+++ b/crates/intrada-api/src/db/items.rs
@@ -44,6 +44,7 @@ fn row_to_item(row: &libsql::Row) -> Result<Item, ApiError> {
     let tags_json: String = col!(row, 8)?;
     let created_at_str: String = col!(row, 9)?;
     let updated_at_str: String = col!(row, 10)?;
+    let priority_int: i64 = col!(row, 11)?;
 
     let created_at: DateTime<Utc> = created_at_str
         .parse()
@@ -63,11 +64,12 @@ fn row_to_item(row: &libsql::Row) -> Result<Item, ApiError> {
         tags: tags_from_json(&tags_json),
         created_at,
         updated_at,
+        priority: priority_int != 0,
     })
 }
 
 const SELECT_COLUMNS: &str =
-    "id, kind, title, composer, key_signature, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at";
+    "id, kind, title, composer, key_signature, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at, priority";
 
 pub async fn list_items(conn: &Connection, user_id: &str) -> Result<Vec<Item>, ApiError> {
     let mut rows = conn
@@ -160,6 +162,7 @@ pub async fn insert_item(
         tags: input.tags.clone(),
         created_at: now,
         updated_at: now,
+        priority: false,
     })
 }
 
@@ -197,6 +200,7 @@ pub async fn update_item(
     };
 
     let tags = input.tags.as_ref().unwrap_or(&current.tags);
+    let priority = input.priority.unwrap_or(current.priority);
 
     let (tempo_marking, tempo_bpm) = match &tempo {
         Some(t) => (t.marking.clone(), t.bpm.map(|b| b as i64)),
@@ -208,7 +212,7 @@ pub async fn update_item(
     let tags_json = tags_to_json(tags);
 
     conn.execute(
-        "UPDATE items SET title = ?1, composer = ?2, key_signature = ?3, tempo_marking = ?4, tempo_bpm = ?5, notes = ?6, tags = ?7, updated_at = ?8 WHERE id = ?9 AND user_id = ?10",
+        "UPDATE items SET title = ?1, composer = ?2, key_signature = ?3, tempo_marking = ?4, tempo_bpm = ?5, notes = ?6, tags = ?7, updated_at = ?8, priority = ?9 WHERE id = ?10 AND user_id = ?11",
         libsql::params![
             title.as_str(),
             composer,
@@ -218,6 +222,7 @@ pub async fn update_item(
             notes,
             tags_json.as_str(),
             now_str.as_str(),
+            priority as i64,
             id,
             user_id
         ],
@@ -235,6 +240,7 @@ pub async fn update_item(
         tags: tags.clone(),
         created_at: current.created_at,
         updated_at: now,
+        priority,
     }))
 }
 

--- a/crates/intrada-api/src/migrations.rs
+++ b/crates/intrada-api/src/migrations.rs
@@ -546,6 +546,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0079_goals_target_tempo",
         "ALTER TABLE goals ADD COLUMN target_tempo INTEGER;",
     ),
+    (
+        "0080_add_priority_to_items",
+        "ALTER TABLE items ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;",
+    ),
 ];
 
 /// Backoff schedule for transient-error retries during migration: try

--- a/crates/intrada-api/tests/items_test.rs
+++ b/crates/intrada-api/tests/items_test.rs
@@ -563,7 +563,7 @@ async fn update_priority_is_scoped_to_owner() {
 
 #[tokio::test]
 async fn update_toggles_item_priority() {
-    let (app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+    let app = common::setup_test_app().await;
 
     let (status, body) = common::post_json(
         app.clone(),
@@ -586,7 +586,6 @@ async fn update_toggles_item_priority() {
     assert!(updated.priority);
 
     assert_eq!(updated.title, "Gymnopedie");
-    let _ = conn;
 }
 
 #[tokio::test]

--- a/crates/intrada-api/tests/items_test.rs
+++ b/crates/intrada-api/tests/items_test.rs
@@ -519,6 +519,49 @@ async fn update_item_clears_notes_with_null() {
 }
 
 #[tokio::test]
+async fn update_priority_is_scoped_to_owner() {
+    use intrada_api::db::items;
+
+    let (_app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+
+    let created = items::insert_item(
+        &conn,
+        "owner",
+        &intrada_core::domain::types::CreateItem {
+            title: "Arabesque".to_string(),
+            kind: intrada_core::domain::item::ItemKind::Piece,
+            composer: Some("Debussy".to_string()),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = items::update_item(
+        &conn,
+        &created.id,
+        "intruder",
+        &intrada_core::domain::types::UpdateItem {
+            priority: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(result.is_none(), "non-owner update must not match the row");
+
+    let still = items::get_item(&conn, &created.id, "owner")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!still.priority, "owner's row must be unchanged");
+}
+
+#[tokio::test]
 async fn update_toggles_item_priority() {
     let (app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
 

--- a/crates/intrada-api/tests/items_test.rs
+++ b/crates/intrada-api/tests/items_test.rs
@@ -519,6 +519,49 @@ async fn update_item_clears_notes_with_null() {
 }
 
 #[tokio::test]
+async fn update_toggles_item_priority() {
+    let (app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+
+    let (status, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({ "title": "Gymnopedie", "kind": "piece", "composer": "Satie", "tags": [] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created: Item = common::json(&body);
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "priority": true }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.priority);
+
+    assert_eq!(updated.title, "Gymnopedie");
+    let _ = conn;
+}
+
+#[tokio::test]
+async fn created_item_defaults_to_not_priority() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/items",
+        json!({ "title": "Nocturne", "kind": "piece", "composer": "Chopin", "tags": [] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let item: Item = common::json(&body);
+    assert!(!item.priority);
+}
+
+#[tokio::test]
 async fn update_item_skip_preserves_existing_when_field_omitted() {
     // Counterpart to the above: omit the field entirely → no change.
     let app = common::setup_test_app().await;

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -1175,6 +1175,7 @@ mod tests {
             tags: vec![],
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            priority: false,
         }
     }
 

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -343,6 +343,7 @@ impl App for Intrada {
                 updated_at: item.updated_at.to_rfc3339(),
                 practice,
                 latest_achieved_tempo,
+                priority: item.priority,
             });
         }
 
@@ -667,6 +668,7 @@ mod tests {
                 tags: vec![],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             },
             Item {
                 id: "ex1".to_string(),
@@ -679,6 +681,7 @@ mod tests {
                 tags: vec![],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             },
         ];
 
@@ -801,6 +804,7 @@ mod tests {
                 tags: vec![],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             }],
             sessions: vec![PracticeSession {
                 id: "sess1".to_string(),
@@ -894,6 +898,7 @@ mod tests {
                     tags: vec!["classical".to_string()],
                     created_at: now,
                     updated_at: now,
+                    priority: false,
                 },
                 Item {
                     id: "e1".to_string(),
@@ -906,6 +911,7 @@ mod tests {
                     tags: vec![],
                     created_at: now,
                     updated_at: now,
+                    priority: false,
                 },
             ],
             ..Default::default()
@@ -961,6 +967,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
         model.items.push(Item {
             id: "e1".to_string(),
@@ -973,6 +980,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         // No filter — both items
@@ -1014,6 +1022,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
         model.items.push(Item {
             id: "p2".to_string(),
@@ -1026,6 +1035,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         model.active_query = Some(ListQuery {
@@ -1055,6 +1065,7 @@ mod tests {
             tags: vec!["classical".to_string(), "piano".to_string()],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
         model.items.push(Item {
             id: "p2".to_string(),
@@ -1067,6 +1078,7 @@ mod tests {
             tags: vec!["romantic".to_string(), "piano".to_string()],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         model.active_query = Some(ListQuery {
@@ -1153,6 +1165,7 @@ mod tests {
                 tags: vec![format!("tag{}", i % 10)],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             });
         }
         for i in 0..5000 {
@@ -1171,6 +1184,7 @@ mod tests {
                 tags: vec![format!("etag{}", i % 10)],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             });
         }
         let populate_time = start.elapsed();
@@ -1311,6 +1325,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
         let p2 = Item {
             id: "p2".to_string(),
@@ -1323,6 +1338,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
         model.items = vec![p1, p2];
 
@@ -1418,6 +1434,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         use crate::domain::session::{
@@ -1515,6 +1532,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         use crate::domain::session::{
@@ -1576,6 +1594,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         use crate::domain::session::{
@@ -1662,6 +1681,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         use crate::domain::session::{
@@ -1826,6 +1846,7 @@ mod tests {
                 tags: vec![],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             }],
             ..Model::test_default()
         };
@@ -1841,6 +1862,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
 
         let _cmd = app.update(Event::ItemUpdated { item: updated }, &mut model);
@@ -1865,6 +1887,7 @@ mod tests {
                 tags: vec![],
                 created_at: now,
                 updated_at: now,
+                priority: false,
             }],
             ..Model::test_default()
         };
@@ -1880,6 +1903,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
 
         let _cmd = app.update(Event::ItemUpdated { item: unknown }, &mut model);
@@ -1933,6 +1957,7 @@ mod tests {
             tags: vec![],
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            priority: false,
         });
 
         let _cmd = app.update(Event::DeleteConfirmed, &mut model);
@@ -2248,6 +2273,7 @@ mod tests {
             tags: vec![],
             created_at,
             updated_at: created_at,
+            priority: false,
         }
     }
 
@@ -2548,6 +2574,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         });
 
         let server_item = Item {
@@ -2561,6 +2588,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
         let _cmd = app.update(
             Event::ItemCreated {
@@ -2591,6 +2619,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
 
         // No optimistic entry — caller may have navigated away and back.
@@ -2829,5 +2858,30 @@ mod tests {
             Some("viewing"),
             "current_goal should be untouched when a different goal is deleted"
         );
+    }
+
+    #[test]
+    fn test_new_item_defaults_to_not_priority() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let _cmd = app.update(
+            Event::Item(ItemEvent::Add(crate::domain::types::CreateItem {
+                title: "Prelude".to_string(),
+                kind: ItemKind::Piece,
+                composer: Some("Bach".to_string()),
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+            })),
+            &mut model,
+        );
+
+        assert_eq!(model.items.len(), 1);
+        assert!(!model.items[0].priority);
+
+        let vm = app.view(&model);
+        assert!(!vm.items[0].priority);
     }
 }

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -2884,4 +2884,40 @@ mod tests {
         let vm = app.view(&model);
         assert!(!vm.items[0].priority);
     }
+
+    #[test]
+    fn test_update_sets_item_priority() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let mut model = Model {
+            items: vec![Item {
+                id: "p1".to_string(),
+                title: "Etude".to_string(),
+                kind: ItemKind::Piece,
+                composer: None,
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+                created_at: now,
+                updated_at: now,
+                priority: false,
+            }],
+            ..Model::test_default()
+        };
+
+        let _cmd = app.update(
+            Event::Item(ItemEvent::Update {
+                id: "p1".to_string(),
+                input: crate::domain::types::UpdateItem {
+                    priority: Some(true),
+                    ..Default::default()
+                },
+            }),
+            &mut model,
+        );
+
+        assert!(model.last_error.is_none());
+        assert!(model.items[0].priority);
+    }
 }

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -38,6 +38,8 @@ pub struct Item {
     pub tags: Vec<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub priority: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -69,6 +71,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
                 tags: input.tags,
                 created_at: now,
                 updated_at: now,
+                priority: false,
             };
 
             let temp_id = item.id.clone();

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -112,6 +112,9 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             if let Some(tags) = input.tags {
                 item.tags = tags;
             }
+            if let Some(priority) = input.priority {
+                item.priority = priority;
+            }
             item.updated_at = chrono::Utc::now();
             model.last_error = None;
 

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -340,6 +340,7 @@ fn create_item_from_title(title: &str, kind: ItemKind) -> Item {
         tags: vec![],
         created_at: now,
         updated_at: now,
+        priority: false,
     }
 }
 
@@ -1264,6 +1265,7 @@ mod tests {
                     tags: vec![],
                     created_at: now,
                     updated_at: now,
+                    priority: false,
                 },
                 Item {
                     id: "piece-2".to_string(),
@@ -1276,6 +1278,7 @@ mod tests {
                     tags: vec![],
                     created_at: now,
                     updated_at: now,
+                    priority: false,
                 },
                 Item {
                     id: "exercise-1".to_string(),
@@ -1288,6 +1291,7 @@ mod tests {
                     tags: vec![],
                     created_at: now,
                     updated_at: now,
+                    priority: false,
                 },
             ],
             api_base_url: "http://localhost:3001".to_string(),

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -93,6 +93,8 @@ pub struct UpdateItem {
     )]
     pub notes: Option<Option<String>>,
     pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<bool>,
 }
 
 use super::session::PracticeSession;

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -102,6 +102,7 @@ pub fn update_item(api_base_url: &str, item: &Item) -> Command<Effect, Event> {
         tempo: Some(item.tempo.clone()),
         notes: Some(item.notes.clone()),
         tags: Some(item.tags.clone()),
+        priority: Some(item.priority),
     };
     Http::put(format!("{api_base_url}/api/items/{}", item.id))
         .body_json(&update)

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -578,6 +578,7 @@ mod tests {
             tags: vec!["scale".into(), "warmup".into()],
             created_at: fixed_time(),
             updated_at: fixed_time(),
+            priority: false,
         }
     }
 

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -332,6 +332,7 @@ pub struct LibraryItemView {
     pub updated_at: String,
     pub practice: Option<ItemPracticeSummary>,
     pub latest_achieved_tempo: Option<u16>,
+    pub priority: bool,
 }
 
 /// Practice summary for a library item.
@@ -626,6 +627,7 @@ mod tests {
             tags: vec![],
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            priority: false,
         });
         model.last_set_save_request_id = Some("req-1".to_string());
         model.reset_for_sign_out();
@@ -902,6 +904,7 @@ mod tests {
                     tempo_history: vec![],
                 }),
                 latest_achieved_tempo: Some(120),
+                priority: false,
             },
             LibraryItemView {
                 id: "item-b".to_string(),
@@ -916,6 +919,7 @@ mod tests {
                 updated_at: String::new(),
                 practice: None,
                 latest_achieved_tempo: None,
+                priority: false,
             },
         ];
 

--- a/crates/intrada-web/src/core_bridge.rs
+++ b/crates/intrada-web/src/core_bridge.rs
@@ -371,6 +371,7 @@ mod tests {
             tags: vec![],
             created_at: now,
             updated_at: now,
+            priority: false,
         };
         let _ = core.process_event(Event::DataLoaded { items: vec![item] });
         let _ = core.process_event(Event::SessionsLoaded { sessions: vec![] });

--- a/crates/intrada-web/src/helpers.rs
+++ b/crates/intrada-web/src/helpers.rs
@@ -424,6 +424,7 @@ mod tests {
             updated_at: String::new(),
             practice: None,
             latest_achieved_tempo: None,
+            priority: false,
         }
     }
 

--- a/crates/intrada-web/src/views/design_catalogue.rs
+++ b/crates/intrada-web/src/views/design_catalogue.rs
@@ -77,6 +77,7 @@ pub fn DesignCatalogue() -> impl IntoView {
         updated_at: "2025-02-01".to_string(),
         practice: None,
         latest_achieved_tempo: None,
+        priority: false,
     };
 
     let sample_exercise = LibraryItemView {
@@ -92,6 +93,7 @@ pub fn DesignCatalogue() -> impl IntoView {
         updated_at: "2025-01-20".to_string(),
         practice: None,
         latest_achieved_tempo: None,
+        priority: false,
     };
 
     let sample_minimal = LibraryItemView {
@@ -107,6 +109,7 @@ pub fn DesignCatalogue() -> impl IntoView {
         updated_at: "2025-03-01".to_string(),
         practice: None,
         latest_achieved_tempo: None,
+        priority: false,
     };
 
     let sample_long_title = LibraryItemView {
@@ -129,6 +132,7 @@ pub fn DesignCatalogue() -> impl IntoView {
         updated_at: "2025-02-20".to_string(),
         practice: None,
         latest_achieved_tempo: None,
+        priority: false,
     };
 
     let sample_set_short = SetView {

--- a/crates/intrada-web/src/views/detail.rs
+++ b/crates/intrada-web/src/views/detail.rs
@@ -90,6 +90,7 @@ pub fn DetailView() -> impl IntoView {
                         updated_at: _,
                         practice,
                         latest_achieved_tempo: _,
+                        priority: _,
                     } = item;
 
                     let indicator_type = item_kind_to_type(item_type);

--- a/crates/intrada-web/src/views/edit_form.rs
+++ b/crates/intrada-web/src/views/edit_form.rs
@@ -212,6 +212,7 @@ pub fn EditLibraryItemForm(
                                 tempo: tempo_val,
                                 notes: notes_val,
                                 tags: Some(tags_val),
+                                priority: None,
                             };
                             let event = Event::Item(ItemEvent::Update {
                                 id: item_id.clone(),

--- a/docs/superpowers/plans/2026-05-31-priority-items-phase-a.md
+++ b/docs/superpowers/plans/2026-05-31-priority-items-phase-a.md
@@ -1,0 +1,568 @@
+# Priority Items — Phase A (core + API + DB foundation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `priority` flag to library items end-to-end (Crux core + Axum API + SQLite), reusing the existing item update pipeline — without touching the web UI and without removing Goals yet.
+
+**Architecture:** `priority: bool` becomes a field on the `Item` domain type and an optional field on `UpdateItem`. Toggling reuses the existing `ItemEvent::Update → ItemUpdated` mutate-response path (no new event, endpoint, or HTTP function). The DB gets one appended column with a `DEFAULT 0`, read via positional indexing appended at the end of `SELECT_COLUMNS` so existing column indices are untouched.
+
+**Tech Stack:** Rust (crux_core 0.18, crux_http), serde, axum 0.8, libsql (Turso/SQLite), tokio.
+
+**Spec:** [`specs/priority-items.md`](../../../specs/priority-items.md). This plan implements the "Added" data-model section only; deletion of Goals and all UI are separate follow-up plans.
+
+**Reuse decision (why no new event/endpoint):** A one-tap star toggle goes through `ItemEvent::Update { id, input: UpdateItem { priority: Some(b), ..Default::default() } }`. This reuses the validated optimistic-update path, the `PUT /api/items/{id}` route, and `update_item` DB function. Per CLAUDE.md "Reuse before creating." `CreateItem` is intentionally NOT given a `priority` field — new items default to `false`; you flag existing ones.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `crates/intrada-core/src/domain/item.rs` | Modify | Add `priority: bool` to `Item`; apply it in the `Update` handler arm |
+| `crates/intrada-core/src/domain/types.rs` | Modify | Add `priority: Option<bool>` to `UpdateItem` |
+| `crates/intrada-core/src/http.rs` | Modify | Carry `priority` in the `UpdateItem` that `update_item` builds |
+| `crates/intrada-core/src/model.rs` | Modify | Add `priority: bool` to `LibraryItemView` and map it |
+| `crates/intrada-core/src/app.rs` | Modify | Tests; fix `Item { … }` literals broken by the new field |
+| `crates/intrada-api/src/migrations.rs` | Modify | Append `add_priority_to_items` migration |
+| `crates/intrada-api/src/db/items.rs` | Modify | `SELECT_COLUMNS`, `row_to_item`, `insert_item`, `update_item` |
+| `crates/intrada-api/tests/items_test.rs` | Modify | Endpoint tests: default false, toggle true, cross-user isolation |
+
+---
+
+## Task 1: Core — add `priority` field to `Item` and expose it on the view model
+
+**Files:**
+- Modify: `crates/intrada-core/src/domain/item.rs` (struct around lines 29–41)
+- Modify: `crates/intrada-core/src/model.rs` (`LibraryItemView` around lines 323–338, and its builder)
+- Test: `crates/intrada-core/src/app.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the tests module in `crates/intrada-core/src/app.rs` (alongside the existing `test_item_*` tests):
+
+```rust
+#[test]
+fn test_new_item_defaults_to_not_priority() {
+    let app = Intrada;
+    let mut model = Model::test_default();
+
+    let _cmd = app.update(
+        Event::Item(ItemEvent::Add(crate::domain::types::CreateItem {
+            title: "Prelude".to_string(),
+            kind: ItemKind::Piece,
+            composer: Some("Bach".to_string()),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        })),
+        &mut model,
+    );
+
+    assert_eq!(model.items.len(), 1);
+    assert!(!model.items[0].priority);
+
+    let vm = app.view(&model);
+    assert!(!vm.items[0].priority);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p intrada-core test_new_item_defaults_to_not_priority`
+Expected: FAIL — compile error, `Item` has no field `priority` / `LibraryItemView` has no field `priority`.
+
+- [ ] **Step 3: Add the field to `Item`**
+
+In `crates/intrada-core/src/domain/item.rs`, add `priority` as the last field of `Item`:
+
+```rust
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Item {
+    pub id: String,
+    pub title: String,
+    pub kind: ItemKind,
+    pub composer: Option<String>,
+    pub key: Option<String>,
+    pub tempo: Option<Tempo>,
+    pub notes: Option<String>,
+    pub tags: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub priority: bool,
+}
+```
+
+The `#[serde(default)]` lets older JSON (without the field) still deserialize as `false`.
+
+- [ ] **Step 4: Set `priority: false` where `Item` is built on Add**
+
+Find where `ItemEvent::Add` constructs the optimistic `Item` in `crates/intrada-core/src/domain/item.rs` (the `Add(input)` handler arm). Add `priority: false,` to that `Item { … }` literal.
+
+- [ ] **Step 5: Add the field to `LibraryItemView` and map it**
+
+In `crates/intrada-core/src/model.rs`, add to `LibraryItemView` (after `latest_achieved_tempo`):
+
+```rust
+    pub priority: bool,
+```
+
+Then locate where `LibraryItemView { … }` is constructed (grep `LibraryItemView {` across `crates/intrada-core/src/`). Add to that literal:
+
+```rust
+        priority: item.priority,
+```
+
+(`item` is the `&Item` being mapped; adjust the binding name to match the surrounding code.)
+
+- [ ] **Step 6: Fix the broken `Item { … }` literals**
+
+Adding a field breaks every `Item { … }` literal in core tests. Build and fix each one the compiler reports:
+
+Run: `cargo build -p intrada-core --tests`
+For each `missing field priority` error, add `priority: false,` to that literal. These are mechanical and identical.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cargo test -p intrada-core test_new_item_defaults_to_not_priority`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/intrada-core/src/domain/item.rs crates/intrada-core/src/model.rs crates/intrada-core/src/app.rs
+git commit -m "feat(core): add priority field to Item and LibraryItemView"
+```
+
+---
+
+## Task 2: Core — toggle priority through the existing `Update` event
+
+**Files:**
+- Modify: `crates/intrada-core/src/domain/types.rs` (`UpdateItem` around lines 69–96)
+- Modify: `crates/intrada-core/src/domain/item.rs` (`Update` handler arm around lines 83–120)
+- Test: `crates/intrada-core/src/app.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/intrada-core/src/app.rs` tests:
+
+```rust
+#[test]
+fn test_update_sets_item_priority() {
+    let app = Intrada;
+    let now = chrono::Utc::now();
+    let mut model = Model {
+        items: vec![Item {
+            id: "p1".to_string(),
+            title: "Etude".to_string(),
+            kind: ItemKind::Piece,
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+            priority: false,
+        }],
+        ..Model::test_default()
+    };
+
+    let _cmd = app.update(
+        Event::Item(ItemEvent::Update {
+            id: "p1".to_string(),
+            input: crate::domain::types::UpdateItem {
+                priority: Some(true),
+                ..Default::default()
+            },
+        }),
+        &mut model,
+    );
+
+    assert!(model.last_error.is_none());
+    assert!(model.items[0].priority);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p intrada-core test_update_sets_item_priority`
+Expected: FAIL — `UpdateItem` has no field `priority`.
+
+- [ ] **Step 3: Add `priority` to `UpdateItem`**
+
+In `crates/intrada-core/src/domain/types.rs`, add to `UpdateItem` (a plain `Option<bool>` — `priority` is not clearable, so no `double_option`):
+
+```rust
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priority: Option<bool>,
+```
+
+- [ ] **Step 4: Apply it in the `Update` handler arm**
+
+In `crates/intrada-core/src/domain/item.rs`, in the `ItemEvent::Update` arm, after the existing `if let Some(tags) = input.tags { … }` block and before `item.updated_at = …`, add:
+
+```rust
+    if let Some(priority) = input.priority {
+        item.priority = priority;
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p intrada-core test_update_sets_item_priority`
+Expected: PASS
+
+- [ ] **Step 6: Run the full core suite**
+
+Run: `cargo test -p intrada-core`
+Expected: PASS (all existing tests still green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/intrada-core/src/domain/types.rs crates/intrada-core/src/domain/item.rs crates/intrada-core/src/app.rs
+git commit -m "feat(core): toggle item priority via UpdateItem"
+```
+
+---
+
+## Task 3: Core — carry `priority` in the outbound HTTP update
+
+**Files:**
+- Modify: `crates/intrada-core/src/http.rs` (`update_item` around lines 98–119)
+
+No new test — this is covered end-to-end by the API tests in Tasks 5–7. This step keeps the optimistic update and the server write consistent.
+
+- [ ] **Step 1: Add `priority` to the `UpdateItem` built by `update_item`**
+
+In `crates/intrada-core/src/http.rs`, in `update_item`, add `priority: Some(item.priority),` to the `UpdateItem { … }` literal:
+
+```rust
+    let update = UpdateItem {
+        title: Some(item.title.clone()),
+        composer: Some(item.composer.clone()),
+        key: Some(item.key.clone()),
+        tempo: Some(item.tempo.clone()),
+        notes: Some(item.notes.clone()),
+        tags: Some(item.tags.clone()),
+        priority: Some(item.priority),
+    };
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cargo build -p intrada-core`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/intrada-core/src/http.rs
+git commit -m "feat(core): send priority in item update request"
+```
+
+---
+
+## Task 4: API — migration to add the `priority` column
+
+**Files:**
+- Modify: `crates/intrada-api/src/migrations.rs` (`MIGRATIONS` array)
+
+- [ ] **Step 1: Confirm the next migration number**
+
+Read the end of the `MIGRATIONS` array in `crates/intrada-api/src/migrations.rs`. Find the highest existing `NNNN_` prefix and use `highest + 1` (at time of writing the highest is `0079`, so the new one is `0080`). Use the actual next number you find.
+
+- [ ] **Step 2: Append the migration**
+
+Add as the LAST entry of the `MIGRATIONS` array (use the number confirmed above):
+
+```rust
+    (
+        "0080_add_priority_to_items",
+        "ALTER TABLE items ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;",
+    ),
+```
+
+- [ ] **Step 3: Verify migrations run**
+
+Run: `cargo test -p intrada-api --test items_test`
+Expected: PASS — the existing item tests run migrations on a fresh SQLite db; this confirms the new statement is valid SQL and applies cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/intrada-api/src/migrations.rs
+git commit -m "feat(api): add priority column to items table"
+```
+
+---
+
+## Task 5: API — read `priority` from the row (default-false endpoint test)
+
+**Files:**
+- Modify: `crates/intrada-api/src/db/items.rs` (`SELECT_COLUMNS` line ~69, `row_to_item` lines ~35–67, `insert_item` return ~150)
+- Test: `crates/intrada-api/tests/items_test.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/intrada-api/tests/items_test.rs`:
+
+```rust
+#[tokio::test]
+async fn created_item_defaults_to_not_priority() {
+    let app = common::setup_test_app().await;
+    let (status, body) = common::post_json(
+        app,
+        "/api/items",
+        json!({ "title": "Nocturne", "kind": "piece", "composer": "Chopin", "tags": [] }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    let item: Item = common::json(&body);
+    assert!(!item.priority);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p intrada-api --test items_test created_item_defaults_to_not_priority`
+Expected: FAIL — `Item` has no field `priority` in scope (compile error from `intrada_core::Item`), OR the field is unread. (Core already has the field from Task 1, so the failure is in `db/items.rs` not populating it.)
+
+- [ ] **Step 3: Append `priority` to `SELECT_COLUMNS`**
+
+In `crates/intrada-api/src/db/items.rs`, append `priority` LAST so existing indices stay stable:
+
+```rust
+const SELECT_COLUMNS: &str =
+    "id, kind, title, composer, key_signature, tempo_marking, tempo_bpm, notes, tags, created_at, updated_at, priority";
+```
+
+- [ ] **Step 4: Read the new column in `row_to_item`**
+
+In `row_to_item`, after reading `updated_at_str` (index 10), add index 11:
+
+```rust
+    let priority_int: i64 = col!(row, 11)?;
+```
+
+and add to the returned `Item { … }`:
+
+```rust
+        priority: priority_int != 0,
+```
+
+- [ ] **Step 5: Set `priority: false` in the `insert_item` return**
+
+`insert_item` does not write the `priority` column (it relies on `DEFAULT 0`), so its returned `Item` must reflect that. Add `priority: false,` to the `Ok(Item { … })` literal at the end of `insert_item`.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cargo test -p intrada-api --test items_test created_item_defaults_to_not_priority`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/intrada-api/src/db/items.rs crates/intrada-api/tests/items_test.rs
+git commit -m "feat(api): read item priority from items table"
+```
+
+---
+
+## Task 6: API — persist `priority` on update (toggle endpoint test)
+
+**Files:**
+- Modify: `crates/intrada-api/src/db/items.rs` (`update_item` lines ~166–239)
+- Test: `crates/intrada-api/tests/items_test.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/intrada-api/tests/items_test.rs`:
+
+```rust
+#[tokio::test]
+async fn update_toggles_item_priority() {
+    let (app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+
+    let (status, body) = common::post_json(
+        app.clone(),
+        "/api/items",
+        json!({ "title": "Gymnopedie", "kind": "piece", "composer": "Satie", "tags": [] }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let created: Item = common::json(&body);
+
+    let (status, body) = common::put_json(
+        app,
+        &format!("/api/items/{}", created.id),
+        json!({ "priority": true }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let updated: Item = common::json(&body);
+    assert!(updated.priority);
+
+    // The other fields must survive the partial update.
+    assert_eq!(updated.title, "Gymnopedie");
+    let _ = conn;
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p intrada-api --test items_test update_toggles_item_priority`
+Expected: FAIL — the response `priority` is `false` (update path ignores the field).
+
+- [ ] **Step 3: Compute `priority` in `update_item`**
+
+In `crates/intrada-api/src/db/items.rs` `update_item`, after the `let tags = input.tags.as_ref().unwrap_or(&current.tags);` line, add:
+
+```rust
+    let priority = input.priority.unwrap_or(current.priority);
+```
+
+- [ ] **Step 4: Write `priority` in the UPDATE statement**
+
+Change the `UPDATE items SET …` statement to include `priority`, shifting the WHERE bindings. Replace the existing `conn.execute(...)` SQL + params with:
+
+```rust
+    conn.execute(
+        "UPDATE items SET title = ?1, composer = ?2, key_signature = ?3, tempo_marking = ?4, tempo_bpm = ?5, notes = ?6, tags = ?7, updated_at = ?8, priority = ?9 WHERE id = ?10 AND user_id = ?11",
+        libsql::params![
+            title.as_str(),
+            composer,
+            key,
+            tempo_marking.as_deref(),
+            tempo_bpm,
+            notes,
+            tags_json.as_str(),
+            now_str.as_str(),
+            priority as i64,
+            id,
+            user_id
+        ],
+    )
+    .await?;
+```
+
+- [ ] **Step 5: Return `priority` in the updated `Item`**
+
+Add `priority,` to the `Ok(Some(Item { … }))` literal at the end of `update_item`.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cargo test -p intrada-api --test items_test update_toggles_item_priority`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/intrada-api/src/db/items.rs crates/intrada-api/tests/items_test.rs
+git commit -m "feat(api): persist item priority on update"
+```
+
+---
+
+## Task 7: API — cross-user isolation test for the priority toggle
+
+**Files:**
+- Test: `crates/intrada-api/tests/items_test.rs`
+
+This guards the CLAUDE.md requirement that DB writes test cross-user isolation. With auth disabled the harness uses a single fake user, so isolation is exercised at the DB-function level: a toggle scoped to a non-owning user must not change the row.
+
+- [ ] **Step 1: Write the failing-then-passing test**
+
+Add to `crates/intrada-api/tests/items_test.rs`. This calls the DB layer directly to assert the `user_id` scope on the UPDATE:
+
+```rust
+#[tokio::test]
+async fn update_priority_is_scoped_to_owner() {
+    use intrada_api::db::items;
+
+    let (_app, conn) = common::setup_test_app_with_conn(None, "http://localhost:3000").await;
+
+    let created = items::insert_item(
+        &conn,
+        "owner",
+        &intrada_core::domain::types::CreateItem {
+            title: "Arabesque".to_string(),
+            kind: intrada_core::domain::item::ItemKind::Piece,
+            composer: Some("Debussy".to_string()),
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = items::update_item(
+        &conn,
+        &created.id,
+        "intruder",
+        &intrada_core::domain::types::UpdateItem {
+            priority: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(result.is_none(), "non-owner update must not match the row");
+
+    let still = items::get_item(&conn, &created.id, "owner").await.unwrap().unwrap();
+    assert!(!still.priority, "owner's row must be unchanged");
+}
+```
+
+> Confirm the exact public paths (`intrada_api::db::items::{insert_item, update_item, get_item}`) compile; if `db` is not re-exported from the crate root, adjust the `use` to the actual module path. `update_item` returns `Option<Item>` (`None` when no row matches the id+user_id) per `db/items.rs`.
+
+- [ ] **Step 2: Run test**
+
+Run: `cargo test -p intrada-api --test items_test update_priority_is_scoped_to_owner`
+Expected: PASS (the `WHERE … AND user_id = ?` scope already enforces this; this test locks it in).
+
+- [ ] **Step 3: Run the full API suite + clippy + fmt**
+
+Run:
+```bash
+cargo test -p intrada-api
+cargo clippy -p intrada-api -p intrada-core -- -D warnings
+cargo fmt --check
+```
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/intrada-api/tests/items_test.rs
+git commit -m "test(api): cross-user isolation for item priority toggle"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] `cargo fmt --check` passes
+- [ ] `cargo clippy -- -D warnings` passes for the touched crates
+- [ ] `cargo test -p intrada-core` passes
+- [ ] `cargo test -p intrada-api` passes
+- [ ] Goals still build and work (this plan does not remove them)
+- [ ] The `specs/priority-items.md` spec is included as the first commit on this branch (Tier-3 spec rides with Phase A per CLAUDE.md)
+
+## Coverage (for the PR description)
+
+Coverage: full — new core behaviour has unit tests (default-false, toggle-via-update); new API behaviour has endpoint tests (default-false, toggle, cross-user isolation). `migrations.rs` is in the Codecov ignore list (SQL strings).
+
+## Out of scope (tracked for follow-up plans)
+
+- **Plan 2** — atomic Goals rip-out across core + API + web; remove the `goals` feature flag.
+- **Plan 3** — priority UI: star toggle, Library priority section, "Practise your priorities" (re-points the salvaged `order_goal_items_least_ready_first` ordering), Library-as-landing.
+- **Plan 4** — Track "neglected priority" signal.

--- a/specs/priority-items.md
+++ b/specs/priority-items.md
@@ -1,0 +1,146 @@
+# Priority Items — replacing Goals in the Plan layer
+
+> Tier 3 (rips out a core entity + DB schema). Spec rides with the Phase A
+> branch per CLAUDE.md. Supersedes `specs/goals.md` and resolves roadmap
+> open question #5 ("Goals redesign").
+
+## Problem
+
+Goals were meant to answer "what should I work on, and why?" — the Plan
+layer's reason to exist. In practice the feature became too heavy *from a
+user's perspective*:
+
+- **Setup burden before value.** To get anything back you had to create a
+  goal, link items, and set targets — admin before you're allowed to just
+  practise.
+- **Conceptual overload.** Goals stacked goals + linked items + per-item
+  confidence *and* tempo targets + deadlines + completion + photos. The
+  user has to hold a data model in their head.
+
+The underlying job is real — a musician benefits from a sense of direction
+before the instrument comes out — but it should be **nearly free to
+express, not a form to fill in**. Goals are already parked behind a feature
+flag and flagged in the roadmap for a "ground-up rethink"; this spec is
+that rethink.
+
+## Approach: direction is a flag on items, not an entity
+
+"Direction" becomes a **priority flag on library items you already own**.
+The Plan surface becomes a *view over the library*, not a thing you create
+and manage. This dissolves both complaints at once: nothing to set up (you
+flag a piece you already have), and no new data model (one boolean on an
+existing thing).
+
+### Data model
+
+One field on the existing `Item`:
+
+```rust
+pub priority: bool,   // "I'm working on this"
+```
+
+A column on the existing `items` table; one field on `Item` / `ItemView`.
+Binary on/off — no levels, no manual ordering. (Ordering can come later
+*only if* flagging many items proves too flat. YAGNI until then.)
+
+### What gets deleted
+
+The entire heavy goal surface:
+
+- `Goal`, `GoalStatus`, `GoalItem`, `GoalPhoto` types + the
+  `goals` / `goal_items` / `goal_photos` tables.
+- All goal events (`Add/Update/Complete/Reopen/Delete/LinkItem/
+  UnlinkItem/UpdateGoalItemTargets`).
+- Goal views: list, detail, create form, edit form, item-targets sheet,
+  link-items sheet.
+- `/goals/*` routes and the **Goals tab** in the bottom bar.
+- Per-item **targets** (confidence + tempo), **deadlines**,
+  **completion/reopen**, **goal photos**, the auto-suggest "looks ready"
+  banner.
+- The `goals` feature flag (the flag *framework* stays — it's freshly
+  built and useful — only the `goals` flag is removed).
+
+### What gets salvaged
+
+The two genuinely good things buried inside goals, re-pointed at the
+priority set:
+
+- **Least-ready-first ordering** (from "Practise this goal") → orders the
+  priority items for a session.
+- **Per-item progress derivation** (`latest_score`, `latest_achieved_tempo`
+  over session data) → shows how a priority item is going. Already a
+  view-model computation; stays as-is.
+
+## How priority wires into the loop
+
+The flag must do more than sort, or it doesn't pull its weight. Three
+touchpoints:
+
+- **Plan** — Library becomes the default landing surface (Goals tab is
+  gone). Priority items get a pinned, collapsible "Priorities" section at
+  the top of the library (or a Priority filter in `LibraryTypeTabs` on
+  longer libraries). No new screen.
+- **Practice** — A one-tap **"Practise your priorities"** loads all flagged
+  items into the session builder, least-ready-first. Replaces "Practise
+  this goal" one-to-one.
+- **Track** — Exactly one new signal: **"a priority piece you haven't
+  practised in N days"** — a neglect nudge linking straight back into a
+  session. Deliberately scoped to one signal; the broader analytics rethink
+  is separate.
+
+### Naming
+
+**"Priority"**, shown as a **star** on each item. "Focus" was rejected — it
+collides with Practice's Focus mode.
+
+## Key decisions
+
+1. **No entity.** Direction is a property of items, not a container. This
+   is the whole point — it removes the create/manage lifecycle.
+2. **Rip out, don't migrate.** Goals are behind a feature flag with no
+   meaningful production data, so we delete the tables rather than convert
+   goals → priority flags. (If real goal data turns up on a dev account, a
+   one-shot "flag all linked items as priority, then drop" migration is the
+   fallback.)
+3. **Library is the front door.** With Goals gone, Library is the default
+   landing surface. Plan = a well-organised library with a priority view on
+   top.
+4. **Ship without its own flag.** Priority is small and safe; it ships
+   directly. The feature-flag framework stays for future use.
+
+## Deliberately not doing (v1)
+
+- **Deadlines / "by when".** The old goals had target dates + overdue
+  badges; priority has no time concept. A musician prepping for a dated
+  exam loses the "due" framing. Accepted as the cost of killing the
+  ceremony — revisit only if it bites.
+- **Targets** (confidence/tempo as goals). Progress is still *derived* and
+  shown, but the user no longer sets targets to hit.
+- **Grouping priorities into named pursuits** (the "light container" idea).
+  Explicitly deferred; only revisit if a flat priority list proves
+  insufficient.
+
+## Open questions
+
+- Pinned section vs. filter for the priority view — decide during UI build
+  against a realistic library length.
+- The "N days" threshold for the neglect nudge — pick a sensible default
+  (e.g. 7) and make it a constant, not a setting.
+
+## Rollout
+
+- **Phase A** — core + API + DB: add `priority` to `Item`, the toggle
+  event, the column migration; delete the goal tables/types/events/routes;
+  remove the `goals` flag. Spec rides on this branch.
+- **Phase B** — web/iOS UI: star toggle on items, the priority view in
+  Library, "Practise your priorities", Library-as-landing.
+- **Phase C** — the one Track neglect signal.
+
+## Testing
+
+- **Core (TDD):** the `priority` toggle event; the priority-set ordering
+  (reuse least-ready-first tests).
+- **API:** the column migration; the toggle endpoint with auth-rejection +
+  cross-user isolation.
+- **Web/iOS:** preview-driven verification of the star toggle, the pinned
+  priority section, and "Practise your priorities".


### PR DESCRIPTION
## What

Phase A of replacing the heavy **Goals** feature with a lightweight per-item **priority** flag — the foundation only: a pure *addition* across `intrada-core` and `intrada-api`. **Goals are untouched and still work**; the rip-out and UI follow as separate PRs.

Spec rides with this PR: [`specs/priority-items.md`](specs/priority-items.md) (Tier 3). Plan: [`docs/superpowers/plans/2026-05-31-priority-items-phase-a.md`](docs/superpowers/plans/2026-05-31-priority-items-phase-a.md).

## Why

Goals became too heavy from a user's perspective — setup burden before value, and too many nested concepts (linked items, per-item confidence + tempo targets, deadlines, completion). The rethink (roadmap open question #5): direction becomes a **flag on items you already own**, not an entity you create and manage. "Plan" becomes a view over the library.

## Changes

- **core**: `priority: bool` on `Item` (+ `#[serde(default)]`) and `LibraryItemView`; `priority: Option<bool>` on `UpdateItem`; applied in the `ItemEvent::Update` handler and carried in `http::update_item`. Reuses the existing update→`ItemUpdated` mutate-response path — **no new event, endpoint, or HTTP fn**. `CreateItem` unchanged (new items default `false`).
- **api**: append-only migration (`0080`, `INTEGER NOT NULL DEFAULT 0`); `priority` appended last to `SELECT_COLUMNS` (positional indices unchanged); read in `row_to_item`; persisted in `update_item`.

## Design calls

- **Reuse over new**: a one-tap star = `Update { priority: Some(true) }` through the existing pipeline.
- **Append-only** column + `SELECT_COLUMNS` entry so existing readers and migration history don't shift; existing rows backfill to `false`.

## Testing

TDD at both layers: core (default-false, toggle-via-update) and API (default-false, PUT toggle round-trip preserving other fields, cross-user isolation). Full suites green: core 386, API 218. `fmt` + `clippy -D warnings` clean.

**Coverage**: full — new core + API behaviour each has unit/endpoint tests; `migrations.rs` is in the Codecov ignore list (SQL strings).

## Follow-ups (tracked)

- #762 — Plan 2: atomic Goals rip-out + remove the `goals` flag
- #763 — Plan 3: priority UI (star, Library section, "Practise your priorities")
- #764 — Plan 4: Track "neglected priority" signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)