### PR TITLE
Native iOS: default DEBUG launch to local-first, make seeding opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,16 @@ just tauri-dev             # Tauri shell (on hold): iOS dev session (sim)
 they stay in sync without slowing pure-Swift edits. `just ios-gen` forces a
 full regenerate. The Tauri `tauri-*` recipes are the on-hold WKWebView shell.
 
+**Demo data vs. real on-device data.** A plain launch (`just ios` → Cmd+R, or
+any build with no launch args) runs **local-first**: the Library hydrates from
+the on-device GRDB store, so items you add survive restarts. The 6 sample
+pieces are **opt-in** via the `--seed-sample-data` launch arg — in Xcode:
+Edit Scheme → Run → Arguments → Arguments Passed On Launch. `just ios-run`
+passes it by default (`SEED=1`); use `SEED=0 just ios-run` to launch against
+your real data. Seed mode (`Event::LoadSampleData`) replaces the model with
+demo items and **skips store hydration**, so don't use it when testing
+persistence — your saved rows are still on disk but won't be read back.
+
 Run `cargo fmt --check` and `cargo clippy -- -D warnings` *locally before pushing* —
 not just before committing. Pushing then watching CI fail wastes a full ~3-minute
 roundtrip per agent or contributor; better to catch the formatting tab here.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ just e2e          # Build + run Playwright E2E tests
 
 # iOS (native SwiftUI — the active app)
 just ios              # Regenerate bindings (if core changed) + open in Xcode
-just ios-run          # Build + launch on a simulator + screenshot
+just ios-run          # Build + launch on a simulator + screenshot (seeds demo data)
+SEED=0 just ios-run   # …launch against your real on-device data instead of demo data
 
 # iOS (Tauri shell — on hold, being replaced)
 just tauri-dev        # Run on simulator (trunk serve + tauri ios dev)

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -30,27 +30,20 @@ struct RootView: View {
     }
     .tint(IntradaColor.accent)
     .task {
-      // Seed mode loads demo data offline via the core; it skips StartApp so a
-      // late fetch can't clobber the seed. Until there's a real backend/auth,
-      // DEBUG builds seed by default (pass --no-seed-sample-data to hit the API).
-      // Release seeds only via the explicit arg (CI screenshots / E2E).
+      // Default (incl. plain DEBUG runs): local-first — the Library hydrates
+      // from the on-device store so saved items survive restarts. Seeding is
+      // opt-in via --seed-sample-data (ios-run-sim.sh / CI screenshots / E2E);
+      // it loads demo data and skips StartApp so a late fetch can't clobber it.
       if seedSampleData {
         store.send(.loadSampleData)
       } else {
-        // local-first: the Library hydrates from the on-device store, no HTTP.
         store.send(.startApp(apiBaseUrl: apiBaseURL, localFirst: true))
       }
     }
   }
 
   private var seedSampleData: Bool {
-    let args = ProcessInfo.processInfo.arguments
-    if args.contains("--no-seed-sample-data") { return false }
-    #if DEBUG
-      return true
-    #else
-      return args.contains("--seed-sample-data")
-    #endif
+    ProcessInfo.processInfo.arguments.contains("--seed-sample-data")
   }
 
   /// Paint the UIKit tab bar with the paper theme: cream fill, faint inactive


### PR DESCRIPTION
## Problem

A new item saved on device disappeared after restart. The save itself was fine — the item persisted to `intrada.sqlite` correctly. The real cause: **DEBUG builds seeded sample data on every launch**.

`RootView` sent `Event::LoadSampleData` whenever `seedSampleData` was true (the DEBUG default). That handler replaces `model.items` with `sample_items()` and **never hydrates from the GRDB store** (`app.rs` — no `load_items()` call). So:

1. Launch (DEBUG) → model filled with in-memory sample data, store never read.
2. Add item → persisted to disk correctly (`local_first` → `save_item`). ✅ on disk.
3. Restart → seeds again, skips the store → the real item is invisible.

## Fix

Flip the default in `RootView.swift`: plain runs (incl. `just ios` → Cmd+R) now send `StartApp(localFirst: true)` and hydrate from disk. Seeding is **opt-in via `--seed-sample-data`** only — the arg `scripts/ios-run-sim.sh` (SEED defaults to 1), CI screenshots, and E2E already pass explicitly, so those paths are unchanged.

Net −7 lines; also drops the now-meaningless `--no-seed-sample-data` override and the `#if DEBUG` branch (behavior is now identical across configs).

## Verification

Built green and ran both paths on the simulator:

- **no-arg launch (new default)** → real local store, "No items yet" empty state (previously showed 6 seeded demo items).
- **`--seed-sample-data` (CI path)** → still shows the 6 demo items, unchanged.

## Coverage

Shell-only launch toggle in a SwiftUI view; not unit-tested (RootView launch wiring has no existing test harness). Underlying persistence + `local_first` lifecycle are already covered by `persistence.rs` core tests and `LibraryStoreTests`. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)