### PR TITLE
iOS dev tooling: subsystem log filter + deterministic sim destination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,15 @@ cargo clippy               # lint check — must pass before push
 cargo test -p intrada-api  # API tests only
 just ios                   # native app: regen bindings (if core changed) + open Xcode
 just ios-run               # native app: build + launch on simulator + screenshot
+just ios-logs              # native app: stream booted-sim logs, filtered to our subsystem
 just tauri-dev             # Tauri shell (on hold): iOS dev session (sim)
 ```
+
+`just ios-logs` filters the unified log to `subsystem == "com.intrada.native"`,
+cutting the simulator's UIKit/keyboard/gesture noise so first-party signal is
+visible. `report(_:)` (`ios/Intrada/Core/Logging.swift`) logs swallowed FFI /
+bincode bridge errors there — the silent-no-op class (#846) that otherwise
+leaves no trace in dev/CI where Sentry has no DSN.
 
 `just ios` / `just ios-run` auto-regenerate the Swift bindings only when
 `intrada-core`/`intrada-ffi` changed (a `ios/generated/.gen-stamp` hash), so

--- a/justfile
+++ b/justfile
@@ -347,6 +347,13 @@ ios-run: _ios-sync
     cd ios && xcodegen generate
     bash scripts/ios-run-sim.sh
 
+# Stream the app's logs from the booted simulator, filtered to our subsystem —
+# drops the UIKit/keyboard/gesture noise so first-party signal is visible.
+# `report(_:)` (Core/Logging.swift) logs swallowed FFI errors here (#846 class).
+[group('iOS')]
+ios-logs:
+    xcrun simctl spawn booted log stream --predicate 'subsystem == "com.intrada.native"'
+
 # Force a full regenerate of both Swift packages + refresh the change-stamp.
 [group('iOS')]
 ios-gen: ios-typegen ios-package

--- a/scripts/ios-run-sim.sh
+++ b/scripts/ios-run-sim.sh
@@ -13,13 +13,26 @@ DD="build/dd"
 SHOT="${1:-/tmp/intrada-native.png}"
 mkdir -p "$(dirname "$SHOT")"
 
-# Newest available iPhone simulator.
+# Pick a simulator deterministically (the old `devs[-1]` depended on JSON
+# ordering, so device/arch drifted between machines — #854). Prefer the device
+# CI pins (overridable via SIM_DEVICE) on the highest installed iOS; fall back
+# to the newest available iPhone. Stable udid tie-break keeps repeated runs
+# identical.
+SIM_DEVICE="${SIM_DEVICE:-iPhone 16}"
 UDID=$(xcrun simctl list devices available --json | python3 -c "
-import json, sys
-d = json.load(sys.stdin)['devices']
-devs = [x for k in sorted(d) if 'iOS' in k for x in d[k] if 'iPhone' in x['name']]
-print(devs[-1]['udid'] if devs else '')
-")
+import json, re, sys
+want = sys.argv[1]
+runtimes = json.load(sys.stdin)['devices']
+def ver(key):
+    m = re.search(r'iOS-(\d+)-(\d+)', key)
+    return (int(m.group(1)), int(m.group(2))) if m else (-1, -1)
+cands = [
+    (dev['name'] == want, ver(key), dev['udid'])
+    for key, devices in runtimes.items() if 'iOS' in key
+    for dev in devices if 'iPhone' in dev['name']
+]
+print(max(cands)[2] if cands else '')
+" "$SIM_DEVICE")
 if [ -z "$UDID" ]; then
     echo "✗ No iPhone simulator available (Xcode → Settings → Platforms → iOS)" >&2
     exit 1


### PR DESCRIPTION
Two follow-ups from the #852 observability audit. Pure tooling/docs — no app or core code.

## `just ios-logs` (closes #853)
Streams the booted simulator's unified log filtered to `subsystem == "com.intrada.native"`, cutting the UIKit/keyboard (`TUIKeyplane`)/gesture noise that buries first-party signal. Now that `report(_:)` logs swallowed FFI/bincode errors under that subsystem (#852), this is the one-liner to watch the #846 silent-no-op class during dev. Documented in CLAUDE.md.

## Deterministic simulator destination (closes #854)
`scripts/ios-run-sim.sh` picked the sim via `devs[-1]` (newest by JSON iteration order), so the resolved device/arch drifted between machines — the source of the ambiguous `arch:arm64` / `arch:x86_64` destination listing. Now selects deterministically: prefers CI's pinned device (`iPhone 16`, overridable via `SIM_DEVICE`) on the highest installed iOS, with a stable udid tie-break, falling back to the newest available iPhone.

## Testing
- `bash -n scripts/ios-run-sim.sh` clean; `just --list` parses the new recipe.
- Ran the new selector against the local sim roster twice → identical UDID both times, resolving to `iPhone 16` (matches CI). Verifies determinism + CI alignment.

Coverage: shell/justfile/docs — no unit-test surface.

Deferred items tracked: none — all audit follow-ups now addressed (#852, #853, #854).

🤖 Generated with [Claude Code](https://claude.com/claude-code)