### PR TITLE
Native iOS: de-flake LibrarySearchUITests

### DIFF
--- a/ios/IntradaUITests/LibrarySearchUITests.swift
+++ b/ios/IntradaUITests/LibrarySearchUITests.swift
@@ -19,24 +19,29 @@ final class LibrarySearchUITests: XCTestCase {
   func testSearchButtonRevealsFiltersAndCancels() {
     let app = launchSeeded()
     XCTAssertTrue(app.staticTexts["Library"].waitForExistence(timeout: 10), "Library header")
-    XCTAssertTrue(app.staticTexts["Clair de Lune"].exists, "Full list before searching")
+    XCTAssertTrue(
+      app.staticTexts["Clair de Lune"].waitForExistence(timeout: 5), "Full list before searching")
 
     let searchField = app.textFields["Search library"]
     XCTAssertFalse(searchField.exists, "Search field hidden until the button is tapped")
 
     app.buttons["Search"].tap()
-    XCTAssertTrue(searchField.waitForExistence(timeout: 3), "Tapping Search reveals the field")
-
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5), "Tapping Search reveals the field")
+    // Tap to ensure focus before typing — the reveal animates in and typeText drops keys otherwise.
+    searchField.tap()
     searchField.typeText("hanon")
+
     XCTAssertTrue(
-      app.staticTexts["Hanon No. 1"].waitForExistence(timeout: 3),
+      app.staticTexts["Hanon No. 1"].waitForExistence(timeout: 5),
       "Matching item stays after filtering")
-    XCTAssertFalse(app.staticTexts["Clair de Lune"].exists, "Non-matching item filtered out")
+    XCTAssertTrue(
+      app.staticTexts["Clair de Lune"].waitForNonExistence(timeout: 5),
+      "Non-matching item filtered out")
 
     app.buttons["Cancel"].tap()
     XCTAssertTrue(
-      app.staticTexts["Clair de Lune"].waitForExistence(timeout: 3),
+      app.staticTexts["Clair de Lune"].waitForExistence(timeout: 5),
       "Cancel clears the query and restores the full list")
-    XCTAssertFalse(searchField.exists, "Cancel hides the search field")
+    XCTAssertTrue(searchField.waitForNonExistence(timeout: 5), "Cancel hides the search field")
   }
 }


### PR DESCRIPTION
## Why

This XCUITest intermittently failed the **native-iOS CI gate** — it failed #878 and #880 back-to-back, passed #879/#884, and passed on re-run. A flaky required check makes "green" meaningless and forces re-run roulette (it cost two re-run cycles shepherding this review's PRs). Per the newly-captured principle *"a stated invariant must be an enforced invariant"*, the CI gate has to be trustworthy.

## Root cause

The search bar reveals via a spring animation and auto-focuses, but the test called `typeText` immediately after `waitForExistence` — before the field was hittable/focused — so under CI load keystrokes dropped and the filtered result (`Hanon No. 1`) never appeared. The absence assertions also used instantaneous `.exists`, racing the filter's re-render.

## Fix

- `searchField.tap()` to guarantee the field is hittable + focused before typing.
- `waitForNonExistence(timeout:)` for the "filtered out" / "field hidden" checks (no instantaneous-`.exists` race).
- Wait for the seeded row instead of an instantaneous `.exists`; loosen the tight 3s timeouts to 5s for CI load.

No production code change — UI-test robustness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)