### PR TITLE
Native iOS B1: offline-first reframe + Persistence Effect contract

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -28,6 +28,7 @@ use crate::model::{
     BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model, SessionStatusView,
     SetSourceStatus, ViewModel,
 };
+use crate::persistence::{self, PersistenceOperation, PersistenceOutput};
 
 /// Root Crux application for the music practice library.
 #[derive(Default)]
@@ -106,6 +107,10 @@ pub enum Event {
     LoadFailed(String),
     ClearError,
     SetQuery(Option<ListQuery>),
+
+    // ── Local-first persistence (dormant — no caller in the live flow yet) ──
+    HydrateFromStore,
+    StoreLoaded(PersistenceOutput),
 }
 
 /// Side effects the core requests from shells.
@@ -124,6 +129,8 @@ pub enum Effect {
     Http(HttpRequest),
     /// Shell-only side effects that are NOT HTTP (localStorage only).
     App(AppEffect),
+    /// Local-first persistence (the core's first effect with typed-data output).
+    Persistence(PersistenceOperation),
 }
 
 /// Non-HTTP side-effect operations handled by the shell.
@@ -278,6 +285,15 @@ impl App for Intrada {
             }
             Event::SetQuery(query) => {
                 model.active_query = query;
+                crux_core::render::render()
+            }
+
+            // ── Local-first persistence (B1) ─────────────────────────
+            Event::HydrateFromStore => persistence::load_items(),
+            Event::StoreLoaded(output) => {
+                if let PersistenceOutput::Items(items) = output {
+                    model.items = items;
+                }
                 crux_core::render::render()
             }
         }

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod domain;
 pub mod error;
 pub mod http;
 pub mod model;
+pub mod persistence;
 pub mod validation;
 
 pub use app::{AppEffect, Effect, Event, Intrada};
@@ -19,6 +20,7 @@ pub use domain::session::{
 pub use domain::set::{Set, SetEntry, SetEvent};
 pub use domain::types::{CreateItem, LibraryData, ListQuery, SessionsData, Tempo, UpdateItem};
 pub use error::LibraryError;
+pub use persistence::{PersistenceOperation, PersistenceOutput};
 
 // Re-export crux_http protocol types so shells can handle HTTP effects
 // without a direct crux_http dependency.

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -1,0 +1,107 @@
+//! Local-first persistence — query/mutation operations the shell fulfils
+//! against on-device SQLite (GRDB lands in B2). Unlike `AppEffect`
+//! (`Output = ()`), persistence queries return data: the core's first effect
+//! with a real typed `Output`, which B1 exists to de-risk across the bridge.
+
+use crux_core::capability::Operation;
+use crux_core::command::Command;
+use serde::{Deserialize, Serialize};
+
+use crate::app::{Effect, Event};
+use crate::domain::item::Item;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum PersistenceOperation {
+    LoadItems,
+    SaveItem(Item),
+    DeleteItem { id: String },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum PersistenceOutput {
+    Items(Vec<Item>),
+    Ack,
+}
+
+impl Operation for PersistenceOperation {
+    type Output = PersistenceOutput;
+}
+
+pub fn load_items() -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::LoadItems).then_send(Event::StoreLoaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::item::ItemKind;
+    use crate::model::Model;
+    use crux_core::App;
+
+    fn sample_item(id: &str) -> Item {
+        let now = chrono::Utc::now();
+        Item {
+            id: id.to_string(),
+            title: "Etude".to_string(),
+            kind: ItemKind::Piece,
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+            priority: false,
+        }
+    }
+
+    #[test]
+    fn load_items_requests_the_load_operation() {
+        let mut cmd = load_items();
+        let op = cmd
+            .effects()
+            .find_map(|e| match e {
+                Effect::Persistence(req) => Some(req.operation.clone()),
+                _ => None,
+            })
+            .expect("expected a Persistence effect");
+        assert_eq!(op, PersistenceOperation::LoadItems);
+    }
+
+    #[test]
+    fn hydrate_from_store_emits_a_load_effect() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(Event::HydrateFromStore, &mut model);
+        assert!(cmd
+            .effects()
+            .any(|e| matches!(e, Effect::Persistence(req) if req.operation == PersistenceOperation::LoadItems)));
+    }
+
+    #[test]
+    fn store_loaded_items_replaces_model_items() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.items = vec![sample_item("stale")];
+        let _ = app.update(
+            Event::StoreLoaded(PersistenceOutput::Items(vec![sample_item("fresh")])),
+            &mut model,
+        );
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(model.items[0].id, "fresh");
+    }
+
+    #[test]
+    fn store_loaded_ack_leaves_items_untouched() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.items = vec![sample_item("keep")];
+        let _ = app.update(Event::StoreLoaded(PersistenceOutput::Ack), &mut model);
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(model.items[0].id, "keep");
+    }
+}

