### PR TITLE
Native iOS: fix Library search bar flashing away on pull

### DIFF
--- a/ios/Intrada/Views/Components/LibrarySearchBar.swift
+++ b/ios/Intrada/Views/Components/LibrarySearchBar.swift
@@ -39,13 +39,12 @@ struct LibrarySearchBar: View {
       .background(Capsule(style: .continuous).fill(IntradaColor.surfaceSunken))
       .overlay(Capsule(style: .continuous).strokeBorder(IntradaColor.hairline, lineWidth: 1))
 
-      if focused.wrappedValue || !text.isEmpty {
-        Button("Cancel", action: onCancel)
-          .font(IntradaFont.bodyMedium)
-          .foregroundStyle(IntradaColor.accent)
-          .buttonStyle(.plain)
-          .transition(.move(edge: .trailing).combined(with: .opacity))
-      }
+      // Always present while the bar is revealed: the dismiss affordance, since
+      // the field isn't auto-focused on reveal.
+      Button("Cancel", action: onCancel)
+        .font(IntradaFont.bodyMedium)
+        .foregroundStyle(IntradaColor.accent)
+        .buttonStyle(.plain)
     }
   }
 }

--- a/ios/Intrada/Views/Screens/LibraryScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryScreen.swift
@@ -79,12 +79,6 @@ struct LibraryScreen: View {
     .onChange(of: searchText) { _, newValue in
       sendQuery(kind: store.viewModel?.activeQuery?.itemType, text: newValue)
     }
-    .onChange(of: searchFocused) { _, focused in
-      // Dismissing the keyboard with nothing typed tucks the bar away again.
-      if !focused && searchText.trimmingCharacters(in: .whitespaces).isEmpty {
-        hideSearch()
-      }
-    }
   }
 
   @ViewBuilder private var content: some View {
@@ -121,11 +115,12 @@ struct LibraryScreen: View {
       .scrollBounceBehavior(.always)
       .scrollDismissesKeyboard(.interactively)
       .onPreferenceChange(ScrollOffsetKey.self) { offset in
+        // Reveal without auto-focusing: a keyboard raised mid-drag gets dismissed
+        // by the same gesture (which tripped auto-hide). Tap the field to focus.
         guard !searchRevealed, offset > Self.pullThreshold else { return }
         withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
           searchRevealed = true
         }
-        searchFocused = true
       }
       .scrollEdgeShadow()
     }
@@ -149,9 +144,7 @@ struct LibraryScreen: View {
   private func cancelSearch() {
     searchText = ""
     searchFocused = false
-  }
-
-  private func hideSearch() {
+    // VoiceOver keeps the bar exposed (pull-to-reveal isn't operable there).
     guard !UIAccessibility.isVoiceOverRunning else { return }
     withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
       searchRevealed = false


### PR DESCRIPTION
Follow-up to #844 (Jon hit this on-device: pulling down flashed the bar and it vanished).

## Root cause

Reveal-on-pull also **auto-focused** the field. The rising keyboard was then dismissed by the still-in-progress drag (`scrollDismissesKeyboard(.interactively)`), and the resulting focus-loss tripped the empty-text auto-hide — all within a single gesture. Net effect: the bar appeared and disappeared too fast to see.

## Fix

- **No auto-focus on reveal** — pulling down just reveals the bar (tap the field to focus), matching Mail/Messages. This removes the keyboard-vs-drag conflict entirely.
- **Removed the focus-driven auto-hide** that was firing mid-gesture.
- **Cancel is always shown** while the bar is revealed, as the dismiss affordance (clears text + tucks the bar away; kept exposed under VoiceOver).

Behaviour-only change — the rendered searching state is unchanged, so the `testLibraryScreenSearching` snapshot reference is untouched and still passes.

## Verification

- `xcodebuild` build clean; `testLibraryScreenSearching` + `testLibraryScreenPopulated` pass on iPhone 16 / iOS 26.5.
- **Still needs on-device confirmation of the gesture** (snapshots can't drive an overscroll): pull down → bar slides in and stays; tap → keyboard; type → filters; Cancel → clears + hides.

**Coverage:** N/A — pure Swift (iOS app), outside Codecov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)