### PR TITLE
ci: speed up iOS CI — ungate deploy from Tauri, cache DerivedData

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,23 @@ jobs:
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
+      # Cache DerivedData (resolved + compiled SwiftPM deps — Sentry,
+      # swift-snapshot-testing — plus build intermediates) so `xcodebuild test`
+      # rebuilds incrementally instead of recompiling the whole dependency tree
+      # every run. derivedDataPath is the stable relative `build/dd`, so cached
+      # absolute paths line up across runs. The exact key rarely hits (Swift
+      # source changes per PR); the restore-key pulls the most recent DerivedData
+      # and Xcode rebuilds only what changed. Safe for snapshot determinism: this
+      # caches compilation only — rendering happens at runtime in the simulator,
+      # so a cache hit can't alter a snapshot result (a stale incremental build
+      # fails loud, it can't silently pass). Bump the key prefix to force-evict.
+      - name: Cache iOS DerivedData
+        uses: actions/cache@v5
+        with:
+          path: ios/build/dd
+          key: ios-dd-v1-${{ runner.os }}-${{ hashFiles('ios/project.yml', 'ios/Intrada/**', 'ios/IntradaTests/**') }}
+          restore-keys: |
+            ios-dd-v1-${{ runner.os }}-
       # Snapshot test = deterministic UI-regression "eyes" (renders RootView
       # against a committed reference). Create a deterministic iOS 26.5 sim —
       # the reference is recorded on iOS 26.5 / Xcode 26.5 (= local dev), and
@@ -738,7 +755,11 @@ jobs:
   deploy:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt, wasm-build, wasm-test, e2e, deploy-smoke, ios-build]
+    # ios-build (Tauri) is intentionally NOT a gate here: the native app isn't
+    # deployed by this job and the Tauri host is on hold, so blocking the web
+    # deploy on its ~14 min macOS build only added latency. It still runs on
+    # main pushes for its own signal — it just no longer holds up the deploy.
+    needs: [test, clippy, fmt, wasm-build, wasm-test, e2e, deploy-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
@@ -810,7 +831,9 @@ jobs:
   deploy-api:
     name: Deploy API to Fly.io
     runs-on: ubuntu-latest
-    needs: [test, clippy, fmt, wasm-build, wasm-test, e2e, ios-build, api-docker-build]
+    # See `deploy`: ios-build (Tauri) deliberately omitted — it gated nothing
+    # the API deploy depends on and only added ~14 min of latency.
+    needs: [test, clippy, fmt, wasm-build, wasm-test, e2e, api-docker-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,9 +442,12 @@ jobs:
         run: |
           UDID=$(xcrun simctl create snap-26-5 "iPhone 16" "iOS26.5")
           test -n "$UDID" || { echo '::error::could not create iOS 26.5 simulator'; exit 1; }
+          # COMPILER_INDEX_STORE_ENABLE=NO skips building the IDE code-navigation
+          # index store — pure dead weight in CI (nothing reads it). -quiet trims
+          # the per-file build log noise.
           xcodebuild test -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
-            -destination "id=$UDID" -derivedDataPath build/dd \
-            CODE_SIGNING_ALLOWED=NO
+            -destination "id=$UDID" -derivedDataPath build/dd -quiet \
+            COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
       - name: Upload snapshot failures
         if: failure()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What

Two pure-win latency cuts to the iOS CI path. No test coverage or build signal removed.

### 1. Ungate web + API deploys from the parked Tauri build
`ios-build` (the ~14 min Tauri macOS job) was in `needs:` for both `deploy` and `deploy-api`, so every main-push deploy waited ~14 min on a build that deploys nothing and is on hold. Removed from both lists — the job still runs on main for its own signal, it just no longer holds up the deploy. **~12 min off main-push deploy latency** (deploy now gated by the next-slowest job, ~6 min).

### 2. Cache iOS DerivedData on the Native iOS job
`xcodebuild test` had no cache, so it re-resolved and recompiled Sentry + swift-snapshot-testing + all intermediates from scratch (~5.7 min) every run. Added an `actions/cache` of `ios/build/dd` keyed on `project.yml` + Swift sources, with a broad restore-key so each run pulls the most recent DerivedData and Xcode rebuilds only what changed. **~1–3 min off every iOS PR** once the cache warms.

Safe for snapshot determinism: caches *compilation* only — rendering happens at runtime in the simulator, so a cache hit can't alter a snapshot result, and a broken incremental build fails loud rather than passing silently. Escape hatch: bump the `ios-dd-v1-` key prefix to force-evict.

## How it was found
Step-level timing from recent runs ([PR run](https://github.com/jonyardley/intrada/actions/runs/26719233206), [main run](https://github.com/jonyardley/intrada/actions/runs/26719837088)): the Native iOS job is the iOS-PR critical path (~10 min), dominated by `xcodebuild test` (~5.7 min); on main, the parked Tauri `ios-build` (~14 min) sat on the deploy critical path.

## Verifying
- **Deploy ungating**: takes effect on the next main push immediately.
- **DerivedData cache**: cold on first push to a branch (populates), so the speedup shows on the *second* push. First run may look ~same or marginally slower from the cache upload.

## Not done (left on the table)
Moving the native launch+screenshot step (~2 min/PR) to main-only — another easy win, but it trades away the per-PR screenshot artifact, so deferred to an explicit call.

## Coverage
N/A — workflow-only change; no Rust/Swift source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)