### PR TITLE
Native iOS: core-driven demo seed (--seed-sample-data)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -11,9 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::analytics::compute_analytics;
 use crate::domain::account::{handle_account_event, AccountEvent};
-#[cfg(test)]
-use crate::domain::item::ItemKind;
-use crate::domain::item::{handle_item_event, Item, ItemEvent};
+use crate::domain::item::{handle_item_event, Item, ItemEvent, ItemKind};
 use crate::domain::mcp_audit::{handle_mcp_audit_event, McpAuditEvent};
 use crate::domain::mcp_tokens::{handle_mcp_token_event, McpTokenEvent};
 use crate::domain::oauth::{handle_oauth_event, OAuthEvent};
@@ -46,6 +44,10 @@ pub enum Event {
     StartApp {
         api_base_url: String,
     },
+    /// Replace the library with a canonical demo dataset. Sent by a shell only
+    /// under an explicit opt-in (e.g. iOS `--seed-sample-data` launch arg) for
+    /// CI screenshots / local demos / E2E — never in production.
+    LoadSampleData,
     /// Fetch all data from the API (items, sessions, sets).
     FetchAll,
     /// Re-fetch a single resource kind after a mutation (refresh-after-mutate).
@@ -166,6 +168,11 @@ impl App for Intrada {
                     http::fetch_sessions(&model.api_base_url),
                     http::fetch_sets(&model.api_base_url),
                 ])
