### PR TITLE
iOS: surface swallowed FFI errors in the log + fix snapshot deprecation

### DIFF
--- a/ios/Intrada/Core/Logging.swift
+++ b/ios/Intrada/Core/Logging.swift
@@ -1,9 +1,17 @@
 import Foundation
 import Sentry
+import os
 
-/// Report a non-fatal error to Sentry (a no-op when Sentry has no DSN). Used for
-/// bridge/serialization failures the UI can't recover from — so a stale-bindings
-/// break surfaces instead of a silently frozen screen.
-func report(_ error: Error) {
+private let logger = Logger(subsystem: "com.intrada.native", category: "core")
+
+/// Non-fatal errors `Store` swallows via `guarded` (the #846 silent-no-op
+/// class). Logs to the unified log too, so they're visible in dev/CI where
+/// Sentry has no DSN.
+func report(_ error: Error, _ context: String? = nil) {
+  if let context {
+    logger.error("\(context, privacy: .public): \(String(describing: error), privacy: .public)")
+  } else {
+    logger.error("\(String(describing: error), privacy: .public)")
+  }
   SentrySDK.capture(error: error)
 }

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -104,7 +104,7 @@ final class Store {
         return .ack
       }
     } catch {
-      report(error)
+      report(error, "persistence")
       return .failed
     }
   }
@@ -114,7 +114,7 @@ final class Store {
   // swallow it silently, and fail soft.
   private func guarded<T>(_ work: () throws -> T) -> T? {
     do { return try work() } catch {
-      report(error)
+      report(error, "bridge")
       return nil
     }
   }

--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -12,7 +12,7 @@ struct IntradaApp: App {
     do {
       return try LibraryStore.onDisk()
     } catch {
-      report(error)
+      report(error, "store-open")
       return nil
     }
   }

--- a/ios/IntradaTests/ScreenSnapshotTests.swift
+++ b/ios/IntradaTests/ScreenSnapshotTests.swift
@@ -48,10 +48,10 @@ final class ScreenSnapshotTests: XCTestCase {
   private var axConfig: Snapshotting<UIViewController, UIImage> {
     .image(
       on: .iPhone13, perceptualPrecision: 0.98,
-      traits: UITraitCollection(traitsFrom: [
-        UITraitCollection(displayScale: 2),
-        UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge),
-      ]))
+      traits: UITraitCollection { traits in
+        traits.displayScale = 2
+        traits.preferredContentSizeCategory = .accessibilityExtraExtraExtraLarge
+      })
   }
 
   func testRootShell() {


### PR DESCRIPTION
## Problem

Two issues, both about catching things:

1. **Silent failures.** `Store` swallows FFI bridge / bincode (de)serialization errors via `guarded` and only forwards them to `report(_:)` → `SentrySDK.capture`, which is a **no-op in dev/CI** (no DSN). So the #846 class of bug — a silent no-op like "editing doesn't save" — produced **zero** signal during development. Hard to pin down by design.
2. **CI deprecation warning.** `ScreenSnapshotTests.swift` used `UITraitCollection(traitsFrom:)`, deprecated since iOS 17 (our deployment target). The only first-party warning in the iOS CI log.

## Change

- `report(_:_:)` now also writes to the unified log (`os.Logger`, subsystem `com.intrada.native`, category `core`) so every swallowed error is visible regardless of Sentry's DSN. Each swallow site passes a grep-able context tag: `bridge` / `persistence` / `store-open`.
- Snapshot AX trait config migrated to the iOS 17 `UITraitCollection(mutations:)` API. **Identical trait values** (`displayScale = 2`, AX-XXXL), so the reference image is unchanged.

Watch live:
```
xcrun simctl spawn booted log stream --predicate 'subsystem == "com.intrada.native"'
```

## Testing

- `xcodebuild build-for-testing` succeeds, **zero warnings/errors** (deprecation gone).
- Snapshot byte-identity confirmed by reasoning (same trait values) and validated by CI on the pinned iOS 26.5 / Xcode 26.5 runtime — I did not run snapshots on a non-pinned local sim to avoid a false diff.

Coverage: iOS shell is in Codecov's ignored paths (WASM/Swift); no unit-test delta expected.

## Follow-ups
Tracked as separate issues (not expanding this PR): a documented `subsystem`-filtered console one-liner, and `scripts/ios-run-sim.sh` simulator-destination determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)