### PR TITLE
Native iOS: unit-test the Store effect loop + HTTP mapping (#788)

### DIFF
--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -1,0 +1,328 @@
+import IntradaCoreFFI
+import SharedTypes
+import XCTest
+
+@testable import Intrada
+
+/// Drives `Store`'s effect loop with a scripted bridge and a mocked URLSession,
+/// so the Render → view / Http → URLSession → resolve / App → ack wiring and the
+/// URLSession → `HttpResult` mapping are covered without the real core or network.
+@MainActor
+final class StoreEffectLoopTests: XCTestCase {
+
+  override func tearDown() {
+    MockURLProtocol.handler = nil
+    MockURLProtocol.lastRequest = nil
+    super.tearDown()
+  }
+
+  // ── Effect dispatch ────────────────────────────────────────────────────
+
+  func testInitRendersInitialViewModel() {
+    let bridge = FakeBridge()
+    let store = Store(bridge: bridge, session: mockSession())
+    XCTAssertNotNil(store.viewModel, "init should seed the ViewModel from the bridge")
+    XCTAssertEqual(bridge.viewCallCount, 1)
+  }
+
+  func testRenderEffectRefreshesViewModel() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in [Request(id: 1, effect: .render(RenderOperation()))] }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    bridge.nextViewModel = {
+      var vm = try emptyViewModel()
+      vm.error = "refreshed"
+      return vm
+    }
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(store.viewModel?.error, "refreshed", "render effect should re-read view()")
+  }
+
+  func testAppEffectResolvesEmpty() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in [Request(id: 7, effect: .app(.clearSessionInProgress))] }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(bridge.emptyResolved, [7], "app effect should ack via resolveEmpty")
+  }
+
+  func testBatchProcessesEveryRequest() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [
+        Request(id: 1, effect: .app(.clearSessionInProgress)),
+        Request(id: 2, effect: .render(RenderOperation())),
+      ]
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    bridge.nextViewModel = {
+      var vm = try emptyViewModel()
+      vm.error = "batched"
+      return vm
+    }
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(bridge.emptyResolved, [1], "every request in the batch should run")
+    XCTAssertEqual(store.viewModel?.error, "batched")
+  }
+
+  // ── Failure-soft (guarded) ─────────────────────────────────────────────
+
+  func testUpdateThrowIsSwallowedWithoutCrashing() {
+    let bridge = FakeBridge()
+    bridge.throwOnUpdate = TestError()
+    let store = Store(bridge: bridge, session: mockSession())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertTrue(bridge.resolved.isEmpty)
+    XCTAssertTrue(bridge.emptyResolved.isEmpty)
+    XCTAssertNotNil(store.viewModel, "a thrown update should fail soft, not wipe the ViewModel")
+  }
+
+  func testViewThrowAtInitLeavesViewModelNil() {
+    let bridge = FakeBridge()
+    bridge.throwOnView = TestError()
+    let store = Store(bridge: bridge, session: mockSession())
+
+    XCTAssertNil(store.viewModel, "a thrown view() should leave nil (loading state), not crash")
+  }
+
+  // ── HTTP execution + result mapping ────────────────────────────────────
+
+  func testHttpEffectMapsOkResponse() async {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [
+        Request(
+          id: 3,
+          effect: .http(
+            HttpRequest(method: "GET", url: "https://x.test/items", headers: [], body: [])))
+      ]
+    }
+    MockURLProtocol.handler = { request in
+      let response = HTTPURLResponse(
+        url: request.url!, statusCode: 201,
+        httpVersion: nil, headerFields: ["X-Test": "yes"])!
+      return (response, Data("hello".utf8))
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    guard case .ok(let response) = bridge.resolved.first?.result else {
+      return XCTFail("expected .ok, got \(String(describing: bridge.resolved.first?.result))")
+    }
+    XCTAssertEqual(bridge.resolved.first?.id, 3)
+    XCTAssertEqual(response.status, 201)
+    XCTAssertEqual(response.body, [UInt8]("hello".utf8))
+    XCTAssertTrue(
+      response.headers.contains { $0.name == "X-Test" && $0.value == "yes" },
+      "server headers should map into HttpResponse")
+  }
+
+  func testHttpEffectMapsNetworkErrorToIo() async {
+    let bridge = httpBridge()
+    MockURLProtocol.handler = { _ in throw URLError(.notConnectedToInternet) }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    guard case .err(.io) = bridge.resolved.first?.result else {
+      return XCTFail("expected .err(.io), got \(String(describing: bridge.resolved.first?.result))")
+    }
+  }
+
+  func testHttpEffectMapsTimeout() async {
+    let bridge = httpBridge()
+    MockURLProtocol.handler = { _ in throw URLError(.timedOut) }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    XCTAssertEqual(bridge.resolved.first?.result, .err(.timeout))
+  }
+
+  func testHttpEffectMapsInvalidUrl() async {
+    let bridge = FakeBridge()
+    // A bare space can't form a URL, so `URL(string:)` returns nil.
+    bridge.updateHandler = { _ in
+      [
+        Request(
+          id: 9,
+          effect: .http(HttpRequest(method: "GET", url: "h ttp://nope", headers: [], body: [])))
+      ]
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    guard case .err(.url) = bridge.resolved.first?.result else {
+      return XCTFail(
+        "expected .err(.url), got \(String(describing: bridge.resolved.first?.result))")
+    }
+  }
+
+  func testHttpRequestMapsMethodAndHeaders() async {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [
+        Request(
+          id: 5,
+          effect: .http(
+            HttpRequest(
+              method: "POST", url: "https://x.test/items",
+              headers: [HttpHeader(name: "Content-Type", value: "application/json")],
+              body: [1, 2, 3])))
+      ]
+    }
+    MockURLProtocol.handler = { request in
+      MockURLProtocol.lastRequest = request
+      return (
+        HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+        Data()
+      )
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    XCTAssertEqual(MockURLProtocol.lastRequest?.httpMethod, "POST")
+    XCTAssertEqual(
+      MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+  }
+
+  func testResolveChainedRenderRefreshesView() async {
+    let bridge = httpBridge()
+    bridge.resolveHandler = { _, _ in [Request(id: 2, effect: .render(RenderOperation()))] }
+    MockURLProtocol.handler = { request in
+      (
+        HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!,
+        Data()
+      )
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    bridge.nextViewModel = {
+      var vm = try emptyViewModel()
+      vm.error = "post-resolve"
+      return vm
+    }
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    XCTAssertEqual(
+      store.viewModel?.error, "post-resolve", "render from a resolve should refresh view")
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  private func httpBridge() -> FakeBridge {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [
+        Request(
+          id: 4,
+          effect: .http(
+            HttpRequest(method: "GET", url: "https://x.test/items", headers: [], body: [])))
+      ]
+    }
+    return bridge
+  }
+
+  /// Run `action`, then await the bridge's first `resolve` — the HTTP leg hops
+  /// through a detached `Task`, so the assertion must wait for it.
+  private func whenResolved(_ bridge: FakeBridge, _ action: () -> Void) async {
+    let resolved = expectation(description: "bridge resolved")
+    bridge.onResolve = { resolved.fulfill() }
+    action()
+    await fulfillment(of: [resolved], timeout: 2)
+  }
+
+  private func mockSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+}
+
+private func emptyViewModel() throws -> ViewModel {
+  try ViewModel.bincodeDeserialize(input: [UInt8](CoreFfi().view()))
+}
+
+/// A scriptable `CoreBridge`: returns canned `[Request]` for update/resolve and
+/// records what the `Store` fed back, so tests assert on the effect loop.
+private final class FakeBridge: CoreBridge {
+  var updateHandler: (Event) -> [Request] = { _ in [] }
+  var resolveHandler: (UInt32, HttpResult) -> [Request] = { _, _ in [] }
+  /// Overrides the next `view()` result, letting a test prove a render refreshed.
+  var nextViewModel: (() throws -> ViewModel)?
+  var onResolve: (() -> Void)?
+  /// When set, the corresponding bridge call throws — drives the Store's
+  /// `guarded` failure-soft path.
+  var throwOnUpdate: Error?
+  var throwOnView: Error?
+
+  private(set) var events: [Event] = []
+  private(set) var resolved: [(id: UInt32, result: HttpResult)] = []
+  private(set) var emptyResolved: [UInt32] = []
+  private(set) var viewCallCount = 0
+
+  func update(_ event: Event) throws -> [Request] {
+    events.append(event)
+    if let throwOnUpdate { throw throwOnUpdate }
+    return updateHandler(event)
+  }
+
+  func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request] {
+    resolved.append((id, httpResult))
+    onResolve?()
+    return resolveHandler(id, httpResult)
+  }
+
+  func resolveEmpty(_ id: UInt32) throws -> [Request] {
+    emptyResolved.append(id)
+    return []
+  }
+
+  func view() throws -> ViewModel {
+    viewCallCount += 1
+    if let throwOnView { throw throwOnView }
+    if let nextViewModel { return try nextViewModel() }
+    return try emptyViewModel()
+  }
+}
+
+private struct TestError: Error {}
+
+/// Intercepts URLSession traffic so `Store.execute` runs against canned
+/// responses/errors. `handler` is set per test; `lastRequest` captures the
+/// mapped `URLRequest` for request-shape assertions.
+final class MockURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+  nonisolated(unsafe) static var lastRequest: URLRequest?
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let handler = Self.handler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    do {
+      let (response, data) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}


### PR DESCRIPTION
Closes #788. Branches off `main` (independent of the open #806 add-item stack — this adds only a test file).

## Why
`Store` pumps the core's effects (Render → view, Http → URLSession → resolve, App → ack) and maps URLSession responses to `HttpResult`, but had **zero coverage**. Every native mutation so far (delete/edit/add) shipped with a "verify on device" caveat because there was no way to exercise the success/failure paths off-device. This is the harness that fixes that — and the foundation for testable error/rollback (#800).

## What
- **`FakeBridge`** — a scriptable `CoreBridge` returning canned `[Request]` and recording what the Store fed back (events, resolves, empty-resolves, `view()` calls). Lets a test drive the effect loop without the real core/FFI.
- **`MockURLProtocol`** — intercepts URLSession so `Store.execute` runs against canned responses/errors; `lastRequest` captures the mapped `URLRequest` for request-shape assertions.
- **9 tests:**
  - Effect dispatch: render → `view()` refresh; http → execute → resolve; app → `resolveEmpty`; chained render-from-resolve refreshes the ViewModel.
  - HTTP mapping: ok (status/headers/body), `.io` (network error), `.timeout`, `.url` (invalid URL), and request method/header mapping.

All 9 pass; full iOS suite green (snapshots unaffected — `MockURLProtocol` only intercepts the test session, and `handler` is cleared in `tearDown`).

## No production change
`Store` was already testable via its injected `bridge` + `session` — no visibility relaxation or refactor needed. One known limitation noted: `URLProtocol` doesn't expose `httpBody` (URLSession converts it to a stream), so the body-mapping assertion is left to the live path; method/url/headers are covered.

## Coverage
iOS shell is in the Codecov ignore list (native shell), so no patch-coverage delta — but this materially raises real coverage of the Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)