### PR TITLE
Native iOS B3a: write-through to the local store

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -235,19 +235,21 @@ impl App for Intrada {
             // ── Write-confirmation callbacks ─────────────────────────
             Event::ItemCreated { temp_id, item } => {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == temp_id) {
-                    *existing = item;
+                    *existing = item.clone();
                 } else {
-                    model.items.push(item);
+                    model.items.push(item.clone());
                 }
                 model.record_success();
-                crux_core::render::render()
+                // Persist on confirmation (real id, not the temp id); web ignores
+                // the Persistence effect, so this is iOS-only write-through.
+                Command::all([persistence::save_item(item), crux_core::render::render()])
             }
             Event::ItemUpdated { item } => {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == item.id) {
-                    *existing = item;
+                    *existing = item.clone();
                 }
                 model.record_success();
-                crux_core::render::render()
+                Command::all([persistence::save_item(item), crux_core::render::render()])
             }
             Event::SetUpdated { set } => {
                 if let Some(existing) = model.sets.iter_mut().find(|r| r.id == set.id) {
@@ -290,12 +292,14 @@ impl App for Intrada {
 
             // ── Local-first persistence (B1) ─────────────────────────
             Event::HydrateFromStore => persistence::load_items(),
-            Event::StoreLoaded(output) => {
-                if let PersistenceOutput::Items(items) = output {
+            Event::StoreLoaded(output) => match output {
+                PersistenceOutput::Items(items) => {
                     model.items = items;
+                    crux_core::render::render()
                 }
-                crux_core::render::render()
-            }
+                // Write-through ack — model already updated; nothing to render.
+                PersistenceOutput::Ack => Command::done(),
+            },
         }
     }
 

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -140,6 +140,8 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
 
             Command::all([
                 crate::http::delete_item(&model.api_base_url, &id),
+                // Write-through: soft-delete locally too (web ignores it).
+                crate::persistence::delete_item(id),
                 crux_core::render::render(),
             ])
         }

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -35,6 +35,18 @@ pub fn load_items() -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::LoadItems).then_send(Event::StoreLoaded)
 }
 
