### PR TITLE
Native iOS B3b: flip the Library to local-first (reads + writes)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -44,6 +44,8 @@ pub enum Event {
     /// Named `StartApp` (not `Init`) to avoid Swift keyword collision.
     StartApp {
         api_base_url: String,
+        /// iOS passes true (Library local-first); web passes false (online).
+        local_first: bool,
     },
     /// Replace the library with a canonical demo dataset. Sent by a shell only
     /// under an explicit opt-in (e.g. iOS `--seed-sample-data` launch arg) for
@@ -167,17 +169,29 @@ impl App for Intrada {
     ) -> Command<Self::Effect, Self::Event> {
         match event {
             // ── Lifecycle ────────────────────────────────────────────
-            Event::StartApp { api_base_url } => {
+            Event::StartApp {
+                api_base_url,
+                local_first,
+            } => {
                 model.api_base_url = api_base_url;
-                // Immediately fetch all data
-                Command::all([
-                    http::fetch_items(&model.api_base_url),
-                    http::fetch_sessions(&model.api_base_url),
-                    http::fetch_sets(&model.api_base_url),
-                ])
+                model.local_first = local_first;
+                if local_first {
+                    // Library is local: hydrate from the on-device store, no HTTP.
+                    // (Sessions/sets aren't on the native shell yet — migrated later.)
+                    persistence::load_items()
+                } else {
+                    Command::all([
+                        http::fetch_items(&model.api_base_url),
+                        http::fetch_sessions(&model.api_base_url),
+                        http::fetch_sets(&model.api_base_url),
+                    ])
+                }
             }
             Event::LoadSampleData => {
                 model.items = sample_items();
+                // Seed mode is offline (DEBUG/CI) — keep writes local so a demo
+                // edit doesn't surprise-POST to the API.
+                model.local_first = true;
                 // crux_http panics on a relative URL; demo mode skips StartApp, so set one.
                 if model.api_base_url.is_empty() {
                     "http://localhost:3001".clone_into(&mut model.api_base_url);
@@ -240,16 +254,14 @@ impl App for Intrada {
                     model.items.push(item.clone());
                 }
                 model.record_success();
-                // Persist on confirmation (real id, not the temp id); web ignores
-                // the Persistence effect, so this is iOS-only write-through.
-                Command::all([persistence::save_item(item), crux_core::render::render()])
+                crux_core::render::render()
             }
             Event::ItemUpdated { item } => {
                 if let Some(existing) = model.items.iter_mut().find(|i| i.id == item.id) {
-                    *existing = item.clone();
+                    *existing = item;
                 }
                 model.record_success();
-                Command::all([persistence::save_item(item), crux_core::render::render()])
+                crux_core::render::render()
             }
             Event::SetUpdated { set } => {
                 if let Some(existing) = model.sets.iter_mut().find(|r| r.id == set.id) {
@@ -1875,6 +1887,7 @@ mod tests {
         let _cmd = app.update(
             Event::StartApp {
                 api_base_url: "https://api.example.com".to_string(),
+                local_first: false,
             },
             &mut model,
         );

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -56,6 +56,25 @@ pub enum ItemEvent {
     RemoveTags { id: String, tags: Vec<String> },
 }
 
+/// Persist a just-saved item locally (local-first) or PUT it to the server
+/// (online). Shared by Update / AddTags / RemoveTags.
+fn save_or_put(model: &mut Model, item: Item) -> Command<Effect, Event> {
+    if model.local_first {
+        // No server callback to clear the dismiss-mute later (online does that
+        // on ItemUpdated), so record the success here.
+        model.record_success();
+        Command::all([
+            crate::persistence::save_item(item),
+            crux_core::render::render(),
+        ])
+    } else {
+        Command::all([
+            crate::http::update_item(&model.api_base_url, &item),
+            crux_core::render::render(),
+        ])
+    }
+}
+
 pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect, Event> {
     match event {
         ItemEvent::Add(input) => {
@@ -79,14 +98,25 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
                 priority: false,
             };
 
-            let temp_id = item.id.clone();
             model.items.push(item.clone());
             model.last_error = None;
 
-            Command::all([
-                crate::http::create_item(&model.api_base_url, &item, &temp_id),
-                crux_core::render::render(),
-            ])
+            if model.local_first {
+                // The client ulid is canonical — persist locally, no server
+                // round-trip, no temp-id replacement. Record success here since
+                // there's no ItemCreated callback to clear the dismiss-mute.
+                model.record_success();
+                Command::all([
+                    crate::persistence::save_item(item),
+                    crux_core::render::render(),
+                ])
+            } else {
+                let temp_id = item.id.clone();
+                Command::all([
+                    crate::http::create_item(&model.api_base_url, &item, &temp_id),
+                    crux_core::render::render(),
+                ])
+            }
         }
         ItemEvent::Update { id, input } => {
             if let Err(e) = validation::validate_update_item(&input) {
@@ -124,10 +154,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
 
             let item = item.clone();
-            Command::all([
-                crate::http::update_item(&model.api_base_url, &item),
-                crux_core::render::render(),
-            ])
+            save_or_put(model, item)
         }
         ItemEvent::Delete { id } => {
             let len_before = model.items.len();
@@ -138,12 +165,18 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             }
             model.last_error = None;
 
-            Command::all([
-                crate::http::delete_item(&model.api_base_url, &id),
-                // Write-through: soft-delete locally too (web ignores it).
-                crate::persistence::delete_item(id),
-                crux_core::render::render(),
-            ])
+            if model.local_first {
+                model.record_success();
+                Command::all([
+                    crate::persistence::delete_item(id),
+                    crux_core::render::render(),
+                ])
+            } else {
+                Command::all([
+                    crate::http::delete_item(&model.api_base_url, &id),
+                    crux_core::render::render(),
+                ])
+            }
         }
         ItemEvent::AddTags { id, tags } => {
             if let Err(e) = validation::validate_tags(&tags) {
@@ -166,10 +199,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
 
             let item = item.clone();
-            Command::all([
-                crate::http::update_item(&model.api_base_url, &item),
-                crux_core::render::render(),
-            ])
+            save_or_put(model, item)
         }
         ItemEvent::RemoveTags { id, tags } => {
             let Some(item) = model.items.iter_mut().find(|i| i.id == id) else {
@@ -184,10 +214,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
 
             let item = item.clone();
-            Command::all([
-                crate::http::update_item(&model.api_base_url, &item),
-                crux_core::render::render(),
-            ])
+            save_or_put(model, item)
         }
     }
 }

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -19,6 +19,10 @@ use crate::domain::ListQuery;
 pub struct Model {
     /// Base URL for the REST API (set via `Event::StartApp`).
     pub api_base_url: String,
+    /// When true (set by the iOS shell at `StartApp`), the Library is local-
+    /// first: reads hydrate from the on-device store and writes persist locally
+    /// with no HTTP. The web shell leaves this false and stays online.
+    pub local_first: bool,
     pub items: Vec<Item>,
     pub sessions: Vec<PracticeSession>,
     pub session_status: SessionStatus,

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -117,90 +117,172 @@ mod tests {
         assert_eq!(model.items[0].id, "keep");
     }
 
-    // ── Write-through (B3a) ─────────────────────────────────────────────
+    // ── Builders ────────────────────────────────────────────────────────
 
-    fn emits_save(cmd: &mut Command<Effect, Event>, expected_id: &str) -> bool {
+    fn has_save(cmd: &mut Command<Effect, Event>, id: &str) -> bool {
         cmd.effects().any(|e| {
             matches!(e, Effect::Persistence(req)
-                if matches!(&req.operation, PersistenceOperation::SaveItem(item) if item.id == expected_id))
+                if matches!(&req.operation, PersistenceOperation::SaveItem(item) if item.id == id))
         })
+    }
+
+    fn has_delete(cmd: &mut Command<Effect, Event>, id: &str) -> bool {
+        cmd.effects().any(|e| {
+            matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::DeleteItem { id: id.to_string() })
+        })
+    }
+
+    fn has_http(cmd: &mut Command<Effect, Event>) -> bool {
+        cmd.effects().any(|e| matches!(e, Effect::Http(_)))
     }
 
     #[test]
     fn save_item_requests_a_save_op() {
         let mut cmd = save_item(sample_item("p1"));
-        assert!(emits_save(&mut cmd, "p1"));
+        assert!(has_save(&mut cmd, "p1"));
     }
 
     #[test]
     fn delete_item_requests_a_delete_op() {
         let mut cmd = delete_item("gone".to_string());
-        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
-            if req.operation == PersistenceOperation::DeleteItem { id: "gone".to_string() })));
+        assert!(has_delete(&mut cmd, "gone"));
+    }
+
+    // ── Local-first mode (B3b): writes persist locally, no HTTP ─────────
+
+    fn create_item() -> crate::domain::types::CreateItem {
+        crate::domain::types::CreateItem {
+            title: "New".into(),
+            kind: ItemKind::Piece,
+            composer: Some("Chopin".into()), // pieces require a composer (validation)
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        }
     }
 
     #[test]
-    fn item_created_writes_through_to_store() {
-        let app = crate::app::Intrada;
-        let mut model = Model::test_default();
-        let mut cmd = app.update(
-            Event::ItemCreated {
-                temp_id: "tmp".into(),
-                item: sample_item("server-id"),
-            },
-            &mut model,
-        );
-        assert!(emits_save(&mut cmd, "server-id"));
-    }
-
-    #[test]
-    fn item_updated_writes_through_to_store() {
-        let app = crate::app::Intrada;
-        let mut model = Model::test_default();
-        model.items = vec![sample_item("p1")];
-        let mut cmd = app.update(
-            Event::ItemUpdated {
-                item: sample_item("p1"),
-            },
-            &mut model,
-        );
-        assert!(emits_save(&mut cmd, "p1"));
-    }
-
-    #[test]
-    fn delete_writes_through_a_tombstone() {
+    fn local_first_add_persists_and_skips_http() {
         use crate::domain::item::ItemEvent;
         let app = crate::app::Intrada;
         let mut model = Model::test_default();
+        model.local_first = true;
+        let mut cmd = app.update(Event::Item(ItemEvent::Add(create_item())), &mut model);
+        let id = model.items[0].id.clone();
+        assert!(
+            has_save(&mut cmd, &id),
+            "local-first create persists with the client ulid"
+        );
+        assert!(
+            !has_http(&mut cmd),
+            "local-first create makes no HTTP request"
+        );
+    }
+
+    #[test]
+    fn local_first_update_persists_and_skips_http() {
+        use crate::domain::item::ItemEvent;
+        use crate::domain::types::UpdateItem;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.local_first = true;
+        model.items = vec![sample_item("p1")];
+        let input = UpdateItem {
+            title: Some("Renamed".into()),
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: None,
+            priority: None,
+        };
+        let mut cmd = app.update(
+            Event::Item(ItemEvent::Update {
+                id: "p1".into(),
+                input,
+            }),
+            &mut model,
+        );
+        assert!(has_save(&mut cmd, "p1"));
+        assert!(!has_http(&mut cmd));
+    }
+
+    #[test]
+    fn local_first_delete_persists_tombstone_and_skips_http() {
+        use crate::domain::item::ItemEvent;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.local_first = true;
         model.items = vec![sample_item("p1")];
         let mut cmd = app.update(
             Event::Item(ItemEvent::Delete { id: "p1".into() }),
             &mut model,
         );
-        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
-            if req.operation == PersistenceOperation::DeleteItem { id: "p1".to_string() })));
+        assert!(has_delete(&mut cmd, "p1"));
+        assert!(!has_http(&mut cmd));
     }
 
     #[test]
-    fn optimistic_create_does_not_persist_yet() {
-        // B3a persists creates only on confirmation (real id), so the optimistic
-        // Add must emit no Persistence effect (until B3b client-ulids — #818).
+    fn online_add_uses_http_not_persistence() {
         use crate::domain::item::ItemEvent;
-        use crate::domain::types::CreateItem;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default(); // local_first defaults false
+        let mut cmd = app.update(Event::Item(ItemEvent::Add(create_item())), &mut model);
+        assert!(has_http(&mut cmd), "online create POSTs to the server");
+        assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
+    }
+
+    #[test]
+    fn local_first_write_clears_the_dismiss_mute() {
+        // Online clears the mute on the server callback; local-first has none,
+        // so a successful local write must record the success itself.
+        use crate::domain::item::ItemEvent;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.local_first = true;
+        model.dismiss_error(); // user dismissed a banner → error_muted = true
+        let _ = app.update(Event::Item(ItemEvent::Add(create_item())), &mut model);
+        assert!(
+            !model.error_muted,
+            "a successful local write should un-mute"
+        );
+    }
+
+    #[test]
+    fn start_app_local_first_hydrates_from_store() {
         let app = crate::app::Intrada;
         let mut model = Model::test_default();
         let mut cmd = app.update(
-            Event::Item(ItemEvent::Add(CreateItem {
-                title: "New".into(),
-                kind: ItemKind::Piece,
-                composer: None,
-                key: None,
-                tempo: None,
-                notes: None,
-                tags: vec![],
-            })),
+            Event::StartApp {
+                api_base_url: "http://x".into(),
+                local_first: true,
+            },
             &mut model,
         );
+        assert!(model.local_first);
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::LoadItems)));
+        assert!(
+            !has_http(&mut cmd),
+            "local-first launch hydrates from the store, no HTTP"
+        );
+    }
+
+    #[test]
+    fn start_app_online_fetches_over_http() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(
+            Event::StartApp {
+                api_base_url: "http://x".into(),
+                local_first: false,
+            },
+            &mut model,
+        );
+        assert!(!model.local_first);
+        assert!(has_http(&mut cmd));
         assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
     }
 }

