### PR TITLE
Add `just ios-test` + `check-all` — local gate for the native iOS build

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,6 +67,11 @@ check:
 # Alias for check — catches errors before the 3-min CI roundtrip
 pre-push: check
 
+# Full gate: Rust (fmt/clippy/test) + the native iOS build & test suite.
+# Slower — builds the iOS app — so run it before pushing changes under `ios/`.
+# Plain `just check` stays Rust-only for fast Rust-only iterations.
+check-all: check ios-test
+
 # Seed development data (API must be running)
 seed:
     bash scripts/seed-dev-data.sh
@@ -361,6 +366,25 @@ ios-snapshots-optimize:
 [group('iOS')]
 ios-snapshots-check:
     bash scripts/check-snapshots.sh
+
+# Build + run the whole IntradaTests suite (snapshots + unit tests) on the
+# pinned iPhone 16 / iOS 26.5 sim — the same command CI's `native-ios` job runs.
+# Catches iOS-only breakage (e.g. a Swift type collision) locally instead of via
+# the ~5-min macOS CI roundtrip. Regenerates bindings first if the core changed.
+# The device pin must match the recorded snapshot references (renderer-specific).
+[group('iOS')]
+ios-test: _ios-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ios
+    xcodegen generate
+    name="intrada-test-26-5"
+    udid=$(xcrun simctl list devices --json | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; print(next((x['udid'] for v in d.values() for x in v if x['name']=='$name'), ''))")
+    [ -n "$udid" ] || udid=$(xcrun simctl create "$name" "iPhone 16" "iOS26.5")
+    xcodebuild test -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
+        -destination "id=$udid" -derivedDataPath build/dd \
+        -clonedSourcePackagesDirPath build/spm -quiet \
+        COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
 
 # Facet typegen → ios/generated/SharedTypes (Event/Effect/ViewModel + bincode).
 [group('iOS')]


### PR DESCRIPTION
## Why

Follow-up to #851. While shipping that PR I hit a Swift-only bug (`Set` colliding with the domain `Set` entity) that passed **every** local gate — `cargo fmt`, `clippy`, `cargo test` are all Rust-only — and would only have been caught by the macOS `native-ios` CI job, a ~5-min roundtrip. The native iOS build had **no local gate**.

CI coverage itself is fine: the `native-ios` job (gated on `ios/**`) builds the app and runs the *whole* `IntradaTests` target (snapshots + `StoreEffectLoopTests` / `LibraryStoreTests` / `KeyHelperTests`). This just brings the same check local.

## What

- **`just ios-test`** — regenerates bindings (only if the core changed) → `xcodegen generate` → runs the full `IntradaTests` suite on the pinned **iPhone 16 / iOS 26.5** sim, with the exact flags CI's `native-ios` job uses (`CODE_SIGNING_ALLOWED=NO`, `COMPILER_INDEX_STORE_ENABLE=NO`, relocated SPM/DerivedData). Finds-or-creates a named sim so repeat runs don't litter.
- **`just check-all`** — `check` + `ios-test`. Plain `just check` / `pre-push` stays **Rust-only** so Rust-only iterations don't pay the xcodebuild cost (the deliberate trade-off — run `check-all` before pushing `ios/` changes).

## Verification

- `just ios-test` run end-to-end on this branch (off `main`): regenerated bindings, generated the project, created the pinned sim, and ran the full `IntradaTests` suite to green (~45s test phase, exit 0 under `set -euo pipefail`).
- `just --list` parses both new recipes.

Tier 1 (tooling/justfile, no Rust/product code). The device pin matches the recorded snapshot references — bump it here in lockstep if local dev moves off Xcode 26.5 / iOS 26.5 (same note already on the CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)