+/// Upsert an item into the local store (write-through). The `Ack` lands in
+/// `Event::StoreLoaded` and is a no-op — the model was already updated.
+pub fn save_item(item: Item) -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::SaveItem(item)).then_send(Event::StoreLoaded)
+}
+
+/// Soft-delete an item from the local store (write-through).
+pub fn delete_item(id: String) -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::DeleteItem { id })
+        .then_send(Event::StoreLoaded)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,5 +115,92 @@ mod tests {
         let _ = app.update(Event::StoreLoaded(PersistenceOutput::Ack), &mut model);
         assert_eq!(model.items.len(), 1);
         assert_eq!(model.items[0].id, "keep");
+    }
+
+    // ── Write-through (B3a) ─────────────────────────────────────────────
+
+    fn emits_save(cmd: &mut Command<Effect, Event>, expected_id: &str) -> bool {
+        cmd.effects().any(|e| {
+            matches!(e, Effect::Persistence(req)
+                if matches!(&req.operation, PersistenceOperation::SaveItem(item) if item.id == expected_id))
+        })
+    }
+
+    #[test]
+    fn save_item_requests_a_save_op() {
+        let mut cmd = save_item(sample_item("p1"));
+        assert!(emits_save(&mut cmd, "p1"));
+    }
+
+    #[test]
+    fn delete_item_requests_a_delete_op() {
+        let mut cmd = delete_item("gone".to_string());
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::DeleteItem { id: "gone".to_string() })));
+    }
+
+    #[test]
+    fn item_created_writes_through_to_store() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(
+            Event::ItemCreated {
+                temp_id: "tmp".into(),
+                item: sample_item("server-id"),
+            },
+            &mut model,
+        );
+        assert!(emits_save(&mut cmd, "server-id"));
+    }
+
+    #[test]
+    fn item_updated_writes_through_to_store() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.items = vec![sample_item("p1")];
+        let mut cmd = app.update(
+            Event::ItemUpdated {
+                item: sample_item("p1"),
+            },
+            &mut model,
+        );
+        assert!(emits_save(&mut cmd, "p1"));
+    }
+
+    #[test]
+    fn delete_writes_through_a_tombstone() {
+        use crate::domain::item::ItemEvent;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.items = vec![sample_item("p1")];
+        let mut cmd = app.update(
+            Event::Item(ItemEvent::Delete { id: "p1".into() }),
+            &mut model,
+        );
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::DeleteItem { id: "p1".to_string() })));
+    }
+
+    #[test]
+    fn optimistic_create_does_not_persist_yet() {
+        // B3a persists creates only on confirmation (real id), so the optimistic
+        // Add must emit no Persistence effect (until B3b client-ulids — #818).
+        use crate::domain::item::ItemEvent;
+        use crate::domain::types::CreateItem;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(
+            Event::Item(ItemEvent::Add(CreateItem {
+                title: "New".into(),
+                kind: ItemKind::Piece,
+                composer: None,
+                key: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+            })),
+            &mut model,
+        );
+        assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
     }
 }

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -164,12 +164,19 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
     schema + sequential migrations (mirroring the API's migration discipline).
     Schema is **sync-agnostic** — `updated_at` + soft-delete tombstone columns
     baked in now so a later sync engine can sit on it (see Sync engine above).
-  - **B3** — migrate Library *reads* to local SQLite. Settles the existing-data
-    question (seed empty vs. one-time import of the user's server data).
-  - **B4** — migrate Library *writes* to local-first — always succeed, no HTTP.
-    **The app becomes genuinely offline here.** Must first fix the ack-on-error
-    data-loss risk from B2 (a failed local write currently resolves `.ack`,
-    which the core trusts as success) — see #816.
+  - **B3a (done)** — write-through: item create/update/delete also persist to
+    the local store (creates/updates on their server-confirmed event, deletes
+    optimistically). Additive — web ignores the Persistence effect; iOS
+    populates the store. Reads still come from HTTP.
+  - **B3b** — flip Library *reads* to the local store (hydrate on launch). With
+    seed-empty settled, this also needs creates to become client-ulid-canonical
+    (retiring the temp-id dance for items — so offline creates reach the store,
+    see #818) and a per-shell "local-first" mode so iOS drops the Library's HTTP
+    while the shared core keeps web online.
+  - **B4** — migrate Library *writes* to fully local-first — always succeed, no
+    HTTP, no network dependency. **The app becomes genuinely offline here.**
+    Must first fix the ack-on-error data-loss risk from B2 (a failed local write
+    currently resolves `.ack`, which the core trusts as success) — see #816.
   - **B5** — decouple auth: the app runs with no account; sign-in is inert until
     sync exists.
   - **Gate:** full Library CRUD works in airplane mode, with no account.
@@ -195,8 +202,10 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
 
 ## Open questions
 
-- **Existing server data on first local-first launch** — seed empty vs. a
-  one-time import of the user's server data. Settled at B3.
+- ~~**Existing server data on first local-first launch**~~ — **settled
+  2026-06-01: seed empty.** No users to migrate, so no one-time import is
+  built; "getting your data onto a device" is just the Phase D sync pull (auth-
+  gated), so we write zero throwaway import code.
 - **Free-tier auth shape** — fully account-free vs. an anonymous local account
   (eases later linking to a sync subscription). Decided before B5.
 - **Android timing** — onto the same local core soon, or stays deferred? Affects


### PR DESCRIPTION
First half of B3. Item create/update/delete now **also persist to the on-device SQLite store** (built in B2), populating it ahead of B3b flipping reads onto it.

## What
- Creates/updates persist on their **server-confirmed** event (`ItemCreated`/`ItemUpdated` carry the real id) — so the store never holds a stale temp-id row. Deletes persist optimistically (id is known). New `persistence::save_item` / `delete_item` command builders.
- **Additive + behaviour-preserving:** the live Library still reads and writes over HTTP. The **web shell ignores the Persistence effect** (B1 ignore-arms), so web is untouched; iOS mirrors confirmed writes into the local store.
- `StoreLoaded(Ack)` → `Command::done()` (no redundant render for a write-through ack; also clears the B1 review nit).

## Decision settled: seed empty
No users to migrate, so we build **no one-time import** — "getting your data onto a device" is just the Phase D sync pull (auth-gated). Zero throwaway code. Spec's open question resolved; B3b/B4 framing refined.

## What's deferred to B3b (flagged in the spec)
Flipping *reads* to the store needs two things this PR deliberately doesn't do: creates becoming **client-ulid-canonical** (retiring the temp-id dance for items) and a **per-shell "local-first" mode** so iOS drops the Library's HTTP while the shared core keeps the web app online.

## Verification
5 new core tests (save/delete builders + create/update/delete write-through). **352 core tests**, clippy, wasm web shell compile, and iOS build + full suite all green. No new FFI types (no binding-shape change).

## Coverage
Core: full (write-through emission covered per operation). iOS shell unchanged (B2 already fulfils persistence); in Codecov ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)