### PR TITLE
core: normalise free-text item fields on create/update

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -1461,6 +1461,78 @@ mod tests {
         assert_eq!(vm.available_composers, vec!["Beethoven", "Chopin", "Ravel"]);
     }
 
+    // --- Free-text normalisation on add (#883) ---
+
+    #[test]
+    fn add_normalises_whitespace_composer() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        // Whitespace-only composer on an exercise stores as None, not "   ".
+        let _ = app.update(
+            Event::Item(ItemEvent::Add(crate::domain::types::CreateItem {
+                title: "  Scales  ".to_string(),
+                kind: ItemKind::Exercise,
+                composer: Some("   ".to_string()),
+                key: None,
+                modality: None,
+                tempo: None,
+                notes: None,
+                tags: vec!["  warm-up ".to_string()],
+            })),
+            &mut model,
+        );
+        assert_eq!(model.items.len(), 1);
+        assert_eq!(model.items[0].title, "Scales");
+        assert_eq!(model.items[0].composer, None);
+        assert_eq!(model.items[0].tags, vec!["warm-up".to_string()]);
+
+        // A padded composer is trimmed, not stored verbatim.
+        let _ = app.update(
+            Event::Item(ItemEvent::Add(crate::domain::types::CreateItem {
+                title: "Hanon".to_string(),
+                kind: ItemKind::Exercise,
+                composer: Some("  Hanon ".to_string()),
+                key: None,
+                modality: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+            })),
+            &mut model,
+        );
+        assert_eq!(model.items[1].composer, Some("Hanon".to_string()));
+    }
+
+    #[test]
+    fn add_piece_with_blank_composer_is_required_error() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+
+        let _ = app.update(
+            Event::Item(ItemEvent::Add(crate::domain::types::CreateItem {
+                title: "Sonata".to_string(),
+                kind: ItemKind::Piece,
+                composer: Some("   ".to_string()),
+                key: None,
+                modality: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+            })),
+            &mut model,
+        );
+
+        assert!(
+            model.items.is_empty(),
+            "blank composer must not create a piece"
+        );
+        assert!(model
+            .last_error
+            .as_deref()
+            .is_some_and(|e| e.contains("Composer is required")));
+    }
+
     // --- T042: Unicode handling in core ---
 
     #[test]

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -90,6 +90,7 @@ fn save_or_put(model: &mut Model, item: Item) -> Command<Effect, Event> {
 pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect, Event> {
     match event {
         ItemEvent::Add(input) => {
+            let input = validation::normalize_create_item(input);
             if let Err(e) = validation::validate_create_item(&input) {
                 model.last_error = Some(e.to_string());
                 return crux_core::render::render();
@@ -131,6 +132,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             }
         }
         ItemEvent::Update { id, input } => {
+            let input = validation::normalize_update_item(input);
             if let Err(e) = validation::validate_update_item(&input) {
                 model.last_error = Some(e.to_string());
                 return crux_core::render::render();

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -26,6 +26,49 @@ pub const MAX_SESSION_TARGET_MINS: u32 = 120;
 pub const MIN_ACHIEVED_TEMPO: u16 = 1;
 pub const MAX_ACHIEVED_TEMPO: u16 = 500;
 
+// ── Normalisation ──
+// Trim free-text on input and collapse a now-blank value to absent, so a
+// whitespace-only field behaves exactly like an empty one through validation
+// and storage (#883). Runs before validate_*, so "   " fails "required" just
+// like "" rather than persisting as stored whitespace.
+
+fn trimmed_nonempty(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    tags.into_iter()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect()
+}
+
+fn normalize_tempo(tempo: Option<Tempo>) -> Option<Tempo> {
+    tempo.and_then(|t| Tempo::from_parts(trimmed_nonempty(t.marking), t.bpm))
+}
+
+pub fn normalize_create_item(mut input: CreateItem) -> CreateItem {
+    input.title = input.title.trim().to_string();
+    input.composer = trimmed_nonempty(input.composer);
+    input.key = trimmed_nonempty(input.key);
+    input.notes = trimmed_nonempty(input.notes);
+    input.tempo = normalize_tempo(input.tempo);
+    input.tags = normalize_tags(input.tags);
+    input
+}
+
+pub fn normalize_update_item(mut input: UpdateItem) -> UpdateItem {
+    input.title = input.title.map(|t| t.trim().to_string());
+    input.composer = input.composer.map(trimmed_nonempty);
+    input.key = input.key.map(trimmed_nonempty);
+    input.notes = input.notes.map(trimmed_nonempty);
+    input.tempo = input.tempo.map(normalize_tempo);
+    input.tags = input.tags.map(normalize_tags);
+    input
+}
+
 pub fn validate_title(title: &str) -> Result<(), LibraryError> {
     if title.is_empty() || title.len() > MAX_TITLE {
         return Err(LibraryError::Validation {
@@ -316,6 +359,123 @@ pub fn validate_set_entry_fields(item_id: &str, item_title: &str) -> Result<(), 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- normalisation (#883) ---
+
+    #[test]
+    fn normalize_create_trims_and_drops_blank_optionals() {
+        let input = CreateItem {
+            title: "  Clair de Lune  ".to_string(),
+            kind: ItemKind::Exercise,
+            composer: Some("   ".to_string()),
+            key: Some("  D major ".to_string()),
+            modality: None,
+            tempo: Some(Tempo {
+                marking: Some("   ".to_string()),
+                bpm: None,
+            }),
+            notes: Some("  ".to_string()),
+            tags: vec![
+                "  warm-up ".to_string(),
+                "   ".to_string(),
+                "scales".to_string(),
+            ],
+        };
+
+        let out = normalize_create_item(input);
+
+        assert_eq!(out.title, "Clair de Lune");
+        assert_eq!(
+            out.composer, None,
+            "whitespace-only composer collapses to None"
+        );
+        assert_eq!(out.key, Some("D major".to_string()));
+        assert_eq!(out.notes, None, "whitespace-only notes collapses to None");
+        assert_eq!(out.tempo, None, "blank marking + no bpm drops the tempo");
+        assert_eq!(out.tags, vec!["warm-up".to_string(), "scales".to_string()]);
+    }
+
+    #[test]
+    fn normalize_tempo_keeps_bpm_when_marking_blank() {
+        // Blank marking must not discard a valid bpm — only a fully-empty
+        // tempo collapses to None.
+        let input = CreateItem {
+            title: "Etude".to_string(),
+            kind: ItemKind::Exercise,
+            composer: None,
+            key: None,
+            modality: None,
+            tempo: Some(Tempo {
+                marking: Some("  ".to_string()),
+                bpm: Some(120),
+            }),
+            notes: None,
+            tags: vec![],
+        };
+        assert_eq!(
+            normalize_create_item(input).tempo,
+            Some(Tempo {
+                marking: None,
+                bpm: Some(120)
+            })
+        );
+    }
+
+    #[test]
+    fn normalize_create_keeps_padded_composer_trimmed() {
+        let input = CreateItem {
+            title: "Hanon".to_string(),
+            kind: ItemKind::Exercise,
+            composer: Some("  Charles-Louis Hanon ".to_string()),
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        };
+        assert_eq!(
+            normalize_create_item(input).composer,
+            Some("Charles-Louis Hanon".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_update_trims_and_three_state_clears_blank() {
+        let input = UpdateItem {
+            title: Some("  Renamed ".to_string()),
+            composer: Some(Some("   ".to_string())),
+            key: Some(Some("  F# minor ".to_string())),
+            tempo: Some(Some(Tempo {
+                marking: Some("  ".to_string()),
+                bpm: None,
+            })),
+            tags: Some(vec![" a ".to_string(), "".to_string()]),
+            ..Default::default()
+        };
+
+        let out = normalize_update_item(input);
+
+        assert_eq!(out.title, Some("Renamed".to_string()));
+        assert_eq!(
+            out.composer,
+            Some(None),
+            "blank set-composer becomes a clear"
+        );
+        assert_eq!(out.key, Some(Some("F# minor".to_string())));
+        assert_eq!(out.tempo, Some(None), "blank tempo becomes a clear");
+        assert_eq!(out.tags, Some(vec!["a".to_string()]));
+    }
+
+    #[test]
+    fn normalize_update_leaves_untouched_fields_none() {
+        let out = normalize_update_item(UpdateItem::default());
+        assert_eq!(
+            out.composer, None,
+            "absent field stays absent (not a clear)"
+        );
+        assert_eq!(out.title, None);
+        assert_eq!(out.tags, None);
+    }
 
     // --- validate_create_item tests (piece kind) ---
 


### PR DESCRIPTION
Fixes #883.

## Problem

`validation.rs` checked `is_empty()` without trimming, so a whitespace-only or padded composer/title/key/notes/tag/tempo-marking passed validation and was stored verbatim (a blank-looking entry). Surfaced in the #879 review; #883's defensive trim in the composer-autocomplete pool was a workaround — this is the source fix.

## Fix

`normalize_create_item` / `normalize_update_item` in `validation.rs`, run **before** `validate_*` in the item handler (Add + Update). They trim all free-text and collapse a now-blank optional to absent, so `"   "` behaves exactly like `""`:

- Blank composer on a **piece** → fails "Composer is required" (not stored as whitespace); on an **exercise** → stored `None`.
- `UpdateItem`'s three-state fields: a blank set (`Some(Some("  "))`) becomes a **clear** (`Some(None)`); absent (`None`) stays untouched.
- Tempo with a blank marking + no bpm collapses to `None`; a blank marking with a valid bpm keeps the bpm.

The normalise sits **above** the `local_first` branch, so both iOS (offline) and web (online) modes get it (invariant 6). No type shapes changed → no FFI binding regen, shells untouched. `AddTags` left as-is (its tags come from the trimmed `TagChipInput`).

## Tests (TDD red→green)

5 unit tests (`validation.rs`: trim + blank-collapse, three-state clear, untouched-stays-absent, padded-composer, bpm-retention) + 2 handler integration tests (`app.rs`: whitespace composer → None / trimmed; blank composer on a piece → required error). Full suite: 565 pass.

**Coverage:** full — pure core logic with dedicated unit + integration tests.

## Out of scope (tracked)

The server-side REST/MCP paths in `intrada-api` validate without normalising — tracked in #888 (low priority; API is paused).