### PR TITLE
Native iOS #825: roll back the optimistic write on local-store failure

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -110,9 +110,11 @@ pub enum Event {
     ClearError,
     SetQuery(Option<ListQuery>),
 
-    // ── Local-first persistence (dormant — no caller in the live flow yet) ──
+    // ── Local-first persistence ──────────────────────────────────────
     HydrateFromStore,
     StoreLoaded(PersistenceOutput),
+    /// Write result (split from `StoreLoaded` so a failed write reloads without looping — #825).
+    StoreWritten(PersistenceOutput),
 }
 
 /// Side effects the core requests from shells.
@@ -302,20 +304,27 @@ impl App for Intrada {
                 crux_core::render::render()
             }
 
-            // ── Local-first persistence (B1) ─────────────────────────
+            // ── Local-first persistence ──────────────────────────────
             Event::HydrateFromStore => persistence::load_items(),
             Event::StoreLoaded(output) => match output {
                 PersistenceOutput::Items(items) => {
                     model.items = items;
                     crux_core::render::render()
                 }
-                // Write-through ack — model already updated; nothing to render.
                 PersistenceOutput::Ack => Command::done(),
-                // Don't trust a write that never reached disk (#816). Message is
-                // op-agnostic since Failed covers load + save + delete.
+                // Failed read: surface only — no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     crux_core::render::render()
+                }
+            },
+            Event::StoreWritten(output) => match output {
+                PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Items(_) => Command::done(),
+                // Failed write → reload to roll back the un-persisted change (#825).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    persistence::load_items()
                 }
             },
         }

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -37,16 +37,13 @@ pub fn load_items() -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::LoadItems).then_send(Event::StoreLoaded)
 }
 
-/// Upsert an item into the local store (write-through). The `Ack` lands in
-/// `Event::StoreLoaded` and is a no-op — the model was already updated.
 pub fn save_item(item: Item) -> Command<Effect, Event> {
-    Command::request_from_shell(PersistenceOperation::SaveItem(item)).then_send(Event::StoreLoaded)
+    Command::request_from_shell(PersistenceOperation::SaveItem(item)).then_send(Event::StoreWritten)
 }
 
-/// Soft-delete an item from the local store (write-through).
 pub fn delete_item(id: String) -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::DeleteItem { id })
-        .then_send(Event::StoreLoaded)
+        .then_send(Event::StoreWritten)
 }
 
 #[cfg(test)]
@@ -113,11 +110,34 @@ mod tests {
     fn store_loaded_failed_surfaces_an_error() {
         let app = crate::app::Intrada;
         let mut model = Model::test_default();
-        let _ = app.update(Event::StoreLoaded(PersistenceOutput::Failed), &mut model);
+        let mut cmd = app.update(Event::StoreLoaded(PersistenceOutput::Failed), &mut model);
         assert!(
             model.last_error.is_some(),
-            "a failed local write must surface an error"
+            "a failed read must surface an error"
         );
+        assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
+    }
+
+    #[test]
+    fn store_written_failed_surfaces_and_rehydrates() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(Event::StoreWritten(PersistenceOutput::Failed), &mut model);
+        assert!(
+            model.last_error.is_some(),
+            "a failed write must surface an error"
+        );
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::LoadItems)));
+    }
+
+    #[test]
+    fn store_written_ack_is_a_noop() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(Event::StoreWritten(PersistenceOutput::Ack), &mut model);
+        assert!(model.last_error.is_none());
+        assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
     }
 
     #[test]

--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -175,11 +175,11 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
     **client-ulid-canonical** (temp-id dance retired for items — #818). The
     shared core keeps the web app online (`local_first = false`). **The iPhone
     Library is genuinely offline here.**
-  - **B4 (folded into B3b).** Hardening done (#816): a failed *local* write now
-    resolves `.failed` (not a phantom `.ack`) and the core surfaces an error, so
-    a write that never reached disk is observable rather than silently trusted.
-    (A rejected optimistic item still lingers until relaunch — acceptable for
-    the rare disk-failure case.)
+  - **B4 (folded into B3b).** Hardening done: a failed *local* write resolves
+    `.failed` (not a phantom `.ack`), the core surfaces an error (#816) **and
+    re-hydrates from the store to roll back the optimistic change** (#825) — a
+    failed write event (`StoreWritten`) is kept separate from a read result
+    (`StoreLoaded`) so a broken store can't loop reloading.
   - **B5** — decouple auth: the app runs with no account; sign-in is inert until
     sync exists.
   - **Gate:** full Library CRUD works in airplane mode, with no account.


### PR DESCRIPTION
Completes the offline write story. A failed local write was *observable* (#816) but the rejected optimistic change lingered in the model until relaunch; now the core rolls it back.

## How
- New `Event::StoreWritten` (write result), split from `Event::StoreLoaded` (read result): `save_item`/`delete_item` route to `StoreWritten`, `load_items` to `StoreLoaded`.
- On `StoreWritten(Failed)`: surface the error **and re-hydrate from the store** (`load_items`). The failed write never reached disk, so reloading the persisted truth rolls back the optimistic create/update/delete **uniformly** — no per-operation snapshot bookkeeping.
- The split is what prevents a loop: a failed *read* (`StoreLoaded(Failed)`) only surfaces — it does not reload. A broken store can't spin.

## Why reload-as-rollback
For a single-user local-first model the store *is* the source of truth, so "reload after a failed write" is the simplest correct rollback that covers create (vanishes), update (reverts), and delete (reappears) with one code path.

## Verification
3 new core tests: write-failure surfaces + re-hydrates; write-ack is a no-op; **failed read does not reload** (the loop guard). 360 core tests, clippy, wasm web shell, iOS build + full suite green. `Event` gained a variant → bindings regenerated.

## Coverage
Core: full (the new event routing + both failure paths). The shell's throw→`.failed` mapping is already covered by `FailingStore` (#816). iOS in Codecov ignore list.

Closes #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)