### PR TITLE
Offline-first guardrails: invariants in CLAUDE.md + sentinel tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,74 @@ in Swift. If you're tempted to write logic in Swift, the logic belongs in
 
 [uniffi-rs#2818]: https://github.com/mozilla/uniffi-rs/issues/2818
 
+### Offline-first invariants (non-negotiable)
+
+The native app is **offline-first**: on-device SQLite is the source of truth,
+the app works with no network and no account, and sync is a future paid tier
+(see [`specs/native-ios.md`](specs/native-ios.md)). These invariants protect
+that as the app grows — break one and the app silently stops being offline.
+
+1. **No network on the local-first path.** A local-first feature must work in
+   airplane mode. New reads/writes go through the persistence `Effect`, never
+   HTTP. *(Test-enforced: local-first launch + mutations assert zero `Http`
+   effects.)*
+2. **Every persisted entity is sync-ready from day one** — carries `updated_at`
+   + a soft-delete `deleted_at` tombstone; **no hard deletes**. So the deferred
+   sync engine never needs a migration. *(Test-enforced for the schema.)*
+3. **Client-owned ids.** New entities mint their ulid locally as the canonical
+   id — no server-assigned-id round-trip (no temp-id dance) in local-first.
+4. **Reconciliation lives in the core**, not the Swift shell. Sync / LWW / merge
+   logic is Rust (shareable to Android); the shell only executes typed storage
+   ops. (The dumb-pipe rule, applied to persistence.)
+5. **A failed local write is never a silent success.** Storage ops resolve a
+   real failure output (`PersistenceOutput::Failed`) and the core surfaces it —
+   never fake an `Ack` (#816).
+6. **Both modes must keep working.** The shared core powers offline-iOS *and*
+   online-web. Any change to a domain handler must preserve both `local_first`
+   branches, and be tested both ways. (The likeliest regression: an iOS-driven
+   core change that breaks web.)
+7. **No account gate on core functionality.** Only sync (the paid tier) may
+   require auth. The free app works fully signed-out.
+8. **Relational data in the GRDB store; only small singletons in `crux_kv`**
+   (settings, `session-in-progress` crash-recovery).
+
+**PR checklist — any change touching persistence, sync, or a new domain entity:**
+
+- [ ] New reads/writes go through the persistence `Effect`, not HTTP (invariant 1)
+- [ ] New persisted table/columns have `updated_at` + `deleted_at`; no hard delete (2)
+- [ ] New entities use a client-minted ulid as the canonical id (3)
+- [ ] Any merge/reconciliation logic is in the core, not the shell (4)
+- [ ] Write handlers branch on `local_first` (or use `save_or_put`) and a local
+      failure resolves `Failed`, not `Ack` (5)
+- [ ] Domain-handler changes tested in **both** `local_first` and online modes (6)
+- [ ] Data-model change: new migration appended (never edits a shipped one),
+      additive where possible; core type + migration + codec updated together;
+      ships an upgrade-path test (see Local data migrations)
+
+### Local data migrations
+
+The on-device SQLite schema (GRDB, in `LibraryStore`) evolves via
+`DatabaseMigrator`. Treat these with **more** care than the server migrations in
+`intrada-api/src/migrations.rs`: **on the free offline tier the device is the
+only copy of the user's data** — no server backup, no DBA. A destructive or
+buggy migration that ships is **unrecoverable** data loss for that user, and you
+can't un-ship it.
+
+- **Append-only, forward-only, ordered.** Add a new `registerMigration("vN_…")`;
+  **never edit or delete a shipped migration** — it has already run on real
+  devices. GRDB applies missing migrations in order and users skip versions, so
+  the chain must run cleanly from *any* past version.
+- **Additive by default.** New nullable columns / new tables are safe.
+  Drop/rename/retype is dangerous — use a copy-table migration, and prefer to
+  **defer destructive changes until sync/backup exists** (a recovery path).
+- **Evolve the core type + schema + codec together.** A new `Item` field needs,
+  in one change: the Rust field (`Option` / `#[serde(default)]`), a migration
+  adding the column with a default for existing rows, and the row↔`Item` codec
+  updated. (Extends "compile the whole workspace for shared core types".)
+- **Test the upgrade path, not just the end state.** Every migration ships with
+  a test that a DB *populated at the previous version* migrates with data
+  intact — not only that it runs on an empty DB.
+
 ## Authentication
 
 Two auth paths, same API surface:

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -298,4 +298,48 @@ mod tests {
         assert!(has_http(&mut cmd));
         assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
     }
+
+    /// Offline-first invariant #1 (CLAUDE.md): the full local-first lifecycle
+    /// (launch/create/update/delete) emits zero HTTP — a regression sentinel.
+    #[test]
+    fn offline_invariant_local_first_lifecycle_makes_no_http() {
+        use crate::domain::item::ItemEvent;
+        use crate::domain::types::UpdateItem;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+
+        let mut launch = app.update(
+            Event::StartApp {
+                api_base_url: "http://x".into(),
+                local_first: true,
+            },
+            &mut model,
+        );
+        assert!(!has_http(&mut launch), "launch");
+
+        let mut add = app.update(Event::Item(ItemEvent::Add(create_item())), &mut model);
+        assert!(!has_http(&mut add), "create");
+        let id = model.items[0].id.clone();
+
+        let input = UpdateItem {
+            title: Some("Renamed".into()),
+            composer: None,
+            key: None,
+            tempo: None,
+            notes: None,
+            tags: None,
+            priority: None,
+        };
+        let mut update = app.update(
+            Event::Item(ItemEvent::Update {
+                id: id.clone(),
+                input,
+            }),
+            &mut model,
+        );
+        assert!(!has_http(&mut update), "update");
+
+        let mut delete = app.update(Event::Item(ItemEvent::Delete { id }), &mut model);
+        assert!(!has_http(&mut delete), "delete");
+    }
 }

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -84,6 +84,12 @@ final class LibraryStore: ItemStore {
     }
   }
 
