### PR TITLE
Fix flaky iOS test: widen StoreEffectLoopTests async wait to 5s

### DIFF
--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -359,7 +359,7 @@ final class StoreEffectLoopTests: XCTestCase {
     let resolved = expectation(description: "bridge resolved")
     bridge.onResolve = { resolved.fulfill() }
     action()
-    await fulfillment(of: [resolved], timeout: 2)
+    await fulfillment(of: [resolved], timeout: 5)  // generous ceiling; absorbs CI scheduling jitter (#861)
   }
 
   static let sampleItem = Item(


### PR DESCRIPTION
Closes #861.

## Problem
`StoreEffectLoopTests.whenResolved(_:_:)` awaited the bridge's resolve with a **2-second** timeout. The HTTP leg hops through a detached `Task`, so on a loaded CI runner (concurrent compile + cold simulator) the wait could be exceeded, failing whichever of the ~15 effect-loop tests happened to run then. It surfaced as `testHttpEffectMapsInvalidUrl` failing on #858 — a PR that touches **zero** Swift, which is what flagged it as flake rather than regression.

## Fix
Bump the timeout to 5s. It's a **failure ceiling, not a delay**: `fulfillment` returns the instant the expectation is fulfilled, so a wider ceiling costs nothing on green runs and only widens the margin before a genuinely-stuck test fails. The class's `tearDown` already resets `MockURLProtocol.handler`/`lastRequest`, so there's no cross-test state coupling to address.

## Testing
One-line literal change (`timeout: 2` → `5`) plus a trailing comment, in a test helper — cannot affect compilation. The Native iOS CI job runs the full effect-loop suite and is the gate here; local binding-regen + sim build was skipped as disproportionate for a numeric-literal edit.

Coverage: test-infra only; no production-code surface.

Deferred items tracked: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)