### PR TITLE
Native iOS: enable Sentry in dev builds (opt-in via SENTRY_DSN_NATIVE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ just tauri-dev             # Tauri shell (on hold): iOS dev session (sim)
 cutting the simulator's UIKit/keyboard/gesture noise so first-party signal is
 visible. `report(_:)` (`ios/Intrada/Core/Logging.swift`) logs swallowed FFI /
 bincode bridge errors there — the silent-no-op class (#846) that otherwise
-leaves no trace in dev/CI where Sentry has no DSN.
+leaves no trace where Sentry has no DSN (CI always; dev unless
+`SENTRY_DSN_NATIVE` is set — see Environment Variables).
 
 `just ios` / `just ios-run` auto-regenerate the Swift bindings only when
 `intrada-core`/`intrada-ffi` changed (a `ios/generated/.gen-stamp` hash), so
@@ -367,6 +368,14 @@ in prod), `ALLOWED_ORIGIN` (default `http://localhost:8080`), `PORT` (default 30
 
 ### Web (compile-time)
 `CLERK_PUBLISHABLE_KEY`, `INTRADA_API_URL` (default `https://intrada-api.fly.dev`)
+
+### Native iOS (optional)
+`SENTRY_DSN_NATIVE` — put in `.env` to capture crash/error events from local dev
+builds (reports to the `intrada-mobile` Sentry project, tagged
+`environment=development`). `xcodegen` bakes it into the app's `Info.plist`; the
+justfile's `set dotenv-load` feeds it in. **Unset in CI**, so test/smoke runs send
+nothing. The app only starts Sentry on a real `https://` DSN, so an empty or
+unexpanded value is a safe no-op.
 
 ## Design System Rules
 

--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -20,10 +20,17 @@ struct IntradaApp: App {
   init() {
     IntradaFonts.register()
 
-    // No DSN in dev/CI → Sentry stays disabled. Set SENTRY_DSN for real builds.
-    if let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String, !dsn.isEmpty {
+    // `hasPrefix` gates out empty (CI) and an unexpanded `${…}` literal alike.
+    if let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String,
+      dsn.hasPrefix("https://")
+    {
       SentrySDK.start { options in
         options.dsn = dsn
+        #if DEBUG
+          options.environment = "development"
+        #else
+          options.environment = "production"
+        #endif
       }
     }
   }

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -43,8 +43,10 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.intrada.native
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        # Empty in dev/CI → Sentry stays disabled (no DSN). Set per-build/env.
-        INFOPLIST_KEY_SENTRY_DSN: ""
+        # DSN from the SENTRY_DSN_NATIVE env var (xcodegen expands ${...}; the
+        # justfile's `set dotenv-load` feeds it from .env). Unset in CI → empty →
+        # Sentry stays disabled there. Reports to the intrada-mobile project.
+        INFOPLIST_KEY_SENTRY_DSN: "${SENTRY_DSN_NATIVE}"
     dependencies:
       - package: IntradaCoreFFI
         product: IntradaCoreFFI


### PR DESCRIPTION
Follow-on from the observability work (#852). Sentry was wired into the native app but **inert everywhere** — the Info.plist DSN defaulted to `""`, so dev builds captured nothing and a swallowed FFI/bincode error left no remote trace during development.

## Change
- **DSN from an env var, not committed** — `ios/project.yml` sets `INFOPLIST_KEY_SENTRY_DSN: "${SENTRY_DSN_NATIVE}"`. xcodegen expands it into the generated Info.plist; the justfile's `set dotenv-load` feeds it from `.env`. Set it locally to capture dev events; **CI leaves it unset**, so snapshot/smoke runs send nothing.
- **Hardened init** ([IntradaApp.swift](ios/Intrada/IntradaApp.swift)) — start Sentry only on a real `https://` DSN. xcodegen leaves the literal `${SENTRY_DSN_NATIVE}` in place when the var is unset, so the `hasPrefix` guard gates out both empty *and* that unexpanded literal — Sentry can't start on a garbage DSN.
- **Environment tagging** — `development` / `production` via `#if DEBUG`, so dev events are filterable and never pollute the production view.
- Reports to the existing **intrada-mobile** Sentry project (the native app replaces the Tauri mobile shell).
- Documented `SENTRY_DSN_NATIVE` in CLAUDE.md's Environment Variables.

## Local setup (one line in `.env`)
```
SENTRY_DSN_NATIVE=https://319e8fd4f17b6182700535ec9b543db7@o4511313186979840.ingest.de.sentry.io/4511313296359504
```

## Testing
- Verified xcodegen expansion both ways: var set → real DSN baked into the build setting; var unset → empty/literal, which the `hasPrefix` guard rejects.
- `xcodebuild build-for-testing` succeeds (bindings regenerated against current main), zero warnings/errors.
- Sentry-disabled path unchanged; the app behaves exactly as before when no DSN is present.

Coverage: iOS shell is in Codecov's ignored paths; no unit-test surface. Sentry init isn't exercised by the test target (the `App` struct's `init` doesn't run in snapshot tests), which is also why CI sends no events.

Deferred items tracked: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)