### PR TITLE
Native iOS #816: surface local-write failures (no phantom acks)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -311,6 +311,12 @@ impl App for Intrada {
                 }
                 // Write-through ack — model already updated; nothing to render.
                 PersistenceOutput::Ack => Command::done(),
+                // Don't trust a write that never reached disk (#816). Message is
+                // op-agnostic since Failed covers load + save + delete.
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    crux_core::render::render()
+                }
             },
         }
     }

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -25,6 +25,8 @@ pub enum PersistenceOperation {
 pub enum PersistenceOutput {
     Items(Vec<Item>),
     Ack,
+    /// Local store failed the op — surfaced, not trusted as success (#816).
+    Failed,
 }
 
 impl Operation for PersistenceOperation {
@@ -105,6 +107,17 @@ mod tests {
         );
         assert_eq!(model.items.len(), 1);
         assert_eq!(model.items[0].id, "fresh");
+    }
+
+    #[test]
+    fn store_loaded_failed_surfaces_an_error() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let _ = app.update(Event::StoreLoaded(PersistenceOutput::Failed), &mut model);
+        assert!(
+            model.last_error.is_some(),
+            "a failed local write must surface an error"
+        );
     }
 
     #[test]

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -2,6 +2,13 @@ import Foundation
 import GRDB
 import SharedTypes
 
+/// Persistence ops the Store resolves against — a protocol so tests can inject a failing fake (#816).
+protocol ItemStore {
+  func loadItems() throws -> [Item]
+  func save(_ item: Item) throws
+  func delete(id: String) throws
+}
+
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
 /// `Effect.persistence` operations resolve against. The schema is deliberately
 /// **sync-agnostic**: every row carries `updated_at` + a soft-delete tombstone
@@ -11,7 +18,7 @@ import SharedTypes
 /// Calls are synchronous; the dataset is single-user and tiny, so GRDB's own
 /// serialization is enough and an off-main hop isn't worth the Sendable dance
 /// against the non-Sendable generated `Item`. Revisit if data volume grows.
