### PR TITLE
CI: lint test code (--all-targets) + iOS device target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,11 +181,14 @@ jobs:
       # code scanning annotations, then check the exit code to fail the job.
       # iOS-pivot focus mode: web shell on hold — intrada-web excluded and the
       # WASM clippy pass dropped. Restore both at parity.
+      # --all-targets so test/bench code is linted too, not just lib/bin — a
+      # dropped `#[must_use]` Command shipped in a test once because the gate
+      # stopped at lib targets.
       - name: Clippy (native)
         shell: bash
         run: |
           set +o pipefail
-          cargo clippy --workspace \
+          cargo clippy --workspace --all-targets \
             --exclude intrada-mobile \
             --exclude intrada-web \
             --exclude tauri-plugin-background-audio \
@@ -384,6 +387,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "native-ios"
@@ -394,6 +398,11 @@ jobs:
         run: |
           echo "$CARGO_HOME/bin" >> $GITHUB_PATH
           cargo --version
+      # iOS-only `#[cfg(target_os = "ios")]` branches in the FFI crate can't be
+      # linted by the Linux `clippy` job (no Apple SDK); lint them here against
+      # the device target. Runs before the expensive build so it fails fast.
+      - name: Clippy (iOS device target)
+        run: cargo clippy -p intrada-ffi --target aarch64-apple-ios -- -D warnings
       - uses: taiki-e/install-action@v2
         with:
           tool: just

--- a/crates/intrada-api/tests/auth_test.rs
+++ b/crates/intrada-api/tests/auth_test.rs
@@ -425,7 +425,7 @@ async fn pat_prefix_takes_precedence_over_jwt_path() {
 
     // Constructed from the prefix + repeating ascii so the literal in
     // source has no high-entropy hex blob for gitleaks to flag.
-    let suffix: String = std::iter::repeat('z').take(60).collect();
+    let suffix = "z".repeat(60);
     let pat_token = format!("{}{suffix}", intrada_api::db::tokens::TOKEN_PREFIX);
     seed_pat(&conn, &pat_token, "user_PAT").await;
 

--- a/crates/intrada-api/tests/common/mod.rs
+++ b/crates/intrada-api/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use axum::Router;

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -3371,7 +3371,7 @@ mod tests {
         };
 
         let update = |m: &mut Model, input: crate::domain::types::UpdateItem| {
-            app.update(
+            let _ = app.update(
                 Event::Item(ItemEvent::Update {
                     id: "p1".to_string(),
                     input,


### PR DESCRIPTION
From the iOS review (CI / checks & balances). Two gaps in the clippy gate let lints ship — surfaced while shipping #887:

1. The Linux `clippy` job linted only **lib/bin** targets, so **test code was never checked** — a dropped `#[must_use]` `Command` rode along in an `app.rs` test.
2. **iOS-only `#[cfg(target_os="ios")]`** branches in `intrada-ffi` were never linted (the old `aarch64-apple-ios` clippy job is `if: false` during the native focus).

## Changes

- **Linux `clippy` job:** add `--all-targets` so test/bench code is linted too.
- **`native-ios` job:** add `cargo clippy -p intrada-ffi --target aarch64-apple-ios -- -D warnings` (the only runner with the Apple SDK), placed before the expensive build so it fails fast.
- **Fixes for what `--all-targets` surfaced:**
  - the dropped `Command` (`app.rs` test → `let _ =`),
  - a manual `str::repeat` (`auth_test.rs`),
  - dead-code on the shared integration-test helpers (`#![allow(dead_code)]` on `tests/common/mod.rs` — each integration test is its own crate and uses only a subset, the canonical false-positive).

Enforces the captured principle *"a stated invariant must be an enforced invariant."*

## Verification

All run locally (CI workflow steps can't be unit-tested, so I ran their exact commands): `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo clippy -p intrada-ffi --target aarch64-apple-ios -- -D warnings` clean; `cargo fmt --check` clean; intrada-api + intrada-core test suites pass. No iOS app/Swift/snapshot surface touched.

## Deferred (next C sub-items)
Comment-density as a CI job (the script is pre-push-shaped — detached HEAD in CI would skip it; needs a base-ref tweak), `Package.resolved` pin, Swift coverage visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)