### PR TITLE
Native iOS: stop resolving fire-and-forget App (notify_shell) effects

### DIFF
--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -46,9 +46,8 @@ final class Store {
       case .http(let httpRequest):
         Task { await self.handleHttp(httpRequest, id: request.id) }
       case .app(let appEffect):
+        // notify_shell effect: fire-and-forget, must not be resolved (#882).
         handleAppEffect(appEffect)
-        // Ack so the core can continue its command chain.
-        process(guarded { try bridge.resolveEmpty(request.id) } ?? [])
       case .persistence(let operation):
         let output = persistenceOutput(for: operation)
         process(guarded { try bridge.resolve(request.id, persistenceOutput: output) } ?? [])

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -37,14 +37,15 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(store.viewModel?.error, "refreshed", "render effect should re-read view()")
   }
 
-  func testAppEffectResolvesEmpty() {
+  func testAppEffectIsNotResolved() {
+    // Why never resolve: testRealBridgeAppEffectIsNeverResolved (#882).
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in [Request(id: 7, effect: .app(.clearSessionInProgress))] }
     let store = Store(bridge: bridge, session: mockSession())
 
     store.send(.setQuery(nil))
 
-    XCTAssertEqual(bridge.emptyResolved, [7], "app effect should ack via resolveEmpty")
+    XCTAssertTrue(bridge.emptyResolved.isEmpty, "app effect must not be resolved")
   }
 
   func testPersistenceLoadResolvesFromStore() {
@@ -93,8 +94,8 @@ final class StoreEffectLoopTests: XCTestCase {
     }
     store.send(.setQuery(nil))
 
-    XCTAssertEqual(bridge.emptyResolved, [1], "every request in the batch should run")
-    XCTAssertEqual(store.viewModel?.error, "batched")
+    XCTAssertTrue(bridge.emptyResolved.isEmpty, "app effect must not be resolved")
+    XCTAssertEqual(store.viewModel?.error, "batched", "render after the app effect still runs")
   }
 
   // ── Library sort persistence ───────────────────────────────────────────
@@ -111,7 +112,7 @@ final class StoreEffectLoopTests: XCTestCase {
     let data = try XCTUnwrap(defaults.data(forKey: Store.sortDefaultsKey))
     let restored = try LibrarySort.bincodeDeserialize(input: [UInt8](data))
     XCTAssertEqual(restored, sort, "save effect persists the chosen sort")
-    XCTAssertEqual(bridge.emptyResolved, [5], "save effect still acks via resolveEmpty")
+    XCTAssertTrue(bridge.emptyResolved.isEmpty, "the app effect must not be resolved (#882)")
   }
 
   func testRestorePersistedSortReplaysSetSort() throws {
@@ -330,6 +331,20 @@ final class StoreEffectLoopTests: XCTestCase {
       afterEdit.items.first?.title, "Renamed",
       "edited title should apply (err=\(afterEdit.error ?? "nil"))")
     XCTAssertEqual(afterEdit.items.first?.itemType, .exercise, "edited type should apply")
+  }
+
+  /// App effects come from `notify_shell` — fire-and-forget notifications the
+  /// live bridge rejects resolving, so the Store must not resolve `.app`. The
+  /// stub bridge can't enforce this; pinned here against the real bridge (#882).
+  func testRealBridgeAppEffectIsNeverResolved() throws {
+    let bridge = LiveBridge()
+    let requests = try bridge.update(
+      .setSort(LibrarySort(field: .title, direction: .ascending)))
+    let appRequest = try XCTUnwrap(
+      requests.first { if case .app = $0.effect { return true } else { return false } },
+      "setSort should emit an App (SaveLibrarySort) effect")
+
+    XCTAssertThrowsError(try bridge.resolveEmpty(appRequest.id))
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #882.

## Problem

The native shell logged (swallowed, once on launch):

```
bridge: Bridge("could not process response: Attempted to resolve a request that is not expected to be resolved.")
```

## Root cause

`Store.process` resolved `.app` effects via `bridge.resolveEmpty(id)`. But every `AppEffect` is dispatched by `Command::notify_shell(...)` in the core (`app.rs`, `session.rs`) — fire-and-forget notifications (`Request::resolves_never`). The live crux `Bridge` refuses to resolve them, so the resolve threw, was caught by `Store.guarded`, and polluted the log. Cosmetic (the side effect runs in `handleAppEffect` *before* the failing resolve) but real. Fired on `SetSort`→`SaveLibrarySort` (e.g. `restorePersistedSort()` at launch), `SignedOut`, and session crash-recovery effects.

## Fix

Handle the App effect and stop — don't resolve `.app`. Safe for all App effects: they're all `notify_shell` with `Operation::Output = ()`, and `Command::all([notify_shell(...), render()])` runs the render independently, so nothing is starved.

## Tests (TDD red→green)

- The 3 stub-bridge tests now assert `.app` is **never** resolved (they failed against the old Store, pass now).
- New **real-bridge** test `testRealBridgeAppEffectIsNeverResolved`: drives `.setSort` through `LiveBridge` and asserts resolving the resulting App effect throws — the canonical coverage the "stub-bridge tests can't catch this" gotcha calls for.
- Full `just ios-test` suite passes on the pinned iPhone 16 / iOS 26.5 sim.

**Coverage:** full — `ios/` is a codecov-ignored path, but the effect-loop change is covered by the updated stub tests + the new real-bridge contract test.