### PR TITLE
chore: comment-density hook also counts Swift

### DIFF
--- a/scripts/check-comment-density.sh
+++ b/scripts/check-comment-density.sh
@@ -24,7 +24,7 @@ fi
 range="origin/main...HEAD"
 
 files=$(git diff --name-only "$range" -- \
-  '*.rs' '*.css' '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null || true)
+  '*.rs' '*.swift' '*.css' '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null || true)
 if [ -z "$files" ]; then
   exit 0
 fi
@@ -70,7 +70,7 @@ if [ "$over" = "1" ]; then
 
    Inspect what tripped the check:
 
-     git diff origin/main...HEAD -- '*.rs' '*.ts' '*.tsx' \\
+     git diff origin/main...HEAD -- '*.rs' '*.swift' '*.ts' '*.tsx' \\
        | grep -E '^\+[[:space:]]*(//|/\*|\*)'
 
    If the comments are genuinely justified (incident write-up, vendored


### PR DESCRIPTION
## What

The pre-push comment-density check (`scripts/check-comment-density.sh`) only globbed `*.rs/*.css/*.ts/*.tsx/*.js/*.jsx` — so the native iOS shell's Swift was exempt from the comment policy. Adds `*.swift` to the checked globs (and the hint message).

The existing comment detection (`//`, `///`, `/*`, `*`) already matches Swift, so only the file glob needed updating.

## Why

The native SwiftUI shell is now a substantial, growing part of the codebase; CLAUDE.md's "default to no comments / non-obvious WHY only" policy should apply there too, not just Rust/web.

## Verification

- `bash -n` syntax-clean; the hook runs and passes on this branch (no Swift/Rust comment changes here).
- Spot-checked against the in-flight delete PR (#799): its Rust+Swift ratio is 0.04, well under the 0.15 threshold — so existing native work isn't retroactively blocked.

Tier 1 (tooling tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)