### PR TITLE
Native iOS: tag pills on library cards

### DIFF
--- a/ios/Intrada/Views/Components/LibraryItemCard.swift
+++ b/ios/Intrada/Views/Components/LibraryItemCard.swift
@@ -22,6 +22,10 @@ struct LibraryItemCard: View {
           .font(IntradaFont.meta)
           .foregroundStyle(IntradaColor.inkFaint)
       }
+      if !item.tags.isEmpty {
+        TagPills(tags: item.tags)
+          .padding(.top, 5)
+      }
     }
     .padding(.vertical, 14)
     .padding(.leading, 20)

--- a/ios/Intrada/Views/Components/TagPills.swift
+++ b/ios/Intrada/Views/Components/TagPills.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// A compact, truncating row of tag chips for list rows: shows up to `limit`
+/// tags and a `+N` overflow chip, so a card with many tags stays the same
+/// height as one with few. The detail screen shows the full set; this is the
+/// at-a-glance version.
+struct TagPills: View {
+  let tags: [String]
+  var limit: Int = 3
+
+  var body: some View {
+    let shown = Array(tags.prefix(limit))
+    let overflow = tags.count - shown.count
+    HStack(spacing: 6) {
+      ForEach(shown, id: \.self) { TagChip(text: $0) }
+      if overflow > 0 {
+        TagChip(text: "+\(overflow)")
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Tags: \(tags.joined(separator: ", "))")
+  }
+}
+
+private struct TagChip: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(IntradaFont.metaMedium)
+      .foregroundStyle(IntradaColor.inkSecondary)
+      .lineLimit(1)
+      .padding(.vertical, 3)
+      .padding(.horizontal, 8)
+      .background(IntradaColor.surfaceSunken, in: Capsule())
+  }
+}
+
+#if DEBUG
+  #Preview {
+    ZStack {
+      PaperBackground()
+      VStack(alignment: .leading, spacing: 12) {
+        TagPills(tags: ["classical", "piano"])
+        TagPills(tags: ["jazz", "improv", "bebop", "ii-V-I", "comping"])
+      }
+      .padding(16)
+    }
+  }
+#endif


### PR DESCRIPTION
First UI slice of re-instating tags in the native Library: **read on the list**.

## What
New **`TagPills`** component — a compact, truncating row of chips (sunken-capsule fill, secondary ink, `metaMedium`) that shows up to 3 tags and a `+N` overflow chip, so a heavily-tagged item's card stays the same height as a lightly-tagged one. Rendered on `LibraryItemCard` below the `key · tempo` meta line, only when the item has tags.

Reuses the existing paper-theme tokens (`surfaceSunken`, `inkSecondary`, `hairline`) — no new colors.

## Verification
Built and verified on the simulator against the seeded library (screenshot in the working session): `recital`/`impressionist`, `warm-up`, `technique` chips render correctly; the untagged Nocturne shows none; card heights stay bounded.

## ⚠️ Snapshot coverage deferred → #863
The local XCTest **test runner** was failing to launch ("Device not configured" / pseudo-terminal) while building this — the app runs fine, but I couldn't record a reference PNG. The existing `testLibraryItemCards` snapshot is **unchanged** (pills only render when tags are present, and its preview items are untagged), so CI stays green. #863 tracks adding the tagged-card snapshot once the runner is healthy.

## Scope
Tier 2, iOS-only, additive. Depends on nothing — uses the existing `LibraryItemView.tags`. (The OR-filter + `available_tags` core work is the separate #855; the filter sheet + chip input come next.)

Deferred items tracked: #863 (tagged-card snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)