--- a/crates/intrada-web/src/core_bridge.rs
+++ b/crates/intrada-web/src/core_bridge.rs
@@ -72,6 +72,7 @@ pub fn init_core(
         let core_ref = core.borrow();
         let effects = core_ref.process_event(Event::StartApp {
             api_base_url: api_client::API_BASE_URL.to_string(),
+            local_first: false,
         });
         view_model.set(core_ref.view());
         effects
@@ -362,6 +363,7 @@ mod tests {
         // Set API base URL via Init (ignore the 3 HTTP fetch effects)
         let _ = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
         let now = chrono::Utc::now();
         let item = Item {
@@ -387,6 +389,7 @@ mod tests {
         let core = Core::<Intrada>::new();
         let _ = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
         let _ = core.process_event(Event::DataLoaded { items: vec![] });
         let _ = core.process_event(Event::SessionsLoaded { sessions: vec![] });
@@ -414,6 +417,7 @@ mod tests {
         let core = Core::<Intrada>::new();
         let _ = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
         let _ = core.process_event(Event::DataLoaded { items: vec![] });
         let _ = core.process_event(Event::SessionsLoaded { sessions: vec![] });
@@ -552,6 +556,7 @@ mod tests {
         let core = Core::<Intrada>::new();
         let _ = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
         let _ = core.process_event(Event::DataLoaded { items: vec![] });
         let _ = core.process_event(Event::SessionsLoaded { sessions: vec![] });
@@ -579,6 +584,7 @@ mod tests {
         let core = Core::<Intrada>::new();
         let _ = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
         let _ = core.process_event(Event::DataLoaded { items: vec![] });
 
@@ -601,6 +607,7 @@ mod tests {
         let core = Core::<Intrada>::new();
         let effects = core.process_event(Event::StartApp {
             api_base_url: "http://localhost:3001".to_string(),
+            local_first: false,
         });
 
         let http = http_effects(&effects);

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -37,7 +37,8 @@ struct RootView: View {
       if seedSampleData {
         store.send(.loadSampleData)
       } else {
-        store.send(.startApp(apiBaseUrl: apiBaseURL))
+        // local-first: the Library hydrates from the on-device store, no HTTP.
+        store.send(.startApp(apiBaseUrl: apiBaseURL, localFirst: true))
       }
     }
   }

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -168,15 +168,16 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
     the local store (creates/updates on their server-confirmed event, deletes
     optimistically). Additive — web ignores the Persistence effect; iOS
     populates the store. Reads still come from HTTP.
-  - **B3b** — flip Library *reads* to the local store (hydrate on launch). With
-    seed-empty settled, this also needs creates to become client-ulid-canonical
-    (retiring the temp-id dance for items — so offline creates reach the store,
-    see #818) and a per-shell "local-first" mode so iOS drops the Library's HTTP
-    while the shared core keeps web online.
-  - **B4** — migrate Library *writes* to fully local-first — always succeed, no
-    HTTP, no network dependency. **The app becomes genuinely offline here.**
-    Must first fix the ack-on-error data-loss risk from B2 (a failed local write
-    currently resolves `.ack`, which the core trusts as success) — see #816.
+  - **B3b (done — the local-first flip)** — seed-empty couples reads and writes,
+    so this did **both** (absorbing the old B4): a per-shell `local_first` mode
+    (set at `StartApp`) where the Library hydrates from the store on launch and
+    create/update/delete persist locally with **no HTTP**; creates are now
+    **client-ulid-canonical** (temp-id dance retired for items — #818). The
+    shared core keeps the web app online (`local_first = false`). **The iPhone
+    Library is genuinely offline here.**
+  - **B4 (folded into B3b).** Remaining hardening: a failed *local* write still
+    resolves `.ack` (reported via Sentry, but the model keeps a non-persisted
+    item that vanishes on relaunch) — graceful recovery tracked in #816.
   - **B5** — decouple auth: the app runs with no account; sign-in is inert until
     sync exists.
   - **Gate:** full Library CRUD works in airplane mode, with no account.


### PR DESCRIPTION
**The iPhone Library is now genuinely offline.** Seed-empty couples reads and writes, so this does the full flip (absorbing the old B4): a per-shell `local_first` mode lets iOS go local while the shared core keeps the web app online.

Closes #818.

## Core
- `model.local_first`; `Event::StartApp` gains a `local_first` field (iOS `true`, web `false`).
- **Reads:** in local-first mode, `StartApp` hydrates the Library from the on-device store (`persistence::load_items`) instead of HTTP fetch.
- **Writes:** create/update/delete persist locally with **no HTTP**. Creates are now **client-ulid-canonical** — the client ulid is the id, persisted immediately, no temp-id/`ItemCreated` replacement (retires the temp-id dance for items, so an offline create lands in the store — #818). A `save_or_put` helper routes Update/AddTags/RemoveTags by mode.
- **Web unchanged:** `local_first = false` keeps the existing HTTP + temp-id path. B3a's persist-on-confirmation write-through is removed (superseded by direct local-first persistence).

## Shell
- iOS `RootView` → `startApp(localFirst: true)`; web call sites pass `false`. Binding regenerated for the new field.

## Verification
- **10 new/updated core tests:** local-first add/update/delete persist **and skip HTTP**; online add still POSTs (no persistence); `StartApp` hydrates-from-store vs fetches-over-HTTP by mode. **355 core tests**, clippy, wasm web shell compile, iOS build + full suite all green.
- **On-simulator:** launched with `--no-seed-sample-data` → the Library hydrates an empty store → "No items yet" empty state, no HTTP, no hang (screenshot verified).

## Manual check worth doing on-device
Tap **+**, add a piece, force-quit, relaunch → it should still be there (persisted locally, no network). The logic is unit-tested but the on-device create→relaunch round-trip isn't auto-driven here.

## Remaining hardening (not blocking)
A failed *local* write still resolves `.ack` — reported via Sentry, but the model keeps a non-persisted item that would vanish on relaunch (rare disk-failure case). Graceful recovery tracked in **#816** (now live, since writes are local-canonical).

## Coverage
Core: full (per-mode write + launch behaviour). iOS shell in Codecov ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)