### PR TITLE
chore(ci): focus mode — web/Tauri/API jobs main-only during iOS pivot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # iOS-pivot focus mode: pause bumps for the web/Tauri shells (on hold).
+    # Core + API deps still auto-update. Remove this ignore list at parity.
+    ignore:
+      - dependency-name: "tauri"
+      - dependency-name: "tauri-*"
+      - dependency-name: "leptos"
+      - dependency-name: "leptos_*"
+      - dependency-name: "leptos-*"
+      - dependency-name: "trunk"
+      - dependency-name: "wasm-bindgen"
+      - dependency-name: "wasm-bindgen-*"
+      - dependency-name: "web-sys"
+      - dependency-name: "js-sys"
+      - dependency-name: "gloo"
+      - dependency-name: "gloo-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 40
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.mobile == 'true'
+    # iOS-pivot focus mode: Tauri host is on hold — run on main only, not PRs.
+    # Revert to `|| needs.changes.outputs.mobile == 'true'` at parity.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -360,7 +362,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.web == 'true'
+    # iOS-pivot focus mode: web shell on hold — run on main only, not PRs.
+    # Revert to `|| needs.changes.outputs.web == 'true'` at parity.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -421,7 +425,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.web == 'true'
+    # iOS-pivot focus mode: web shell on hold — run on main only, not PRs.
+    # Revert to `|| needs.changes.outputs.web == 'true'` at parity.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -443,6 +449,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: wasm-build
+    # iOS-pivot focus mode: web shell on hold — run on main only, not PRs.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -501,6 +509,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: wasm-build
+    # iOS-pivot focus mode: web shell on hold — run on main only, not PRs.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -609,7 +619,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.api == 'true'
+    # iOS-pivot focus mode: API on hold — run on main only, not PRs.
+    # Revert to `|| needs.changes.outputs.api == 'true'` at parity.
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
## What

We're starting the **native SwiftUI iOS pivot** and putting the web (Leptos), Tauri host, and API on hold. This quiets their CI + Dependabot noise so the iOS work has a clean signal. **Fully reversible** — every change carries a "revert at parity" comment.

### `ci.yml` — web/Tauri/API build jobs → main-only
These jobs change from "push OR path-changed" to **push-only** (push only fires on `main`):
`ios-build` (Tauri), `wasm-build`, `wasm-test`, `e2e`, `deploy-smoke`, `api-docker-build`. (`deploy`/`deploy-api` were already main-only.)

**Core CI still runs on every PR:** `test`, `clippy`, `fmt`, `security`, `coverage` — these cover `intrada-core`. Critically, the `clippy` job still builds `intrada-web` for `wasm32`, so a core change that breaks the web build is **still caught on PRs**.

### `dependabot.yml` — pause web/Tauri ecosystem bumps
Added an `ignore` list for `tauri*`, `leptos*`, `trunk`, `wasm-bindgen*`, `web-sys`, `js-sys`, `gloo*`. Core + API deps keep auto-updating. This kills the bulk of the recent bump-PR noise.

## Tradeoff

While on hold, web/Tauri/API changes aren't validated on PRs — they're validated when they reach `main` (where the full chain still gates deploys). Acceptable since those surfaces are dormant during the pivot; reverting is a one-line-per-job change.

## Test plan

- YAML parses (ruby `YAML.load_file`).
- This PR touches `ci.yml` (matches the `rust` path filter) → expect `test`/`clippy`/`fmt`/`security` to **run**, and `wasm-*`/`e2e`/`ios-build`/`deploy-smoke`/`api-docker-build` to **skip**. Verify on the checks tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)