### PR TITLE
Native iOS: test the migration upgrade path (data survives v1→v2)

### DIFF
--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -176,3 +176,16 @@ final class LibraryStore: ItemStore {
     ISO8601DateFormatter().string(from: Date())
   }
 }
+
+#if DEBUG
+  extension LibraryStore {
+    /// Test seam for upgrade-path tests (CLAUDE.md "Local data migrations"):
+    /// migrate to `version`, seed raw rows at that schema, then finish to HEAD.
+    static func upgradeTestStore(migratedTo version: String, seed: String) throws -> LibraryStore {
+      let queue = try DatabaseQueue()
+      try migrator.migrate(queue, upTo: version)
+      try queue.write { db in try db.execute(sql: seed) }
+      return try LibraryStore(queue)
+    }
+  }
+#endif

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -48,8 +48,30 @@ final class LibraryStoreTests: XCTestCase {
     var it = item("p1")
     it.modality = nil
     try store.save(it)
-    // Also covers the legacy path: a pre-v2 row has a NULL modality column.
     XCTAssertNil(try XCTUnwrap(try store.loadItems().first).modality)
+  }
+
+  /// Upgrade path: a v1 row survives the v2 `modality` migration intact.
+  func testV1RowSurvivesModalityMigration() throws {
+    let store = try LibraryStore.upgradeTestStore(
+      migratedTo: "v1_item",
+      seed: """
+        INSERT INTO item
+          (id, title, kind, composer, key, tempo_marking, tempo_bpm, notes, tags,
+           created_at, updated_at, priority, deleted_at)
+        VALUES ('p1', 'Legacy Etude', 'piece', 'Bach', 'C', 'Allegro', 120, 'phrasing',
+                '["scale"]', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 0, NULL)
+        """)
+    let loaded = try store.loadItems()
+    XCTAssertEqual(loaded.count, 1, "the pre-existing v1 row must survive the v2 migration")
+    let got = try XCTUnwrap(loaded.first)
+    XCTAssertEqual(got.id, "p1")
+    XCTAssertEqual(got.title, "Legacy Etude")
+    XCTAssertEqual(got.composer, "Bach")
+    XCTAssertNil(got.modality, "v2 adds modality as NULL for pre-existing rows")
+    XCTAssertEqual(got.tempo, Tempo(marking: "Allegro", bpm: 120))
+    XCTAssertEqual(got.tags, ["scale"])
+    XCTAssertFalse(got.priority)
   }
 
   func testUpsertUpdatesInPlace() throws {


### PR DESCRIPTION
## What

From the iOS architecture review (CRITICAL #3). CLAUDE.md "Local data migrations" mandates a test that **a DB populated at the previous version migrates with data intact** — the device is the only copy of user data, so a destructive migration is unrecoverable. That test was missing: every `LibraryStore` test ran the full migrator on an *empty* DB, and `testNilModalityRoundTrips` falsely claimed to "cover the legacy path" (the row was written through the v2 schema, so the v1→v2 path was never exercised).

## Changes

- `LibraryStore.upgradeTestStore(migratedTo:seed:)` — a DEBUG-only test seam (same file, uses the `private` migrator) that migrates a fresh DB only as far as a given version, seeds raw rows written against *that* schema, then finishes migrating to HEAD — driving the **real** `DatabaseMigrator`.
- `testV1RowSurvivesModalityMigration` — a row written at v1 survives the v2 `modality` migration with every field intact (`modality` NULL for the pre-existing row). This is the **template** for every future migration's regression test.
- Removed the misleading "legacy path" comment.

## Testing

Full `IntradaTests` suite green on the pinned iPhone 16 / iOS 26.5 sim. No production behavior change (test + DEBUG seam only).

**Coverage:** N/A for Codecov (Swift/`ios` is a coverage-ignored path); this PR *adds* the missing regression coverage for the migration path.

This is the first of several PRs addressing the review; principles being captured land with their respective PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)