+  /// Column names of a table (for the schema-invariant test). `[String]` not
+  /// `Set` — `SharedTypes`' domain `Set` shadows `Swift.Set` here.
+  func columnNames(ofTable table: String) throws -> [String] {
+    try dbQueue.read { db in try db.columns(in: table).map(\.name) }
+  }
+
   // ── Schema ───────────────────────────────────────────────────────────
 
   private static var migrator: DatabaseMigrator {

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -76,4 +76,13 @@ final class LibraryStoreTests: XCTestCase {
     try store.save(item("new", title: "New", createdAt: "2026-02-01T00:00:00Z"))
     XCTAssertEqual(try store.loadItems().map(\.id), ["new", "old"])
   }
+
+  /// Offline-first invariant #2 (CLAUDE.md): persisted tables carry the sync columns.
+  func testSchemaHasSyncColumns() throws {
+    let columns = try makeStore().columnNames(ofTable: "item")
+    XCTAssertTrue(
+      columns.contains("updated_at"), "item table must carry updated_at; has \(columns)")
+    XCTAssertTrue(
+      columns.contains("deleted_at"), "item table must carry deleted_at; has \(columns)")
+  }
 }


### PR DESCRIPTION
Codifies the offline-first non-negotiables so continued development can't silently break them (a new screen reaching for HTTP, a table without sync columns, etc.). Asked for after completing the offline-Library arc.

## What
- **CLAUDE.md → "Native iOS Shell":** 8 offline-first invariants (no-network local path · sync-ready schema · client-ulids · reconciliation-in-core · no-silent-ack · both-modes-work · no-account-gate · store-vs-kv) **+ a PR checklist** for any change touching persistence / sync / a new domain entity.
- **Two sentinel tests** convert the two most-regressable invariants from review-discipline to automation:
  - `offline_invariant_local_first_lifecycle_makes_no_http` (intrada-core) — launch + create + update + delete in local-first mode emit **zero** `Http` effects.
  - `testSchemaHasSyncColumns` (LibraryStoreTests) — the `item` table carries `updated_at` + `deleted_at`. New `LibraryStore.columnNames(ofTable:)` helper returns `[String]` (not `Set` — `SharedTypes` exports a domain `Set` that shadows `Swift.Set` in importing files; noted in CLAUDE.md's gotchas spirit).

The other six invariants stay review-discipline (the checklist covers them).

## Scope
Docs + tests + one tiny internal introspection helper. **No production behaviour change.** 15 core persistence tests + full iOS suite green; clippy/fmt clean.

Self-review: skipped the subagent — this is docs + tests + a 2-line helper, no logic to review. The two new tests are non-vacuous (they drive real effects/schema and would fail if the invariant regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)