### PR TITLE
CI: enforce comment-density as a job (not just an opt-in local hook)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -787,6 +787,25 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # The same comment-density gate as the local pre-push hook, enforced for
+  # everyone — an opt-in hook is effectively off (CLAUDE.md "stated invariant =
+  # enforced invariant"). HEAD is detached on a PR checkout, so the base branch
+  # is passed explicitly via COMMENT_CHECK_BASE.
+  comment-density:
+    name: Comment density
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check comment density
+        env:
+          COMMENT_CHECK_BASE: origin/${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$GITHUB_BASE_REF"
+          bash scripts/check-comment-density.sh
+
   security:
     name: Security (cargo-deny + Gitleaks)
     runs-on: ubuntu-latest

--- a/scripts/check-comment-density.sh
+++ b/scripts/check-comment-density.sh
@@ -9,19 +9,26 @@ if [ "${SKIP_COMMENT_CHECK:-}" = "1" ]; then
   exit 0
 fi
 
-branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
-if [ -z "$branch" ]; then
+# CI passes the PR base ref via COMMENT_CHECK_BASE — HEAD is detached there, so
+# the branch-name guard below would otherwise skip the check entirely. Locally
+# the pre-push hook leaves it unset and we derive the base from origin/main.
+base="${COMMENT_CHECK_BASE:-}"
+if [ -z "$base" ]; then
+  branch=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    exit 0
+  fi
+  case "$branch" in
+    main|master) exit 0 ;;
+  esac
+  base="origin/main"
+fi
+
+if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
   exit 0
 fi
-case "$branch" in
-  main|master) exit 0 ;;
-esac
 
-if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
-  exit 0
-fi
-
-range="origin/main...HEAD"
+range="$base...HEAD"
 
 files=$(git diff --name-only "$range" -- \
   '*.rs' '*.swift' '*.css' '*.ts' '*.tsx' '*.js' '*.jsx' 2>/dev/null || true)


### PR DESCRIPTION
From the iOS review (CI / checks & balances). The comment-density gate ran **only** via the pre-push hook — so anyone who didn't run `scripts/install-git-hooks.sh` had no enforcement, and there was no CI backstop. A stated rule that wasn't actually enforced.

## Changes

- New **`comment-density`** CI job (PRs only) that runs the existing `scripts/check-comment-density.sh`.
- Teach the script a **`COMMENT_CHECK_BASE`** override: a PR checkout is on a detached HEAD, so the script's branch-name guard would otherwise skip the check entirely. CI passes the base ref explicitly; **local pre-push behaviour is unchanged** (env unset → derives `origin/main` as before).

Enforces the captured principle *"a stated invariant must be an enforced invariant."*

## Verification (local)
- Script in **CI mode** (`COMMENT_CHECK_BASE=origin/main`) and **local mode** (unset) both exit 0 on this branch.
- Verified detection still fires: a temporary over-dense `.rs` diff produced `density 3.00 (threshold 0.15)` + exit 1 in CI mode.
- This PR touches only `.sh` + `.yml` (neither counted by the gate), so it passes its own new check.

This job is self-validating — it runs on this PR via the updated workflow.

Deferred (remaining C): `Package.resolved` pin, Swift coverage visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)