### PR TITLE
Native iOS: sync-boundary timestamp parity + extend bridge round-trip tests

### DIFF
--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -186,7 +186,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             if model.local_first {
                 model.record_success();
                 Command::all([
-                    crate::persistence::delete_item(id),
+                    crate::persistence::delete_item(id, chrono::Utc::now()),
                     crux_core::render::render(),
                 ])
             } else {

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -339,4 +339,36 @@ mod tests {
             tags: vec!["impressionist".to_string()],
         });
     }
+
+    // Remaining bridge-crossing write payloads — guard against a #846-class break.
+
+    #[test]
+    fn item_tag_events_round_trip_on_ffi_bincode_wire() {
+        use crate::domain::item::ItemEvent;
+        assert_round_trips(ItemEvent::AddTags {
+            id: "p1".to_string(),
+            tags: vec!["etude".to_string(), "warmup".to_string()],
+        });
+        assert_round_trips(ItemEvent::RemoveTags {
+            id: "p1".to_string(),
+            tags: vec!["etude".to_string()],
+        });
+    }
+
+    #[test]
+    fn set_requests_round_trip_on_ffi_bincode_wire() {
+        let entries = vec![CreateSetEntryRequest {
+            item_id: "p1".to_string(),
+            item_title: "Clair de Lune".to_string(),
+            item_type: ItemKind::Piece,
+        }];
+        assert_round_trips(CreateSetRequest {
+            name: "Warm-ups".to_string(),
+            entries: entries.clone(),
+        });
+        assert_round_trips(UpdateSetRequest {
+            name: "Warm-ups (revised)".to_string(),
+            entries,
+        });
+    }
 }

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -2,6 +2,7 @@
 //! against on-device SQLite. Unlike `AppEffect` (`Output = ()`), these
 //! queries return data: the core's first effect with a real typed `Output`.
 
+use chrono::{DateTime, Utc};
 use crux_core::capability::Operation;
 use crux_core::command::Command;
 use serde::{Deserialize, Serialize};
@@ -15,7 +16,12 @@ use crate::domain::item::Item;
 pub enum PersistenceOperation {
     LoadItems,
     SaveItem(Item),
-    DeleteItem { id: String },
+    /// Same `DateTime<Utc>` type as `Item::updated_at` so the tombstone bridges
+    /// through the identical codec — byte-identical format under LWW, no drift.
+    DeleteItem {
+        id: String,
+        deleted_at: DateTime<Utc>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -40,8 +46,8 @@ pub fn save_item(item: Item) -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::SaveItem(item)).then_send(Event::StoreWritten)
 }
 
-pub fn delete_item(id: String) -> Command<Effect, Event> {
-    Command::request_from_shell(PersistenceOperation::DeleteItem { id })
+pub fn delete_item(id: String, deleted_at: DateTime<Utc>) -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::DeleteItem { id, deleted_at })
         .then_send(Event::StoreWritten)
 }
 
@@ -162,7 +168,7 @@ mod tests {
     fn has_delete(cmd: &mut Command<Effect, Event>, id: &str) -> bool {
         cmd.effects().any(|e| {
             matches!(e, Effect::Persistence(req)
-            if req.operation == PersistenceOperation::DeleteItem { id: id.to_string() })
+            if matches!(&req.operation, PersistenceOperation::DeleteItem { id: op_id, .. } if op_id == id))
         })
     }
 
