### PR TITLE
Native iOS B2: GRDB local store (sync-agnostic SQLite)

### DIFF
--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -1,0 +1,144 @@
+import Foundation
+import GRDB
+import SharedTypes
+
+/// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
+/// `Effect.persistence` operations resolve against. The schema is deliberately
+/// **sync-agnostic**: every row carries `updated_at` + a soft-delete tombstone
+/// so a later sync engine (custom LWW or Automerge) can sit on top without a
+/// migration (see specs/native-ios.md "Sync engine").
+///
+/// Calls are synchronous; the dataset is single-user and tiny, so GRDB's own
+/// serialization is enough and an off-main hop isn't worth the Sendable dance
+/// against the non-Sendable generated `Item`. Revisit if data volume grows.
+final class LibraryStore {
+  private let dbQueue: DatabaseQueue
+
+  init(_ dbQueue: DatabaseQueue) throws {
+    self.dbQueue = dbQueue
+    try Self.migrator.migrate(dbQueue)
+  }
+
+  /// File-backed store in Application Support (the real app).
+  static func onDisk() throws -> LibraryStore {
+    let dir = try FileManager.default.url(
+      for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    return try LibraryStore(DatabaseQueue(path: dir.appendingPathComponent("intrada.sqlite").path))
+  }
+
+  /// In-memory store for tests/previews.
+  static func inMemory() throws -> LibraryStore {
+    try LibraryStore(DatabaseQueue())
+  }
+
+  // ── Operations ───────────────────────────────────────────────────────
+
+  /// All live (non-tombstoned) items, newest first.
+  func loadItems() throws -> [Item] {
+    try dbQueue.read { db in
+      try Row.fetchAll(
+        db, sql: "SELECT * FROM item WHERE deleted_at IS NULL ORDER BY created_at DESC"
+      )
+      .map(Self.item(from:))
+    }
+  }
+
+  /// Insert or update by id; clears any tombstone (an upsert revives a row).
+  func save(_ item: Item) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO item
+            (id, title, kind, composer, key, tempo_marking, tempo_bpm, notes, tags,
+             created_at, updated_at, priority, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+          ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title, kind = excluded.kind, composer = excluded.composer,
+            key = excluded.key, tempo_marking = excluded.tempo_marking,
+            tempo_bpm = excluded.tempo_bpm, notes = excluded.notes, tags = excluded.tags,
+            updated_at = excluded.updated_at, priority = excluded.priority, deleted_at = NULL
+          """,
+        arguments: [
+          item.id, item.title, Self.kindString(item.kind), item.composer, item.key,
+          item.tempo?.marking, item.tempo?.bpm.map { Int($0) }, item.notes,
+          Self.encodeTags(item.tags),
+          item.createdAt, item.updatedAt, item.priority,
+        ])
+    }
+  }
+
+  /// Soft-delete: stamp `deleted_at` (tombstone) rather than removing the row,
+  /// so the deletion can win a later last-write-wins sync.
+  func delete(id: String) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: "UPDATE item SET deleted_at = ? WHERE id = ?",
+        arguments: [Self.timestamp(), id])
+    }
+  }
+
+  // ── Schema ───────────────────────────────────────────────────────────
+
+  private static var migrator: DatabaseMigrator {
+    var migrator = DatabaseMigrator()
+    migrator.registerMigration("v1_item") { db in
+      try db.execute(
+        sql: """
+          CREATE TABLE item (
+            id TEXT PRIMARY KEY NOT NULL,
+            title TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            composer TEXT,
+            key TEXT,
+            tempo_marking TEXT,
+            tempo_bpm INTEGER,
+            notes TEXT,
+            tags TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            deleted_at TEXT
+          )
+          """)
+    }
+    return migrator
+  }
+
+  // ── Row ↔ Item codec ─────────────────────────────────────────────────
+
+  private static func item(from row: Row) -> Item {
+    let marking: String? = row["tempo_marking"]
+    let bpm: UInt16? = (row["tempo_bpm"] as Int?).map { UInt16($0) }
+    let tempo = (marking == nil && bpm == nil) ? nil : Tempo(marking: marking, bpm: bpm)
+    return Item(
+      id: row["id"], title: row["title"], kind: kind(from: row["kind"]),
+      composer: row["composer"], key: row["key"], tempo: tempo, notes: row["notes"],
+      tags: decodeTags(row["tags"]), createdAt: row["created_at"], updatedAt: row["updated_at"],
+      priority: row["priority"])
+  }
+
+  private static func kindString(_ kind: ItemKind) -> String {
+    switch kind {
+    case .piece: "piece"
+    case .exercise: "exercise"
+    }
+  }
+
+  private static func kind(from raw: String) -> ItemKind {
+    raw == "exercise" ? .exercise : .piece
+  }
+
+  private static func encodeTags(_ tags: [String]) -> String {
+    guard let data = try? JSONEncoder().encode(tags), let json = String(data: data, encoding: .utf8)
+    else { return "[]" }
+    return json
+  }
+
+  private static func decodeTags(_ json: String) -> [String] {
+    (try? JSONDecoder().decode([String].self, from: Data(json.utf8))) ?? []
+  }
+
+  private static func timestamp() -> String {
+    ISO8601DateFormatter().string(from: Date())
+  }
+}

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -11,10 +11,17 @@ final class Store {
 
   private let bridge: CoreBridge
   private let session: URLSession
+  private let store: LibraryStore?
 
-  init(bridge: CoreBridge = LiveBridge(), session: URLSession = .shared) {
+  init(
+    bridge: CoreBridge = LiveBridge(), session: URLSession = .shared, store: LibraryStore? = nil
+  ) {
     self.bridge = bridge
     self.session = session
+    // Default to in-memory so tests/previews never touch disk; the real app
+    // passes an on-disk store. `try?` (not `guarded`) because `self` isn't fully
+    // initialized yet here; in-memory creation effectively never fails.
+    self.store = store ?? (try? LibraryStore.inMemory())
     // Initial render comes straight from the core; nil only if the bridge
     // itself fails, in which case the view shows a loading state.
     self.viewModel = guarded { try bridge.view() }
@@ -36,13 +43,7 @@ final class Store {
         // the core can continue its command chain.
         process(guarded { try bridge.resolveEmpty(request.id) } ?? [])
       case .persistence(let operation):
-        // B1 stub — no GRDB yet (B2); answer with the empty/ack shape the core
-        // expects so the contract + typed-Output round-trip are exercised.
-        let output: PersistenceOutput =
-          switch operation {
-          case .loadItems: .items([])
-          case .saveItem, .deleteItem: .ack
-          }
+        let output = persistenceOutput(for: operation)
         process(guarded { try bridge.resolve(request.id, persistenceOutput: output) } ?? [])
       }
     }
@@ -57,6 +58,35 @@ final class Store {
   private func handleHttp(_ request: HttpRequest, id: UInt32) async {
     let result = await Self.execute(request, session: session)
     process(guarded { try bridge.resolve(id, httpResult: result) } ?? [])
+  }
+
+  /// Run a persistence op against the local store. A store failure is reported
+  /// and answered with the empty/ack shape so the core's command chain still
+  /// completes (offline-first assumes local writes succeed; failures are rare
+  /// disk/corruption cases worth surfacing, not silently dropping the effect).
+  private func persistenceOutput(for operation: PersistenceOperation) -> PersistenceOutput {
+    guard let store else { return Self.emptyOutput(for: operation) }
+    do {
+      switch operation {
+      case .loadItems: return .items(try store.loadItems())
+      case .saveItem(let item):
+        try store.save(item)
+        return .ack
+      case .deleteItem(let id):
+        try store.delete(id: id)
+        return .ack
+      }
+    } catch {
+      report(error)
+      return Self.emptyOutput(for: operation)
+    }
+  }
+
+  private static func emptyOutput(for operation: PersistenceOperation) -> PersistenceOutput {
+    switch operation {
+    case .loadItems: .items([])
+    case .saveItem, .deleteItem: .ack
+    }
   }
 
   // A bridge failure means a serialization/protocol break (e.g. stale bindings

--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -3,7 +3,19 @@ import SwiftUI
 
 @main
 struct IntradaApp: App {
-  @State private var store = Store()
+  // On-disk store for the real app; on failure we report it and Store falls
+  // back to in-memory (this session won't persist). Tests/previews pass nil and
+  // get the in-memory default.
+  @State private var store = Store(store: IntradaApp.openOnDiskStore())
+
+  private static func openOnDiskStore() -> LibraryStore? {
+    do {
+      return try LibraryStore.onDisk()
+    } catch {
+      report(error)
+      return nil
+    }
+  }
 
   init() {
     IntradaFonts.register()

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -1,0 +1,79 @@
+import SharedTypes
+import XCTest
+
+@testable import Intrada
+
+/// Exercises the GRDB-backed local store against an in-memory database: the
+/// row↔Item codec round-trips, upsert updates in place, and delete tombstones
+/// (hides the row from loads) without dropping it.
+final class LibraryStoreTests: XCTestCase {
+  private func makeStore() throws -> LibraryStore { try LibraryStore.inMemory() }
+
+  private func item(
+    _ id: String, title: String = "Etude", kind: ItemKind = .piece,
+    createdAt: String = "2026-01-01T00:00:00Z"
+  ) -> Item {
+    Item(
+      id: id, title: title, kind: kind, composer: "Chopin", key: "C major",
+      tempo: Tempo(marking: "Allegro", bpm: 132), notes: "evenness",
+      tags: ["scale", "warmup"], createdAt: createdAt, updatedAt: createdAt, priority: true)
+  }
+
+  func testSaveThenLoadRoundTrips() throws {
+    let store = try makeStore()
+    try store.save(item("p1"))
+    let loaded = try store.loadItems()
+    XCTAssertEqual(loaded.count, 1)
+    let got = try XCTUnwrap(loaded.first)
+    XCTAssertEqual(got.id, "p1")
+    XCTAssertEqual(got.kind, .piece)
+    XCTAssertEqual(got.tempo, Tempo(marking: "Allegro", bpm: 132))
+    XCTAssertEqual(got.tags, ["scale", "warmup"])
+    XCTAssertTrue(got.priority)
+  }
+
+  func testExerciseKindAndNilTempoRoundTrip() throws {
+    let store = try makeStore()
+    var ex = item("e1", kind: .exercise)
+    ex.tempo = nil
+    ex.tags = []
+    try store.save(ex)
+    let got = try XCTUnwrap(try store.loadItems().first)
+    XCTAssertEqual(got.kind, .exercise)
+    XCTAssertNil(got.tempo)
+    XCTAssertEqual(got.tags, [])
+  }
+
+  func testUpsertUpdatesInPlace() throws {
+    let store = try makeStore()
+    try store.save(item("p1", title: "Before"))
+    try store.save(item("p1", title: "After"))
+    let loaded = try store.loadItems()
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded.first?.title, "After")
+  }
+
+  func testDeleteTombstonesAndHidesFromLoad() throws {
+    let store = try makeStore()
+    try store.save(item("p1"))
+    try store.delete(id: "p1")
+    XCTAssertTrue(try store.loadItems().isEmpty)
+  }
+
+  func testSaveRevivesADeletedRow() throws {
+    let store = try makeStore()
+    try store.save(item("p1"))
+    try store.delete(id: "p1")
+    try store.save(item("p1", title: "Revived"))
+    let loaded = try store.loadItems()
+    XCTAssertEqual(loaded.count, 1)
+    XCTAssertEqual(loaded.first?.title, "Revived")
+  }
+
+  func testLoadOrdersNewestFirst() throws {
+    let store = try makeStore()
+    try store.save(item("old", title: "Old", createdAt: "2026-01-01T00:00:00Z"))
+    try store.save(item("new", title: "New", createdAt: "2026-02-01T00:00:00Z"))
+    XCTAssertEqual(try store.loadItems().map(\.id), ["new", "old"])
+  }
+}

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -50,7 +50,7 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(bridge.emptyResolved, [7], "app effect should ack via resolveEmpty")
   }
 
-  func testPersistenceLoadResolvesWithStubItems() {
+  func testPersistenceLoadResolvesFromStore() {
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in [Request(id: 8, effect: .persistence(.loadItems))] }
     let store = Store(bridge: bridge, session: mockSession())
@@ -62,7 +62,7 @@ final class StoreEffectLoopTests: XCTestCase {
       return XCTFail(
         "expected .items, got \(String(describing: bridge.persistenceResolved.first?.output))")
     }
-    XCTAssertTrue(items.isEmpty, "B1 stub returns no rows (GRDB lands in B2)")
+    XCTAssertTrue(items.isEmpty, "fresh in-memory store has no rows")
   }
 
   func testBatchProcessesEveryRequest() {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -26,6 +26,9 @@ packages:
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
     from: "1.18.0"
+  GRDB:
+    url: https://github.com/groue/GRDB.swift
+    from: "7.0.0"
 
 targets:
   Intrada:
@@ -49,6 +52,8 @@ targets:
         product: SharedTypes
       - package: Sentry
         product: Sentry
+      - package: GRDB
+        product: GRDB
     scheme:
       testTargets:
         - IntradaTests

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -123,6 +123,29 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
   - Offline-first: writes apply locally immediately; sync is deferred and
     retried.
 
+### Sync engine — evaluated 2026-06 (deep-research, verified)
+
+We surveyed the landscape before committing. Outcome: **build the local store
+sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
+
+- **Turso/libSQL offline-sync** — the tempting "we already use Turso" path — is
+  **still beta in 2026 with a documented "data loss is possible" warning**, and
+  Turso is mid-rewrite (Rust "Turso DB" also beta). Disqualifying for a *paid*
+  tier today. (Its default row-level Last-Push-Wins *does* match our LWW, so it
+  stays a candidate once it GAs with durability.)
+- **Automerge 3.0** (CRDT, Rust-native; `autosurgeon` reconcile in the core) is
+  the strongest *conceptual* fit and the fallback if we ever want CRDT-grade
+  resilience — but its **Swift sync layer is alpha/stale**, so it'd mean driving
+  sync from the Rust core with hand-rolled Swift glue. Not now.
+- **CloudKit / SwiftData** — free (can't monetize), iOS-only (breaks Android),
+  and bypasses the core (Swift owns the schema). Architecturally out.
+- **PowerSync / ElectricSQL** — assume the client owns the DB in Swift/JS; poor
+  fit for a Rust core. Out.
+- **Decision:** the local SQLite schema bakes in `updated_at` + soft-delete
+  tombstones from B2 so **both** survivors — custom LWW-to-Turso *or*
+  Automerge-in-the-core — can sit on it later. We commit to neither yet. The
+  biggest risk to avoid: shipping Turso's offline-sync beta to paying users.
+
 ## Phased plan
 
 - **Phase 0 (done):** focus-mode CI + iOS agent tooling.
@@ -139,10 +162,14 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
     core (TDD); the Swift shell stubs it. No behaviour change — just the pipe.
   - **B2** — GRDB store: the shell fulfils the effect against real SQLite;
     schema + sequential migrations (mirroring the API's migration discipline).
+    Schema is **sync-agnostic** — `updated_at` + soft-delete tombstone columns
+    baked in now so a later sync engine can sit on it (see Sync engine above).
   - **B3** — migrate Library *reads* to local SQLite. Settles the existing-data
     question (seed empty vs. one-time import of the user's server data).
   - **B4** — migrate Library *writes* to local-first — always succeed, no HTTP.
-    **The app becomes genuinely offline here.**
+    **The app becomes genuinely offline here.** Must first fix the ack-on-error
+    data-loss risk from B2 (a failed local write currently resolves `.ack`,
+    which the core trusts as success) — see #816.
   - **B5** — decouple auth: the app runs with no account; sign-in is inert until
     sync exists.
   - **Gate:** full Library CRUD works in airplane mode, with no account.
@@ -198,6 +225,11 @@ persistence is **not** a custom capability; it's a **custom `Effect` driven by
   model for offline-first; the error-surface folds into Phase D sync.
 - 2026-06-01 — **Phase B (local-first persistence) promoted to the active
   critical path**, retrofitting under the already-built online Library screens.
+- 2026-06-01 — **Sync engine deferred; local store built sync-agnostic**
+  (verified deep-research). Turso offline-sync ruled out for the paid tier
+  while beta/lossy; roll-our-own LWW-to-Turso is the lead, Automerge-in-the-core
+  the fallback. B2 schema bakes in `updated_at` + tombstones so the choice
+  stays open.
 
 ## YAGNI (explicitly out of scope for now)
 


### PR DESCRIPTION
Second Phase-B increment. The persistence Effect now resolves against a **real on-device SQLite database** (GRDB), replacing the B1 stub. Preceded by a verified deep-research pass on the sync landscape (recorded in the spec).

## Sync-engine research outcome (in the spec)
Surveyed Turso offline-sync, Automerge, cr-sqlite, PowerSync/ElectricSQL, CloudKit. **Decision: defer the engine; build the local store sync-agnostic now.** Turso's offline-sync is still beta in 2026 with a documented "data loss is possible" warning → ruled out for a *paid* tier. Lead is roll-our-own server-authoritative LWW over our existing Turso backend (matches the tiny single-user conflict scope, we control the semantics, monetizable, Android-friendly); Automerge-in-the-core is the fallback. CloudKit/SwiftData are out (free, iOS-only, bypass the core).

## B2
- **`LibraryStore` (GRDB)** — one `item` table with a deliberately **sync-agnostic** schema: `updated_at` + a soft-delete `deleted_at` tombstone + all Item fields, so either survivor sync strategy can sit on it later without a migration. `loadItems` (live rows, newest-first), `save` (upsert that revives tombstones), `delete` (soft-delete). Row↔Item codec handles kind / tempo / tags(JSON) / priority. On-disk in the app; in-memory for tests/previews.
- **`Store`** holds the store and resolves `.persistence` ops against it. Synchronous: the dataset is single-user/tiny, so GRDB's own serialization suffices and an off-main hop isn't worth the Sendable dance against the non-Sendable generated `Item` (noted to revisit if volume grows). Local-store failures are `report`ed and answered with the empty/ack shape so the core's command chain still completes.
- **6 store tests** (roundtrip incl. exercise/nil-tempo, upsert, tombstone-hides, revive-deleted, newest-first) + the dispatch test now exercises the real (empty) store.

## Still dormant
Nothing in the live flow emits persistence yet — the Library still reads/writes over HTTP. **B3** flips Library reads onto the store; **B4** flips writes (the app goes genuinely offline there).

## Verification
iOS build + full snapshot/Store/LibraryStore suite green on an iOS 26.5 sim; GRDB resolves cleanly. No Rust/core change (no binding regen, no snapshot changes).

## Coverage
Store layer: 6 GRDB unit tests + the effect-dispatch test. iOS is in the Codecov ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)