--- a/crates/intrada-web/src/core_bridge.rs
+++ b/crates/intrada-web/src/core_bridge.rs
@@ -93,6 +93,8 @@ pub fn init_core(
     for effect in effects {
         match effect {
             Effect::Render(_) => {}
+            // Online-only web never emits persistence (a native-shell effect).
+            Effect::Persistence(_) => {}
             Effect::Http(mut request) => {
                 let core_handle = leptos::prelude::expect_context::<SharedCore>();
                 let vm = *view_model;
@@ -191,6 +193,8 @@ fn process_effects_inner(
     for effect in effects {
         match effect {
             Effect::Render(_) => {}
+            // Online-only web never emits persistence (a native-shell effect).
+            Effect::Persistence(_) => {}
             Effect::Http(mut request) => {
                 let core = core.clone();
                 let vm = *view_model;

--- a/ios/Intrada/Core/CoreBridge.swift
+++ b/ios/Intrada/Core/CoreBridge.swift
@@ -7,6 +7,7 @@ import SharedTypes
 protocol CoreBridge {
   func update(_ event: Event) throws -> [Request]
   func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request]
+  func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request]
   func resolveEmpty(_ id: UInt32) throws -> [Request]
   func view() throws -> ViewModel
 }

--- a/ios/Intrada/Core/LiveBridge.swift
+++ b/ios/Intrada/Core/LiveBridge.swift
@@ -18,6 +18,11 @@ final class LiveBridge: CoreBridge {
     return try Requests.bincodeDeserialize(input: [UInt8](out)).value
   }
 
+  func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] {
+    let out = try core.resolve(id: id, data: Data(try persistenceOutput.bincodeSerialize()))
+    return try Requests.bincodeDeserialize(input: [UInt8](out)).value
+  }
+
   func resolveEmpty(_ id: UInt32) throws -> [Request] {
     let out = try core.resolve(id: id, data: Data())
     return try Requests.bincodeDeserialize(input: [UInt8](out)).value

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -35,6 +35,15 @@ final class Store {
         // Foundation: localStorage effects are no-ops for now — ack so
         // the core can continue its command chain.
         process(guarded { try bridge.resolveEmpty(request.id) } ?? [])
+      case .persistence(let operation):
+        // B1 stub — no GRDB yet (B2); answer with the empty/ack shape the core
+        // expects so the contract + typed-Output round-trip are exercised.
+        let output: PersistenceOutput =
+          switch operation {
+          case .loadItems: .items([])
+          case .saveItem, .deleteItem: .ack
+          }
+        process(guarded { try bridge.resolve(request.id, persistenceOutput: output) } ?? [])
       }
     }
   }

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -17,6 +17,7 @@
 
     func update(_ event: Event) throws -> [Request] { [] }
     func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request] { [] }
+    func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] { [] }
     func resolveEmpty(_ id: UInt32) throws -> [Request] { [] }
     func view() throws -> ViewModel {
       var viewModel = try ViewModel.bincodeDeserialize(input: [UInt8](core.view()))

--- a/ios/IntradaTests/ScreenSnapshotTests.swift
+++ b/ios/IntradaTests/ScreenSnapshotTests.swift
@@ -12,6 +12,7 @@ private final class StubBridge: CoreBridge {
   private let core = CoreFfi()
   func update(_ event: Event) throws -> [Request] { [] }
   func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request] { [] }
+  func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] { [] }
   func resolveEmpty(_ id: UInt32) throws -> [Request] { [] }
   func view() throws -> ViewModel {
     try ViewModel.bincodeDeserialize(input: [UInt8](core.view()))

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -50,6 +50,21 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(bridge.emptyResolved, [7], "app effect should ack via resolveEmpty")
   }
 
+  func testPersistenceLoadResolvesWithStubItems() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in [Request(id: 8, effect: .persistence(.loadItems))] }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(bridge.persistenceResolved.first?.id, 8)
+    guard case .items(let items) = bridge.persistenceResolved.first?.output else {
+      return XCTFail(
+        "expected .items, got \(String(describing: bridge.persistenceResolved.first?.output))")
+    }
+    XCTAssertTrue(items.isEmpty, "B1 stub returns no rows (GRDB lands in B2)")
+  }
+
   func testBatchProcessesEveryRequest() {
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in
@@ -269,6 +284,7 @@ private final class FakeBridge: CoreBridge {
 
   private(set) var events: [Event] = []
   private(set) var resolved: [(id: UInt32, result: HttpResult)] = []
+  private(set) var persistenceResolved: [(id: UInt32, output: PersistenceOutput)] = []
   private(set) var emptyResolved: [UInt32] = []
   private(set) var viewCallCount = 0
 
@@ -282,6 +298,12 @@ private final class FakeBridge: CoreBridge {
     resolved.append((id, httpResult))
     onResolve?()
     return resolveHandler(id, httpResult)
+  }
+
+  func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] {
+    persistenceResolved.append((id, persistenceOutput))
+    onResolve?()
+    return []
   }
 
   func resolveEmpty(_ id: UInt32) throws -> [Request] {

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -1,10 +1,11 @@
 # Native iOS Shell (SwiftUI + Crux)
 
 > Tier 3 (Crux FFI bridge + new persistence/sync capability, multi-week,
-> spans core + a net-new native shell). Spec rides with the Phase A branch per
-> CLAUDE.md. Reverses PR #382, which removed the prior SwiftUI shell — the
-> "app-first + local-first" framing below is the deliberate answer to *why
-> reverse it*.
+> spans core + a net-new native shell). The original spec rode with the Phase A
+> branch; the 2026-06-01 **offline-first / paid-sync reframe** (see Decisions
+> log) rides with the Phase B (B1) branch, per CLAUDE.md. Reverses PR #382,
+> which removed the prior SwiftUI shell — the "app-first + offline-first"
+> framing below is the deliberate answer to *why reverse it*.
 
 ## Problem
 
@@ -34,10 +35,31 @@ Strategic decisions (settled; not re-litigated here):
 
 - **App-first.** Native iOS now, native Android later — both on the shared
   Crux core. Web stays on Leptos, untouched. Web's data model is decided later.
-- **Local-first.** On-device SQLite is the source of truth. The existing
-  Axum+Turso backend demotes from live data source to a **sync target**.
+- **Offline-first is the product model.** On-device SQLite is the source of
+  truth. The app is fully functional with **no network and no account** — local
+  writes always succeed. The existing Axum+Turso backend demotes from live data
+  source to an **optional sync target**.
+- **Sync is the paid tier.** Free tier = a complete single-device offline app.
+  Paid tier (subscription) = multi-device sync + backup/restore. The backend
+  earns its keep as a sync/backup service, not as the data source. **Auth is
+  therefore optional** — only required to enable sync.
 - **Sync scope is deliberately small.** Single-user, multi-device,
   **last-write-wins on `updated_at` — not CRDTs**, not multi-user collaboration.
+- **Rethink as we build.** The native build is **not** a 1:1 port of the web
+  app. Each feature area gets a fresh design pass (Pencil + HIG, grounded in how
+  the app is actually used at the piano — see `docs/design-principles.md`)
+  *before* implementation. The Crux domain model stays the stable foundation;
+  the UX/feature framing is open to reinvention per pillar.
+
+### What offline-first changes about "robustness"
+
+Online-first, a failed mutation `POST` needs a per-action error banner + rollback
+(tracked as [#800]). Offline-first, **local writes don't fail** — there is no
+per-action HTTP to roll back. Failures live only at the *sync* layer, where they
+are background and retryable, not per-tap banners. So #800 is **parked**: a
+lighter error-surface folds into the Phase D sync work, not the mutation path.
+
+[#800]: https://github.com/jonyardley/intrada/issues/800
 
 ## The Crux → Swift bridge
 
@@ -103,22 +125,37 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
 
 ## Phased plan
 
-- **Phase 0 (done):** focus mode (web/Tauri/API CI main-only + Dependabot
-  pause) and iOS agent tooling (XcodeBuildMCP, swift-format hook, sourcekit-lsp
-  plugin).
-- **Phase A (this spec):** restore typegen attrs to core (TDD); new
-  `crates/intrada-ffi` (UniFFI + facet typegen); cargo-swift spike → minimal
-  SwiftUI app that sends one `Event` and renders the `ViewModel`. Bake in from
-  day one: swift-snapshot-testing (pinned sim + runtime, perceptual tolerance),
-  Sentry, accessibility (VoiceOver + Dynamic Type). **Gate:** pipeline green on
-  device + simulator, #2818 mitigated.
-- **Phase B:** persistence `Effect` + GRDB store + schema + LWW scaffolding;
-  first real screen (Library) end-to-end local-first. **Gate:** per-screen cost
-  + persistence design validated.
-- **Phase C:** screen-by-screen parity (Plan → Practice → Track), each with
-  iPad `SplitView` built *with* the screen (not retrofit), per-screen
-  accessibility, snapshot tests, and HIG-referenced native shape/behaviour.
-- **Phase D:** LWW sync to the Axum API; retire the Tauri host at parity.
+- **Phase 0 (done):** focus-mode CI + iOS agent tooling.
+- **Phase A (done):** `crates/intrada-ffi` (UniFFI + facet typegen), the
+  cargo-swift pipeline, and a minimal SwiftUI app rendering the `ViewModel`.
+  swift-snapshot-testing, Sentry, and accessibility baked in from day one.
+- **Phase C-early (done — but online-first):** Library screens — list, detail,
+  add, edit, delete — plus filter-from-ViewModel, fonts + Dynamic Type, and a
+  Store effect-loop test harness. Built over HTTP-through-core *ahead* of
+  persistence. **Phase B now retrofits local-first underneath these screens.**
+- **Phase B (ACTIVE — the critical path):** make the app genuinely offline,
+  built as small reviewable increments:
+  - **B1** — `Persistence` Effect *contract*: typed query/mutation ops in the
+    core (TDD); the Swift shell stubs it. No behaviour change — just the pipe.
+  - **B2** — GRDB store: the shell fulfils the effect against real SQLite;
+    schema + sequential migrations (mirroring the API's migration discipline).
+  - **B3** — migrate Library *reads* to local SQLite. Settles the existing-data
+    question (seed empty vs. one-time import of the user's server data).
+  - **B4** — migrate Library *writes* to local-first — always succeed, no HTTP.
+    **The app becomes genuinely offline here.**
+  - **B5** — decouple auth: the app runs with no account; sign-in is inert until
+    sync exists.
+  - **Gate:** full Library CRUD works in airplane mode, with no account.
+- **Phase C (rethink + build the other pillars):** Practice, then Track, each on
+  the local-first foundation. "Rethink as we build" lands here — a design pass
+  (Pencil + HIG, reconsidering vs. web) *starts* each pillar, then local-first
+  data, then per-screen quality (snapshot + accessibility) and iPad `SplitView`
+  built *with* the screen. A redesign on a stable core, not a port.
+- **Phase D (sync = the paid tier):** LWW sync to the Axum API (server-
+  authoritative `updated_at`, tombstones, deterministic tiebreak — designed
+  above); account/sign-in gates sync; StoreKit subscription + entitlement
+  gating; backup/restore. The parked #800 error-surface folds in here. Retire
+  the Tauri host at parity.
 
 ## Quality baked in (day one, not retrofit)
 
@@ -131,9 +168,13 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
 
 ## Open questions
 
+- **Existing server data on first local-first launch** — seed empty vs. a
+  one-time import of the user's server data. Settled at B3.
+- **Free-tier auth shape** — fully account-free vs. an anonymous local account
+  (eases later linking to a sync subscription). Decided before B5.
+- **Android timing** — onto the same local core soon, or stays deferred? Affects
+  how much Phase B generalises now vs. later.
 - **Web data model** — deferred; web shell stays online-only for now.
-- **Per-screen rewrite cost** — answered at the Phase B gate (first real screen).
-- **cargo-swift vs build-ios.sh** — answered by the Phase A spike.
 - **Sync transport detail** (full-table vs delta, batching) — designed in Phase D.
 
 ## Decisions log
@@ -145,6 +186,18 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
 - 2026-05-31 — SQLite owned by the Swift shell (GRDB); reconciliation in core.
 - 2026-05-31 — Mitigate UniFFI #2818 in the build recipe (non-MainActor /
   `nonisolated` post-process).
+- 2026-06-01 — **Offline-first is the product model**, not just an
+  implementation detail: the app is fully functional with no network and no
+  account. (Strengthens the 2026-05-31 local-first decision.)
+- 2026-06-01 — **Sync is the paid tier.** Free = single-device offline; paid
+  subscription = multi-device sync + backup/restore. Backend = sync/backup
+  service. Auth is optional (only gates sync).
+- 2026-06-01 — **Rethink as we build:** native is not a web port; each pillar
+  gets a design pass before implementation.
+- 2026-06-01 — **#800 parked** (online-mutation error banner + rollback) — wrong
+  model for offline-first; the error-surface folds into Phase D sync.
+- 2026-06-01 — **Phase B (local-first persistence) promoted to the active
+  critical path**, retrofitting under the already-built online Library screens.
 
 ## YAGNI (explicitly out of scope for now)
 


### PR DESCRIPTION
First increment of **Phase B (offline-first)**. Two commits: the strategy reframe in the spec (rides with this first phase, per CLAUDE.md), and B1 — the persistence contract.

## Spec reframe (`specs/native-ios.md`)
Commits the product direction: **offline-first** (fully functional with no network *and no account*), **sync as the paid tier** (backend = optional sync/backup service, auth optional), and **"rethink as we build"** (native is not a web port). Promotes Phase B to the active critical path (increments B1–B5), reframes Phase C as the per-pillar rethink and Phase D as the paid-sync arc, and **parks #800** (a failed-mutation banner+rollback is the wrong model when local writes don't fail).

## B1 — the Persistence Effect contract
Establishes the contract and proves the **typed-Output effect round-trips across the FFI bridge** — the core's first effect that returns *data* (unlike `AppEffect`'s `Output = ()`). That round-trip was the main risk; B1 retires it.

**Core (TDD):**
- `persistence.rs` — `PersistenceOperation` (LoadItems / SaveItem / DeleteItem) + `PersistenceOutput` (Items / Ack); `impl Operation`; `load_items()` builder.
- `Effect::Persistence` variant; `Event::HydrateFromStore` (trigger) + `Event::StoreLoaded` (receive) + handlers.
- 4 tests: builder emits the op; hydrate emits a load effect; StoreLoaded replaces items / Ack leaves them.

**Shell:**
- `Store.process` handles `.persistence` with a B1 stub (loadItems → `items([])`, save/delete → `ack`) — no GRDB yet (B2). `CoreBridge`/`LiveBridge` gain `resolve(_:persistenceOutput:)`. New harness test asserts the dispatch + stub output.
- Web is online-only: ignore-arms keep its `Effect` match exhaustive.

**No behaviour change** — the pipe exists and is tested but **dormant**; nothing in the live flow emits it (the Library still uses HTTP). B3 wires Library reads onto it.

## Verification
347 core tests · workspace + wasm compile (shared `Effect`/`Event` changed) · iOS build + full snapshot/Store suite green · `cargo fmt` + clippy (CI gate) clean.

## Coverage
Core: full (4 new unit tests on the contract + handlers). Shell: the dispatch path has a harness test; iOS is in the Codecov ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)