@@ -178,8 +184,38 @@ mod tests {
 
     #[test]
     fn delete_item_requests_a_delete_op() {
-        let mut cmd = delete_item("gone".to_string());
+        let mut cmd = delete_item("gone".to_string(), chrono::Utc::now());
         assert!(has_delete(&mut cmd, "gone"));
+    }
+
+    #[test]
+    fn local_first_delete_stamps_the_delete_instant() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.local_first = true;
+        model.items = vec![sample_item("p1")];
+
+        let before = chrono::Utc::now();
+        let mut cmd = app.update(
+            Event::Item(crate::domain::item::ItemEvent::Delete {
+                id: "p1".to_string(),
+            }),
+            &mut model,
+        );
+        let after = chrono::Utc::now();
+
+        let deleted_at = cmd
+            .effects()
+            .find_map(|e| match e {
+                Effect::Persistence(req) => match req.operation {
+                    PersistenceOperation::DeleteItem { deleted_at, .. } => Some(deleted_at),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .expect("a DeleteItem persistence op");
+        // Core stamps the delete instant (DateTime<Utc>, same type as updated_at).
+        assert!(deleted_at >= before && deleted_at <= after);
     }
 
     // ── Local-first mode: writes persist locally, no HTTP ───────────────

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -6,7 +6,7 @@ import SharedTypes
 protocol ItemStore {
   func loadItems() throws -> [Item]
   func save(_ item: Item) throws
-  func delete(id: String) throws
+  func delete(id: String, deletedAt: String) throws
 }
 
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
@@ -75,13 +75,14 @@ final class LibraryStore: ItemStore {
     }
   }
 
-  /// Soft-delete: stamp `deleted_at` (tombstone) rather than removing the row,
-  /// so the deletion can win a later last-write-wins sync.
-  func delete(id: String) throws {
+  /// Soft-delete: write the core-stamped `deletedAt` tombstone (RFC3339, same
+  /// format as `updated_at`) rather than removing the row, so the deletion can
+  /// win a later last-write-wins sync.
+  func delete(id: String, deletedAt: String) throws {
     try dbQueue.write { db in
       try db.execute(
         sql: "UPDATE item SET deleted_at = ? WHERE id = ?",
-        arguments: [Self.timestamp(), id])
+        arguments: [deletedAt, id])
     }
   }
 
@@ -172,9 +173,6 @@ final class LibraryStore: ItemStore {
     (try? JSONDecoder().decode([String].self, from: Data(json.utf8))) ?? []
   }
 
-  private static func timestamp() -> String {
-    ISO8601DateFormatter().string(from: Date())
-  }
 }
 
 #if DEBUG

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -94,8 +94,8 @@ final class Store {
       case .saveItem(let item):
         try store.save(item)
         return .ack
-      case .deleteItem(let id):
-        try store.delete(id: id)
+      case .deleteItem(let id, let deletedAt):
+        try store.delete(id: id, deletedAt: deletedAt)
         return .ack
       }
     } catch {

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -86,14 +86,14 @@ final class LibraryStoreTests: XCTestCase {
   func testDeleteTombstonesAndHidesFromLoad() throws {
     let store = try makeStore()
     try store.save(item("p1"))
-    try store.delete(id: "p1")
+    try store.delete(id: "p1", deletedAt: "2026-01-02T00:00:00+00:00")
     XCTAssertTrue(try store.loadItems().isEmpty)
   }
 
   func testSaveRevivesADeletedRow() throws {
     let store = try makeStore()
     try store.save(item("p1"))
-    try store.delete(id: "p1")
+    try store.delete(id: "p1", deletedAt: "2026-01-02T00:00:00+00:00")
     try store.save(item("p1", title: "Revived"))
     let loaded = try store.loadItems()
     XCTAssertEqual(loaded.count, 1)

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -441,7 +441,7 @@ private struct TestError: Error {}
 private struct FailingStore: ItemStore {
   func loadItems() throws -> [Item] { throw TestError() }
   func save(_ item: Item) throws { throw TestError() }
-  func delete(id: String) throws { throw TestError() }
+  func delete(id: String, deletedAt: String) throws { throw TestError() }
 }
 
 final class MockURLProtocol: URLProtocol {


### PR DESCRIPTION
Two related core-hardening items from the iOS review (increments **D + E**).

## D — stamp `deleted_at` in the core (sync-boundary format parity)

The shell stamped delete tombstones with `ISO8601DateFormatter` (no fractional seconds) while the core stamps `updated_at` via `to_rfc3339()` (fractional + offset). Two formats in the same columns that **don't lexically compare at equal instants** — a latent last-write-wins bug the offline-first schema is meant to protect against.

Fix: move the "when" into the core (reconciliation lives in the core — captured principle #3). `PersistenceOperation::DeleteItem` now carries a core-stamped `deleted_at` (`to_rfc3339`, identical format to `updated_at`); the shell writes it verbatim. Removed `LibraryStore.timestamp()`.

- **TDD:** `local_first_delete_stamps_rfc3339_deleted_at` (red→green).
- FFI contract change → bindings regenerated; Swift `ItemStore.delete(id:deletedAt:)` + `Store` case updated. Online path (HTTP delete) unchanged; web shell unaffected (no persistence ops).

## E — extend FFI-bincode round-trip coverage (#846 class)

`assert_round_trips` (the real-`BincodeFfiFormat` guard) only covered `CreateItem`/`UpdateItem`. Extended to the remaining write payloads that cross the bridge — `ItemEvent::AddTags`/`RemoveTags` and `CreateSetRequest`/`UpdateSetRequest` — so a JSON-only serde attr on any of them can't silently misalign the wire before it's wired to a native screen.

## Testing

378 core tests pass (TDD for D; +tests for E). Full `IntradaTests` suite green on the pinned sim. `cargo fmt` + `clippy --workspace -D warnings` clean.

**Coverage:** full for the core change (new behavior + round-trips covered). Swift/`ios` is Codecov-ignored.

> Side note for a CI-hardening follow-up: CI clippy doesn't use `--all-targets`, so **test code is never linted** (there's already a pre-existing dropped-`Command` `must_use` in an app.rs test it doesn't catch). Folding into the planned CI increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)