### PR TITLE
chore: gitignore local scratch (.swiftpm, .superpowers, design screenshots)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,15 @@ crates/intrada-mobile/plugins/*/.tauri/
 # Swift package resolution lockfile — regenerated on each iOS build.
 crates/intrada-mobile/plugins/*/ios/Package.resolved
 *.xcuserdata/
+# Xcode/SwiftPM per-user data (schemes, breakpoints) — not just *.xcuserdata dirs
+.swiftpm/
 DerivedData/
 *.ipa
 *.dSYM.zip
 *.dSYM
 crates/intrada-web/test-results/
 design/images/generated-*.png
+# Ad-hoc macOS screenshots dropped into design/ — scratch, not design sources
+design/Screenshot*.png
+# Superpowers plugin scratch (brainstorm servers, etc.)
+.superpowers/


### PR DESCRIPTION
## What

Three machine-local artifacts were persistently showing in `git status`. This gitignores them (Tier 1 chore) to clear the tree before the native iOS pivot work begins.

| Artifact | Why ignore |
|----------|-----------|
| `**/.swiftpm/` | Xcode/SwiftPM per-user scheme data. The existing `*.xcuserdata/` pattern doesn't match the `.swiftpm/` wrapper dir. |
| `.superpowers/` | Superpowers plugin brainstorm-server scratch (HTML/PID/logs). |
| `design/Screenshot*.png` | Stray auto-named macOS screenshots dropped into `design/` are scratch, not design sources. One existing such file was deleted. |

## Test plan

- `git status` is clean after the change (no untracked scratch entries).
- No source or build behaviour affected — `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)