### PR TITLE
design(pencil): light-mode paper exploration + type-language notes

### DIFF
--- a/design/intrada.pen
+++ b/design/intrada.pen
@@ -1,5 +1,5 @@
 {
-  "version": "2.11",
+  "version": "2.13",
   "children": [
     {
       "type": "frame",
@@ -493,12 +493,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -822,10 +821,9 @@
                       "width": "fill_container",
                       "fill": "$surface-primary",
                       "cornerRadius": "$radius-card",
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "$border-card"
-                      },
+                      "stroke": "$border-card",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "effect": {
                         "type": "background_blur",
                         "radius": 12
@@ -892,13 +890,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "Py67c",
                                   "name": "Status",
                                   "width": 14,
                                   "height": 14,
-                                  "iconFontName": "check",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "check",
+                                  "library": "lucide",
                                   "fill": "$success-text"
                                 },
                                 {
@@ -957,13 +955,13 @@
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "icon_font",
+                                  "type": "icon",
                                   "id": "yFgOv",
                                   "name": "Status",
                                   "width": 14,
                                   "height": 14,
-                                  "iconFontName": "check",
-                                  "iconFontFamily": "lucide",
+                                  "icon": "check",
+                                  "library": "lucide",
                                   "fill": "$success-text"
                                 },
                                 {
@@ -1014,12 +1012,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -1268,10 +1265,9 @@
                   "width": "fill_container",
                   "fill": "$surface-primary",
                   "cornerRadius": "$radius-card",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-card"
-                  },
+                  "stroke": "$border-card",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "effect": {
                     "type": "background_blur",
                     "radius": 12
@@ -1308,10 +1304,9 @@
                           "geometry": "M0 120c40-10 80-20 120-40 40-20 80 10 120-10 40-20 80-40 120-30 40 10 80 40 120 20 40-20 80-40 120-30 40 10 80 40 120 20 40-20 80-10 140-30",
                           "width": 860,
                           "height": 160,
-                          "stroke": {
-                            "thickness": 2,
-                            "fill": "$accent-focus"
-                          }
+                          "stroke": "$accent-focus",
+                          "strokeWidth": 2,
+                          "strokeAlignment": "inner"
                         },
                         {
                           "type": "path",
@@ -1360,10 +1355,9 @@
                       "width": "fill_container",
                       "fill": "$surface-primary",
                       "cornerRadius": "$radius-card",
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "$border-card"
-                      },
+                      "stroke": "$border-card",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "effect": {
                         "type": "background_blur",
                         "radius": 12
@@ -1471,10 +1465,9 @@
                       "width": "fill_container",
                       "fill": "$surface-primary",
                       "cornerRadius": "$radius-card",
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "$border-card"
-                      },
+                      "stroke": "$border-card",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "effect": {
                         "type": "background_blur",
                         "radius": 12
@@ -1567,12 +1560,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -1914,12 +1906,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -2590,12 +2581,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -4504,10 +4494,9 @@
                               "height": 48,
                               "fill": "$surface-primary",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 1,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -4537,10 +4526,9 @@
                               "height": 48,
                               "fill": "$surface-secondary",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 1,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -4570,10 +4558,9 @@
                               "height": 48,
                               "fill": "$surface-chrome",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 1,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -4603,10 +4590,9 @@
                               "height": 48,
                               "fill": "$surface-hover",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 1,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -4636,10 +4622,9 @@
                               "height": 48,
                               "fill": "$surface-input",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 1,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -5271,10 +5256,9 @@
                               "height": 48,
                               "fill": "#00000000",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 2,
-                                "fill": "$border-default"
-                              }
+                              "stroke": "$border-default",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -5304,10 +5288,9 @@
                               "height": 48,
                               "fill": "#00000000",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 2,
-                                "fill": "$border-card"
-                              }
+                              "stroke": "$border-card",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -5337,10 +5320,9 @@
                               "height": 48,
                               "fill": "#00000000",
                               "cornerRadius": 8,
-                              "stroke": {
-                                "thickness": 2,
-                                "fill": "$border-input"
-                              }
+                              "stroke": "$border-input",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "inner"
                             },
                             {
                               "type": "text",
@@ -7028,14 +7010,14 @@
                       "width": "fill_container",
                       "name": "err1",
                       "height": "fit_content",
-                      "y": 698,
+                      "y": 706,
                       "descendants": {
                         "ElKXA": {
                           "x": 16,
-                          "y": 12
+                          "y": 15.5
                         },
                         "nGIII": {
-                          "x": 870,
+                          "x": 867,
                           "y": 12
                         }
                       }
@@ -8596,10 +8578,10 @@
                           "descendants": {
                             "ElKXA": {
                               "x": 16,
-                              "y": 12
+                              "y": 15.5
                             },
                             "nGIII": {
-                              "x": 870,
+                              "x": 867,
                               "y": 12
                             }
                           }
@@ -8610,7 +8592,7 @@
                           "ref": "Kr2Jm",
                           "name": "fe1",
                           "x": 0,
-                          "y": 53,
+                          "y": 60,
                           "width": "fit_content",
                           "height": "fit_content",
                           "descendants": {
@@ -9151,10 +9133,9 @@
                                           "height": 40,
                                           "fill": "$surface-input",
                                           "cornerRadius": "$radius-input",
-                                          "stroke": {
-                                            "thickness": 1,
-                                            "fill": "$border-input"
-                                          },
+                                          "stroke": "$border-input",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
                                           "gap": 6,
                                           "padding": [
                                             0,
@@ -9212,10 +9193,9 @@
                                           "height": 40,
                                           "fill": "$surface-input",
                                           "cornerRadius": "$radius-input",
-                                          "stroke": {
-                                            "thickness": 1,
-                                            "fill": "$border-input"
-                                          },
+                                          "stroke": "$border-input",
+                                          "strokeWidth": 1,
+                                          "strokeAlignment": "inner",
                                           "gap": 6,
                                           "padding": [
                                             0,
@@ -9629,12 +9609,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -10023,12 +10002,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -10272,12 +10250,11 @@
                           "id": "bsmpj",
                           "name": "item1",
                           "width": "fill_container",
-                          "stroke": {
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "#ffffff0d"
+                          "stroke": "#ffffff0d",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "layout": "vertical",
                           "gap": 10,
                           "padding": [
@@ -10559,12 +10536,11 @@
                           "id": "RSKmv",
                           "name": "item2",
                           "width": "fill_container",
-                          "stroke": {
-                            "thickness": {
-                              "bottom": 1
-                            },
-                            "fill": "#ffffff0d"
+                          "stroke": "#ffffff0d",
+                          "strokeWidth": {
+                            "bottom": 1
                           },
+                          "strokeAlignment": "inner",
                           "layout": "vertical",
                           "gap": 10,
                           "padding": [
@@ -10883,7 +10859,7 @@
                                   "name": "item3badge",
                                   "width": "fit_content",
                                   "height": "fit_content",
-                                  "x": 188,
+                                  "x": 182,
                                   "descendants": {
                                     "UcUpV": {
                                       "x": 10,
@@ -10916,7 +10892,7 @@
                   "width": "fill_container",
                   "name": "notesCard",
                   "height": "fit_content",
-                  "y": 670,
+                  "y": 676,
                   "children": [
                     {
                       "id": "DxFjV",
@@ -10996,12 +10972,11 @@
           "name": "Footer",
           "width": "fill_container",
           "height": 40,
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "justifyContent": "center",
           "alignItems": "center",
           "children": [
@@ -11388,10 +11363,9 @@
                                   "height": 36,
                                   "fill": "$surface-input",
                                   "cornerRadius": "$radius-input",
-                                  "stroke": {
-                                    "thickness": 1,
-                                    "fill": "$border-input"
-                                  },
+                                  "stroke": "$border-input",
+                                  "strokeWidth": 1,
+                                  "strokeAlignment": "inner",
                                   "gap": 4,
                                   "padding": [
                                     0,
@@ -11429,10 +11403,9 @@
                                   "height": 36,
                                   "fill": "$surface-input",
                                   "cornerRadius": "$radius-input",
-                                  "stroke": {
-                                    "thickness": 1,
-                                    "fill": "$border-input"
-                                  },
+                                  "stroke": "$border-input",
+                                  "strokeWidth": 1,
+                                  "strokeAlignment": "inner",
                                   "gap": 4,
                                   "padding": [
                                     0,
@@ -12818,10 +12791,9 @@
           "height": 44,
           "fill": "$surface-primary",
           "cornerRadius": "$radius-button",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "padding": [
             0,
             16
@@ -12876,10 +12848,9 @@
           "height": 44,
           "fill": "#00000000",
           "cornerRadius": "$radius-button",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$danger"
-          },
+          "stroke": "$danger",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "padding": [
             0,
             16
@@ -12934,10 +12905,9 @@
           "width": "fit_content(400)",
           "fill": "$surface-primary",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13023,10 +12993,9 @@
               "height": 40,
               "fill": "$surface-input",
               "cornerRadius": "$radius-input",
-              "stroke": {
-                "thickness": 1,
-                "fill": "$border-input"
-              },
+              "stroke": "$border-input",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "padding": [
                 0,
                 12
@@ -13083,10 +13052,9 @@
               "height": 80,
               "fill": "$surface-input",
               "cornerRadius": "$radius-input",
-              "stroke": {
-                "thickness": 1,
-                "fill": "$border-input"
-              },
+              "stroke": "$border-input",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "padding": [
                 8,
@@ -13166,10 +13134,9 @@
           "reusable": true,
           "fill": "$surface-primary",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13250,10 +13217,9 @@
           "reusable": true,
           "fill": "$surface-primary",
           "cornerRadius": "$radius-pill",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-default"
-          },
+          "stroke": "$border-default",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "padding": [
             4,
             10
@@ -13281,12 +13247,11 @@
           "width": "fill_container",
           "height": 56,
           "fill": "$surface-chrome",
-          "stroke": {
-            "thickness": {
-              "bottom": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "bottom": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13387,12 +13352,11 @@
           "width": "fill_container",
           "height": 60,
           "fill": "$surface-chrome",
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13413,13 +13377,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "56m4f",
                   "name": "Icon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -13443,13 +13407,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "kLnRa",
                   "name": "Icon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "timer",
-                  "iconFontFamily": "lucide",
+                  "icon": "timer",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -13473,13 +13437,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "tlAMN",
                   "name": "Icon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "list",
-                  "iconFontFamily": "lucide",
+                  "icon": "list",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -13503,13 +13467,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "tBV3Y",
                   "name": "Icon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "target",
-                  "iconFontFamily": "lucide",
+                  "icon": "target",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -13533,13 +13497,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "8QKGl",
                   "name": "Icon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "chart-bar",
-                  "iconFontFamily": "lucide",
+                  "icon": "chart-bar",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -13564,10 +13528,9 @@
           "width": "fill_container",
           "fill": "$surface-primary",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13733,12 +13696,11 @@
           "reusable": true,
           "fill": "$success-surface",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": {
-              "left": 3
-            },
-            "fill": "$success"
+          "stroke": "$success",
+          "strokeWidth": {
+            "left": 3
           },
+          "strokeAlignment": "inner",
           "gap": 8,
           "padding": [
             12,
@@ -13747,13 +13709,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "Zs8zy",
               "name": "Icon",
               "width": 18,
               "height": 18,
-              "iconFontName": "circle-check",
-              "iconFontFamily": "lucide",
+              "icon": "circle-check",
+              "library": "lucide",
               "fill": "$success-text"
             },
             {
@@ -13813,10 +13775,9 @@
           "width": "fill_container",
           "fill": "$surface-primary",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -13943,10 +13904,9 @@
                       "width": 32,
                       "height": 32,
                       "cornerRadius": "$radius-pill",
-                      "stroke": {
-                        "thickness": 2,
-                        "fill": "$accent-focus"
-                      },
+                      "stroke": "$accent-focus",
+                      "strokeWidth": 2,
+                      "strokeAlignment": "inner",
                       "justifyContent": "center",
                       "alignItems": "center",
                       "children": [
@@ -14220,33 +14180,33 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "jI3ie",
                   "name": "signal",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "signal_cellular_alt",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "signal_cellular_alt",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "Fa6Dy",
                   "name": "wifi",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "wifi",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "wifi",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "JIN9A",
                   "name": "battery",
                   "width": 22,
                   "height": 16,
-                  "iconFontName": "battery_full",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "battery_full",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 }
               ]
@@ -14278,13 +14238,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "fypZq",
                   "name": "TrailingIcon",
                   "width": 24,
                   "height": 24,
-                  "iconFontName": "person",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "person",
+                  "library": "Material Symbols Rounded",
                   "fill": "$accent-text"
                 }
               ]
@@ -14309,12 +14269,11 @@
           "width": "fill_container",
           "height": 83,
           "fill": "$surface-chrome",
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -14337,13 +14296,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "VADIu",
                   "name": "Icon",
                   "width": 22,
                   "height": 22,
-                  "iconFontName": "book-open",
-                  "iconFontFamily": "lucide",
+                  "icon": "book-open",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -14368,13 +14327,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "IJFQW",
                   "name": "Icon",
                   "width": 22,
                   "height": 22,
-                  "iconFontName": "circle-play",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-play",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -14399,13 +14358,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "uYq1m",
                   "name": "Icon",
                   "width": 22,
                   "height": 22,
-                  "iconFontName": "list",
-                  "iconFontFamily": "lucide",
+                  "icon": "list",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -14430,13 +14389,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "EpCnU",
                   "name": "Icon",
                   "width": 22,
                   "height": 22,
-                  "iconFontName": "trending-up",
-                  "iconFontFamily": "lucide",
+                  "icon": "trending-up",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 },
                 {
@@ -14462,13 +14421,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "Cjbio",
               "name": "Icon",
               "width": 14,
               "height": 14,
-              "iconFontName": "circle-alert",
-              "iconFontFamily": "lucide",
+              "icon": "circle-alert",
+              "library": "lucide",
               "fill": "$danger-text"
             },
             {
@@ -14512,12 +14471,11 @@
           "reusable": true,
           "fill": "#4A8AD81A",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": {
-              "left": 3
-            },
-            "fill": "$info"
+          "stroke": "$info",
+          "strokeWidth": {
+            "left": 3
           },
+          "strokeAlignment": "inner",
           "gap": 8,
           "padding": [
             12,
@@ -14526,13 +14484,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "M8Vbh",
               "name": "Icon",
               "width": 18,
               "height": 18,
-              "iconFontName": "info",
-              "iconFontFamily": "lucide",
+              "icon": "info",
+              "library": "lucide",
               "fill": "$info-text"
             },
             {
@@ -14554,12 +14512,11 @@
           "reusable": true,
           "fill": "#D4920E1A",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": {
-              "left": 3
-            },
-            "fill": "$warning"
+          "stroke": "$warning",
+          "strokeWidth": {
+            "left": 3
           },
+          "strokeAlignment": "inner",
           "gap": 8,
           "padding": [
             12,
@@ -14568,13 +14525,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "EVdny",
               "name": "Icon",
               "width": 18,
               "height": 18,
-              "iconFontName": "triangle-alert",
-              "iconFontFamily": "lucide",
+              "icon": "triangle-alert",
+              "library": "lucide",
               "fill": "$warning-text"
             },
             {
@@ -14596,12 +14553,11 @@
           "reusable": true,
           "fill": "$danger-surface",
           "cornerRadius": "$radius-card",
-          "stroke": {
-            "thickness": {
-              "left": 3
-            },
-            "fill": "$danger"
+          "stroke": "$danger",
+          "strokeWidth": {
+            "left": 3
           },
+          "strokeAlignment": "inner",
           "gap": 8,
           "padding": [
             12,
@@ -14610,13 +14566,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "b2VIi",
               "name": "Icon",
               "width": 18,
               "height": 18,
-              "iconFontName": "circle-x",
-              "iconFontFamily": "lucide",
+              "icon": "circle-x",
+              "library": "lucide",
               "fill": "$danger-text"
             },
             {
@@ -14656,13 +14612,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "yXLli",
               "name": "MusicIcon",
               "width": 48,
               "height": 48,
-              "iconFontName": "music",
-              "iconFontFamily": "lucide",
+              "icon": "music",
+              "library": "lucide",
               "fill": "$accent"
             },
             {
@@ -14717,13 +14673,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "3sskX",
                   "name": "PersonIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "person",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "person",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
@@ -14820,7 +14776,7 @@
               "x": 337,
               "y": 10,
               "fill": "$accent-text",
-              "iconFontName": "add"
+              "icon": "add"
             },
             "jKTX8": {
               "x": 16,
@@ -15189,13 +15145,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "6j6kh",
               "name": "picon",
               "width": 48,
               "height": 48,
-              "iconFontName": "circle-play",
-              "iconFontFamily": "lucide",
+              "icon": "circle-play",
+              "library": "lucide",
               "fill": "$text-faint"
             },
             {
@@ -15385,13 +15341,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "1IiQK",
               "name": "ricon",
               "width": 48,
               "height": 48,
-              "iconFontName": "list",
-              "iconFontFamily": "lucide",
+              "icon": "list",
+              "library": "lucide",
               "fill": "$text-faint"
             },
             {
@@ -15581,13 +15537,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "G45zg",
               "name": "aicon",
               "width": 48,
               "height": 48,
-              "iconFontName": "trending-up",
-              "iconFontFamily": "lucide",
+              "icon": "trending-up",
+              "library": "lucide",
               "fill": "$text-faint"
             },
             {
@@ -15756,9 +15712,9 @@
             },
             "fypZq": {
               "x": 319,
-              "iconFontName": "add",
               "fill": "$accent-text",
-              "y": 10
+              "y": 10,
+              "icon": "add"
             },
             "jKTX8": {
               "content": "Library",
@@ -16156,13 +16112,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "GfzTm",
                   "name": "backIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "chevron-left",
-                  "iconFontFamily": "lucide",
+                  "icon": "chevron-left",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -16992,10 +16948,9 @@
                   "width": "fill_container",
                   "fill": "$surface-input",
                   "cornerRadius": "$radius-input",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-input"
-                  },
+                  "stroke": "$border-input",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": 8,
                   "children": [
@@ -17411,10 +17366,9 @@
                   "width": "fill_container",
                   "fill": "$surface-input",
                   "cornerRadius": "$radius-input",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-input"
-                  },
+                  "stroke": "$border-input",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 6,
                   "padding": 8,
                   "children": [
@@ -17606,12 +17560,11 @@
           "width": 380,
           "height": "fill_container",
           "fill": "$surface-secondary",
-          "stroke": {
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -17729,14 +17682,15 @@
                   "ref": "jdZ0z",
                   "width": "fill_container",
                   "fill": "$surface-hover",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$accent"
-                  },
+                  "stroke": "$accent",
                   "name": "sc1",
                   "x": 12,
                   "y": 75,
                   "height": "fit_content",
+                  "strokeWidth": 1,
+                  "strokeLinejoin": "miter",
+                  "strokeLinecap": "butt",
+                  "strokeAlignment": "inner",
                   "descendants": {
                     "O6ddV": {
                       "width": "fit_content",
@@ -18721,12 +18675,11 @@
           "width": 380,
           "height": "fill_container",
           "fill": "$surface-secondary",
-          "stroke": {
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -19403,12 +19356,11 @@
           "width": 380,
           "height": "fill_container",
           "fill": "$surface-secondary",
-          "stroke": {
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -19526,14 +19478,15 @@
                   "ref": "jdZ0z",
                   "width": "fill_container",
                   "fill": "$surface-hover",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$accent"
-                  },
+                  "stroke": "$accent",
                   "name": "lc1",
                   "x": 12,
                   "y": 75,
                   "height": "fit_content",
+                  "strokeWidth": 1,
+                  "strokeLinejoin": "miter",
+                  "strokeLinecap": "butt",
+                  "strokeAlignment": "inner",
                   "descendants": {
                     "O6ddV": {
                       "width": "fit_content",
@@ -20456,13 +20409,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "fJ2oR",
               "name": "backIcon",
               "width": 20,
               "height": 20,
-              "iconFontName": "chevron-left",
-              "iconFontFamily": "lucide",
+              "icon": "chevron-left",
+              "library": "lucide",
               "fill": "$accent-text"
             },
             {
@@ -20519,10 +20472,9 @@
               "height": 36,
               "fill": "$surface-input",
               "cornerRadius": "$radius-input",
-              "stroke": {
-                "thickness": 1,
-                "fill": "$border-input"
-              },
+              "stroke": "$border-input",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "gap": 8,
               "padding": [
                 0,
@@ -20531,13 +20483,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "ElrSn",
                   "name": "searchIcon",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "search",
-                  "iconFontFamily": "lucide",
+                  "icon": "search",
+                  "library": "lucide",
                   "fill": "$text-faint"
                 },
                 {
@@ -20571,12 +20523,11 @@
               "id": "kW2Mb",
               "name": "Row1-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -20640,13 +20591,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "12w0u",
                   "name": "check1",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -20656,12 +20607,11 @@
               "id": "fSf4l",
               "name": "Row2-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -20725,13 +20675,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "2FaWF",
                   "name": "check2",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -20741,12 +20691,11 @@
               "id": "Z5T3X",
               "name": "Row3-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -20810,13 +20759,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "gsjk5",
                   "name": "plus3",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -20826,12 +20775,11 @@
               "id": "CdLJr",
               "name": "Row4-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -20895,13 +20843,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "R12Ql",
                   "name": "plus4",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -20911,12 +20859,11 @@
               "id": "aQnFZ",
               "name": "Row5-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -20980,13 +20927,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "i2CsC",
                   "name": "plus5",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -20996,12 +20943,11 @@
               "id": "WIiEP",
               "name": "Row6-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -21065,13 +21011,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "IJudV",
                   "name": "plus6",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -21081,12 +21027,11 @@
               "id": "YhOdd",
               "name": "Row7-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -21150,13 +21095,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "2x8Uj",
                   "name": "check7",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -21169,12 +21114,11 @@
           "name": "StickyBottomBar",
           "width": "fill_container",
           "fill": "$surface-chrome",
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -21244,13 +21188,13 @@
                   "fontWeight": "600"
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "mhAXp",
                   "name": "startArrow",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "arrow-right",
-                  "iconFontFamily": "lucide",
+                  "icon": "arrow-right",
+                  "library": "lucide",
                   "fill": "$text-primary"
                 }
               ]
@@ -21298,12 +21242,11 @@
           "name": "LeftColumn",
           "width": 420,
           "height": "fill_container",
-          "stroke": {
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -21346,13 +21289,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "LDiNy",
                   "name": "leftBackIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "chevron-left",
-                  "iconFontFamily": "lucide",
+                  "icon": "chevron-left",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -21407,10 +21350,9 @@
                   "height": 36,
                   "fill": "$surface-input",
                   "cornerRadius": "$radius-input",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-input"
-                  },
+                  "stroke": "$border-input",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 8,
                   "padding": [
                     0,
@@ -21419,13 +21361,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "wR0pg",
                       "name": "leftSearchIcon",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "search",
-                      "iconFontFamily": "lucide",
+                      "icon": "search",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -21459,12 +21401,11 @@
                   "id": "36Dlx",
                   "name": "LR1-Selected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21528,13 +21469,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "5qsFc",
                       "name": "lc1",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "circle-check",
-                      "iconFontFamily": "lucide",
+                      "icon": "circle-check",
+                      "library": "lucide",
                       "fill": "$accent-text"
                     }
                   ]
@@ -21544,12 +21485,11 @@
                   "id": "XdDS7",
                   "name": "LR2-Selected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21613,13 +21553,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "xthQL",
                       "name": "lc2",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "circle-check",
-                      "iconFontFamily": "lucide",
+                      "icon": "circle-check",
+                      "library": "lucide",
                       "fill": "$accent-text"
                     }
                   ]
@@ -21629,12 +21569,11 @@
                   "id": "01cy3",
                   "name": "LR3-Unselected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21698,13 +21637,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "O2dOU",
                       "name": "lp3",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -21714,12 +21653,11 @@
                   "id": "meD5P",
                   "name": "LR4-Unselected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21783,13 +21721,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "hd8YE",
                       "name": "lp4",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -21799,12 +21737,11 @@
                   "id": "cKkoV",
                   "name": "LR5-Unselected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21868,13 +21805,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "2LzoR",
                       "name": "lp5",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "plus",
-                      "iconFontFamily": "lucide",
+                      "icon": "plus",
+                      "library": "lucide",
                       "fill": "$text-muted"
                     }
                   ]
@@ -21884,12 +21821,11 @@
                   "id": "5qX9O",
                   "name": "LR6-Selected",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     12,
@@ -21953,13 +21889,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "oKk6r",
                       "name": "lc6",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "circle-check",
-                      "iconFontFamily": "lucide",
+                      "icon": "circle-check",
+                      "library": "lucide",
                       "fill": "$accent-text"
                     }
                   ]
@@ -22044,10 +21980,9 @@
                   "height": 40,
                   "fill": "$surface-input",
                   "cornerRadius": "$radius-input",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-input"
-                  },
+                  "stroke": "$border-input",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "padding": [
                     0,
                     12
@@ -22117,12 +22052,11 @@
                   "id": "uBtqt",
                   "name": "RE1",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     12,
@@ -22131,13 +22065,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "NTpwp",
                       "name": "rd1",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -22187,13 +22121,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "yuVLz",
                       "name": "rx1",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -22203,12 +22137,11 @@
                   "id": "6eHFp",
                   "name": "RE2",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     12,
@@ -22217,13 +22150,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "HwVn2",
                       "name": "rd2",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -22273,13 +22206,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "5rnqZ",
                       "name": "rx2",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -22289,12 +22222,11 @@
                   "id": "fWQR6",
                   "name": "RE3",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     12,
@@ -22303,13 +22235,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Q2zHg",
                       "name": "rd3",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -22359,13 +22291,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "pO6dO",
                       "name": "rx3",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -22431,13 +22363,13 @@
                       "fontWeight": "600"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "5dOI7",
                       "name": "startArrow",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "arrow-right",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-right",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     }
                   ]
@@ -22524,13 +22456,13 @@
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "iz9Om",
               "name": "backIcon",
               "width": 20,
               "height": 20,
-              "iconFontName": "chevron-left",
-              "iconFontFamily": "lucide",
+              "icon": "chevron-left",
+              "library": "lucide",
               "fill": "$accent-text"
             },
             {
@@ -22591,10 +22523,9 @@
               "height": 36,
               "fill": "$surface-input",
               "cornerRadius": "$radius-input",
-              "stroke": {
-                "thickness": 1,
-                "fill": "$border-input"
-              },
+              "stroke": "$border-input",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "gap": 8,
               "padding": [
                 0,
@@ -22603,13 +22534,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "KwNjx",
                   "name": "searchIcon",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "search",
-                  "iconFontFamily": "lucide",
+                  "icon": "search",
+                  "library": "lucide",
                   "fill": "$text-faint"
                 },
                 {
@@ -22645,12 +22576,11 @@
               "id": "Ok4u5",
               "name": "Row1-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -22714,13 +22644,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "eVoSN",
                   "name": "check1",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -22730,12 +22660,11 @@
               "id": "wCdVA",
               "name": "Row2-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -22799,13 +22728,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "z7UD6",
                   "name": "check2",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -22815,12 +22744,11 @@
               "id": "npSBK",
               "name": "Row3-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -22884,13 +22812,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "4pnCt",
                   "name": "plus3",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -22900,12 +22828,11 @@
               "id": "pp1Tv",
               "name": "Row4-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -22969,13 +22896,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "ThRVg",
                   "name": "plus4",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -22985,12 +22912,11 @@
               "id": "j5cFl",
               "name": "Row5-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -23054,13 +22980,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "rwmht",
                   "name": "plus5",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -23070,12 +22996,11 @@
               "id": "X5CVn",
               "name": "Row6-Unselected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -23139,13 +23064,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "TzSYD",
                   "name": "plus6",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "plus",
-                  "iconFontFamily": "lucide",
+                  "icon": "plus",
+                  "library": "lucide",
                   "fill": "$text-muted"
                 }
               ]
@@ -23155,12 +23080,11 @@
               "id": "9v4Nc",
               "name": "Row7-Selected",
               "width": "fill_container",
-              "stroke": {
-                "thickness": {
-                  "bottom": 1
-                },
-                "fill": "$border-default"
+              "stroke": "$border-default",
+              "strokeWidth": {
+                "bottom": 1
               },
+              "strokeAlignment": "inner",
               "gap": 12,
               "padding": [
                 12,
@@ -23224,13 +23148,13 @@
                   }
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "egpT6",
                   "name": "check7",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "circle-check",
-                  "iconFontFamily": "lucide",
+                  "icon": "circle-check",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 }
               ]
@@ -23245,12 +23169,11 @@
           "name": "StickyBottomBar",
           "width": 375,
           "fill": "$surface-chrome",
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -23320,13 +23243,13 @@
                   "fontWeight": "600"
                 },
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "ZBdZZ",
                   "name": "startArrow",
                   "width": 16,
                   "height": 16,
-                  "iconFontName": "arrow-right",
-                  "iconFontFamily": "lucide",
+                  "icon": "arrow-right",
+                  "library": "lucide",
                   "fill": "$text-primary"
                 }
               ]
@@ -23381,14 +23304,13 @@
             0,
             0
           ],
-          "stroke": {
-            "thickness": {
-              "top": 1,
-              "right": 1,
-              "left": 1
-            },
-            "fill": "$border-card"
+          "stroke": "$border-card",
+          "strokeWidth": {
+            "top": 1,
+            "right": 1,
+            "left": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -23484,10 +23406,9 @@
                   "height": 36,
                   "fill": "$surface-input",
                   "cornerRadius": "$radius-input",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "$border-input"
-                  },
+                  "stroke": "$border-input",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "padding": [
                     0,
                     12
@@ -23525,12 +23446,11 @@
                   "id": "l7JJa",
                   "name": "Entry1",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     10,
@@ -23539,13 +23459,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Gqpiq",
                       "name": "dragHandle1",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -23595,13 +23515,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "9lNYz",
                       "name": "entryRemove1",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -23611,12 +23531,11 @@
                   "id": "al7NK",
                   "name": "Entry2",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     10,
@@ -23625,13 +23544,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "N9yV5",
                       "name": "dragHandle2",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -23681,13 +23600,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "qsr5u",
                       "name": "entryRemove2",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -23697,12 +23616,11 @@
                   "id": "lOQCy",
                   "name": "Entry3",
                   "width": "fill_container",
-                  "stroke": {
-                    "thickness": {
-                      "bottom": 1
-                    },
-                    "fill": "$border-default"
+                  "stroke": "$border-default",
+                  "strokeWidth": {
+                    "bottom": 1
                   },
+                  "strokeAlignment": "inner",
                   "gap": 10,
                   "padding": [
                     10,
@@ -23711,13 +23629,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "KUSTv",
                       "name": "dragHandle3",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "grip-vertical",
-                      "iconFontFamily": "lucide",
+                      "icon": "grip-vertical",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -23767,13 +23685,13 @@
                       }
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "GTzrR",
                       "name": "entryRemove3",
                       "width": 16,
                       "height": 16,
-                      "iconFontName": "x",
-                      "iconFontFamily": "lucide",
+                      "icon": "x",
+                      "library": "lucide",
                       "fill": "$danger-text"
                     }
                   ]
@@ -23840,13 +23758,13 @@
                       "fontWeight": "600"
                     },
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "Tj89i",
                       "name": "startArr",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "arrow-right",
-                      "iconFontFamily": "lucide",
+                      "icon": "arrow-right",
+                      "library": "lucide",
                       "fill": "$text-primary"
                     }
                   ]
@@ -23985,11 +23903,8 @@
                   "fill": "#00000000",
                   "width": 160,
                   "height": 160,
-                  "stroke": {
-                    "align": "center",
-                    "thickness": 5,
-                    "fill": "$surface-primary"
-                  }
+                  "stroke": "$surface-primary",
+                  "strokeWidth": 5
                 },
                 {
                   "type": "ellipse",
@@ -24004,12 +23919,9 @@
                   "fill": "#00000000",
                   "width": 160,
                   "height": 160,
-                  "stroke": {
-                    "align": "center",
-                    "thickness": 5,
-                    "cap": "round",
-                    "fill": "$accent"
-                  }
+                  "stroke": "$accent",
+                  "strokeWidth": 5,
+                  "strokeLinecap": "round"
                 },
                 {
                   "type": "text",
@@ -24413,11 +24325,8 @@
                       "fill": "#00000000",
                       "width": 160,
                       "height": 160,
-                      "stroke": {
-                        "align": "center",
-                        "thickness": 5,
-                        "fill": "$surface-primary"
-                      }
+                      "stroke": "$surface-primary",
+                      "strokeWidth": 5
                     },
                     {
                       "type": "ellipse",
@@ -24432,12 +24341,9 @@
                       "fill": "#00000000",
                       "width": 160,
                       "height": 160,
-                      "stroke": {
-                        "align": "center",
-                        "thickness": 5,
-                        "cap": "round",
-                        "fill": "$accent"
-                      }
+                      "stroke": "$accent",
+                      "strokeWidth": 5,
+                      "strokeLinecap": "round"
                     },
                     {
                       "type": "text",
@@ -24727,14 +24633,13 @@
             0,
             0
           ],
-          "stroke": {
-            "thickness": {
-              "top": 1,
-              "right": 1,
-              "left": 1
-            },
-            "fill": "$border-card"
+          "stroke": "$border-card",
+          "strokeWidth": {
+            "top": 1,
+            "right": 1,
+            "left": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -24983,10 +24888,9 @@
                       "height": 36,
                       "fill": "$surface-input",
                       "cornerRadius": "$radius-input",
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "$border-input"
-                      },
+                      "stroke": "$border-input",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "padding": [
                         0,
                         12
@@ -25033,10 +24937,9 @@
                       "height": 36,
                       "fill": "$surface-input",
                       "cornerRadius": "$radius-input",
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "$border-input"
-                      },
+                      "stroke": "$border-input",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "padding": [
                         0,
                         12
@@ -25275,11 +25178,8 @@
                       "fill": "#00000000",
                       "width": 160,
                       "height": 160,
-                      "stroke": {
-                        "align": "center",
-                        "thickness": 5,
-                        "fill": "$surface-primary"
-                      }
+                      "stroke": "$surface-primary",
+                      "strokeWidth": 5
                     },
                     {
                       "type": "ellipse",
@@ -25294,12 +25194,9 @@
                       "fill": "#00000000",
                       "width": 160,
                       "height": 160,
-                      "stroke": {
-                        "align": "center",
-                        "thickness": 5,
-                        "cap": "round",
-                        "fill": "$accent"
-                      }
+                      "stroke": "$accent",
+                      "strokeWidth": 5,
+                      "strokeLinecap": "round"
                     },
                     {
                       "type": "text",
@@ -25578,23 +25475,22 @@
             ]
           },
           "cornerRadius": 16,
-          "stroke": {
-            "thickness": 1,
-            "fill": "$border-card"
-          },
+          "stroke": "$border-card",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 16,
           "padding": 24,
           "alignItems": "center",
           "children": [
             {
-              "type": "icon_font",
+              "type": "icon",
               "id": "Ykrcj",
               "name": "PauseIcon",
               "width": 48,
               "height": 48,
-              "iconFontName": "circle-pause",
-              "iconFontFamily": "lucide",
+              "icon": "circle-pause",
+              "library": "lucide",
               "fill": "$accent-text"
             },
             {
@@ -25725,12 +25621,11 @@
           "name": "Sidebar",
           "width": 320,
           "height": "fill_container",
-          "stroke": {
-            "thickness": {
-              "right": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "right": 1
           },
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "children": [
             {
@@ -25903,13 +25798,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "8s1bo",
                       "name": "i1check",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "circle-check",
-                      "iconFontFamily": "lucide",
+                      "icon": "circle-check",
+                      "library": "lucide",
                       "fill": "$success-text"
                     },
                     {
@@ -25975,12 +25870,11 @@
                   "name": "Item2Active",
                   "width": "fill_container",
                   "fill": "$surface-secondary",
-                  "stroke": {
-                    "thickness": {
-                      "left": 3
-                    },
-                    "fill": "$accent"
+                  "stroke": "$accent",
+                  "strokeWidth": {
+                    "left": 3
                   },
+                  "strokeAlignment": "inner",
                   "gap": 12,
                   "padding": [
                     10,
@@ -25989,13 +25883,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "nLZ0F",
                       "name": "i2icon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "disc",
-                      "iconFontFamily": "lucide",
+                      "icon": "disc",
+                      "library": "lucide",
                       "fill": "$accent-text"
                     },
                     {
@@ -26068,13 +25962,13 @@
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "qFDCi",
                       "name": "i3icon",
                       "width": 18,
                       "height": 18,
-                      "iconFontName": "circle",
-                      "iconFontFamily": "lucide",
+                      "icon": "circle",
+                      "library": "lucide",
                       "fill": "$text-faint"
                     },
                     {
@@ -26187,11 +26081,8 @@
                   "fill": "#00000000",
                   "width": 160,
                   "height": 160,
-                  "stroke": {
-                    "align": "center",
-                    "thickness": 5,
-                    "fill": "$surface-primary"
-                  }
+                  "stroke": "$surface-primary",
+                  "strokeWidth": 5
                 },
                 {
                   "type": "ellipse",
@@ -26206,12 +26097,9 @@
                   "fill": "#00000000",
                   "width": 160,
                   "height": 160,
-                  "stroke": {
-                    "align": "center",
-                    "thickness": 5,
-                    "cap": "round",
-                    "fill": "$accent"
-                  }
+                  "stroke": "$accent",
+                  "strokeWidth": 5,
+                  "strokeLinecap": "round"
                 },
                 {
                   "type": "text",
@@ -26429,13 +26317,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "UqdBM",
                   "name": "brandIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent"
                 },
                 {
@@ -26499,10 +26387,9 @@
           "width": "fill_container",
           "fill": "#ffffff08",
           "cornerRadius": 10,
-          "stroke": {
-            "thickness": 1,
-            "fill": "#00000000"
-          },
+          "stroke": "#00000000",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
           "layout": "vertical",
           "gap": 8,
           "padding": 14,
@@ -26546,30 +26433,28 @@
               "fill": "$surface-secondary",
               "cornerRadius": 8,
               "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "left": 4
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
                 },
-                "fill": {
-                  "type": "gradient",
-                  "gradientType": "linear",
-                  "enabled": true,
-                  "rotation": 180,
-                  "size": {
-                    "height": 1
+                "colors": [
+                  {
+                    "color": "$bar-gold-start",
+                    "position": 0
                   },
-                  "colors": [
-                    {
-                      "color": "$bar-gold-start",
-                      "position": 0
-                    },
-                    {
-                      "color": "$bar-gold-end",
-                      "position": 1
-                    }
-                  ]
-                }
+                  {
+                    "color": "$bar-gold-end",
+                    "position": 1
+                  }
+                ]
               },
+              "strokeWidth": {
+                "left": 4
+              },
+              "strokeAlignment": "inner",
               "padding": [
                 12,
                 14,
@@ -26609,30 +26494,28 @@
               "fill": "$surface-secondary",
               "cornerRadius": 8,
               "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "left": 4
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
                 },
-                "fill": {
-                  "type": "gradient",
-                  "gradientType": "linear",
-                  "enabled": true,
-                  "rotation": 180,
-                  "size": {
-                    "height": 1
+                "colors": [
+                  {
+                    "color": "$bar-blue-start",
+                    "position": 0
                   },
-                  "colors": [
-                    {
-                      "color": "$bar-blue-start",
-                      "position": 0
-                    },
-                    {
-                      "color": "$bar-blue-end",
-                      "position": 1
-                    }
-                  ]
-                }
+                  {
+                    "color": "$bar-blue-end",
+                    "position": 1
+                  }
+                ]
               },
+              "strokeWidth": {
+                "left": 4
+              },
+              "strokeAlignment": "inner",
               "padding": [
                 12,
                 14,
@@ -26684,13 +26567,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "X5xgU",
                   "name": "p1Icon",
                   "width": 18,
                   "height": 18,
-                  "iconFontName": "library",
-                  "iconFontFamily": "lucide",
+                  "icon": "library",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -26715,13 +26598,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "O2Cdb",
                   "name": "p2Icon",
                   "width": 18,
                   "height": 18,
-                  "iconFontName": "timer",
-                  "iconFontFamily": "lucide",
+                  "icon": "timer",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -26746,13 +26629,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "glkry",
                   "name": "p3Icon",
                   "width": 18,
                   "height": 18,
-                  "iconFontName": "trending-up",
-                  "iconFontFamily": "lucide",
+                  "icon": "trending-up",
+                  "library": "lucide",
                   "fill": "$accent-text"
                 },
                 {
@@ -26791,13 +26674,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "y0Z46",
                   "name": "btnIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "person",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "person",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
@@ -26881,13 +26764,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "O2rci",
                   "name": "tbIcon",
                   "width": 18,
                   "height": 18,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent"
                 },
                 {
@@ -26970,13 +26853,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "BzJG6",
                   "name": "heroBtnIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "person",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "person",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
@@ -27067,10 +26950,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 14,
                   "padding": 16,
                   "children": [
@@ -27086,13 +26968,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "o6BDBA",
                           "name": "pIco1",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "library",
-                          "iconFontFamily": "lucide",
+                          "icon": "library",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -27139,10 +27021,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 14,
                   "padding": 16,
                   "children": [
@@ -27158,13 +27039,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "shWh4",
                           "name": "pIco2",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "timer",
-                          "iconFontFamily": "lucide",
+                          "icon": "timer",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -27211,10 +27092,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 14,
                   "padding": 16,
                   "children": [
@@ -27230,13 +27110,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "hW7i7",
                           "name": "pIco3",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "trending-up",
-                          "iconFontFamily": "lucide",
+                          "icon": "trending-up",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -27346,10 +27226,9 @@
               "width": "fill_container",
               "fill": "#ffffff08",
               "cornerRadius": 10,
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 8,
               "padding": 14,
@@ -27447,30 +27326,28 @@
                   "fill": "$surface-secondary",
                   "cornerRadius": 8,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-gold-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-gold-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-gold-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-gold-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "padding": [
                     12,
                     14,
@@ -27546,30 +27423,28 @@
                   "fill": "$surface-secondary",
                   "cornerRadius": 8,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-blue-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-blue-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-blue-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-blue-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "padding": [
                     12,
                     14,
@@ -27707,10 +27582,9 @@
               "width": "fill_container",
               "fill": "#ffffff08",
               "cornerRadius": 10,
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 14,
               "padding": [
@@ -27795,13 +27669,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "orcW2",
                           "name": "f2BtnAi",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "pause",
-                          "iconFontFamily": "lucide",
+                          "icon": "pause",
+                          "library": "lucide",
                           "fill": "$text-primary"
                         },
                         {
@@ -27921,30 +27795,28 @@
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-gold-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-gold-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-gold-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-gold-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 4,
                   "padding": [
@@ -27995,30 +27867,28 @@
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-blue-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-blue-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-blue-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-blue-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 4,
                   "padding": [
@@ -28121,13 +27991,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "yzkcn",
                   "name": "fcBtnIcon",
                   "width": 20,
                   "height": 20,
-                  "iconFontName": "person",
-                  "iconFontFamily": "Material Symbols Rounded",
+                  "icon": "person",
+                  "library": "Material Symbols Rounded",
                   "fill": "$text-primary"
                 },
                 {
@@ -28212,13 +28082,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "krjml",
                   "name": "dlLogoIcon",
                   "width": 24,
                   "height": 24,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent"
                 },
                 {
@@ -28294,13 +28164,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "PaQv3",
                               "name": "dlBul1Ic",
                               "width": 18,
                               "height": 18,
-                              "iconFontName": "library",
-                              "iconFontFamily": "lucide",
+                              "icon": "library",
+                              "library": "lucide",
                               "fill": "$accent-text"
                             }
                           ]
@@ -28336,13 +28206,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "kxgX4",
                               "name": "dlBul2Ic",
                               "width": 18,
                               "height": 18,
-                              "iconFontName": "timer",
-                              "iconFontFamily": "lucide",
+                              "icon": "timer",
+                              "library": "lucide",
                               "fill": "$accent-text"
                             }
                           ]
@@ -28378,13 +28248,13 @@
                           "alignItems": "center",
                           "children": [
                             {
-                              "type": "icon_font",
+                              "type": "icon",
                               "id": "fH9JQ",
                               "name": "dlBul3Ic",
                               "width": 18,
                               "height": 18,
-                              "iconFontName": "trending-up",
-                              "iconFontFamily": "lucide",
+                              "icon": "trending-up",
+                              "library": "lucide",
                               "fill": "$accent-text"
                             }
                           ]
@@ -28424,9 +28294,6 @@
           "width": "fill_container",
           "height": "fill_container",
           "fill": "#00000000",
-          "stroke": {
-            "thickness": 0
-          },
           "layout": "vertical",
           "padding": [
             80,
@@ -28444,10 +28311,9 @@
               "width": 420,
               "fill": "#ffffff08",
               "cornerRadius": 10,
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -28505,21 +28371,18 @@
                   "height": 52,
                   "fill": "$accent",
                   "cornerRadius": "$radius-button",
-                  "stroke": {
-                    "thickness": 0
-                  },
                   "gap": 12,
                   "justifyContent": "center",
                   "alignItems": "center",
                   "children": [
                     {
-                      "type": "icon_font",
+                      "type": "icon",
                       "id": "T15Kae",
                       "name": "dlGoogIcon",
                       "width": 20,
                       "height": 20,
-                      "iconFontName": "person",
-                      "iconFontFamily": "Material Symbols Rounded",
+                      "icon": "person",
+                      "library": "Material Symbols Rounded",
                       "fill": "$text-primary"
                     },
                     {
@@ -28591,12 +28454,11 @@
           "name": "mTopNav",
           "width": "fill_container",
           "fill": "#11182799",
-          "stroke": {
-            "thickness": {
-              "bottom": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "bottom": 1
           },
+          "strokeAlignment": "inner",
           "effect": {
             "type": "background_blur",
             "radius": 12
@@ -28616,13 +28478,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "mDqle",
                   "name": "mNavBrandIco",
                   "width": 22,
                   "height": 22,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent"
                 },
                 {
@@ -28742,10 +28604,9 @@
               "name": "mHeroBadge",
               "fill": "#ffffff08",
               "cornerRadius": "$radius-pill",
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "gap": 8,
               "padding": [
                 6,
@@ -28839,10 +28700,9 @@
                   "name": "mHeroCta2",
                   "fill": "#ffffff08",
                   "cornerRadius": "$radius-button",
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "gap": 8,
                   "padding": [
                     14,
@@ -28890,9 +28750,6 @@
               "height": 560,
               "fill": "#000000",
               "cornerRadius": 48,
-              "stroke": {
-                "thickness": 0
-              },
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -29161,9 +29018,6 @@
               "height": 600,
               "fill": "#000000",
               "cornerRadius": 48,
-              "stroke": {
-                "thickness": 0
-              },
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -29379,9 +29233,6 @@
               "height": 560,
               "fill": "#000000",
               "cornerRadius": 48,
-              "stroke": {
-                "thickness": 0
-              },
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -29456,10 +29307,9 @@
                           "width": "fill_container",
                           "fill": "#ffffff08",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "thickness": 1,
-                            "fill": "#00000000"
-                          },
+                          "stroke": "#00000000",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "layout": "vertical",
                           "gap": 2,
                           "padding": 12,
@@ -29504,10 +29354,9 @@
                           "width": "fill_container",
                           "fill": "#ffffff08",
                           "cornerRadius": 10,
-                          "stroke": {
-                            "thickness": 1,
-                            "fill": "#00000000"
-                          },
+                          "stroke": "#00000000",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
                           "layout": "vertical",
                           "gap": 2,
                           "padding": 12,
@@ -29554,10 +29403,9 @@
                       "width": "fill_container",
                       "fill": "#ffffff08",
                       "cornerRadius": 10,
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "#00000000"
-                      },
+                      "stroke": "#00000000",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 8,
                       "padding": 12,
@@ -29755,10 +29603,9 @@
                       "width": "fill_container",
                       "fill": "#ffffff08",
                       "cornerRadius": 10,
-                      "stroke": {
-                        "thickness": 1,
-                        "fill": "#00000000"
-                      },
+                      "stroke": "#00000000",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 8,
                       "padding": 12,
@@ -29925,10 +29772,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 16,
                   "padding": 32,
@@ -29945,13 +29791,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "mq2AQ",
                           "name": "mPilAIco",
                           "width": 26,
                           "height": 26,
-                          "iconFontName": "library",
-                          "iconFontFamily": "lucide",
+                          "icon": "library",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -29988,10 +29834,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 16,
                   "padding": 32,
@@ -30008,13 +29853,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "YUnuq",
                           "name": "mPilBIco",
                           "width": 26,
                           "height": 26,
-                          "iconFontName": "timer",
-                          "iconFontFamily": "lucide",
+                          "icon": "timer",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -30051,10 +29896,9 @@
                   "width": "fill_container",
                   "fill": "#ffffff08",
                   "cornerRadius": 10,
-                  "stroke": {
-                    "thickness": 1,
-                    "fill": "#00000000"
-                  },
+                  "stroke": "#00000000",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
                   "layout": "vertical",
                   "gap": 16,
                   "padding": 32,
@@ -30071,13 +29915,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "vkWdN",
                           "name": "mPilCIco",
                           "width": 26,
                           "height": 26,
-                          "iconFontName": "trending-up",
-                          "iconFontFamily": "lucide",
+                          "icon": "trending-up",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         }
                       ]
@@ -30181,13 +30025,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "UrXTS",
                           "name": "mF1B1Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -30210,13 +30054,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "e52pI",
                           "name": "mF1B2Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -30239,13 +30083,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "L8wYpA",
                           "name": "mF1B3Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -30271,10 +30115,9 @@
               "width": "fill_container",
               "fill": "#ffffff08",
               "cornerRadius": 10,
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 14,
               "padding": 24,
@@ -30311,13 +30154,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "X6XwhK",
                           "name": "mF1MAi",
                           "width": 14,
                           "height": 14,
-                          "iconFontName": "plus",
-                          "iconFontFamily": "lucide",
+                          "icon": "plus",
+                          "library": "lucide",
                           "fill": "$text-primary"
                         },
                         {
@@ -30397,30 +30240,28 @@
                   "fill": "$surface-secondary",
                   "cornerRadius": 8,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-gold-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-gold-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-gold-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-gold-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "padding": [
                     14,
                     14,
@@ -30494,30 +30335,28 @@
                   "fill": "$surface-secondary",
                   "cornerRadius": 8,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-gold-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-gold-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-gold-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-gold-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "padding": [
                     14,
                     14,
@@ -30591,30 +30430,28 @@
                   "fill": "$surface-secondary",
                   "cornerRadius": 8,
                   "stroke": {
-                    "align": "inside",
-                    "thickness": {
-                      "left": 4
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
                     },
-                    "fill": {
-                      "type": "gradient",
-                      "gradientType": "linear",
-                      "enabled": true,
-                      "rotation": 180,
-                      "size": {
-                        "height": 1
+                    "colors": [
+                      {
+                        "color": "$bar-blue-start",
+                        "position": 0
                       },
-                      "colors": [
-                        {
-                          "color": "$bar-blue-start",
-                          "position": 0
-                        },
-                        {
-                          "color": "$bar-blue-end",
-                          "position": 1
-                        }
-                      ]
-                    }
+                      {
+                        "color": "$bar-blue-end",
+                        "position": 1
+                      }
+                    ]
                   },
+                  "strokeWidth": {
+                    "left": 4
+                  },
+                  "strokeAlignment": "inner",
                   "padding": [
                     14,
                     14,
@@ -30701,30 +30538,28 @@
               "fill": "#ffffff08",
               "cornerRadius": 10,
               "stroke": {
-                "align": "inside",
-                "thickness": {
-                  "left": 4
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
                 },
-                "fill": {
-                  "type": "gradient",
-                  "gradientType": "linear",
-                  "enabled": true,
-                  "rotation": 180,
-                  "size": {
-                    "height": 1
+                "colors": [
+                  {
+                    "color": "$bar-teal-start",
+                    "position": 0
                   },
-                  "colors": [
-                    {
-                      "color": "$bar-teal-start",
-                      "position": 0
-                    },
-                    {
-                      "color": "$bar-teal-end",
-                      "position": 1
-                    }
-                  ]
-                }
+                  {
+                    "color": "$bar-teal-end",
+                    "position": 1
+                  }
+                ]
               },
+              "strokeWidth": {
+                "left": 4
+              },
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 18,
               "padding": 48,
@@ -30814,13 +30649,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "PnLcn",
                           "name": "mF2BAi",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "pause",
-                          "iconFontFamily": "lucide",
+                          "icon": "pause",
+                          "library": "lucide",
                           "fill": "$text-primary"
                         },
                         {
@@ -30925,13 +30760,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "aoFOL",
                           "name": "mF2B1Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -30954,13 +30789,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "io7SM",
                           "name": "mF2B2Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -30983,13 +30818,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "YBzGK",
                           "name": "mF2B3Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -31080,13 +30915,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "Vke5I",
                           "name": "mF3B1Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -31109,13 +30944,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "sQP5x",
                           "name": "mF3B2Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -31138,13 +30973,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "a3vLa",
                           "name": "mF3B3Ic",
                           "width": 18,
                           "height": 18,
-                          "iconFontName": "circle-check",
-                          "iconFontFamily": "lucide",
+                          "icon": "circle-check",
+                          "library": "lucide",
                           "fill": "$accent-text"
                         },
                         {
@@ -31170,10 +31005,9 @@
               "width": "fill_container",
               "fill": "#ffffff08",
               "cornerRadius": 10,
-              "stroke": {
-                "thickness": 1,
-                "fill": "#00000000"
-              },
+              "stroke": "#00000000",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "layout": "vertical",
               "gap": 14,
               "padding": 24,
@@ -31193,30 +31027,28 @@
                       "fill": "$surface-secondary",
                       "cornerRadius": 10,
                       "stroke": {
-                        "align": "inside",
-                        "thickness": {
-                          "left": 4
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 180,
+                        "size": {
+                          "height": 1
                         },
-                        "fill": {
-                          "type": "gradient",
-                          "gradientType": "linear",
-                          "enabled": true,
-                          "rotation": 180,
-                          "size": {
-                            "height": 1
+                        "colors": [
+                          {
+                            "color": "$bar-gold-start",
+                            "position": 0
                           },
-                          "colors": [
-                            {
-                              "color": "$bar-gold-start",
-                              "position": 0
-                            },
-                            {
-                              "color": "$bar-gold-end",
-                              "position": 1
-                            }
-                          ]
-                        }
+                          {
+                            "color": "$bar-gold-end",
+                            "position": 1
+                          }
+                        ]
                       },
+                      "strokeWidth": {
+                        "left": 4
+                      },
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 4,
                       "padding": [
@@ -31267,30 +31099,28 @@
                       "fill": "$surface-secondary",
                       "cornerRadius": 10,
                       "stroke": {
-                        "align": "inside",
-                        "thickness": {
-                          "left": 4
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 180,
+                        "size": {
+                          "height": 1
                         },
-                        "fill": {
-                          "type": "gradient",
-                          "gradientType": "linear",
-                          "enabled": true,
-                          "rotation": 180,
-                          "size": {
-                            "height": 1
+                        "colors": [
+                          {
+                            "color": "$bar-blue-start",
+                            "position": 0
                           },
-                          "colors": [
-                            {
-                              "color": "$bar-blue-start",
-                              "position": 0
-                            },
-                            {
-                              "color": "$bar-blue-end",
-                              "position": 1
-                            }
-                          ]
-                        }
+                          {
+                            "color": "$bar-blue-end",
+                            "position": 1
+                          }
+                        ]
                       },
+                      "strokeWidth": {
+                        "left": 4
+                      },
+                      "strokeAlignment": "inner",
                       "layout": "vertical",
                       "gap": 4,
                       "padding": [
@@ -31576,11 +31406,9 @@
               "width": "fill_container",
               "fill": "$surface-faint",
               "cornerRadius": 10,
-              "stroke": {
-                "align": "inside",
-                "thickness": 1,
-                "fill": "$border-default"
-              },
+              "stroke": "$border-default",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
               "effect": {
                 "type": "shadow",
                 "shadowType": "outer",
@@ -31645,13 +31473,13 @@
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "icon_font",
+                          "type": "icon",
                           "id": "M738e6",
                           "name": "mFcB1i",
                           "width": 20,
                           "height": 20,
-                          "iconFontName": "person",
-                          "iconFontFamily": "Material Symbols Rounded",
+                          "icon": "person",
+                          "library": "Material Symbols Rounded",
                           "fill": "$text-primary"
                         },
                         {
@@ -31687,12 +31515,11 @@
           "id": "EFjGV",
           "name": "mFooter",
           "width": "fill_container",
-          "stroke": {
-            "thickness": {
-              "top": 1
-            },
-            "fill": "$border-default"
+          "stroke": "$border-default",
+          "strokeWidth": {
+            "top": 1
           },
+          "strokeAlignment": "inner",
           "padding": [
             40,
             80
@@ -31708,13 +31535,13 @@
               "alignItems": "center",
               "children": [
                 {
-                  "type": "icon_font",
+                  "type": "icon",
                   "id": "eVMj7",
                   "name": "mFLi",
                   "width": 18,
                   "height": 18,
-                  "iconFontName": "music",
-                  "iconFontFamily": "lucide",
+                  "icon": "music",
+                  "library": "lucide",
                   "fill": "$accent"
                 },
                 {
@@ -31783,441 +31610,2266 @@
       ]
     },
     {
-      "type": "text",
-      "id": "y19tb",
-      "x": -1600,
-      "y": 12360,
-      "name": "title",
-      "fill": "#FFFFFF",
-      "content": "Logo Concepts — Intrada",
-      "fontFamily": "Inter",
-      "fontSize": 18,
-      "fontWeight": "700"
-    },
-    {
-      "type": "text",
-      "id": "J7oer0",
-      "x": -1600,
-      "y": 12385,
-      "name": "lbl1",
-      "fill": "#9CA3AF",
-      "content": "1 — Serif Wordmark + Gold Accent",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
       "type": "frame",
-      "id": "LHt4w",
-      "x": -1600,
-      "y": 12400,
-      "name": "Logo 1 — Serif Wordmark",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
+      "id": "B0j1a",
+      "x": 16000,
+      "y": 300,
+      "name": "Mobile / Library — Sepia monochrome",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F6F0E3",
+            "position": 0
+          },
+          {
+            "color": "#ECE3D1",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
       "children": [
         {
           "type": "frame",
-          "id": "QDx9W",
-          "x": 0,
-          "y": 0,
-          "name": "center",
-          "width": 400,
-          "height": 400,
+          "id": "bxGE0",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
           "layout": "vertical",
-          "gap": 14,
-          "justifyContent": "center",
-          "alignItems": "center",
-          "children": [
-            {
-              "type": "text",
-              "id": "W7wp1u",
-              "name": "wordmark",
-              "fill": "$text-primary",
-              "content": "Intrada",
-              "fontFamily": "$font-heading",
-              "fontSize": 52,
-              "fontWeight": "600",
-              "letterSpacing": 1.5
-            },
-            {
-              "type": "rectangle",
-              "cornerRadius": 2,
-              "id": "P3858c",
-              "name": "bar",
-              "fill": "$warm-accent",
-              "width": 80,
-              "height": 3
-            },
-            {
-              "type": "text",
-              "id": "b5o81",
-              "name": "tagline",
-              "fill": "$text-muted",
-              "content": "music practice",
-              "fontFamily": "$font-body",
-              "fontSize": 13,
-              "letterSpacing": 3
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "HpBwf",
-      "x": -1150,
-      "y": 12385,
-      "name": "lbl2",
-      "fill": "#9CA3AF",
-      "content": "2 — Treble Clef Monogram",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "lvLMJ",
-      "x": -1150,
-      "y": 12400,
-      "name": "Logo 2 — Treble Monogram",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "path",
-          "id": "r6YBX7",
-          "x": 165,
-          "y": 55,
-          "name": "Treble Clef Mark",
-          "geometry": "M52 10c14-6 22 6 16 20-6 12-20 6-20 22l0 76c0 20-12 34-26 28-12-6-8-22 4-24 8-2 12 6 9 14",
-          "viewBox": [
-            0,
-            0,
-            80,
-            180
-          ],
-          "fill": {
-            "type": "color",
-            "color": "#000000",
-            "enabled": false
-          },
-          "width": 80,
-          "height": 180,
-          "stroke": {
-            "thickness": 7,
-            "join": "round",
-            "cap": "round",
-            "fill": {
-              "type": "gradient",
-              "gradientType": "linear",
-              "enabled": true,
-              "rotation": 180,
-              "size": {
-                "height": 1
-              },
-              "colors": [
-                {
-                  "color": "#6346E5",
-                  "position": 0
-                },
-                {
-                  "color": "#9B6DC8",
-                  "position": 0.5
-                },
-                {
-                  "color": "#D4A050",
-                  "position": 1
-                }
-              ]
-            }
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 24
-          }
-        },
-        {
-          "type": "text",
-          "id": "FiBMo",
-          "x": 0,
-          "y": 260,
-          "name": "Logo Text",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 38,
-          "fontWeight": "600",
-          "letterSpacing": 1
-        },
-        {
-          "type": "text",
-          "id": "Z1pAM",
-          "x": 0,
-          "y": 312,
-          "name": "Tagline",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "music practice",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 13,
-          "letterSpacing": 4
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "v93Dt",
-      "x": -700,
-      "y": 12385,
-      "name": "lbl3",
-      "fill": "#9CA3AF",
-      "content": "3 — Staff Lines Abstract",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "w3FsJ",
-      "x": -700,
-      "y": 12400,
-      "name": "Logo 3 — Staff Lines",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "XjGl1",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "EpZn1",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "x1baMp",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "VBCPb",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Y4zuO",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "Y7Rue",
-          "x": 230,
-          "y": 132,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "xb12K",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "pl0ey",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "DsCRT",
-      "x": -250,
-      "y": 12385,
-      "name": "lbl4",
-      "fill": "#9CA3AF",
-      "content": "4 — Opening Gate + Note",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "D8boIP",
-      "x": -250,
-      "y": 12400,
-      "name": "Logo 4 — Gate Note",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "frame",
-          "id": "OaFR4",
-          "x": 0,
-          "y": 0,
-          "name": "Logo Content",
-          "width": 400,
-          "height": 400,
-          "layout": "vertical",
-          "gap": 28,
-          "justifyContent": "center",
-          "alignItems": "center",
+          "gap": 16,
+          "padding": 16,
           "children": [
             {
               "type": "frame",
-              "id": "C9unbO",
-              "name": "Icon",
-              "width": 150,
-              "height": 180,
-              "layout": "none",
+              "id": "DKQdz",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
               "children": [
                 {
-                  "type": "path",
-                  "id": "Ve3DP",
-                  "x": 0,
-                  "y": 0,
-                  "name": "Arch Gate",
-                  "geometry": "M0 180v-105a75 75 0 0 1 150 0v105h-20v-105a55 55 0 0 0-110 0v105z",
-                  "viewBox": [
-                    0,
-                    0,
-                    150,
-                    180
-                  ],
-                  "fill": "$text-primary",
-                  "width": 150,
-                  "height": 180
+                  "type": "text",
+                  "id": "b3Q0t",
+                  "fill": "#2B2A26",
+                  "content": "Library",
+                  "fontFamily": "Source Serif 4",
+                  "fontSize": 28,
+                  "fontWeight": "600"
                 },
                 {
-                  "type": "ellipse",
-                  "id": "JsybR",
-                  "x": 60,
-                  "y": 96,
-                  "name": "Note Head",
-                  "rotation": 20,
-                  "fill": "$warm-accent",
-                  "width": 34,
-                  "height": 24
-                },
-                {
-                  "type": "rectangle",
-                  "id": "l659o",
-                  "x": 89,
-                  "y": 44,
-                  "name": "Note Stem",
-                  "fill": "$warm-accent",
-                  "width": 4,
-                  "height": 76
+                  "type": "text",
+                  "id": "QRIH8",
+                  "fill": "#876334",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
                 }
               ]
             },
             {
               "type": "frame",
-              "id": "IstWJ",
-              "name": "Text Group",
+              "id": "xGGAm",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E2D7C2"
+            },
+            {
+              "type": "frame",
+              "id": "Fe6bk",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "igGfv",
+                  "name": "TabActive",
+                  "fill": "#7A5A2E",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rgVYo",
+                      "fill": "#F6F0E3",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iFTcd",
+                  "name": "TabInactive",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ujmfK",
+                      "fill": "#9C927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Lo2ML",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "kHvT3",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#A8854A"
+                },
+                {
+                  "type": "frame",
+                  "id": "R2odLH",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OoTi9",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "m2QFe6",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eSTou",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "RQb3f",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cbIbj",
+                      "name": "Badge",
+                      "fill": "#EFE3CC",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "e2OhvM",
+                          "fill": "#876334",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OagL5",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vbT1t",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#A8854A"
+                },
+                {
+                  "type": "frame",
+                  "id": "dKUTC",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "j2y7O",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kPfY3",
+                          "fill": "#2B2A26",
+                          "content": "Nocturne Op.9 No.2",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Z11yB",
+                          "fill": "#6E6557",
+                          "content": "Frédéric Chopin",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "LatZq",
+                          "fill": "#9C927F",
+                          "content": "E♭ major · Andante · 66 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZYdAf",
+                      "name": "Badge",
+                      "fill": "#EFE3CC",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Qnuhg",
+                          "fill": "#876334",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F7vRU",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KQ6XW",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#A8854A"
+                },
+                {
+                  "type": "frame",
+                  "id": "lYbqg",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HdhqP",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "sQIsC",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hxJTB",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "N5sHq",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WCU70",
+                      "name": "Badge",
+                      "fill": "#ECE3D2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bYmoR",
+                          "fill": "#6E6557",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "M7xR7T",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#F0E7D6",
+          "stroke": "#E2D7C2",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "OQoOb",
+              "width": "fill_container",
               "layout": "vertical",
               "gap": 4,
               "alignItems": "center",
               "children": [
                 {
+                  "type": "icon",
+                  "id": "ZYKDK",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#7A5A2E"
+                },
+                {
                   "type": "text",
-                  "id": "XvN0N",
-                  "name": "Logo Text",
-                  "fill": "$text-primary",
-                  "content": "Intrada",
-                  "fontFamily": "$font-heading",
-                  "fontSize": 40,
+                  "id": "m5vzC6",
+                  "fill": "#7A5A2E",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CDJDl",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "BGg0j",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "UU7vv",
+                  "fill": "#A89C86",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sbPA3",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "U0huT",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "Bhafp",
+                  "fill": "#A89C86",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UyZdh",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "bAH2v",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "J0GFB",
+                  "fill": "#A89C86",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dcO2Y",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "Z8JNQS",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "Z4E5L",
+                  "fill": "#A89C86",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "HjCVS",
+      "x": 16495,
+      "y": 300,
+      "name": "Mobile / Library — Ink + oxblood",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F6F0E3",
+            "position": 0
+          },
+          {
+            "color": "#ECE3D1",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "R7PUD",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "tgJb9",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "v4p7YF",
+                  "fill": "#2B2A26",
+                  "content": "Library",
+                  "fontFamily": "Source Serif 4",
+                  "fontSize": 28,
                   "fontWeight": "600"
                 },
                 {
                   "type": "text",
-                  "id": "cSoq8",
-                  "name": "Tagline",
-                  "fill": "$text-muted",
-                  "content": "MUSIC PRACTICE",
-                  "fontFamily": "$font-body",
-                  "fontSize": 12,
-                  "fontWeight": "500",
-                  "letterSpacing": 3
+                  "id": "SIbXQ",
+                  "fill": "#7A2E33",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pXftk",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E2D7C2"
+            },
+            {
+              "type": "frame",
+              "id": "K833b",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "F7nVqv",
+                  "name": "TabActive",
+                  "fill": "#6E2B2E",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JPxWY",
+                      "fill": "#F6F0E3",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SQGX0",
+                  "name": "TabInactive",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fYVv1",
+                      "fill": "#9C927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "FG3e2",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "t24zy",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#7A2E33"
+                },
+                {
+                  "type": "frame",
+                  "id": "ElHXY",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "t9E9a",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qyEGO",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "AB2gN",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "Du2Ef",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LkacD",
+                      "name": "Badge",
+                      "fill": "#F0DED9",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "fuwXV",
+                          "fill": "#7A2E33",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "w2mxmu",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JHu8v",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#7A2E33"
+                },
+                {
+                  "type": "frame",
+                  "id": "QNtDs",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "AJN8X",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YApkq",
+                          "fill": "#2B2A26",
+                          "content": "Nocturne Op.9 No.2",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "B9nRR6",
+                          "fill": "#6E6557",
+                          "content": "Frédéric Chopin",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "c1TXHr",
+                          "fill": "#9C927F",
+                          "content": "E♭ major · Andante · 66 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Q8KUC",
+                      "name": "Badge",
+                      "fill": "#F0DED9",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Wvanb",
+                          "fill": "#7A2E33",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "j3DSA",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aoTps",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#7A2E33"
+                },
+                {
+                  "type": "frame",
+                  "id": "FTls1",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Q24awL",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wFGbs",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hUeoU",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "IE8ox",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Mw9Eh",
+                      "name": "Badge",
+                      "fill": "#ECE3D2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "II7Cj",
+                          "fill": "#6E6557",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "eTO81",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#F0E7D6",
+          "stroke": "#E2D7C2",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "u4qVZ2",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "bjTQr",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#6E2B2E"
+                },
+                {
+                  "type": "text",
+                  "id": "E7GbL",
+                  "fill": "#6E2B2E",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iAMpb",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "mRcoC",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "INFbb",
+                  "fill": "#A89C86",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eR5ui",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "zPbLU",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "t9eDRI",
+                  "fill": "#A89C86",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "S2Fhw",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "YjNsq",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "HqNvH",
+                  "fill": "#A89C86",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Le3TY",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "olDaT",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "hRqcI",
+                  "fill": "#A89C86",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "vtaGE",
+      "x": 16990,
+      "y": 300,
+      "name": "Mobile / Library — Deep teal / petrol",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F6F0E3",
+            "position": 0
+          },
+          {
+            "color": "#ECE3D1",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "CH1BB",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "CS1JU",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ukxGo",
+                  "fill": "#2B2A26",
+                  "content": "Library",
+                  "fontFamily": "Source Serif 4",
+                  "fontSize": 28,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "KlnGU",
+                  "fill": "#1F5E5B",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sG9ri",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E2D7C2"
+            },
+            {
+              "type": "frame",
+              "id": "F1eIZ",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CwiCG",
+                  "name": "TabActive",
+                  "fill": "#1F5E5B",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "v2Ui2s",
+                      "fill": "#F4EFE3",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lvc5G",
+                  "name": "TabInactive",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "LeOnF",
+                      "fill": "#9C927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EXRg4",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q0rvd3",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#266863"
+                },
+                {
+                  "type": "frame",
+                  "id": "poI2Z",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "te1CX",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JV1fZ",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "g6w09y",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "rZ15l",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ECEQv",
+                      "name": "Badge",
+                      "fill": "#DCE8E3",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "uUS8u",
+                          "fill": "#1F5E5B",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OQtzh",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JILLz",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#266863"
+                },
+                {
+                  "type": "frame",
+                  "id": "dNngx",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "UuEkc",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wNag7",
+                          "fill": "#2B2A26",
+                          "content": "Nocturne Op.9 No.2",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ua6aA",
+                          "fill": "#6E6557",
+                          "content": "Frédéric Chopin",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "Yee0W",
+                          "fill": "#9C927F",
+                          "content": "E♭ major · Andante · 66 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "g8Wco",
+                      "name": "Badge",
+                      "fill": "#DCE8E3",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "n9FS1N",
+                          "fill": "#1F5E5B",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kD8UR",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YSYHl",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#266863"
+                },
+                {
+                  "type": "frame",
+                  "id": "BaOhn",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "yAzqr",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "NcyjI",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JNVVj",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "YHmVm",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FJc7C",
+                      "name": "Badge",
+                      "fill": "#ECE3D2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JoHdW",
+                          "fill": "#6E6557",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "kDxTF",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#F0E7D6",
+          "stroke": "#E2D7C2",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "prRgC",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "cOfto",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#1F5E5B"
+                },
+                {
+                  "type": "text",
+                  "id": "KxHme",
+                  "fill": "#1F5E5B",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "V2gLan",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "mu8cw",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "VQXol",
+                  "fill": "#A89C86",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "plSMm",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "ZAsJJ",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "GJp2U",
+                  "fill": "#A89C86",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zef1H",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "P1ZTwx",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "v1oUQ",
+                  "fill": "#A89C86",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fKUgh",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "sj4Ik",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "TeY5g",
+                  "fill": "#A89C86",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "Wisos",
+      "x": 17485,
+      "y": 300,
+      "name": "Mobile / Library — Indigo carryover",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F6F0E3",
+            "position": 0
+          },
+          {
+            "color": "#ECE3D1",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "RL5Au",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "YxKfw",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "xOyOF",
+                  "fill": "#2B2A26",
+                  "content": "Library",
+                  "fontFamily": "Source Serif 4",
+                  "fontSize": 28,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "FZiMA",
+                  "fill": "#4C3FA6",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IDCH6",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E2D7C2"
+            },
+            {
+              "type": "frame",
+              "id": "emWRi",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q1leL",
+                  "name": "TabActive",
+                  "fill": "#4C3FA6",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "WZicb",
+                      "fill": "#F2EFE8",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "kCtwy",
+                  "name": "TabInactive",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ZHO5V",
+                      "fill": "#9C927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uP16p",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "UcgOu",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#5A49C9"
+                },
+                {
+                  "type": "frame",
+                  "id": "pt1f4",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n7Keo",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "aw8Tq",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Kv54N",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "m1G2u",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FEdFd",
+                      "name": "Badge",
+                      "fill": "#E4E0F2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JYitq",
+                          "fill": "#4C3FA6",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TlqNK",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "HWa6C",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#5A49C9"
+                },
+                {
+                  "type": "frame",
+                  "id": "g6jFa",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "w2vjM",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "K6ZP0",
+                          "fill": "#2B2A26",
+                          "content": "Nocturne Op.9 No.2",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "A33Mt",
+                          "fill": "#6E6557",
+                          "content": "Frédéric Chopin",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "lu7n0",
+                          "fill": "#9C927F",
+                          "content": "E♭ major · Andante · 66 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hV2x8",
+                      "name": "Badge",
+                      "fill": "#E4E0F2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B7ZL6F",
+                          "fill": "#4C3FA6",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "P2lAo",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF7EF",
+              "cornerRadius": 12,
+              "stroke": "#E8DEC9",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BHcok",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": "#5A49C9"
+                },
+                {
+                  "type": "frame",
+                  "id": "RnXDb",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 8,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ir69G",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "YBR36",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "M67bc8",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "OUbiQ",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Abtjs",
+                      "name": "Badge",
+                      "fill": "#ECE3D2",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dvRHu",
+                          "fill": "#6E6557",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "HFSSi",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#F0E7D6",
+          "stroke": "#E2D7C2",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "MwOJR",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "bXuF7",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                },
+                {
+                  "type": "text",
+                  "id": "cWm2v",
+                  "fill": "#4C3FA6",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l5s3Wr",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "UVj3R",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "qyoUG",
+                  "fill": "#A89C86",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "SWp2E",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "HOx3K",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "PkpUG",
+                  "fill": "#A89C86",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TFeEZ",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "VAiJB",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "msxM8",
+                  "fill": "#A89C86",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LhG4L",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "HkUh4",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B9AC93"
+                },
+                {
+                  "type": "text",
+                  "id": "uwplj",
+                  "fill": "#A89C86",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
                 }
               ]
             }
@@ -32227,2086 +33879,4418 @@
     },
     {
       "type": "text",
-      "id": "q2vEr",
-      "x": 200,
-      "y": 12385,
-      "name": "lbl5",
-      "fill": "#9CA3AF",
-      "content": "5 — Spine Mark + Logotype",
+      "id": "yLu1G",
+      "x": 16000,
+      "y": 170,
+      "fill": "#2B2A26",
+      "content": "Light mode — paper / score explorations",
+      "fontFamily": "Source Serif 4",
+      "fontSize": 26,
+      "fontWeight": "600"
+    },
+    {
+      "type": "text",
+      "id": "t9OAzL",
+      "x": 16000,
+      "y": 270,
+      "fill": "#6E6557",
+      "content": "1 · Sepia monochrome",
       "fontFamily": "Inter",
       "fontSize": 12,
       "fontWeight": "500"
     },
     {
+      "type": "text",
+      "id": "vfWlf",
+      "x": 16495,
+      "y": 270,
+      "fill": "#6E6557",
+      "content": "2 · Ink + oxblood",
+      "fontFamily": "Inter",
+      "fontSize": 12,
+      "fontWeight": "500"
+    },
+    {
+      "type": "text",
+      "id": "L2hMOA",
+      "x": 16990,
+      "y": 270,
+      "fill": "#6E6557",
+      "content": "3 · Deep teal / petrol",
+      "fontFamily": "Inter",
+      "fontSize": 12,
+      "fontWeight": "500"
+    },
+    {
+      "type": "text",
+      "id": "pRPiq",
+      "x": 17485,
+      "y": 270,
+      "fill": "#6E6557",
+      "content": "4 · Indigo carryover",
+      "fontFamily": "Inter",
+      "fontSize": 12,
+      "fontWeight": "500"
+    },
+    {
+      "type": "text",
+      "id": "aZQxd",
+      "x": 16000,
+      "y": 1400,
+      "fill": "#2B2A26",
+      "content": "Indigo carryover — refinements",
+      "fontFamily": "Source Serif 4",
+      "fontSize": 26,
+      "fontWeight": "600"
+    },
+    {
+      "type": "text",
+      "id": "C1UBU",
+      "x": 16000,
+      "y": 1466,
+      "fill": "#6E6557",
+      "content": "A · Refined (cooler cream, count, gold exercise, chevron)",
+      "fontFamily": "Inter",
+      "fontSize": 11,
+      "fontWeight": "500"
+    },
+    {
+      "type": "text",
+      "id": "h6s8Iq",
+      "x": 16495,
+      "y": 1466,
+      "fill": "#6E6557",
+      "content": "B · Editorial minimal (underline tabs, dot, no bar)",
+      "fontFamily": "Inter",
+      "fontSize": 11,
+      "fontWeight": "500"
+    },
+    {
+      "type": "text",
+      "id": "tsg5q",
+      "x": 16990,
+      "y": 1466,
+      "fill": "#6E6557",
+      "content": "C · Warm soft (warm cream, rounder cards)",
+      "fontFamily": "Inter",
+      "fontSize": 11,
+      "fontWeight": "500"
+    },
+    {
       "type": "frame",
-      "id": "emTPp",
-      "x": 200,
-      "y": 12400,
-      "name": "Logo 5 — Spine Mark",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
+      "id": "tGUw3",
+      "x": 16000,
+      "y": 1500,
+      "name": "Mobile / Library — Indigo Refined",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F4F1E8",
+            "position": 0
+          },
+          {
+            "color": "#EBE7D9",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
       "children": [
         {
           "type": "frame",
-          "id": "p39R2A",
-          "x": 140,
-          "y": 130,
-          "name": "spineIcon",
-          "gap": 3,
-          "alignItems": "end",
+          "id": "y462c5",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "padding": 16,
           "children": [
             {
-              "type": "rectangle",
-              "cornerRadius": 3,
-              "id": "eiAIs",
-              "name": "bar1",
-              "fill": {
-                "type": "gradient",
-                "gradientType": "linear",
-                "enabled": true,
-                "rotation": 180,
-                "size": {
-                  "height": 1
+              "type": "frame",
+              "id": "pDxvE",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "HgSNn",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "AhjFf",
+                      "fill": "#2B2A26",
+                      "content": "Library",
+                      "fontFamily": "Source Serif 4",
+                      "fontSize": 32,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xlb6U",
+                      "fill": "#9A927F",
+                      "content": "12 pieces · 5 exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 12
+                    }
+                  ]
                 },
-                "colors": [
-                  {
-                    "color": "#D4A050",
-                    "position": 0
-                  },
-                  {
-                    "color": "#B8860B",
-                    "position": 1
-                  }
-                ]
-              },
-              "width": 6,
-              "height": 40
+                {
+                  "type": "text",
+                  "id": "buiDr",
+                  "fill": "#4C3FA6",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
             },
             {
-              "type": "rectangle",
-              "cornerRadius": 3,
-              "id": "PXImT",
-              "name": "bar2",
-              "fill": {
-                "type": "gradient",
-                "gradientType": "linear",
-                "enabled": true,
-                "rotation": 180,
-                "size": {
-                  "height": 1
-                },
-                "colors": [
-                  {
-                    "color": "#6346E5",
-                    "position": 0
-                  },
-                  {
-                    "color": "#4A3AB8",
-                    "position": 1
-                  }
-                ]
-              },
-              "width": 6,
-              "height": 56
+              "type": "frame",
+              "id": "QAPiW",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#DCD5C4"
             },
             {
-              "type": "rectangle",
-              "cornerRadius": 3,
-              "id": "N24uU",
-              "name": "bar3",
-              "fill": {
-                "type": "gradient",
-                "gradientType": "linear",
-                "enabled": true,
-                "rotation": 180,
-                "size": {
-                  "height": 1
+              "type": "frame",
+              "id": "suANa",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qpCjq",
+                  "fill": "#4C3FA6",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VGJdP",
+                      "fill": "#F2EFE8",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
                 },
-                "colors": [
-                  {
-                    "color": "#D4A050",
-                    "position": 0
-                  },
-                  {
-                    "color": "#C48A30",
-                    "position": 1
-                  }
-                ]
-              },
-              "width": 6,
-              "height": 70
+                {
+                  "type": "frame",
+                  "id": "fIrgA",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UFQHK",
+                      "fill": "#9A927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "type": "rectangle",
-              "cornerRadius": 3,
-              "id": "uDFYN",
-              "name": "bar4",
-              "fill": {
-                "type": "gradient",
-                "gradientType": "linear",
-                "enabled": true,
-                "rotation": 180,
-                "size": {
-                  "height": 1
-                },
-                "colors": [
-                  {
-                    "color": "#6346E5",
-                    "position": 0
-                  },
-                  {
-                    "color": "#4A3AB8",
-                    "position": 1
+              "type": "frame",
+              "id": "lhqet",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "e0ugro",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
                   }
-                ]
-              },
-              "width": 6,
-              "height": 56
+                },
+                {
+                  "type": "frame",
+                  "id": "Z32mcL",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BPUt3",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "XwYXY",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "V0M3i9",
+                              "fill": "#2B2A26",
+                              "content": "Clair de Lune",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "DNWFr",
+                              "fill": "#6E6557",
+                              "content": "Claude Debussy",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "FX8Nc",
+                              "fill": "#9C927F",
+                              "content": "D♭ major · Andante · 72 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m6kzAE",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Z4avn",
+                          "name": "Badge",
+                          "fill": "#E4E0F2",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "yXucl",
+                              "fill": "#4C3FA6",
+                              "content": "Piece",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "h6QdNd",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "type": "rectangle",
-              "cornerRadius": 3,
-              "id": "wf054",
-              "name": "bar5",
-              "fill": {
-                "type": "gradient",
-                "gradientType": "linear",
-                "enabled": true,
-                "rotation": 180,
-                "size": {
-                  "height": 1
-                },
-                "colors": [
-                  {
-                    "color": "#D4A050",
-                    "position": 0
-                  },
-                  {
-                    "color": "#B8860B",
-                    "position": 1
+              "type": "frame",
+              "id": "AJcMM",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YLKui",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
                   }
-                ]
-              },
-              "width": 6,
-              "height": 40
+                },
+                {
+                  "type": "frame",
+                  "id": "pNWEA",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "IqwEr",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "mAh43",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Q3z5EO",
+                              "fill": "#2B2A26",
+                              "content": "Nocturne Op.9 No.2",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "fvrAo",
+                              "fill": "#6E6557",
+                              "content": "Frédéric Chopin",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "R3NI4",
+                              "fill": "#9C927F",
+                              "content": "E♭ major · Andante · 66 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cJHy9",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hoo1n",
+                          "name": "Badge",
+                          "fill": "#E4E0F2",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "VEHli",
+                              "fill": "#4C3FA6",
+                              "content": "Piece",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "tKbmQ",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "otYts",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 78,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Qup4t",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "ZLkav",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "cxUHe",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "VjmGi",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "QQgX0",
+                              "fill": "#2B2A26",
+                              "content": "Hanon Exercise No.1",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "uUqa2",
+                              "fill": "#6E6557",
+                              "content": "Charles-Louis Hanon",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "cNUIG",
+                              "fill": "#9C927F",
+                              "content": "C major · Allegro · 108 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "n6Ed5w",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "eVjHn",
+                          "name": "Badge",
+                          "fill": "#EFE3CC",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "K2Arbu",
+                              "fill": "#8A6A2E",
+                              "content": "Exercise",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "N2kHx",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
-          "type": "text",
-          "id": "xcqCP",
-          "x": 122,
-          "y": 218,
-          "name": "wordmark",
-          "fill": "#FFFFFF",
-          "content": "Intrada",
-          "fontFamily": "Source Serif 4",
-          "fontSize": 36,
-          "fontWeight": "700"
-        },
-        {
-          "type": "text",
-          "id": "PyvVl",
-          "x": 148,
-          "y": 262,
-          "name": "tagline",
-          "fill": "#9CA3AF",
-          "content": "music practice",
-          "fontFamily": "Inter",
-          "fontSize": 13,
-          "letterSpacing": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "emH7n",
-          "x": 160,
-          "y": 118,
-          "name": "note1",
-          "opacity": 0.4,
-          "fill": "#D4A050",
-          "width": 8,
-          "height": 8
-        },
-        {
-          "type": "ellipse",
-          "id": "DuwQU",
-          "x": 230,
-          "y": 108,
-          "name": "note2",
-          "opacity": 0.3,
-          "fill": "#6346E5",
-          "width": 6,
-          "height": 6
-        },
-        {
-          "type": "rectangle",
-          "id": "BG26Z",
-          "x": 170,
-          "y": 256,
-          "name": "divider",
-          "fill": {
-            "type": "gradient",
-            "gradientType": "linear",
-            "enabled": true,
-            "rotation": 270,
-            "size": {
-              "height": 1
-            },
-            "colors": [
-              {
-                "color": "#D4A05000",
-                "position": 0
-              },
-              {
-                "color": "#D4A050",
-                "position": 0.5
-              },
-              {
-                "color": "#D4A05000",
-                "position": 1
-              }
-            ]
+          "type": "frame",
+          "id": "hBSq0",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#EFEADD",
+          "stroke": "#DCD5C4",
+          "strokeWidth": {
+            "top": 1
           },
-          "width": 60,
-          "height": 1
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "ZKm9i",
-      "x": -700,
-      "y": 12845,
-      "name": "lbl1",
-      "fill": "#9CA3AF",
-      "content": "3A — Interval (Two Notes)",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "XOkPH",
-      "x": -700,
-      "y": 12860,
-      "name": "Logo 3A — Interval",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "dKps9",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "F8LhZ",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "zJ6FJ",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "ZgupW",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "JK7ZE",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "M6xPbm",
-          "x": 230,
-          "y": 132,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "vwVJL",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "q9Xg0u",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        },
-        {
-          "type": "ellipse",
-          "id": "Yuykj",
-          "x": 145,
-          "y": 165,
-          "name": "Purple Note",
-          "fill": "#6346E5",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 12,
-            "spread": 2
-          }
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "Pgtgh",
-      "x": -250,
-      "y": 12845,
-      "name": "lbl2",
-      "fill": "#9CA3AF",
-      "content": "3B — Half Note Ring",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "rF1Jp",
-      "x": -250,
-      "y": 12860,
-      "name": "Logo 3B — Half Note",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Arjds",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "HzQrB",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "OBlnW",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "vZ1sG",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "j9futB",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "ytZGo",
-          "x": 230,
-          "y": 132,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "okqkU",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "XuKSH",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        },
-        {
-          "type": "ellipse",
-          "id": "K4K2ml",
-          "x": 155,
-          "y": 162,
-          "name": "Purple Half Note",
-          "fill": "#00000000",
-          "width": 20,
-          "height": 20,
-          "stroke": {
-            "align": "center",
-            "thickness": 2.5,
-            "fill": "#6346E5"
-          },
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E530",
-            "blur": 10
-          }
-        }
-      ]
-    },
-    {
-      "type": "text",
-      "id": "b1aMqk",
-      "x": 200,
-      "y": 12845,
-      "name": "lbl3",
-      "fill": "#9CA3AF",
-      "content": "3C — Ascending Melody",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
-    },
-    {
-      "type": "frame",
-      "id": "lWvPE",
-      "x": 200,
-      "y": 12860,
-      "name": "Logo 3C — Ascending",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "eFIqU",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "H0fcvK",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "z9882",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "qnlE6",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "KnN7j",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "hQ3Ca",
-          "x": 185,
-          "y": 148,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "xpaUr",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "TiL2H",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        },
-        {
-          "type": "path",
-          "id": "ybnWd",
-          "x": 145,
-          "y": 148,
-          "name": "Melody Trail",
-          "geometry": "M6 26c10-6 24-16 40-26",
-          "viewBox": [
-            0,
-            0,
-            52,
-            26
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
           ],
-          "width": 52,
-          "height": 26,
-          "stroke": {
-            "align": "center",
-            "thickness": 1.5,
-            "cap": "round",
-            "fill": "#FFFFFF18"
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "fDQef",
-          "x": 145,
-          "y": 168,
-          "name": "Purple Note",
-          "fill": "#6346E5",
-          "width": 12,
-          "height": 12,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 12,
-            "spread": 2
-          }
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "QbZMr",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "Yq453",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                },
+                {
+                  "type": "text",
+                  "id": "JvLib",
+                  "fill": "#4C3FA6",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zDCvw",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "n7GU0",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "I7uZr",
+                  "fill": "#9A927F",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "np2VL",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "c0Lbo",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "d2YHK",
+                  "fill": "#9A927F",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JO5MU",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "V18Yh",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "t6HcM",
+                  "fill": "#9A927F",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "k04XZ",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "zuVOx",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "dAj6O",
+                  "fill": "#9A927F",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
         }
       ]
-    },
-    {
-      "type": "text",
-      "id": "YMaQ5",
-      "x": 650,
-      "y": 12845,
-      "name": "lbl4",
-      "fill": "#9CA3AF",
-      "content": "3D — Chord (Three Notes)",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
     },
     {
       "type": "frame",
-      "id": "pwt7D",
-      "x": 650,
-      "y": 12860,
-      "name": "Logo 3D — Chord",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
+      "id": "RxulI",
+      "x": 16990,
+      "y": 1500,
+      "name": "Mobile / Library — Indigo Warm soft",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F6F0E3",
+            "position": 0
+          },
+          {
+            "color": "#ECE3D1",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
       "children": [
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "XHATY",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
+          "type": "frame",
+          "id": "y9KtVo",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "eUaK0",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EVTXK",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "P7vIe",
+                      "fill": "#2B2A26",
+                      "content": "Library",
+                      "fontFamily": "Source Serif 4",
+                      "fontSize": 30,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "BObps",
+                  "fill": "#4C3FA6",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ReR40",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E2D7C2"
+            },
+            {
+              "type": "frame",
+              "id": "yWQCx",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ELRfF",
+                  "fill": "#4C3FA6",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VXrSu",
+                      "fill": "#F2EFE8",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "f7ui91",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "fgKCK",
+                      "fill": "#9A927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "n7DIT",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FBF7EF",
+              "cornerRadius": 16,
+              "stroke": "#E2D7C2",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "E8Xsn",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "M1xIG",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HbaFO",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ALf2Q",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "G6Osmw",
+                              "fill": "#2B2A26",
+                              "content": "Clair de Lune",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qqGRT",
+                              "fill": "#6E6557",
+                              "content": "Claude Debussy",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "wPou6",
+                              "fill": "#9C927F",
+                              "content": "D♭ major · Andante · 72 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "AqpU3",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tLlXw",
+                          "name": "Badge",
+                          "fill": "#E4E0F2",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "K9IoO",
+                              "fill": "#4C3FA6",
+                              "content": "Piece",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "pLwjO",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "q8whK",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FBF7EF",
+              "cornerRadius": 16,
+              "stroke": "#E2D7C2",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zK5wq",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "R10vIL",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "gbjcX",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "f0nLf8",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DdbrG",
+                              "fill": "#2B2A26",
+                              "content": "Nocturne Op.9 No.2",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "tevLX",
+                              "fill": "#6E6557",
+                              "content": "Frédéric Chopin",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "s0dvxM",
+                              "fill": "#9C927F",
+                              "content": "E♭ major · Andante · 66 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rjyg1",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Cf7V7",
+                          "name": "Badge",
+                          "fill": "#E4E0F2",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "MJee0",
+                              "fill": "#4C3FA6",
+                              "content": "Piece",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "pEVZq",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "w6nlyk",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FBF7EF",
+              "cornerRadius": 16,
+              "stroke": "#E2D7C2",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "MriWM",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "nSBQV",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n1928p",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "RXD9R",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LaNML",
+                              "fill": "#2B2A26",
+                              "content": "Hanon Exercise No.1",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "lnA4y",
+                              "fill": "#6E6557",
+                              "content": "Charles-Louis Hanon",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "XZTpJ",
+                              "fill": "#9C927F",
+                              "content": "C major · Allegro · 108 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "M6fisd",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oflr9",
+                          "name": "Badge",
+                          "fill": "#EFE3CC",
+                          "cornerRadius": 9999,
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "cr0PE",
+                              "fill": "#8A6A2E",
+                              "content": "Exercise",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "icon",
+                          "id": "vLmss",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#B6AEC4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "ZynLM",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "RDoRo",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "S8iThc",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "C2JWFR",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "PPFJi",
-          "x": 230,
-          "y": 132,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "ebPsR",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "JJhJa",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        },
-        {
-          "type": "ellipse",
-          "id": "tPFQj",
-          "x": 175,
-          "y": 144,
-          "name": "Purple Note",
-          "fill": "#6346E5",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "kFXnm",
-          "x": 213,
-          "y": 161,
-          "name": "Small Gold Note",
-          "fill": "#D4A050",
-          "width": 10,
-          "height": 10,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
+          "type": "frame",
+          "id": "i2TkYd",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#F0E7D6",
+          "stroke": "#E2D7C2",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yh2Q9",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "JIBxx",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                },
+                {
+                  "type": "text",
+                  "id": "btMc5",
+                  "fill": "#4C3FA6",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YcTuw",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "i8THH9",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "ITu7j",
+                  "fill": "#9A927F",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "b5aRF6",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "bkICO",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "aVGcZ",
+                  "fill": "#9A927F",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "D2CBJB",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "CV1LF",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "w3q16",
+                  "fill": "#9A927F",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TLqqm",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "pF8gW",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "JyrgT",
+                  "fill": "#9A927F",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
         }
       ]
-    },
-    {
-      "type": "text",
-      "id": "Q2YfXK",
-      "x": 1100,
-      "y": 12845,
-      "name": "lbl5",
-      "fill": "#9CA3AF",
-      "content": "3E — Duet (Side by Side)",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "500"
     },
     {
       "type": "frame",
-      "id": "eYCNN",
-      "x": 1100,
-      "y": 12860,
-      "name": "Logo 3E — Duet",
-      "width": 400,
-      "height": 400,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
+      "id": "BHdEK",
+      "x": 16495,
+      "y": 1500,
+      "name": "Mobile / Library — Indigo Editorial",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F4F1E8",
+            "position": 0
+          },
+          {
+            "color": "#EBE7D9",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
       "children": [
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "ESZGp",
-          "x": 135,
-          "y": 125,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
+          "type": "frame",
+          "id": "chcw4",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 18,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "nSlkz",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JfoOG",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ikwFb",
+                      "fill": "#2B2A26",
+                      "content": "Library",
+                      "fontFamily": "Source Serif 4",
+                      "fontSize": 34,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ODneI",
+                      "fill": "#9A927F",
+                      "content": "12 pieces · 5 exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 12
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "VmXaD",
+                  "fill": "#4C3FA6",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jkyW4",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#DCD5C4"
+            },
+            {
+              "type": "frame",
+              "id": "EmaWV",
+              "name": "Tabs",
+              "gap": 20,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "A0WxE",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "C3hUBy",
+                      "fill": "#4C3FA6",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Durb1",
+                      "width": 46,
+                      "height": 2,
+                      "fill": "#4C3FA6",
+                      "cornerRadius": 2
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "wlj5u",
+                  "fill": "#9A927F",
+                  "content": "Exercises",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JQbom",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 74,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "u8bl2",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OPU7F",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "NZDJ2",
+                          "width": 8,
+                          "height": 8,
+                          "fill": "#4C3FA6",
+                          "cornerRadius": 9999
+                        },
+                        {
+                          "type": "frame",
+                          "id": "DRjFo",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Xjz5k",
+                              "fill": "#2B2A26",
+                              "content": "Clair de Lune",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "eXJET",
+                              "fill": "#6E6557",
+                              "content": "Claude Debussy",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "uJFvI",
+                              "fill": "#9C927F",
+                              "content": "D♭ major · Andante · 72 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rX2DU",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 74,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hH5Gc",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ntv9v",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "e8tY1",
+                          "width": 8,
+                          "height": 8,
+                          "fill": "#4C3FA6",
+                          "cornerRadius": 9999
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fvhdj",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "vrCRg",
+                              "fill": "#2B2A26",
+                              "content": "Nocturne Op.9 No.2",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "IHMeh",
+                              "fill": "#6E6557",
+                              "content": "Frédéric Chopin",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "HzbsF",
+                              "fill": "#9C927F",
+                              "content": "E♭ major · Andante · 66 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Oaaji",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 74,
+              "fill": "#FBF9F1",
+              "cornerRadius": 12,
+              "stroke": "#DCD5C4",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "MTv9C",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": 14,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "JCGV6",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "yynjE",
+                          "width": 8,
+                          "height": 8,
+                          "fill": "#A98A3E",
+                          "cornerRadius": 9999
+                        },
+                        {
+                          "type": "frame",
+                          "id": "V0yqM7",
+                          "name": "Text",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 4,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "G3CrE6",
+                              "fill": "#2B2A26",
+                              "content": "Hanon Exercise No.1",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "h18ek",
+                              "fill": "#6E6557",
+                              "content": "Charles-Louis Hanon",
+                              "fontFamily": "Inter",
+                              "fontSize": 13
+                            },
+                            {
+                              "type": "text",
+                              "id": "thxoc",
+                              "fill": "#9C927F",
+                              "content": "C major · Allegro · 108 BPM",
+                              "fontFamily": "Inter",
+                              "fontSize": 12
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "a2CBKl",
-          "x": 115,
-          "y": 138,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "i18iMh",
-          "x": 95,
-          "y": 151,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 210,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "fkZQZ",
-          "x": 115,
-          "y": 164,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 170,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "ri2OT",
-          "x": 135,
-          "y": 177,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 130,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "nWpCI",
-          "x": 185,
-          "y": 142,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "K0TZt",
-          "x": 0,
-          "y": 214,
-          "name": "Intrada",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "urspl",
-          "x": 0,
-          "y": 260,
-          "name": "Subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        },
-        {
-          "type": "ellipse",
-          "id": "N0p9M",
-          "x": 203,
-          "y": 156,
-          "name": "Purple Note",
-          "fill": "#6346E5",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 12,
-            "spread": 2
-          }
+          "type": "frame",
+          "id": "MgYTY",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#EFEADD",
+          "stroke": "#DCD5C4",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fkF2J",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "OdTNz",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                },
+                {
+                  "type": "text",
+                  "id": "xVaFl",
+                  "fill": "#4C3FA6",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OaHSD",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "S8uEkK",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "rdMAZ",
+                  "fill": "#9A927F",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fUQJy",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "L4YeI",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "mPEkn",
+                  "fill": "#9A927F",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "VgEDI",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "kxuKe",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "AzXqz",
+                  "fill": "#9A927F",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Qi0Ct",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "WUTZD",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "DBWx4",
+                  "fill": "#9A927F",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
       "type": "text",
-      "id": "eBcTI",
-      "x": -1600,
-      "y": 13310,
-      "name": "title",
-      "fill": "#FFFFFF",
-      "content": "Digital Logo Kit — Intrada",
-      "fontFamily": "Inter",
-      "fontSize": 24,
+      "id": "aQfVD",
+      "x": 16000,
+      "y": 2620,
+      "fill": "#2B2A26",
+      "content": "Library — light mode (locked: Indigo · Refined)",
+      "fontFamily": "Source Serif 4",
+      "fontSize": 26,
       "fontWeight": "600"
     },
     {
+      "type": "text",
+      "id": "D7VzBl",
+      "x": 16000,
+      "y": 2686,
+      "fill": "#6E6557",
+      "content": "Polished reference — cooler cream, brighter cards, gold exercise, lighter chevron",
+      "fontFamily": "Inter",
+      "fontSize": 11,
+      "fontWeight": "500"
+    },
+    {
       "type": "frame",
-      "id": "oc1Qg",
-      "x": -1600,
-      "y": 13360,
-      "name": "App Icon",
-      "width": 200,
-      "height": 200,
-      "fill": "#0A0F1A",
-      "cornerRadius": 16,
-      "layout": "none",
+      "id": "v6sSdb",
+      "x": 16000,
+      "y": 2720,
+      "name": "Mobile / Library — Light (locked)",
+      "clip": true,
+      "width": 375,
+      "height": 812,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F4F1E8",
+            "position": 0
+          },
+          {
+            "color": "#EBE7D9",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
       "children": [
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "wqdnM",
-          "x": 63,
-          "y": 65,
-          "name": "sl1",
-          "fill": "#FFFFFF28",
-          "width": 74,
-          "height": 2
+          "type": "frame",
+          "id": "i8QeY8",
+          "name": "Content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "w50C7",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Apevs",
+                  "layout": "vertical",
+                  "gap": 3,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "C5oStz",
+                      "fill": "#2B2A26",
+                      "content": "Library",
+                      "fontFamily": "Source Serif 4",
+                      "fontSize": 32,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XxmXg",
+                      "fill": "#9A927F",
+                      "content": "12 pieces · 5 exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 12
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "V3XM7",
+                  "fill": "#4C3FA6",
+                  "content": "+ Add",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l0ORSo",
+              "name": "Rule",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#E0D9C8"
+            },
+            {
+              "type": "frame",
+              "id": "O23r72",
+              "name": "Tabs",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BtJmm",
+                  "fill": "#4C3FA6",
+                  "cornerRadius": 9999,
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "L3Xxcs",
+                      "fill": "#F2EFE8",
+                      "content": "Pieces",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "H36JI",
+                  "padding": [
+                    6,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "xfVGe",
+                      "fill": "#9A927F",
+                      "content": "Exercises",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rZ54I",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "enabled": false,
+                "color": "#0000001A",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 8
+              },
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Dik60",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "L8X6Hv",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    14,
+                    14,
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "I9lnKm",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "oGt1P",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "fUEuT",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "MhwTm",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WH1ap",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "Y3sPM",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#C7C0D4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KzHtA",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "enabled": false,
+                "color": "#0000001A",
+                "offset": {
+                  "x": 0,
+                  "y": 2
+                },
+                "blur": 8
+              },
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XU9bH",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "HIJqK",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    14,
+                    14,
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RM4ne",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "UC4Qz",
+                          "fill": "#2B2A26",
+                          "content": "Nocturne Op.9 No.2",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EDp6o",
+                          "fill": "#6E6557",
+                          "content": "Frédéric Chopin",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "t1Znp",
+                          "fill": "#9C927F",
+                          "content": "E♭ major · Andante · 66 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rFVie",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "iVr7Z",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#C7C0D4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yJDsG",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 80,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "LLeZQ",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "l5oC0A",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    14,
+                    14,
+                    14,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aFhtt",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "F2wdaD",
+                          "fill": "#2B2A26",
+                          "content": "Gymnopédie No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "qZKzs",
+                          "fill": "#6E6557",
+                          "content": "Erik Satie",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "nGmP2",
+                          "fill": "#9C927F",
+                          "content": "D major · Lent · 70 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Bg51r",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "MHFrZ",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#C7C0D4"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "UEj66",
-          "x": 51.5,
-          "y": 82,
-          "name": "sl2",
-          "fill": "#FFFFFF40",
-          "width": 97,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Rt8vN",
-          "x": 40,
-          "y": 99,
-          "name": "sl3",
-          "fill": "#FFFFFF5C",
-          "width": 120,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "f8gN6s",
-          "x": 51.5,
-          "y": 116,
-          "name": "sl4",
-          "fill": "#FFFFFF40",
-          "width": 97,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "hMHkO",
-          "x": 63,
-          "y": 133,
-          "name": "sl5",
-          "fill": "#FFFFFF28",
-          "width": 74,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "qtDrT",
-          "x": 117,
-          "y": 76,
-          "name": "gn",
-          "fill": "$warm-accent",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "qEx5e",
-          "x": 86,
-          "y": 92,
-          "name": "pn",
-          "fill": "#6346E5",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "Q6q3g",
-          "x": 107,
-          "y": 112,
-          "name": "sgn",
-          "fill": "#D4A050",
-          "width": 10,
-          "height": 10,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 12,
-            "spread": 2
-          }
+          "type": "frame",
+          "id": "pJmiH",
+          "name": "TabBar",
+          "width": "fill_container",
+          "height": 60,
+          "fill": "#EFEBDF",
+          "stroke": "#E0D9C8",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "padding": [
+            8,
+            12
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "kAjgA",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "wPHMq",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "book-open",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                },
+                {
+                  "type": "text",
+                  "id": "UXpPN",
+                  "fill": "#4C3FA6",
+                  "content": "Library",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "VUoWy",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "GM3o3",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "KeqKz",
+                  "fill": "#9A927F",
+                  "content": "Sessions",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "uQhZE",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "U52QLe",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "WF2Bj",
+                  "fill": "#9A927F",
+                  "content": "Routines",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GrT2u",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "LKnLO",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "chart-pie",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "Qvc7X",
+                  "fill": "#9A927F",
+                  "content": "Stats",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "B6cLjx",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "CxsFt",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "trending-up",
+                  "library": "lucide",
+                  "fill": "#B6AEC4"
+                },
+                {
+                  "type": "text",
+                  "id": "s6dOQ",
+                  "fill": "#9A927F",
+                  "content": "Analytics",
+                  "fontFamily": "Inter",
+                  "fontSize": 10
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
       "type": "frame",
-      "id": "x7KfB",
-      "x": -1350,
-      "y": 13360,
-      "name": "Favicon",
-      "width": 64,
-      "height": 64,
-      "fill": "#0A0F1A",
-      "cornerRadius": 8,
-      "layout": "none",
+      "id": "VnavF",
+      "x": 16500,
+      "y": 2720,
+      "name": "Type language study",
+      "width": 412,
+      "height": 912,
+      "fill": "#F2EFE6",
+      "layout": "vertical",
+      "gap": 20,
+      "padding": 20,
       "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "gAduG",
-          "x": 20,
-          "y": 21,
-          "name": "sl1",
-          "fill": "#FFFFFF28",
-          "width": 24,
-          "height": 1
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "B765J",
-          "x": 16.5,
-          "y": 27,
-          "name": "sl2",
-          "fill": "#FFFFFF40",
-          "width": 31,
-          "height": 1
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "TghOn",
-          "x": 13,
-          "y": 32,
-          "name": "sl3",
-          "fill": "#FFFFFF5C",
-          "width": 38,
-          "height": 1
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "n2k0ML",
-          "x": 16.5,
-          "y": 37,
-          "name": "sl4",
-          "fill": "#FFFFFF40",
-          "width": 31,
-          "height": 1
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "WhMzV",
-          "x": 20,
-          "y": 43,
-          "name": "sl5",
-          "fill": "#FFFFFF28",
-          "width": 24,
-          "height": 1
-        },
-        {
-          "type": "ellipse",
-          "id": "dEDRg",
-          "x": 37,
-          "y": 25,
-          "name": "gn",
-          "fill": "$warm-accent",
-          "width": 4,
-          "height": 4,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 3,
-            "spread": 1
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "v0ItE",
-          "x": 28,
-          "y": 30,
-          "name": "pn",
-          "fill": "#6346E5",
-          "width": 4,
-          "height": 4,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 3,
-            "spread": 1
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "jzDxL",
-          "x": 34,
-          "y": 36,
-          "name": "sgn",
-          "fill": "#D4A050",
-          "width": 3,
-          "height": 3,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 3,
-            "spread": 1
-          }
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "y1Vyf",
-      "x": -1236,
-      "y": 13360,
-      "name": "Horizontal Lockup — Dark",
-      "width": 480,
-      "height": 120,
-      "fill": "#0A0F1A",
-      "cornerRadius": 12,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "wD2ce",
-          "x": 40,
-          "y": 37,
-          "name": "Staff Line 1",
-          "fill": "#FFFFFF28",
-          "width": 49,
-          "height": 1.5
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "mcFM3",
-          "x": 33,
-          "y": 49,
-          "name": "Staff Line 2",
-          "fill": "#FFFFFF40",
-          "width": 65,
-          "height": 1.5
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "M8jvJ",
-          "x": 25,
-          "y": 60,
-          "name": "Staff Line 3",
-          "fill": "#FFFFFF5C",
-          "width": 80,
-          "height": 1.5
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "vuIxA",
-          "x": 33,
-          "y": 71,
-          "name": "Staff Line 4",
-          "fill": "#FFFFFF40",
-          "width": 65,
-          "height": 1.5
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "yhfx3",
-          "x": 40,
-          "y": 83,
-          "name": "Staff Line 5",
-          "fill": "#FFFFFF28",
-          "width": 49,
-          "height": 1.5
-        },
-        {
-          "type": "ellipse",
-          "id": "MSGVJ",
-          "x": 76,
-          "y": 45,
-          "name": "Gold Note",
-          "fill": "$warm-accent",
-          "width": 9,
-          "height": 9,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 8,
-            "spread": 1
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "meLO8",
-          "x": 56,
-          "y": 55,
-          "name": "Purple Note",
-          "fill": "#6346E5",
-          "width": 9,
-          "height": 9,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 8,
-            "spread": 1
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "DqfJk",
-          "x": 70,
-          "y": 69,
-          "name": "Small Gold Note",
-          "fill": "#D4A050",
-          "width": 7,
-          "height": 7,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 8,
-            "spread": 1
-          }
-        },
         {
           "type": "text",
-          "id": "ZrImd",
-          "x": 140,
-          "y": 36,
-          "fill": "$text-primary",
-          "content": "Intrada",
-          "fontFamily": "$font-heading",
-          "fontSize": 32,
+          "id": "VQc81",
+          "fill": "#2B2A26",
+          "content": "Type language — Piece vs Exercise",
+          "fontFamily": "Source Serif 4",
+          "fontSize": 20,
           "fontWeight": "600"
         },
         {
-          "type": "text",
-          "id": "SjkQq",
-          "x": 140,
-          "y": 76,
-          "fill": "$text-muted",
-          "content": "MUSIC PRACTICE",
-          "fontFamily": "$font-body",
-          "fontSize": 9,
-          "fontWeight": "normal",
-          "letterSpacing": 2
+          "type": "frame",
+          "id": "lWIGD",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "kvEpq",
+              "fill": "#6E6557",
+              "content": "A · Coloured pill — bar + pill share the type colour",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "mKiQ9",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Ijyr2",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "jVo7i",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "L4QwGQ",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "c1GYTr",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "w7ker3",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "tAYJc",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "w0m5u2",
+                      "name": "Badge",
+                      "fill": "#E7E3F4",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Mr3Wx",
+                          "fill": "#4C3FA6",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eP5SP",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "K9w1c8",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#C9A24E",
+                        "position": 0
+                      },
+                      {
+                        "color": "#9E7B33",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "OK4b1",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "N5MAv3",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PFFeF",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "jvm4u",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "Nmrhd",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lld6Q",
+                      "name": "Badge",
+                      "fill": "#F0E5CC",
+                      "cornerRadius": 9999,
+                      "padding": [
+                        4,
+                        10
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "y0hPdv",
+                          "fill": "#8A6A2E",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "SDryj",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "jYjgh",
+              "fill": "#6E6557",
+              "content": "B · Dot + label — lighter, less space",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "ZetGS",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XEDuB",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "wUo1e",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "l7CNS",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JvNlN",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "MpTAb",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "K1KqfO",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uPvvg",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "zRRng",
+                          "width": 7,
+                          "height": 7,
+                          "fill": "#4C3FA6",
+                          "cornerRadius": 9999
+                        },
+                        {
+                          "type": "text",
+                          "id": "p0ZLI",
+                          "fill": "#4C3FA6",
+                          "content": "Piece",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "m5jz76",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "dTQrR",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#C9A24E",
+                        "position": 0
+                      },
+                      {
+                        "color": "#9E7B33",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "U8fE3y",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V0qm6",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "k7ac2v",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "bJ2j3",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "e2ZPN5",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EbabA",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "vKhBK",
+                          "width": 7,
+                          "height": 7,
+                          "fill": "#9E7B33",
+                          "cornerRadius": 9999
+                        },
+                        {
+                          "type": "text",
+                          "id": "Tc0e2",
+                          "fill": "#9E7B33",
+                          "content": "Exercise",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "nAtIN",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "yD08F",
+              "fill": "#6E6557",
+              "content": "C · Bar only — no badge (the Pieces/Exercises tab already filters)",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "VUpAb",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QBJIw",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "y2RXJl",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "z6EiQC",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zdmix",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "l5Gq8n",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "Fl13k",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cY5Fo",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jsyS9",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#C9A24E",
+                        "position": 0
+                      },
+                      {
+                        "color": "#9E7B33",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "VYHJ5",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kHgMW",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T8msB",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "DXZ3C",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "POakL",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "JboFb",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "children": [
+            {
+              "type": "text",
+              "id": "XLHjK",
+              "fill": "#6E6557",
+              "content": "D · Icon chip — colour + glyph, compact + accessible",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "WgR6c",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NB63Q",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#6346E5",
+                        "position": 0
+                      },
+                      {
+                        "color": "#4C3FA6",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "kQsXE",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "LoodZ",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "u47YZ",
+                          "fill": "#2B2A26",
+                          "content": "Clair de Lune",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "NJjCF",
+                          "fill": "#6E6557",
+                          "content": "Claude Debussy",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "gaf0r",
+                          "fill": "#9C927F",
+                          "content": "D♭ major · Andante · 72 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QtrrV",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "#E7E3F4",
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "hTaTb",
+                          "width": 15,
+                          "height": 15,
+                          "icon": "music",
+                          "library": "lucide",
+                          "fill": "#4C3FA6"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ECDeJ",
+              "name": "Card",
+              "clip": true,
+              "width": "fill_container",
+              "height": 72,
+              "fill": "#FCFAF3",
+              "cornerRadius": 12,
+              "stroke": "#E5DECD",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "g4dDgI",
+                  "name": "Bar",
+                  "width": 4,
+                  "height": "fill_container",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 180,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#C9A24E",
+                        "position": 0
+                      },
+                      {
+                        "color": "#9E7B33",
+                        "position": 1
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "frame",
+                  "id": "YpnZX",
+                  "name": "Body",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 10,
+                  "padding": [
+                    12,
+                    14,
+                    12,
+                    16
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "epr6B",
+                      "name": "Text",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "T5FER3",
+                          "fill": "#2B2A26",
+                          "content": "Hanon Exercise No.1",
+                          "fontFamily": "Inter",
+                          "fontSize": 15,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PK4DW",
+                          "fill": "#6E6557",
+                          "content": "Charles-Louis Hanon",
+                          "fontFamily": "Inter",
+                          "fontSize": 13
+                        },
+                        {
+                          "type": "text",
+                          "id": "u3vm3",
+                          "fill": "#9C927F",
+                          "content": "C major · Allegro · 108 BPM",
+                          "fontFamily": "Inter",
+                          "fontSize": 12
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yBYQ9",
+                      "width": 26,
+                      "height": 26,
+                      "fill": "#F0E5CC",
+                      "cornerRadius": 8,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "N596m",
+                          "width": 15,
+                          "height": 15,
+                          "icon": "repeat",
+                          "library": "lucide",
+                          "fill": "#8A6A2E"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
       "type": "frame",
-      "id": "RXTry",
-      "x": -1600,
-      "y": 13660,
-      "name": "Full Logo — Light BG",
-      "width": 400,
-      "height": 400,
-      "fill": "#F5F5F0",
-      "cornerRadius": 16,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "qMiRl",
-          "x": 144.5,
-          "y": 101,
-          "name": "sl1",
-          "fill": "#00000028",
-          "width": 111,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "X7dpAl",
-          "x": 127,
-          "y": 127,
-          "name": "sl2",
-          "fill": "#00000040",
-          "width": 146,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Clc9i",
-          "x": 110,
-          "y": 152,
-          "name": "sl3",
-          "fill": "#0000005C",
-          "width": 180,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "iyW0a",
-          "x": 127,
-          "y": 178,
-          "name": "sl4",
-          "fill": "#00000040",
-          "width": 146,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "PVGmZ",
-          "x": 144.5,
-          "y": 204,
-          "name": "sl5",
-          "fill": "#00000028",
-          "width": 111,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "DHieg",
-          "x": 226,
-          "y": 118,
-          "name": "gn",
-          "fill": "$warm-accent",
-          "width": 21,
-          "height": 21,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 18,
-            "spread": 3
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "Q3TxH",
-          "x": 179,
-          "y": 142,
-          "name": "pn",
-          "fill": "#6346E5",
-          "width": 21,
-          "height": 21,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 18,
-            "spread": 3
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "OjLaS",
-          "x": 211,
-          "y": 172,
-          "name": "sgn",
-          "fill": "#D4A050",
-          "width": 15,
-          "height": 15,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 18,
-            "spread": 3
-          }
-        },
-        {
-          "type": "text",
-          "id": "CF8C5",
-          "x": 0,
-          "y": 234,
-          "name": "title",
-          "fill": "#111827",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "CZFvI",
-          "x": 0,
-          "y": 278,
-          "name": "subtitle",
-          "fill": "#6B7280",
-          "textGrowth": "fixed-width",
-          "width": 400,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "letterSpacing": 3
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "pSVzx",
-      "x": -1150,
-      "y": 13660,
-      "name": "OG Social Card",
-      "width": 600,
-      "height": 315,
-      "fill": "#0A0F1A",
-      "cornerRadius": 12,
-      "layout": "none",
-      "children": [
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "GCiuv",
-          "x": 254,
-          "y": 57,
-          "name": "sl1",
-          "fill": "#FFFFFF28",
-          "width": 93,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "kRV0l",
-          "x": 239,
-          "y": 78,
-          "name": "sl2",
-          "fill": "#FFFFFF40",
-          "width": 121,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "FpKVR",
-          "x": 225,
-          "y": 99,
-          "name": "sl3",
-          "fill": "#FFFFFF5C",
-          "width": 150,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "XrAHk",
-          "x": 239,
-          "y": 120,
-          "name": "sl4",
-          "fill": "#FFFFFF40",
-          "width": 121,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "eN3jB",
-          "x": 254,
-          "y": 142,
-          "name": "sl5",
-          "fill": "#FFFFFF28",
-          "width": 93,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "U8uBG",
-          "x": 321,
-          "y": 70,
-          "name": "n1",
-          "fill": "$warm-accent",
-          "width": 18,
-          "height": 18,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 15,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "apzzS",
-          "x": 283,
-          "y": 90,
-          "name": "n2",
-          "fill": "#6346E5",
-          "width": 18,
-          "height": 18,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#6346E540",
-            "blur": 15,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "fkd1U",
-          "x": 309,
-          "y": 115,
-          "name": "n3",
-          "fill": "#D4A050",
-          "width": 13,
-          "height": 13,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#D4A05040",
-            "blur": 15,
-            "spread": 2
-          }
-        },
-        {
-          "type": "text",
-          "id": "J9heF",
-          "x": 0,
-          "y": 168,
-          "name": "title",
-          "fill": "$text-primary",
-          "textGrowth": "fixed-width",
-          "width": 600,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 34,
-          "fontWeight": "600"
-        },
-        {
-          "type": "text",
-          "id": "WIasB",
-          "x": 0,
-          "y": 218,
-          "name": "subtitle",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 600,
-          "content": "MUSIC PRACTICE",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 12,
-          "fontWeight": "normal",
-          "letterSpacing": 3
-        },
-        {
-          "type": "text",
-          "id": "arT6b",
-          "x": 0,
-          "y": 244,
-          "name": "tagline",
-          "fill": "$text-muted",
-          "textGrowth": "fixed-width",
-          "width": 600,
-          "content": "Your personal music practice companion",
-          "textAlign": "center",
-          "fontFamily": "$font-body",
-          "fontSize": 14,
-          "fontWeight": "normal"
-        }
-      ]
-    },
-    {
-      "type": "frame",
-      "id": "a5c7r2",
-      "x": -500,
-      "y": 13660,
-      "name": "Monochrome — White on Dark",
+      "id": "BwffA",
+      "x": 16960,
+      "y": 2720,
+      "name": "Type language — legend",
       "width": 300,
-      "height": 200,
-      "fill": "#0A0F1A",
-      "cornerRadius": 12,
-      "layout": "none",
+      "height": 300,
+      "fill": "#F2EFE6",
+      "layout": "vertical",
+      "gap": 18,
+      "padding": 20,
       "children": [
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "y7RAc",
-          "x": 113,
-          "y": 44,
-          "name": "wsl1",
-          "fill": "#FFFFFF28",
-          "width": 74,
-          "height": 2
+          "type": "text",
+          "id": "ToeS7",
+          "fill": "#2B2A26",
+          "content": "Type language",
+          "fontFamily": "Source Serif 4",
+          "fontSize": 20,
+          "fontWeight": "600"
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Q4Wfh",
-          "x": 101.5,
-          "y": 61,
-          "name": "wsl2",
-          "fill": "#FFFFFF40",
-          "width": 97,
-          "height": 2
+          "type": "frame",
+          "id": "WqxnW",
+          "width": "fill_container",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "azFpN",
+              "width": 4,
+              "height": 36,
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#6346E5",
+                    "position": 0
+                  },
+                  {
+                    "color": "#4C3FA6",
+                    "position": 1
+                  }
+                ]
+              },
+              "cornerRadius": 2
+            },
+            {
+              "type": "frame",
+              "id": "DkgzH",
+              "width": 36,
+              "height": 36,
+              "fill": "#E7E3F4",
+              "cornerRadius": 9,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "zkDOQ",
+                  "width": 18,
+                  "height": 18,
+                  "icon": "music",
+                  "library": "lucide",
+                  "fill": "#4C3FA6"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GLIaA",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "x35pqN",
+                  "fill": "#2B2A26",
+                  "content": "Piece",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Ptzmg",
+                  "fill": "#6E6557",
+                  "content": "Indigo · repertoire",
+                  "fontFamily": "Inter",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "O3bTVx",
-          "x": 90,
-          "y": 78,
-          "name": "wsl3",
-          "fill": "#FFFFFF5C",
-          "width": 120,
-          "height": 2
+          "type": "frame",
+          "id": "IjPMx",
+          "width": "fill_container",
+          "gap": 12,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "eibHI",
+              "width": 4,
+              "height": 36,
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#C9A24E",
+                    "position": 0
+                  },
+                  {
+                    "color": "#9E7B33",
+                    "position": 1
+                  }
+                ]
+              },
+              "cornerRadius": 2
+            },
+            {
+              "type": "frame",
+              "id": "pcpsh",
+              "width": 36,
+              "height": 36,
+              "fill": "#F0E5CC",
+              "cornerRadius": 9,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "EsqSQ",
+                  "width": 18,
+                  "height": 18,
+                  "icon": "repeat",
+                  "library": "lucide",
+                  "fill": "#8A6A2E"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vasc0",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "R7aOvC",
+                  "fill": "#2B2A26",
+                  "content": "Exercise",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "sJXcC",
+                  "fill": "#6E6557",
+                  "content": "Gold · technical drill",
+                  "fontFamily": "Inter",
+                  "fontSize": 12
+                }
+              ]
+            }
+          ]
         },
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "huh0M",
-          "x": 101.5,
-          "y": 95,
-          "name": "wsl4",
-          "fill": "#FFFFFF40",
-          "width": 97,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "easID",
-          "x": 113,
-          "y": 112,
-          "name": "wsl5",
-          "fill": "#FFFFFF28",
-          "width": 74,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "UM6Ku",
-          "x": 167,
-          "y": 55,
-          "name": "wn1",
-          "fill": "#FFFFFF",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#FFFFFF30",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "H8Zij",
-          "x": 136,
-          "y": 71,
-          "name": "wn2",
-          "fill": "#FFFFFF",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#FFFFFF30",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "NxXZA",
-          "x": 157,
-          "y": 91,
-          "name": "wn3",
-          "fill": "#FFFFFF",
-          "width": 10,
-          "height": 10,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#FFFFFF30",
-            "blur": 12,
-            "spread": 2
-          }
+          "type": "frame",
+          "id": "rwrUv",
+          "width": "fill_container",
+          "height": 1,
+          "fill": "#E0D9C8"
         },
         {
           "type": "text",
-          "id": "vpWOt",
-          "x": 0,
-          "y": 132,
-          "name": "wt",
-          "fill": "#FFFFFF",
-          "textGrowth": "fixed-width",
-          "width": 300,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 22,
-          "fontWeight": "600"
+          "id": "Y0sfaR",
+          "fill": "#9A927F",
+          "content": "Bar = always-on signal.  Chip = mixed lists only.",
+          "fontFamily": "Inter",
+          "fontSize": 11
         }
       ]
     },
     {
       "type": "frame",
-      "id": "xWfrO",
-      "x": -150,
-      "y": 13660,
-      "name": "Monochrome — Dark on Light",
-      "width": 300,
-      "height": 200,
-      "fill": "#F5F5F0",
-      "cornerRadius": 12,
-      "layout": "none",
+      "id": "Yw9NB",
+      "x": 16000,
+      "y": 3600,
+      "name": "Mixed list — icon chip (D)",
+      "width": 375,
+      "height": 404,
+      "fill": {
+        "type": "gradient",
+        "gradientType": "linear",
+        "enabled": true,
+        "rotation": 180,
+        "size": {
+          "height": 1
+        },
+        "colors": [
+          {
+            "color": "#F4F1E8",
+            "position": 0
+          },
+          {
+            "color": "#EBE7D9",
+            "position": 1
+          }
+        ]
+      },
+      "layout": "vertical",
+      "gap": 12,
+      "padding": 16,
       "children": [
         {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "I1hjq",
-          "x": 113,
-          "y": 44,
-          "name": "dsl1",
-          "fill": "#00000028",
-          "width": 74,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Z3EtM",
-          "x": 101.5,
-          "y": 61,
-          "name": "dsl2",
-          "fill": "#00000040",
-          "width": 97,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "ch4me",
-          "x": 90,
-          "y": 78,
-          "name": "dsl3",
-          "fill": "#0000005C",
-          "width": 120,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "PQwd2",
-          "x": 101.5,
-          "y": 95,
-          "name": "dsl4",
-          "fill": "#00000040",
-          "width": 97,
-          "height": 2
-        },
-        {
-          "type": "rectangle",
-          "cornerRadius": 1,
-          "id": "Q0LFB",
-          "x": 113,
-          "y": 112,
-          "name": "dsl5",
-          "fill": "#00000028",
-          "width": 74,
-          "height": 2
-        },
-        {
-          "type": "ellipse",
-          "id": "X7AFE2",
-          "x": 167,
-          "y": 55,
-          "name": "dn1",
-          "fill": "#111827",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#11182730",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "YX8aR",
-          "x": 136,
-          "y": 71,
-          "name": "dn2",
-          "fill": "#111827",
-          "width": 14,
-          "height": 14,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#11182730",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
-          "type": "ellipse",
-          "id": "BV74C",
-          "x": 157,
-          "y": 91,
-          "name": "dn3",
-          "fill": "#111827",
-          "width": 10,
-          "height": 10,
-          "effect": {
-            "type": "shadow",
-            "shadowType": "outer",
-            "color": "#11182730",
-            "blur": 12,
-            "spread": 2
-          }
-        },
-        {
           "type": "text",
-          "id": "r19AS",
-          "x": 0,
-          "y": 132,
-          "name": "dt",
-          "fill": "#111827",
-          "textGrowth": "fixed-width",
-          "width": 300,
-          "content": "Intrada",
-          "textAlign": "center",
-          "fontFamily": "$font-heading",
-          "fontSize": 22,
-          "fontWeight": "600"
+          "id": "jnt2N",
+          "fill": "#6E6557",
+          "content": "Mixed list (search · all · set contents) — chip carries type",
+          "fontFamily": "Inter",
+          "fontSize": 11,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "TDTQI",
+          "width": "fill_container",
+          "height": 40,
+          "fill": "#ECE7DA",
+          "cornerRadius": 12,
+          "gap": 8,
+          "padding": [
+            0,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon",
+              "id": "IcnJV",
+              "width": 16,
+              "height": 16,
+              "icon": "search",
+              "library": "lucide",
+              "fill": "#9A927F"
+            },
+            {
+              "type": "text",
+              "id": "zSp1H",
+              "fill": "#9A927F",
+              "content": "Search library",
+              "fontFamily": "Inter",
+              "fontSize": 14
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Kf3nG",
+          "name": "Card",
+          "clip": true,
+          "width": "fill_container",
+          "height": 62,
+          "fill": "#FCFAF3",
+          "cornerRadius": 12,
+          "stroke": "#E5DECD",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "children": [
+            {
+              "type": "frame",
+              "id": "KmNCZ",
+              "name": "Bar",
+              "width": 4,
+              "height": "fill_container",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#6346E5",
+                    "position": 0
+                  },
+                  {
+                    "color": "#4C3FA6",
+                    "position": 1
+                  }
+                ]
+              }
+            },
+            {
+              "type": "frame",
+              "id": "K6mdy",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 10,
+              "padding": [
+                10,
+                14,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "L7oPr",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "f9kRe4",
+                      "fill": "#2B2A26",
+                      "content": "Clair de Lune",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "WLMyC",
+                      "fill": "#6E6557",
+                      "content": "Claude Debussy",
+                      "fontFamily": "Inter",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Bjxfv",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "#E7E3F4",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Z4ZvfY",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "music",
+                      "library": "lucide",
+                      "fill": "#4C3FA6"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jWNg0",
+          "name": "Card",
+          "clip": true,
+          "width": "fill_container",
+          "height": 62,
+          "fill": "#FCFAF3",
+          "cornerRadius": 12,
+          "stroke": "#E5DECD",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "children": [
+            {
+              "type": "frame",
+              "id": "OQo17",
+              "name": "Bar",
+              "width": 4,
+              "height": "fill_container",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#C9A24E",
+                    "position": 0
+                  },
+                  {
+                    "color": "#9E7B33",
+                    "position": 1
+                  }
+                ]
+              }
+            },
+            {
+              "type": "frame",
+              "id": "hnxlS",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 10,
+              "padding": [
+                10,
+                14,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rpGi4",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "K54XzU",
+                      "fill": "#2B2A26",
+                      "content": "Hanon Exercise No.1",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yq5Tw",
+                      "fill": "#6E6557",
+                      "content": "Charles-Louis Hanon",
+                      "fontFamily": "Inter",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qgRj1",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "#F0E5CC",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "blEMG",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "repeat",
+                      "library": "lucide",
+                      "fill": "#8A6A2E"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "TABAt",
+          "name": "Card",
+          "clip": true,
+          "width": "fill_container",
+          "height": 62,
+          "fill": "#FCFAF3",
+          "cornerRadius": 12,
+          "stroke": "#E5DECD",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "children": [
+            {
+              "type": "frame",
+              "id": "X7dZoT",
+              "name": "Bar",
+              "width": 4,
+              "height": "fill_container",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#6346E5",
+                    "position": 0
+                  },
+                  {
+                    "color": "#4C3FA6",
+                    "position": 1
+                  }
+                ]
+              }
+            },
+            {
+              "type": "frame",
+              "id": "wczxx",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 10,
+              "padding": [
+                10,
+                14,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JKUnJ",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "J71Lti",
+                      "fill": "#2B2A26",
+                      "content": "Nocturne Op.9 No.2",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "T7d0M",
+                      "fill": "#6E6557",
+                      "content": "Frédéric Chopin",
+                      "fontFamily": "Inter",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z1A30d",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "#E7E3F4",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "j7Hmd",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "music",
+                      "library": "lucide",
+                      "fill": "#4C3FA6"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "J5eNk",
+          "name": "Card",
+          "clip": true,
+          "width": "fill_container",
+          "height": 62,
+          "fill": "#FCFAF3",
+          "cornerRadius": 12,
+          "stroke": "#E5DECD",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "children": [
+            {
+              "type": "frame",
+              "id": "QPnsS",
+              "name": "Bar",
+              "width": 4,
+              "height": "fill_container",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#C9A24E",
+                    "position": 0
+                  },
+                  {
+                    "color": "#9E7B33",
+                    "position": 1
+                  }
+                ]
+              }
+            },
+            {
+              "type": "frame",
+              "id": "FZ3Pr",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "gap": 10,
+              "padding": [
+                10,
+                14,
+                10,
+                16
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "O70lI",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "YwpaS",
+                      "fill": "#2B2A26",
+                      "content": "Scales — C major",
+                      "fontFamily": "Inter",
+                      "fontSize": 15,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xL5i5",
+                      "fill": "#6E6557",
+                      "content": "Daily warm-up",
+                      "fontFamily": "Inter",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KvMte",
+                  "width": 26,
+                  "height": 26,
+                  "fill": "#F0E5CC",
+                  "cornerRadius": 8,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "M1r7hk",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "repeat",
+                      "library": "lucide",
+                      "fill": "#8A6A2E"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
-    },
-    {
-      "type": "text",
-      "id": "a7NyyP",
-      "x": -1600,
-      "y": 13570,
-      "name": "lbl1",
-      "fill": "#FFFFFF80",
-      "content": "App Icon — 200×200",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "bmlim",
-      "x": -1350,
-      "y": 13434,
-      "name": "lbl2",
-      "fill": "#FFFFFF80",
-      "content": "Favicon — 64×64",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "vKSao",
-      "x": -1236,
-      "y": 13490,
-      "name": "lbl3",
-      "fill": "#FFFFFF80",
-      "content": "Horizontal Lockup — 480×120",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "ABq5z",
-      "x": -1600,
-      "y": 14070,
-      "name": "lbl4",
-      "fill": "#FFFFFF80",
-      "content": "Full Logo Light — 400×400",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "R9fIe",
-      "x": -1150,
-      "y": 13985,
-      "name": "lbl5",
-      "fill": "#FFFFFF80",
-      "content": "OG / Social Card — 600×315",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "wLzwt",
-      "x": -500,
-      "y": 13870,
-      "name": "lbl6",
-      "fill": "#FFFFFF80",
-      "content": "Monochrome White — 300×200",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
-    },
-    {
-      "type": "text",
-      "id": "kg1iJ",
-      "x": -150,
-      "y": 13870,
-      "name": "lbl7",
-      "fill": "#FFFFFF80",
-      "content": "Monochrome Dark — 300×200",
-      "fontFamily": "Inter",
-      "fontSize": 12,
-      "fontWeight": "normal"
     }
   ],
   "variables": {

--- a/design/light-mode-exploration.md
+++ b/design/light-mode-exploration.md
@@ -1,0 +1,98 @@
+# Light-mode "paper" exploration — design notes
+
+> Added 2026-05-31. **Status: exploration, not shipped.** The live app is still
+> the dark glassmorphism theme (`crates/intrada-web/input.css`). These notes
+> document a light "paper / jazz score" direction explored in Pencil so it can
+> be referenced when picking up the native iOS rebuild.
+
+All frames live in `design/intrada.pen` (open in Pencil), grouped to the right
+of the existing screens (canvas x ≈ 16000–17500). The `.pen` is encrypted —
+this markdown is the readable record.
+
+## The idea
+
+A light theme inspired by **Moleskine paper** and a **jazz Real Book / manuscript
+page**: warm cream surfaces, ink-like text, clean minimal type. Explored four
+palettes on the Mobile Library screen (Sepia monochrome, Ink + oxblood, Deep
+teal/petrol, Indigo carryover), then locked **Indigo carryover** — the brand
+indigo deepened to sit on paper, for continuity.
+
+Typography held constant: **serif headings + clean sans body** (Source Serif 4
+over Inter in the mock).
+
+## Locked palette — "Indigo · Refined" (light/paper)
+
+| Role | Value |
+|------|-------|
+| Paper background | gradient `#F4F1E8 → #EBE7D9` (cooler cream so indigo stays crisp) |
+| Card surface | `#FCFAF3` |
+| Hairline / border | `#E5DECD` (cards), `#E0D9C8` (rules / tab bar) |
+| Ink (primary text) | `#2B2A26` (warm near-black, not pure black) |
+| Secondary text | `#6E6557` |
+| Muted / meta text | `#9C927F` |
+| Accent (indigo) | `#4C3FA6`; signature left bar = gradient `#6346E5 → #4C3FA6` |
+| Tab bar surface | `#EFEBDF` |
+
+Cards sit flat on the paper (border + slightly brighter fill for separation; a
+soft shadow was tried and removed — the flatter look read more "printed page").
+
+## Type language — Piece vs Exercise
+
+The strongest decision to carry forward. Each type is a **colour + icon pair**,
+used together everywhere (list, detail header, session setlist):
+
+| Type | Colour | Icon (Lucide mock) | Meaning |
+|------|--------|--------------------|---------|
+| **Piece** | indigo `#4C3FA6` | `music` (♪) | repertoire |
+| **Exercise** | gold `#9E7B33` | `repeat` (reps/cycle) | technical drill |
+
+Badge tints: Piece `#E7E3F4` / `#4C3FA6`, Exercise `#F0E5CC` / `#8A6A2E`.
+
+Rules:
+- **The type-coloured left bar is the always-on signal** (zero horizontal space).
+- **Filtered list** (Pieces / Exercises tab) → **bar only, no badge.** The tab
+  already tells you the type; a per-row label is redundant.
+- **Mixed list** (search · "All" · a Set's contents · a session setlist) →
+  **icon chip** (small tinted square + glyph). Compact (≈ half the width of the
+  old text pill) and colour-blind-safe because the glyph differs, not just hue.
+
+This fixed the earlier incoherence where the bar was always indigo while the
+badge was type-coloured — bar and chip now share one hue per type.
+
+The exercise glyph (`repeat`) was a Lucide placeholder; pick deliberately when
+building the real icon set (see native note below).
+
+## Carrying this into the native iOS rebuild
+
+The pixels are throwaway; the **direction, tokens, and type language** are not.
+Native SwiftUI also *improves* several of these answers:
+
+- **Type icons — solved natively.** SF Symbols has `metronome` (ideal for
+  Exercise) and `music.note` / `music.quarternote.3` (Piece). Use those instead
+  of the Lucide placeholders.
+- **Typography — no font bundling needed.** **New York** (the system serif,
+  `Font.system(.largeTitle, design: .serif)`) over **SF Pro** body is the native
+  expression of "Source Serif + Inter" and pairs beautifully with iOS large
+  titles. Bundle Source Serif 4 only if exact brand match matters.
+- **Colours → an asset catalog** (`Color` sets) or a small `Theme`. Asset-catalog
+  colours get **automatic light/dark** for free — which is the natural place to
+  decide whether native ships light-paper, keeps dark, or supports both.
+- **Native primitives replace web hacks.** `NavigationStack` large titles give the
+  big serif page title; `List`/insetGrouped or custom rows give the cards; safe
+  areas, no-zoom inputs, and view transitions are free. The CSS reset / 16px-font
+  / `env(safe-area-*)` / View-Transitions plumbing from the web shell does **not**
+  carry over.
+- **Card → a row:** leading type-coloured accent (a thin `Capsule`/`Rectangle`,
+  or a tinted row), title / composer / `key · tempo` meta, trailing type chip
+  **only in mixed lists**.
+- **Do not carry:** Tauri / WKWebView specifics, Leptos component names,
+  glassmorphism, or any exact Pencil pixel metrics — use system metrics.
+
+## Open questions
+
+- Does native launch in **light-paper**, keep **dark**, or support **both** (the
+  asset catalog makes both cheap)?
+- Final **exercise glyph** (lean `metronome` on native).
+- **Paper warmth per pillar** (Plan / Practice / Track) — held constant here.
+- Apply the language to **Item Detail** (type chip in header) and the **session
+  setlist** (mixed by nature — where the chip pays off most).


### PR DESCRIPTION
## What

A Pencil design exploration of a **light "Moleskine / jazz score" theme** for the Mobile Library screen, plus a readable notes doc. **Exploration only — no code, the live dark theme is unchanged.**

Merging so it's referenceable from `main` while picking up the native iOS rebuild.

## Contents
- **`design/intrada.pen`** — new frames (canvas x ≈ 16000–17500), to the right of the existing screens:
  - 4-palette comparison (Sepia / Oxblood / Teal / Indigo) on cream paper
  - 3 indigo refinements → **locked `Mobile / Library — Light (locked)`**
  - a **Type language** legend, a 4-option type-treatment study, and a mixed-list icon-chip example
- **`design/light-mode-exploration.md`** — readable record (the `.pen` is encrypted): locked palette tokens, the Piece-vs-Exercise type language, and a **carry-over guide for the native iOS build** (SF Symbols `metronome`/`music.note`, New York serif + SF Pro, asset-catalog colours for free light/dark).

## Key decision — type language
Each type = **colour + icon pair**. Type-coded left **bar is the always-on signal**; **filtered lists** show bar only (the tab already filters); **mixed lists** (search / all / set contents / setlist) show a compact **icon chip**. Resolves the prior mismatch where the bar was always indigo but the badge was type-coloured.

## Notes
- Binary `.pen` diff isn't reviewable in GitHub; review via the markdown + opening the file in Pencil.
- No tests / no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)