### PR TITLE
ci: native iOS build + launch + screenshot job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
       mobile: ${{ steps.filter.outputs.mobile }}
+      native: ${{ steps.filter.outputs.native }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -70,6 +71,14 @@ jobs:
               - 'scripts/ios-simulator-smoke.sh'
               - 'scripts/fix-ios-build-config.rb'
               - 'scripts/add-live-activity-target.rb'
+              - '.github/workflows/ci.yml'
+            native:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/intrada-core/**'
+              - 'crates/intrada-ffi/**'
+              - 'ios/**'
+              - 'scripts/ios-run-sim.sh'
               - '.github/workflows/ci.yml'
 
   test:
@@ -343,6 +352,68 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ios-simulator-screenshots
+          path: ios-screenshots/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  native-ios:
+    # Native SwiftUI app — regenerate bindings (facet typegen + cargo-swift),
+    # build for the simulator, launch, and screenshot. The automated "eyes" on
+    # the iOS app until snapshot tests land (A4b). The intrada-ffi bridge + core
+    # typegen are also covered by the Linux `test`/`clippy` jobs.
+    name: Native iOS (build + launch)
+    runs-on: macos-latest
+    timeout-minutes: 40
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.native == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "native-ios"
+          cache-on-failure: true
+      # dtolnay/rust-toolchain skips adding ~/.cargo/bin to PATH on the macOS
+      # image; without this `cargo` resolves to Apple's stub. (See ios-build.)
+      - name: Ensure cargo is on PATH
+        run: |
+          echo "$CARGO_HOME/bin" >> $GITHUB_PATH
+          cargo --version
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Cache cargo-swift
+        id: cargo-swift-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-swift
+          key: cargo-swift-0.11-${{ runner.os }}-${{ runner.arch }}
+      - name: Install cargo-swift
+        if: steps.cargo-swift-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-swift --version "^0.11" --locked
+      - name: Cache Homebrew packages
+        id: brew-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+      - name: Install xcodegen
+        run: brew install xcodegen
+      - name: Regenerate Swift bindings (facet typegen + cargo-swift)
+        run: just ios-gen
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+      - name: Build + launch on simulator + screenshot
+        run: bash scripts/ios-run-sim.sh "$GITHUB_WORKSPACE/ios-screenshots/native.png"
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-ios-screenshot
           path: ios-screenshots/
           retention-days: 7
           if-no-files-found: ignore

--- a/scripts/ios-run-sim.sh
+++ b/scripts/ios-run-sim.sh
@@ -11,6 +11,7 @@ cd "$(dirname "$0")/../ios"
 APP_ID="com.intrada.native"
 DD="build/dd"
 SHOT="${1:-/tmp/intrada-native.png}"
+mkdir -p "$(dirname "$SHOT")"
 
 # Newest available iPhone simulator.
 UDID=$(xcrun simctl list devices available --json | python3 -c "


### PR DESCRIPTION
A5 of the native iOS pivot (#775) — automated CI verification that the native app builds and runs, so we have confidence as it grows.

## New `native-ios` job (macOS)
Regenerate bindings (`just ios-gen`: facet typegen + cargo-swift) → `xcodegen` → build + boot simulator + launch + screenshot (via `scripts/ios-run-sim.sh`), uploading the screenshot as an artifact.

- Path-filtered to `crates/intrada-core/**`, `crates/intrada-ffi/**`, `ios/**`, `scripts/ios-run-sim.sh`, the workflow. Runs on PRs (iOS is the focus) + main.
- The `intrada-ffi` bridge + core typegen are already covered by the Linux `test`/`clippy` jobs; this adds the iOS **app** build + launch — the automated "eyes" until snapshot tests land (A4b).
- cargo-swift + xcodegen + just are cached.

**This PR's own run exercises the new job** (it touches `ci.yml`, matching the `native` filter) — so the checks tab is the proof it works end-to-end in CI.

## Test plan
- YAML parses; job + `native` filter wired.
- Watch this PR's `Native iOS (build + launch)` check go green + produce a screenshot artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)