### PR TITLE
chore: iOS agent tooling — XcodeBuildMCP + swift-format-on-edit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.rs) command -v rustfmt >/dev/null 2>&1 && rustfmt --edition 2021 \"$f\" >/dev/null 2>&1 ;; esac; exit 0"
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.rs) command -v rustfmt >/dev/null 2>&1 && rustfmt --edition 2021 \"$f\" >/dev/null 2>&1 ;; *.swift) command -v swift-format >/dev/null 2>&1 && swift-format format -i \"$f\" >/dev/null 2>&1 ;; esac; exit 0"
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/mcp.json",
+  "mcpServers": {
+    "xcodebuild": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["xcodebuildmcp@latest"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## What

Tooling prep for the native SwiftUI iOS pivot. Both additions are **inert until Phase A** (no `.swift` files or Xcode project exist yet) but land them now so they're ready and shared.

- **`.mcp.json`** (new) — project-scoped **XcodeBuildMCP** (`npx xcodebuildmcp@latest`, v2.5.2). Gives the agent hands to build/run on the simulator and capture screenshots — pairs with swift-snapshot-testing as the agent's "eyes" in later phases. Prompts for trust on first use.
- **`.claude/settings.json`** — adds a `*.swift)` case to the existing PostToolUse format-on-edit hook (`swift-format format -i`), mirroring the rustfmt case from [#767](https://github.com/jonyardley/intrada/pull/767).

## Not in this PR (your action)

Swift code intelligence (**sourcekit-lsp**) isn't configured via repo files — Claude Code surfaces it through the `swift-lsp` plugin. Install per-user:
```
/plugin install swift-lsp@claude-plugins-official
```

## Test plan

- Both files parse as JSON; neither is gitignored.
- `swift-format format -i` verified locally (reformats a sample struct).
- Hook mirrors the proven rustfmt entry; activates on the first `.swift` edit in Phase A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)