### PR TITLE
Phase A1: native iOS bridge — core typegen readiness + spec (#775)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,44 @@ data in shell-local state. UI-only state stays in Leptos signals.
   Updates use `*Updated { entity }` (server echoes the row); deletes use
   `DeleteConfirmed` (model already mutated optimistically).
 
+## Native iOS Shell (SwiftUI + Crux)
+
+> Applies once Phase A lands. The native SwiftUI app is replacing the Tauri
+> shell — see [`specs/native-ios.md`](specs/native-ios.md). App-first,
+> local-first. These rules are non-negotiable when touching the native shell.
+
+**The shell is a dumb pipe — it owns ZERO domain logic.** It sends `Event`s,
+fulfils `Effect`s (HTTP via `URLSession`, persistence via GRDB, etc.), and
+renders the `ViewModel`. No business rules, no validation, no domain decisions
+in Swift. If you're tempted to write logic in Swift, the logic belongs in
+`intrada-core` as an `Event`/`Command`.
+
+- **Bindings are a build precondition, never source.** The Swift `Event` /
+  `Effect` / `ViewModel` types and serializers are **generated** (facet-generate
+  + UniFFI). **Never hand-edit generated bindings.** If a generated type is
+  wrong or missing, **fix the Rust type in `intrada-core` and regenerate** —
+  the typegen run is part of the build, not an optional step. A diff that edits
+  generated Swift is a blocker.
+- **`@Observable`, not `ObservableObject`.** The core-wrapping store is an
+  `@Observable @MainActor` object exposing the `ViewModel` and an `update(Event)`
+  method. Effect handlers run off the main actor, then hop back to resolve.
+- **`try!` is banned like `unwrap()`.** No `try!` / force-unwraps / `as!`
+  without a written justification (same bar as Rust `unwrap()`). FFI calls and
+  bincode (de)serialization return real errors — handle them.
+- **Persistence is a core `Effect` driven by `Command`, not Swift logic.** GRDB
+  owns the SQLite tables and executes typed query/mutation effects; the core
+  decides what to read/write and runs LWW reconciliation. `crux_kv` is for small
+  singletons only, never relational data.
+- **Quality is per-screen, not deferred.** Every screen ships with a
+  swift-snapshot-test, VoiceOver labels + Dynamic Type, and an iPad `SplitView`
+  built *with* the screen. Sentry is wired from the first build.
+- **Build hazard:** UniFFI-generated Swift fails under Xcode 26 / Swift 6.2
+  `MainActor`-default isolation ([uniffi-rs#2818]). Keep the generated package
+  non-MainActor-defaulted (build recipe handles it); don't "fix" it by editing
+  generated code.
+
+[uniffi-rs#2818]: https://github.com/mozilla/uniffi-rs/issues/2818
+
 ## Authentication
 
 Two auth paths, same API surface:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,9 @@ dependencies = [
  "crossbeam-channel",
  "crux_macros",
  "facet 0.44.5",
+ "facet_generate",
  "futures",
+ "log",
  "serde",
  "serde_json",
  "slab",
@@ -1628,6 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04625a816bc27bb757b5f62ec17a228b90c08631f579ee0b36eccd6c426df207"
 dependencies = [
  "autocfg",
+ "chrono",
  "const-fnv1a-hash",
  "iddqd",
  "impls",
@@ -1716,6 +1719,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unsynn",
+]
+
+[[package]]
+name = "facet_generate"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+dependencies = [
+ "derive_builder",
+ "facet 0.44.5",
+ "facet-generate-attrs",
+ "heck 0.5.0",
+ "include_dir",
+ "indent",
+ "indoc",
+ "regex",
+ "serde",
+ "serde_json",
+ "textwrap",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2925,6 +2948,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +2993,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2997,6 +3054,7 @@ dependencies = [
  "chrono",
  "crux_core",
  "crux_http",
+ "facet 0.44.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6020,6 +6078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6654,6 +6718,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7230,10 +7305,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ package.rust-version = "1.75"
 [workspace.dependencies]
 crux_core = "0.18.0"
 crux_http = "0.17.0"
+# Must track the facet version crux_core 0.18 pulls in (0.44.x) so the
+# gated `derive(facet::Facet)` impls match crux's typegen reflection.
+facet = "0.44"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ulid = "1"

--- a/crates/intrada-core/Cargo.toml
+++ b/crates/intrada-core/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 publish = false
 rust-version.workspace = true
 
+[features]
+# Enables facet reflection on the FFI-boundary types so the native iOS
+# bridge's typegen (crux_core::type_generation::facet) can emit Swift types.
+# Gated so the default web/api builds are unaffected.
+facet_typegen = ["dep:facet", "crux_core/facet_typegen", "crux_http/facet_typegen"]
+
 [dependencies]
 crux_core = { workspace = true }
 crux_http = { workspace = true }
@@ -13,3 +19,6 @@ serde_json = { workspace = true }
 ulid = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
+# `chrono` feature provides the Facet impl for the `DateTime<Utc>` fields on
+# domain types (created_at/updated_at) so they're typegen-representable.
+facet = { workspace = true, optional = true, features = ["chrono"] }

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -17,6 +17,8 @@ use crate::domain::session::PracticeSession;
 
 /// Directional comparison indicator for week-over-week metrics.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 #[serde(rename_all = "lowercase")]
 pub enum Direction {
     Up,
@@ -27,6 +29,7 @@ pub enum Direction {
 
 /// A library item not practised within the 14-day lookback window.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct NeglectedItem {
     pub item_id: String,
     pub item_title: String,
@@ -36,6 +39,7 @@ pub struct NeglectedItem {
 
 /// An item whose score changed during the current week.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ScoreChange {
     pub item_id: String,
     pub item_title: String,
@@ -50,6 +54,7 @@ pub struct ScoreChange {
 
 /// Top-level analytics container, added to the existing `ViewModel`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct AnalyticsView {
     pub weekly_summary: WeeklySummary,
     pub streak: PracticeStreak,
@@ -63,6 +68,7 @@ pub struct AnalyticsView {
 /// Aggregated stats for the current and previous ISO weeks (Monday–Sunday),
 /// with directional comparison indicators.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct WeeklySummary {
     pub total_minutes: u32,
     pub session_count: usize,
@@ -78,12 +84,14 @@ pub struct WeeklySummary {
 
 /// Consecutive-day practice count.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct PracticeStreak {
     pub current_days: u32,
 }
 
 /// One entry per day for the 28-day history chart.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct DailyPracticeTotal {
     pub date: String,
     pub minutes: u32,
@@ -91,6 +99,7 @@ pub struct DailyPracticeTotal {
 
 /// Per-item aggregation for the "most practised" list.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ItemRanking {
     pub item_id: String,
     pub item_title: String,
@@ -101,6 +110,7 @@ pub struct ItemRanking {
 
 /// Score progression for a single item.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ItemScoreTrend {
     pub item_id: String,
     pub item_title: String,
@@ -110,6 +120,7 @@ pub struct ItemScoreTrend {
 
 /// Single data point in a score trend.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ScorePoint {
     pub date: String,
     pub score: u8,

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -37,6 +37,8 @@ pub struct Intrada;
 
 /// All events the application can process.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum Event {
     // ── Lifecycle ────────────────────────────────────────────────────
     /// Shell provides the API base URL on startup.
@@ -114,7 +116,7 @@ pub enum Event {
 /// HTTP API calls go through `Http` (crux_http). The shell executes the raw
 /// HTTP request and feeds the response back; all request construction and
 /// response parsing happens in the core (see `http.rs`).
-#[effect]
+#[effect(facet_typegen)]
 pub enum Effect {
     Render(RenderOperation),
     Http(HttpRequest),
@@ -127,6 +129,8 @@ pub enum Effect {
 /// After the crux_http migration, only localStorage crash-recovery operations
 /// remain here. All API calls now go through the `Http` effect variant.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum AppEffect {
     /// Persist the active session to localStorage for crash recovery (FR-008).
     SaveSessionInProgress(ActiveSession),

--- a/crates/intrada-core/src/domain/account.rs
+++ b/crates/intrada-core/src/domain/account.rs
@@ -15,6 +15,7 @@ use crate::model::Model;
 /// `intrada-api/src/db/account.rs`) so the same JSON deserialises on both
 /// sides.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct AccountPreferences {
     pub default_focus_minutes: u32,
     pub default_rep_count: u32,
@@ -30,6 +31,8 @@ impl Default for AccountPreferences {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum AccountEvent {
     /// Fetch the current user's preferences from the API.
     LoadPreferences,

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -11,6 +11,8 @@ use crate::validation;
 
 /// Discriminates between a piece (repertoire) and an exercise (technique drill).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 #[serde(rename_all = "lowercase")]
 pub enum ItemKind {
     Piece,
@@ -27,6 +29,7 @@ impl fmt::Display for ItemKind {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct Item {
     pub id: String,
     pub title: String,
@@ -43,6 +46,8 @@ pub struct Item {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum ItemEvent {
     Add(CreateItem),
     Update { id: String, input: UpdateItem },

--- a/crates/intrada-core/src/domain/mcp_audit.rs
+++ b/crates/intrada-core/src/domain/mcp_audit.rs
@@ -12,6 +12,7 @@ use crate::app::{Effect, Event};
 use crate::model::Model;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct McpAuditEntry {
     pub id: String,
     /// `None` for JWT-authenticated MCP writes (browser/iOS session, no PAT).
@@ -28,6 +29,8 @@ pub struct McpAuditEntry {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum McpAuditEvent {
     LoadAudit,
     AuditLoaded(Vec<McpAuditEntry>),

--- a/crates/intrada-core/src/domain/mcp_tokens.rs
+++ b/crates/intrada-core/src/domain/mcp_tokens.rs
@@ -14,6 +14,7 @@ use crate::model::Model;
 /// A single PAT in the user's account, as surfaced by the list endpoint.
 /// Fields mirror `intrada-api`'s `TokenListItem`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct McpToken {
     pub id: String,
     pub name: String,
@@ -26,6 +27,7 @@ pub struct McpToken {
 /// Response from the create endpoint. The `token` field is the only place the
 /// full bearer string is ever returned — UI shows it once and never again.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreatedMcpToken {
     pub id: String,
     pub name: String,
@@ -35,6 +37,8 @@ pub struct CreatedMcpToken {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum McpTokenEvent {
     /// Fetch the user's tokens.
     LoadTokens,

--- a/crates/intrada-core/src/domain/oauth.rs
+++ b/crates/intrada-core/src/domain/oauth.rs
@@ -15,6 +15,7 @@ use crate::app::{Effect, Event};
 use crate::model::Model;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct OAuthFinalizeParams {
     pub response_type: String,
     pub client_id: String,
@@ -28,6 +29,8 @@ pub struct OAuthFinalizeParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum OAuthEvent {
     /// User clicked Allow on the consent screen.
     FinalizeConsent(OAuthFinalizeParams),

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 
 /// Completion status of a single setlist entry.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum EntryStatus {
     /// Item was practised and time was recorded.
     Completed,
@@ -22,6 +24,8 @@ pub enum EntryStatus {
 
 /// Whether the session ran to completion or was ended early.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum CompletionStatus {
     /// All items in the setlist were addressed (completed or skipped).
     Completed,
@@ -35,6 +39,8 @@ pub enum CompletionStatus {
 /// Enables analytics: sum for net progress, running total for sparkline charts,
 /// count of `-1`s for total misses, longest streak of `1`s for best run.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum RepAction {
     /// Failed rep — count decremented.
     Missed,
@@ -46,6 +52,7 @@ pub enum RepAction {
 
 /// An individual item within a session's setlist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SetlistEntry {
     pub id: String,
     pub item_id: String,
@@ -75,6 +82,7 @@ pub struct SetlistEntry {
 
 /// A completed practice session (persisted to localStorage).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct PracticeSession {
     pub id: String,
     pub entries: Vec<SetlistEntry>,
@@ -106,6 +114,7 @@ pub struct BuildingSession {
 /// State during active practice (Active phase).
 /// Persisted to `intrada:session-in-progress` for crash recovery.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ActiveSession {
     pub id: String,
     pub entries: Vec<SetlistEntry>,
@@ -141,6 +150,8 @@ pub enum SessionStatus {
 // ── Events ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum SessionEvent {
     // === Building Phase ===
     StartBuilding,

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -12,6 +12,7 @@ use crate::validation;
 
 /// A named, reusable setlist template containing an ordered list of library item references.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct Set {
     pub id: String,
     pub name: String,
@@ -22,6 +23,7 @@ pub struct Set {
 
 /// A single item within a set, representing a library piece or exercise.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SetEntry {
     pub id: String,
     pub item_id: String,
@@ -33,6 +35,8 @@ pub struct SetEntry {
 // ── Events ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum SetEvent {
     SaveBuildingAsSet {
         name: String,

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -15,6 +15,7 @@ where
 
 /// Top-level serialisation unit for library data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct LibraryData {
     #[serde(default)]
     pub items: Vec<Item>,
@@ -22,6 +23,7 @@ pub struct LibraryData {
 
 /// Tempo representation with optional marking (e.g. "Allegro") and BPM.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct Tempo {
     pub marking: Option<String>,
     pub bpm: Option<u16>,
@@ -51,6 +53,7 @@ impl Tempo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreateItem {
     pub title: String,
     pub kind: ItemKind,
@@ -66,6 +69,7 @@ pub struct CreateItem {
 /// - `Some(None)` = clear the field
 /// - `Some(Some(v))` = set to new value
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct UpdateItem {
     pub title: Option<String>,
     #[serde(
@@ -101,6 +105,7 @@ use super::session::PracticeSession;
 
 /// Top-level serialisation unit for `sessions.json` / `intrada:sessions`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SessionsData {
     #[serde(default)]
     pub sessions: Vec<PracticeSession>,
@@ -110,6 +115,7 @@ pub struct SessionsData {
 
 /// Request body for creating a set via the REST API.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreateSetRequest {
     pub name: String,
     pub entries: Vec<CreateSetEntryRequest>,
@@ -117,6 +123,7 @@ pub struct CreateSetRequest {
 
 /// Entry within a create/update set API request.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreateSetEntryRequest {
     pub item_id: String,
     pub item_title: String,
@@ -125,6 +132,7 @@ pub struct CreateSetEntryRequest {
 
 /// Request body for updating a set via the REST API.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct UpdateSetRequest {
     pub name: String,
     pub entries: Vec<CreateSetEntryRequest>,
@@ -170,6 +178,7 @@ impl UpdateSetRequest {
 
 /// Filters for listing/searching library items.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ListQuery {
     pub text: Option<String>,
     pub item_type: Option<ItemKind>,

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -143,6 +143,8 @@ impl Model {
 /// exposed to shells via the `ViewModel`. Using an enum instead of a
 /// String gives compile-time safety in both Rust and generated Swift code.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum SessionStatusView {
     #[default]
     Idle,
@@ -153,6 +155,7 @@ pub enum SessionStatusView {
 
 /// Serializable view state sent to shells for rendering.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ViewModel {
     pub items: Vec<LibraryItemView>,
     pub sessions: Vec<PracticeSessionView>,
@@ -183,6 +186,7 @@ pub struct ViewModel {
 
 /// Represents a set for display in the UI.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SetView {
     pub id: String,
     pub name: String,
@@ -192,6 +196,7 @@ pub struct SetView {
 
 /// Represents a single entry within a set for display.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SetEntryView {
     pub id: String,
     pub item_id: String,
@@ -202,6 +207,7 @@ pub struct SetEntryView {
 
 /// Flattened representation of a piece or exercise for display.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct LibraryItemView {
     pub id: String,
     pub item_type: ItemKind,
@@ -220,6 +226,7 @@ pub struct LibraryItemView {
 
 /// Practice summary for a library item.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ItemPracticeSummary {
     pub session_count: usize,
     pub total_minutes: u32,
@@ -231,6 +238,7 @@ pub struct ItemPracticeSummary {
 
 /// A single score data point for an item's progress history.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ScoreHistoryEntry {
     pub session_date: String,
     pub score: u8,
@@ -239,6 +247,7 @@ pub struct ScoreHistoryEntry {
 
 /// A single tempo data point for an item's tempo progress history.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct TempoHistoryEntry {
     pub session_date: String,
     pub tempo: u16,
@@ -247,6 +256,7 @@ pub struct TempoHistoryEntry {
 
 /// A completed practice session in history view.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct PracticeSessionView {
     pub id: String,
     pub started_at: String,
@@ -260,6 +270,7 @@ pub struct PracticeSessionView {
 
 /// A single entry within a session view.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SetlistEntryView {
     pub id: String,
     pub item_id: String,
@@ -282,6 +293,7 @@ pub struct SetlistEntryView {
 
 /// View for the in-progress active session.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ActiveSessionView {
     pub current_item_title: String,
     pub current_item_type: ItemKind,
@@ -307,6 +319,8 @@ pub struct ActiveSessionView {
 /// View for the building phase setlist.
 /// Whether the builder's entries originate from, and relate to, a saved Set.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum SetSourceStatus {
     #[default]
     NoSource,
@@ -322,6 +336,7 @@ pub enum SetSourceStatus {
 
 /// View for the building phase setlist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct BuildingSetlistView {
     pub entries: Vec<SetlistEntryView>,
     pub item_count: usize,
@@ -332,6 +347,7 @@ pub struct BuildingSetlistView {
 
 /// View for the end-of-session summary.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct SummaryView {
     pub total_duration_display: String,
     pub completion_status: CompletionStatus,

--- a/crates/intrada-core/tests/typegen_readiness.rs
+++ b/crates/intrada-core/tests/typegen_readiness.rs
@@ -1,0 +1,21 @@
+//! Typegen-readiness: the native iOS bridge generates Swift types from the
+//! core via `crux_core`'s facet reflection. That only works if every type
+//! reachable from `Event` / `Effect` / `ViewModel` derives `Facet`. This test
+//! is the discovery + regression guard: if a new field introduces a type that
+//! isn't facet-representable, `register_app` fails here rather than in the iOS
+//! build. Gated on `facet_typegen` so it's a no-op for default builds.
+#![cfg(feature = "facet_typegen")]
+
+use crux_core::type_generation::facet::TypeRegistry;
+use intrada_core::Intrada;
+
+#[test]
+fn registers_full_app_type_graph() {
+    let mut registry = TypeRegistry::new();
+    registry
+        .register_app::<Intrada>()
+        .expect("register_app should cover the full Intrada Event/Effect/ViewModel graph");
+    registry
+        .build()
+        .expect("type registry should build into a code generator");
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -91,15 +91,26 @@ ships and as we learn.
 
 ## Mobile shell
 
-iOS ships through the Tauri 2 + Leptos shell — the SwiftUI shell has
-been removed. The Leptos UI is the single codebase; iOS-specific
-look-and-feel is layered in via `[data-platform="ios"]` rules and Tauri
-plugins (haptics, deep-link, background audio). Every web feature ships
-on iOS at the same time.
+**Pivoting to a native SwiftUI app (2026-05-31).** iOS is moving off the
+Tauri 2 + Leptos WKWebView to a **fully native SwiftUI app on the shared
+Crux (Rust) core** — finally using Crux as designed (pure core + thin
+native shell over FFI/typegen). This is app-first (native iOS now, native
+Android later) and **local-first** (on-device SQLite is the source of
+truth; the Axum+Turso backend becomes a sync target). The web app stays on
+Leptos, untouched.
 
-See [`specs/tauri-leptos-ios-shell.md`](../specs/tauri-leptos-ios-shell.md)
-for the phased plan. Active mobile-shell work tracks under the
-[`ios`](https://github.com/jonyardley/intrada/labels/ios) label.
+This resurrects-and-modernizes the SwiftUI shell that was removed in #382,
+rather than starting from scratch. The Tauri shell stays shipping until the
+native app reaches parity, then retires.
+
+See [`specs/native-ios.md`](../specs/native-ios.md) for the phased plan
+(Phase A bridge spike → B local-first persistence → C screen parity → D
+sync + retire Tauri). Active work tracks under the
+[`ios`](https://github.com/jonyardley/intrada/labels/ios) label and the
+native-iOS [`epic`](https://github.com/jonyardley/intrada/labels/epic).
+The prior Tauri/Leptos plan in
+[`specs/tauri-leptos-ios-shell.md`](../specs/tauri-leptos-ios-shell.md)
+remains the reference for the shell being retired.
 
 ---
 

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -50,9 +50,9 @@ iOS Shell" section).
 - **Typegen:** `facet-generate` (≥0.17) + the `facet_typegen` feature on
   `crux_core` 0.18 generates a Swift package of `Event` / `Effect` /
   `ViewModel` + domain types and their bincode (BCS) serializers. The core
-  types in `app.rs` (`Event`, `Effect` via `#[effect]`, `AppEffect`) get their
-  `#[derive(Facet)]` / `#[repr(C)]` attributes restored behind the feature
-  (they were stripped in #382).
+  types in `app.rs` (`Event`, `AppEffect`, and `Effect` via
+  `#[effect(facet_typegen)]`) get their `#[derive(Facet)]` (+ `#[repr(C)]` on
+  enums) restored behind the feature (they were stripped in #382).
 - **Packaging:** **spike `cargo-swift`** (the Crux book's current documented
   path: `cargo-swift` + `xcodegen` + `just`) which produces a Swift package
   wrapping the compiled static lib. **Fallback:** revive the hand-rolled

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -1,0 +1,151 @@
+# Native iOS Shell (SwiftUI + Crux)
+
+> Tier 3 (Crux FFI bridge + new persistence/sync capability, multi-week,
+> spans core + a net-new native shell). Spec rides with the Phase A branch per
+> CLAUDE.md. Reverses PR #382, which removed the prior SwiftUI shell — the
+> "app-first + local-first" framing below is the deliberate answer to *why
+> reverse it*.
+
+## Problem
+
+intrada's iOS app today is a Tauri 2 WKWebView wrapping the Leptos web shell.
+At the piano — the primary place the app is used — a webview doesn't feel like
+a native instrument-side tool: scroll/gesture/transition fidelity, launch feel,
+and platform affordances all read as "web in a frame."
+
+We have a pure Crux (Rust) core that already owns all business logic. We have
+never actually used Crux as designed — a pure core with a *thin native shell*
+over FFI/typegen. The Tauri shell skips that step. Going native iOS finally
+exercises the Crux payoff and sets up native Android later on the same core.
+
+A complete native SwiftUI shell **already existed and was removed in PR #382**
+(`bdd815c..84b26d6`) — it reached Plan/Practice/Track + iPad parity over
+HTTP-through-core. So this is **resurrect-and-modernize, not greenfield**: the
+core is fully intact and the old pipeline is recoverable via `git show
+84b26d6^:<path>`.
+
+## Approach
+
+Resurrect the proven #382 architecture and modernize it (Swift 6 strict
+concurrency, `@Observable`, NavigationStack/SplitView, Swift Testing, iOS 26
+SDK), while adding the one thing #382 never had: **local-first persistence**.
+
+Strategic decisions (settled; not re-litigated here):
+
+- **App-first.** Native iOS now, native Android later — both on the shared
+  Crux core. Web stays on Leptos, untouched. Web's data model is decided later.
+- **Local-first.** On-device SQLite is the source of truth. The existing
+  Axum+Turso backend demotes from live data source to a **sync target**.
+- **Sync scope is deliberately small.** Single-user, multi-device,
+  **last-write-wins on `updated_at` — not CRDTs**, not multi-user collaboration.
+
+## The Crux → Swift bridge
+
+The core stays pure and synchronous; all I/O is an `Effect` the shell fulfils.
+The shell is a **dumb pipe** — it owns zero domain logic (see CLAUDE.md "Native
+iOS Shell" section).
+
+- **FFI:** UniFFI exposes the three byte-buffer bridge methods
+  (`update` / `resolve` / `view`, unified in Crux 0.17). Bytes in, bytes out.
+- **Typegen:** `facet-generate` (≥0.17) + the `facet_typegen` feature on
+  `crux_core` 0.18 generates a Swift package of `Event` / `Effect` /
+  `ViewModel` + domain types and their bincode (BCS) serializers. The core
+  types in `app.rs` (`Event`, `Effect` via `#[effect]`, `AppEffect`) get their
+  `#[derive(Facet)]` / `#[repr(C)]` attributes restored behind the feature
+  (they were stripped in #382).
+- **Packaging:** **spike `cargo-swift`** (the Crux book's current documented
+  path: `cargo-swift` + `xcodegen` + `just`) which produces a Swift package
+  wrapping the compiled static lib. **Fallback:** revive the hand-rolled
+  `scripts/build-ios.sh` from #382 if cargo-swift fights us. Decision resolved
+  by the Phase A spike.
+- **HTTP-through-core:** the `Http` effect carries a fully-built `HttpRequest`
+  (url/method/headers/body); the Swift shell runs `URLSession`, adds the
+  platform auth header (Clerk JWT / iOS PAT), handles the 401-retry, and
+  resolves the response bytes. No domain types cross the boundary as anything
+  but bytes.
+
+### Known build hazard — UniFFI #2818
+
+UniFFI-generated Swift fails to compile under Xcode 26 / Swift 6.2 when the
+module defaults to `MainActor` isolation ([mozilla/uniffi-rs#2818], open since
+Feb 2026). Mitigation baked into the build recipe: keep the generated `Shared`
+package **non-MainActor-defaulted**, or post-process the generated Swift to
+prepend `nonisolated` (a `just` step) until UniFFI ships a config option.
+
+[mozilla/uniffi-rs#2818]: https://github.com/mozilla/uniffi-rs/issues/2818
+
+## NEW capability — local-first persistence + sync
+
+Crux removed the Capability API in 0.17 (the core already uses `Command`
+exclusively — see `Command::all` / `Command::notify_shell` in `app.rs`). So
+persistence is **not** a custom capability; it's a **custom `Effect` driven by
+`Command`**.
+
+- **Core side:** add a `Persistence` effect variant carrying typed
+  query/mutation operations (an `Operation` whose `Output` is the typed result
+  — same shape as `AppEffect`). The core decides *what* to read/write and runs
+  **LWW reconciliation**; that logic lives in core so it's shareable to Android.
+- **Shell side:** **GRDB owns the real SQLite tables** and fulfils the
+  persistence effect off the main actor, returning serialized rows. `crux_kv`
+  is used **only** for small singletons (settings, `session-in-progress`
+  crash-recovery), never for relational data.
+- **Sync (LWW) design, with the known pitfalls handled:**
+  - **Server-authoritative `updated_at`** stamped on write (avoids device
+    clock skew silently losing newer edits).
+  - **Tombstones** (`deleted_at`) compared under the same LWW rule (avoids the
+    delete-vs-update resurrection race), GC'd after a safe window.
+  - **Deterministic tiebreak** on equal timestamps (compare ulid / device id)
+    so all devices converge on the same winner.
+  - **Row-level** LWW (documented; field-level is out of scope for a
+    single-user practice app).
+  - Offline-first: writes apply locally immediately; sync is deferred and
+    retried.
+
+## Phased plan
+
+- **Phase 0 (done):** focus mode (web/Tauri/API CI main-only + Dependabot
+  pause) and iOS agent tooling (XcodeBuildMCP, swift-format hook, sourcekit-lsp
+  plugin).
+- **Phase A (this spec):** restore typegen attrs to core (TDD); new
+  `crates/intrada-ffi` (UniFFI + facet typegen); cargo-swift spike → minimal
+  SwiftUI app that sends one `Event` and renders the `ViewModel`. Bake in from
+  day one: swift-snapshot-testing (pinned sim + runtime, perceptual tolerance),
+  Sentry, accessibility (VoiceOver + Dynamic Type). **Gate:** pipeline green on
+  device + simulator, #2818 mitigated.
+- **Phase B:** persistence `Effect` + GRDB store + schema + LWW scaffolding;
+  first real screen (Library) end-to-end local-first. **Gate:** per-screen cost
+  + persistence design validated.
+- **Phase C:** screen-by-screen parity (Plan → Practice → Track), each with
+  iPad `SplitView` built *with* the screen (not retrofit), per-screen
+  accessibility, snapshot tests, and HIG-referenced native shape/behaviour.
+- **Phase D:** LWW sync to the Axum API; retire the Tauri host at parity.
+
+## Quality baked in (day one, not retrofit)
+
+- **swift-snapshot-testing** (pointfreeco, 1.19.x) — the automated agent's
+  "eyes" for UI regression. Pin one CI simulator + iOS runtime; use perceptual
+  tolerance; reference images are reviewable diffs.
+- **Sentry** crash reporting from the first build.
+- **Accessibility** per screen — VoiceOver labels + Dynamic Type — verified as
+  each screen lands, not at the end.
+
+## Open questions
+
+- **Web data model** — deferred; web shell stays online-only for now.
+- **Per-screen rewrite cost** — answered at the Phase B gate (first real screen).
+- **cargo-swift vs build-ios.sh** — answered by the Phase A spike.
+- **Sync transport detail** (full-table vs delta, batching) — designed in Phase D.
+
+## Decisions log
+
+- 2026-05-31 — App-first, local-first, LWW-not-CRDT. (Reverses #382.)
+- 2026-05-31 — Build pipeline: spike cargo-swift first, build-ios.sh fallback.
+- 2026-05-31 — Persistence is a custom `Effect`/`Command`, not a Capability
+  (Capability API removed in Crux 0.17).
+- 2026-05-31 — SQLite owned by the Swift shell (GRDB); reconciliation in core.
+- 2026-05-31 — Mitigate UniFFI #2818 in the build recipe (non-MainActor /
+  `nonisolated` post-process).
+
+## YAGNI (explicitly out of scope for now)
+
+Android shell, Xcode Cloud, fastlane match, localization.


### PR DESCRIPTION
First PR of the **native iOS pivot** (epic #775). Restores "typegen readiness" to the shared Crux core so the forthcoming native SwiftUI shell can generate Swift types from Rust, and lands the Tier 3 spec alongside it (spec-rides-with-Phase-A).

This is the **only** Phase A change that touches the shared `intrada-core` — splitting it out so the core change gets focused review and the subsequent iOS-shell PR (A2–A5: `intrada-ffi` crate + `ios/` app + CI) is purely additive and can't regress web/api.

## What's here
- **`specs/native-ios.md`** — the Tier 3 spec (problem, Crux→Swift bridge, the new local-first persistence+sync design, phased plan, decisions log).
- **`docs/roadmap.md`** — Mobile-shell section rewritten for the pivot.
- **`CLAUDE.md`** — "Native iOS Shell (SwiftUI + Crux)" dumb-pipe contract.
- **`intrada-core`** — gated `facet_typegen` feature + `facet` (with `chrono`) optional dep; `#[cfg_attr(feature="facet_typegen", derive(facet::Facet))]` across the full `Event`/`Effect`/`ViewModel` graph; `#[repr(C)]` on FFI enums only; `#[effect]`→`#[effect(facet_typegen)]`; new gated `tests/typegen_readiness.rs`.

## Design notes
- **Additive + fully gated.** Default builds (web/api) are byte-identical and pull no `facet` dependency. Verified: 337 core tests pass on default features, `cargo check --workspace` (excl. mobile) green, clippy/fmt clean both feature states.
- **Matches the canonical crux `counter` example** (verified against the Crux book/master + example): `#[effect(facet_typegen)]`, `repr(C)` on enums only, `TypeRegistry::register_app` entry point. Intentional divergence: facet is **feature-gated** because our core is shared by web/api/ios (the example's core is FFI-only) — idiomatic Crux feature hygiene.
- **On the latest crux**: crux_core 0.18.0, crux_http 0.17.0, crux_macros 0.9.0, facet 0.44.5, facet_generate 0.17.0.

## Coverage
Full for this phase — the new `facet_typegen` path is guarded by `tests/typegen_readiness.rs` (asserts `register_app::<Intrada>().build()` covers the whole graph; fails in CI if a future type is un-derived). No new runtime logic to cover.

## Test plan
- `cargo test -p intrada-core` (default) — 337 pass.
- `cargo test -p intrada-core --features facet_typegen --test typegen_readiness` — passes.
- `cargo check --workspace --exclude intrada-mobile …` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)