-final class LibraryStore {
+final class LibraryStore: ItemStore {
   private let dbQueue: DatabaseQueue
 
   init(_ dbQueue: DatabaseQueue) throws {

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -11,10 +11,10 @@ final class Store {
 
   private let bridge: CoreBridge
   private let session: URLSession
-  private let store: LibraryStore?
+  private let store: (any ItemStore)?
 
   init(
-    bridge: CoreBridge = LiveBridge(), session: URLSession = .shared, store: LibraryStore? = nil
+    bridge: CoreBridge = LiveBridge(), session: URLSession = .shared, store: (any ItemStore)? = nil
   ) {
     self.bridge = bridge
     self.session = session
@@ -60,12 +60,9 @@ final class Store {
     process(guarded { try bridge.resolve(id, httpResult: result) } ?? [])
   }
 
-  /// Run a persistence op against the local store. A store failure is reported
-  /// and answered with the empty/ack shape so the core's command chain still
-  /// completes (offline-first assumes local writes succeed; failures are rare
-  /// disk/corruption cases worth surfacing, not silently dropping the effect).
+  /// Failure (or no store) → `.failed` so the core surfaces it, not a phantom ack (#816).
   private func persistenceOutput(for operation: PersistenceOperation) -> PersistenceOutput {
-    guard let store else { return Self.emptyOutput(for: operation) }
+    guard let store else { return .failed }
     do {
       switch operation {
       case .loadItems: return .items(try store.loadItems())
@@ -78,14 +75,7 @@ final class Store {
       }
     } catch {
       report(error)
-      return Self.emptyOutput(for: operation)
-    }
-  }
-
-  private static func emptyOutput(for operation: PersistenceOperation) -> PersistenceOutput {
-    switch operation {
-    case .loadItems: .items([])
-    case .saveItem, .deleteItem: .ack
+      return .failed
     }
   }
 

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -65,6 +65,20 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertTrue(items.isEmpty, "fresh in-memory store has no rows")
   }
 
+  func testPersistenceWriteFailureResolvesFailed() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [Request(id: 9, effect: .persistence(.saveItem(Self.sampleItem)))]
+    }
+    let store = Store(bridge: bridge, session: mockSession(), store: FailingStore())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.first?.output, .failed,
+      "a failing local store must resolve .failed, not a phantom .ack")
+  }
+
   func testBatchProcessesEveryRequest() {
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in
@@ -258,6 +272,11 @@ final class StoreEffectLoopTests: XCTestCase {
     await fulfillment(of: [resolved], timeout: 2)
   }
 
+  static let sampleItem = Item(
+    id: "p1", title: "Etude", kind: .piece, composer: "Chopin", key: nil, tempo: nil,
+    notes: nil, tags: [], createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z",
+    priority: false)
+
   private func mockSession() -> URLSession {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [MockURLProtocol.self]
@@ -320,6 +339,13 @@ private final class FakeBridge: CoreBridge {
 }
 
 private struct TestError: Error {}
+
+/// An `ItemStore` that always throws — drives the failure path (#816).
+private struct FailingStore: ItemStore {
+  func loadItems() throws -> [Item] { throw TestError() }
+  func save(_ item: Item) throws { throw TestError() }
+  func delete(id: String) throws { throw TestError() }
+}
 
 /// Intercepts URLSession traffic so `Store.execute` runs against canned
 /// responses/errors. `handler` is set per test; `lastRequest` captures the

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -175,9 +175,11 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
     **client-ulid-canonical** (temp-id dance retired for items — #818). The
     shared core keeps the web app online (`local_first = false`). **The iPhone
     Library is genuinely offline here.**
-  - **B4 (folded into B3b).** Remaining hardening: a failed *local* write still
-    resolves `.ack` (reported via Sentry, but the model keeps a non-persisted
-    item that vanishes on relaunch) — graceful recovery tracked in #816.
+  - **B4 (folded into B3b).** Hardening done (#816): a failed *local* write now
+    resolves `.failed` (not a phantom `.ack`) and the core surfaces an error, so
+    a write that never reached disk is observable rather than silently trusted.
+    (A rejected optimistic item still lingers until relaunch — acceptable for
+    the rare disk-failure case.)
   - **B5** — decouple auth: the app runs with no account; sign-in is inert until
     sync exists.
   - **Gate:** full Library CRUD works in airplane mode, with no account.


### PR DESCRIPTION
Closes #816. Hardens the offline Library's one live rough edge.

## Problem
Since B3b made writes local-canonical, a failed local persist resolved `.ack` — the core trusted a write that never reached disk. The optimistic item lingered in the UI, then vanished on relaunch: **silent data loss** (reported to Sentry, but invisible to the user and trusted by the core).

## Fix
- **Core:** new `PersistenceOutput::Failed`; `StoreLoaded(Failed)` surfaces an error ("Couldn't save to local storage.") instead of trusting the write.
- **Shell:** `Store.persistenceOutput` returns `.failed` on a store throw / missing store (removed the masking empty/ack fallback). Introduced an `ItemStore` protocol (`LibraryStore` conforms) so a failing fake can be injected.
- **Tests:** core `store_loaded_failed_surfaces_an_error`; shell `testPersistenceWriteFailureResolvesFailed` (a `FailingStore` → `.failed`, the injectable-failing-store the issue asked for).

## Scope note
A rejected optimistic item still **lingers until relaunch** (no rollback) — acceptable for the rare disk-failure case; the failure is now *observable* (error banner + Sentry), which is #816's acceptance ("observable, never silently presented as success"). Full rollback would need the core to snapshot pre-write state — out of scope, not worth it for this rarity.

## Verification
14 core persistence tests, clippy, wasm web shell compile, iOS build + full suite all green.

## Coverage
Core: the Failed handler + the shell failure mapping both covered. iOS in Codecov ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)