+            }
+            Event::LoadSampleData => {
+                model.items = sample_items();
+                model.last_error = None;
+                crux_core::render::render()
             }
             Event::FetchAll => Command::all([
                 http::fetch_items(&model.api_base_url),
@@ -560,6 +567,105 @@ fn apply_query_filter(items: Vec<LibraryItemView>, query: &ListQuery) -> Vec<Lib
         .collect()
 }
 
+/// Canonical demo dataset for `Event::LoadSampleData` — shared by every shell
+/// (CI screenshots, local demos, E2E). Stable ids; staggered timestamps so the
+/// newest-first sort is deterministic.
+fn sample_items() -> Vec<Item> {
+    use crate::domain::types::Tempo;
+    let now = chrono::Utc::now();
+
+    #[allow(clippy::too_many_arguments)]
+    let item = |minutes_ago: i64,
+                id: &str,
+                title: &str,
+                kind: ItemKind,
+                composer: Option<&str>,
+                key: Option<&str>,
+                marking: Option<&str>,
+                bpm: Option<u16>,
+                notes: Option<&str>,
+                tags: &[&str]|
+     -> Item {
+        let ts = now - chrono::Duration::minutes(minutes_ago);
+        Item {
+            id: id.to_string(),
+            title: title.to_string(),
+            kind,
+            composer: composer.map(str::to_string),
+            key: key.map(str::to_string),
+            tempo: Tempo::from_parts(marking.map(str::to_string), bpm),
+            notes: notes.map(str::to_string),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            created_at: ts,
+            updated_at: ts,
+            priority: false,
+        }
+    };
+
+    vec![
+        item(
+            0,
+            "sample-clair",
+            "Clair de Lune",
+            ItemKind::Piece,
+            Some("Claude Debussy"),
+            Some("D♭ major"),
+            Some("Andante"),
+            Some(72),
+            Some("Focus on the rubato in the opening phrase; keep the left hand soft."),
+            &["recital", "impressionist"],
+        ),
+        item(
+            1,
+            "sample-gymnopedie",
+            "Gymnopédie No. 1",
+            ItemKind::Piece,
+            Some("Erik Satie"),
+            Some("D major"),
+            Some("Lent"),
+            Some(70),
+            None,
+            &["recital"],
+        ),
+        item(
+            2,
+            "sample-nocturne",
+            "Nocturne Op. 9 No. 2",
+            ItemKind::Piece,
+            Some("Frédéric Chopin"),
+            Some("E♭ major"),
+            Some("Andante"),
+            Some(68),
+            None,
+            &[],
+        ),
+        item(
+            3,
+            "sample-hanon",
+            "Hanon No. 1",
+            ItemKind::Exercise,
+            Some("Charles-Louis Hanon"),
+            Some("C major"),
+            None,
+            Some(108),
+            Some("Even tone, relaxed wrist."),
+            &["warm-up"],
+        ),
+        item(
+            4,
+            "sample-scales",
+            "Major Scales",
+            ItemKind::Exercise,
+            None,
+            None,
+            None,
+            Some(120),
+            None,
+            &["technique"],
+        ),
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -790,6 +896,23 @@ mod tests {
         assert_eq!(vm.items.len(), 0);
         assert!(vm.error.is_none());
         assert_eq!(vm.session_status, SessionStatusView::Idle);
+    }
+
+    #[test]
+    fn test_load_sample_data_populates_pieces_and_exercises() {
+        let app = Intrada;
+        let mut model = Model::default();
+
+        let _ = app.update(Event::LoadSampleData, &mut model);
+
+        assert!(model.items.len() >= 4, "expected a few sample items");
+        assert!(model.items.iter().any(|i| i.kind == ItemKind::Piece));
+        assert!(model.items.iter().any(|i| i.kind == ItemKind::Exercise));
+        // At least one carries structured tempo so the card's ♩ = bpm shows.
+        assert!(model
+            .items
+            .iter()
+            .any(|i| i.tempo.as_ref().and_then(|t| t.bpm).is_some()));
     }
 
     #[test]

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -25,9 +25,20 @@
     /// A deterministic, offline store for `#Preview` blocks.
     static var preview: Store { Store(bridge: PreviewBridge()) }
 
-    /// An offline store seeded with sample library items.
+    /// An offline store with curated sample items (specific edge cases).
+    /// Used by snapshot tests where the exact data must be deterministic.
     static var previewLibrary: Store {
       Store(bridge: PreviewBridge(items: [.previewPiece, .previewExercise, .previewMinimal]))
+    }
+
+    /// A store driven by the *real* core seeded with the canonical demo dataset
+    /// (`Event.loadSampleData` → `sample_items()`). Render-only, so it completes
+    /// synchronously and offline. Use in screen previews: same data as the CI
+    /// screenshot, and the filter pills actually work in the canvas.
+    static var previewSeeded: Store {
+      let store = Store()
+      store.send(.loadSampleData)
+      return store
     }
   }
 

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -35,6 +35,7 @@
     /// (`Event.loadSampleData` → `sample_items()`). Render-only, so it completes
     /// synchronously and offline. Use in screen previews: same data as the CI
     /// screenshot, and the filter pills actually work in the canvas.
+    /// Not for snapshot tests — `sample_items()` stamps wall-clock timestamps.
     static var previewSeeded: Store {
       let store = Store()
       store.send(.loadSampleData)

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -30,11 +30,13 @@ struct RootView: View {
     }
     .tint(IntradaColor.accent)
     .task {
-      store.send(.startApp(apiBaseUrl: apiBaseURL))
-      // Opt-in demo data for CI screenshots / local demos / E2E — the core
-      // owns the dataset (Event.loadSampleData); production never passes this.
+      // Demo mode (CI screenshots / local / E2E) seeds offline via the core and
+      // skips StartApp's fetches — otherwise a late fetch response would clobber
+      // the seed. Production never passes the arg.
       if ProcessInfo.processInfo.arguments.contains("--seed-sample-data") {
         store.send(.loadSampleData)
+      } else {
+        store.send(.startApp(apiBaseUrl: apiBaseURL))
       }
     }
   }

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -75,6 +75,6 @@ struct RootView: View {
 #if DEBUG
   #Preview {
     RootView()
-      .environment(Store.preview)
+      .environment(Store.previewSeeded)
   }
 #endif

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -31,6 +31,11 @@ struct RootView: View {
     .tint(IntradaColor.accent)
     .task {
       store.send(.startApp(apiBaseUrl: apiBaseURL))
+      // Opt-in demo data for CI screenshots / local demos / E2E — the core
+      // owns the dataset (Event.loadSampleData); production never passes this.
+      if ProcessInfo.processInfo.arguments.contains("--seed-sample-data") {
+        store.send(.loadSampleData)
+      }
     }
   }
 

--- a/ios/Intrada/Views/Screens/LibraryScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryScreen.swift
@@ -81,7 +81,7 @@ struct LibraryScreen: View {
 #if DEBUG
   #Preview("Populated") {
     NavigationStack { LibraryScreen() }
-      .environment(Store.previewLibrary)
+      .environment(Store.previewSeeded)
   }
 
   #Preview("Empty") {

--- a/scripts/ios-run-sim.sh
+++ b/scripts/ios-run-sim.sh
@@ -44,7 +44,11 @@ fi
 APP=$(find "$DD/Build/Products" -name "Intrada.app" -type d | head -1)
 [ -n "$APP" ] || { echo "✗ no Intrada.app in $DD (build first)" >&2; exit 1; }
 xcrun simctl install "$UDID" "$APP"
-xcrun simctl launch "$UDID" "$APP_ID" >/dev/null
+# Seed the core's demo dataset so the screenshot shows a populated app.
+# Override with SEED=0 to launch against the empty/real-data state.
+LAUNCH_ARGS=()
+[ "${SEED:-1}" = "1" ] && LAUNCH_ARGS+=(--seed-sample-data)
+xcrun simctl launch "$UDID" "$APP_ID" "${LAUNCH_ARGS[@]}" >/dev/null
 sleep 3
 xcrun simctl io "$UDID" screenshot "$SHOT" >/dev/null
 echo "✓ launched on $UDID — screenshot: $SHOT"

--- a/scripts/ios-run-sim.sh
+++ b/scripts/ios-run-sim.sh
@@ -48,7 +48,8 @@ xcrun simctl install "$UDID" "$APP"
 # Override with SEED=0 to launch against the empty/real-data state.
 LAUNCH_ARGS=()
 [ "${SEED:-1}" = "1" ] && LAUNCH_ARGS+=(--seed-sample-data)
-xcrun simctl launch "$UDID" "$APP_ID" "${LAUNCH_ARGS[@]}" >/dev/null
+# `${arr[@]+...}` guards the empty-array case under `set -u` on bash 3.2 (macOS).
+xcrun simctl launch "$UDID" "$APP_ID" "${LAUNCH_ARGS[@]+"${LAUNCH_ARGS[@]}"}" >/dev/null
 sleep 3
 xcrun simctl io "$UDID" screenshot "$SHOT" >/dev/null
 echo "✓ launched on $UDID — screenshot: $SHOT"


### PR DESCRIPTION
## What

Adds an opt-in **demo dataset** so the running app is demonstrable without auth/backend — for the CI launch-screenshot, local dev, and E2E. The data is owned by the **core**, not faked in the shell.

- **Core**: `Event::LoadSampleData` + a canonical `sample_items()` (3 pieces + 2 exercises, covering marking+bpm / bpm-only / no-tempo). Replaces `model.items` and renders.
- **Shell** (`RootView`): sends `.loadSampleData` **only** when launched with `--seed-sample-data` — production never passes it.
- **`scripts/ios-run-sim.sh`**: passes the arg by default (`SEED=0` to opt out), so the CI screenshot artifact and `just ios-run` show a populated app.

## Why this shape (not a shell-side fake)

The seed flows through the real `Event → Model → ViewModel` loop, so:
- the shell stays a **dumb pipe** (no hand-built `ViewModel` in Swift for the running app);
- the data is **live** — the filter pills (`SetQuery`) and card→detail navigation actually work against it, unlike shell-injected data;
- it's **reusable** by every shell (web + Android later) and by E2E, from one source of truth.

Previews/snapshot tests keep their curated Swift sample factories (they need edge cases — minimal, long-title — a realistic demo set wouldn't have), so there are **no snapshot changes**.

## Verification

- ✅ Core: failing-test-first TDD (`test_load_sample_data_populates_pieces_and_exercises`); **338 tests pass**
- ✅ `cargo fmt --check` + `cargo clippy -p intrada-core -p intrada-web -- -D warnings` clean; `cargo check --workspace` + web-WASM compile
- ✅ Bindings regenerated (`just ios-gen`) → `Event.loadSampleData`
- ✅ iOS builds; **all 10 snapshot tests pass** (RootView change is inert without the launch arg)
- ✅ Launched seeded on the simulator → populated Library ("3 pieces · 2 exercises", all cards with type bars + `♩ = ` tempos)

## Coverage

Core change covered by the new unit test. Shell wiring + script are non-unit-testable (launch-arg / sim launch); verified by the seeded sim screenshot above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)