### PR TITLE
Fix: editing items silently fails on iOS (UpdateItem bincode decode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,6 +510,36 @@ Bear-traps that have caught us at least once. Skim before you start; the cost
 of a recheck is a few seconds, the cost of one of these landing in main is a
 follow-up PR.
 
+### JSON-only serde attrs break the Crux bincode FFI bridge
+
+The native iOS shell exchanges `Event` / `Effect` / `ViewModel` with the core as
+**positional bincode** (a non-self-describing format). serde attributes that
+only make sense for a self-describing format (JSON) silently corrupt that wire:
+the Swift side serializes every field/level by structure, but a JSON-oriented
+deserializer reads a different shape, **misaligns the byte stream, and the whole
+event fails to decode** — and `Store.send` swallows the bridge error via
+`guarded`, so the symptom is a silent no-op (e.g. "editing doesn't save", #846),
+not a crash.
+
+The specific offender we hit: `#[serde(deserialize_with = "double_option")]` on
+`UpdateItem`'s three-state `Option<Option<T>>` fields. `double_option` reads a
+single option level (right for JSON, where a present key is one `Option<T>` and
+`null` = clear); bincode needs both levels. Fix: make such helpers **format-aware**
+via `Deserializer::is_human_readable()` (JSON branch vs bincode branch) so the
+same type round-trips on both wires.
+
+Rules of thumb for any type that crosses the FFI bridge (`Event`, `Effect`,
+`ViewModel`, and everything they contain):
+
+- Be wary of `deserialize_with` / `serialize_with`, and of `skip_serializing_if`
+  combined with non-trailing fields — anything that assumes "absent" vs "present"
+  semantics. bincode has no "absent". If you need format-specific behaviour,
+  branch on `is_human_readable()`.
+- **Stub-bridge tests can't catch this.** Cover bridge-crossing types with a
+  *real*-bridge round-trip (`LiveBridge` in `StoreEffectLoopTests`) that drives
+  the actual Swift↔Rust bincode (de)serialization — see
+  `testRealBridgeEditAppliesToViewModel`.
+
 ### Tauri WebView origin is `tauri://localhost`
 
 Inside the Tauri 2 iOS shell the WebView's runtime origin is `tauri://localhost`

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -2,15 +2,26 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use super::item::{Item, ItemKind, Modality};
 
-/// Deserialize an `Option<Option<T>>` field with three-state semantics:
-/// absent → `None` (skip), `null` → `Some(None)` (clear), `v` → `Some(Some(v))` (set).
-/// Pair with `#[serde(default, deserialize_with = "double_option")]`.
+/// Deserialize a three-state `Option<Option<T>>` PATCH field, format-aware so it
+/// round-trips on BOTH wire formats the same type crosses:
+/// - **Self-describing (JSON, the API):** a present field is a single `Option<T>`
+///   — absent → `None` (skip, via `#[serde(default)]`), `null` → `Some(None)`
+///   (clear), `v` → `Some(Some(v))` (set). Classic `double_option`.
+/// - **Non-self-describing (bincode, the iOS FFI bridge):** positional — the
+///   Swift serializer always writes *both* option levels, so read them directly.
+///   Applying the JSON path here reads one level too few, misaligning the byte
+///   stream so the whole Update event fails to decode (edits silently don't
+///   save — #846).
 fn double_option<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
 where
     T: Deserialize<'de>,
     D: Deserializer<'de>,
 {
-    Deserialize::deserialize(deserializer).map(Some)
+    if deserializer.is_human_readable() {
+        Deserialize::deserialize(deserializer).map(Some)
+    } else {
+        Deserialize::deserialize(deserializer)
+    }
 }
 
 /// Top-level serialisation unit for library data.
@@ -66,10 +77,10 @@ pub struct CreateItem {
     pub tags: Vec<String>,
 }
 
-/// PATCH-style update. `Option<Option<T>>` fields use three-state semantics:
-/// - `None` = field not being updated (skip)
-/// - `Some(None)` = clear the field
-/// - `Some(Some(v))` = set to new value
+/// PATCH-style update. `Option<Option<T>>` fields are three-state:
+/// `None` = skip, `Some(None)` = clear, `Some(Some(v))` = set — deserialized via
+/// the format-aware `double_option` so the type round-trips on both JSON (API)
+/// and bincode (iOS bridge); see that fn's docs.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct UpdateItem {

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -248,6 +248,45 @@ final class StoreEffectLoopTests: XCTestCase {
       store.viewModel?.error, "post-resolve", "render from a resolve should refresh view")
   }
 
+  // ── Real bridge (Swift↔Rust bincode round-trip) ────────────────────────
+
+  /// Drives the *real* core via LiveBridge to prove an edit round-trips through
+  /// bincode and reflects in the ViewModel — the path the edit screen uses.
+  /// Calls the bridge directly (not via Store) so a serialization throw surfaces
+  /// instead of being swallowed by Store.send's `guarded`.
+  func testRealBridgeEditAppliesToViewModel() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    _ = try bridge.update(
+      .item(
+        .add(
+          CreateItem(
+            title: "Original", kind: .piece, composer: "Bach", key: nil, modality: nil,
+            tempo: nil, notes: nil, tags: []))))
+
+    let afterAdd = try bridge.view()
+    XCTAssertEqual(
+      afterAdd.items.count, 1,
+      "add should land: count=\(afterAdd.items.count) err=\(afterAdd.error ?? "nil")")
+    let id = try XCTUnwrap(afterAdd.items.first?.id)
+
+    // Full edit mirroring LibraryEditScreen.save(): every PATCH field set,
+    // composer carried as Some, type flipped Piece -> Exercise.
+    _ = try bridge.update(
+      .item(
+        .update(
+          id: id,
+          input: UpdateItem(
+            title: "Renamed", kind: .exercise, composer: .some("Bach"), key: .some(nil),
+            modality: .some(nil), tempo: .some(nil), notes: .some(nil), tags: nil, priority: nil))))
+
+    let afterEdit = try bridge.view()
+    XCTAssertEqual(
+      afterEdit.items.first?.title, "Renamed",
+      "edited title should apply (err=\(afterEdit.error ?? "nil"))")
+    XCTAssertEqual(afterEdit.items.first?.itemType, .exercise, "edited type should apply")
+  }
+
   // ── Helpers ────────────────────────────────────────────────────────────
 
   private func httpBridge() -> FakeBridge {


### PR DESCRIPTION
Follow-up to #843, which shipped the edit-item-type feature but with a latent serialization bug: **editing a library item on the native iOS app silently does nothing.** Fixes #846.

## Root cause
`UpdateItem`'s three-state `Option<Option<T>>` PATCH fields (composer/key/modality/tempo/notes) used `#[serde(deserialize_with = "double_option")]`. `double_option` reads a **single** option level — correct for self-describing JSON (the API), where a present field is one `Option<T>` and `null` means "clear". But the iOS FFI bridge sends events as **positional bincode**, where the Swift serializer writes **both** option levels. Reading one level too few misaligns the byte stream, so the whole `Update` event fails to decode (`"could not deserialize event: io error"`). `Store.send` swallows the bridge error via `guarded`, so every edit that set one of those fields (the edit form always does) silently no-oped.

This predates #843 but was surfaced by it (editing-the-type is the first edit flow exercised end-to-end).

## Fix
Make `double_option` **format-aware** via `Deserializer::is_human_readable()`:
- JSON (API) → single-level, `null` clears (unchanged behaviour).
- bincode (iOS) → reads both option levels.

Three-state (`None`=skip / `Some(None)`=clear / `Some(Some(v))`=set) survives on both wires.

## How it was found / regression coverage
Added `testRealBridgeEditAppliesToViewModel` — drives add → edit → view through the **real** `LiveBridge` (Swift↔Rust bincode round-trip), which the stub-bridge tests can't catch. This is the first real-bridge mutation test; it fails before the fix, passes after.

## Verification
- Full Rust workspace: 547 pass (incl. the API `null`-clears tests, which a naive "drop double_option" fix would have broken).
- Full iOS suite passes on an iOS 26.5 sim; the edit round-trips (title + type change apply).

## Coverage
Core: the format-aware deserializer + real-bridge regression test. No new tests for the (unchanged) JSON path beyond the existing API suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)