### PR TITLE
TagChipInput: removable chips actionable under VoiceOver

### DIFF
--- a/ios/Intrada/Views/Components/TagChipInput.swift
+++ b/ios/Intrada/Views/Components/TagChipInput.swift
@@ -142,6 +142,9 @@ private struct RemovableChip: View {
     .onTapGesture(perform: onRemove)
     .accessibilityElement(children: .combine)
     .accessibilityLabel(text)
+    // `.isButton` so VoiceOver advertises the tap as activatable (matches the
+    // KeyPicker convention); a bare onTapGesture isn't surfaced reliably.
+    .accessibilityAddTraits(.isButton)
     .accessibilityHint("Double tap to remove")
   }
 }


### PR DESCRIPTION
Follow-up to #867, from its (belated) self-review. The removable tag chip used a bare `.onTapGesture` for removal with a "double tap to remove" hint, but didn't advertise the `.isButton` trait — so VoiceOver wouldn't reliably surface the tap as activatable, and it diverged from the codebase convention (`KeyPicker` pairs `onTapGesture` with `.accessibilityAddTraits(.isButton)`).

Adds `.accessibilityAddTraits(.isButton)`. A11y-trait only — no visual change, so no snapshot churn. Builds clean.

(The other self-review finding — core Create/Update not deduping tags case-insensitively like AddTags does — is tracked in #869.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)