### PR TITLE
Native iOS: extract shared ItemForm (de-dupe Add/Edit screens)

### DIFF
--- a/ios/Intrada/Views/Screens/ItemFormModel.swift
+++ b/ios/Intrada/Views/Screens/ItemFormModel.swift
@@ -1,0 +1,78 @@
+import SharedTypes
+import SwiftUI
+
+/// Field state for the add/edit item form, shared by `LibraryAddScreen` and
+/// `LibraryEditScreen`. The shell only collects values; the core validates.
+@Observable
+final class ItemFormModel {
+  var kind: ItemKind
+  var title = ""
+  var composer = ""
+  var key = ""
+  var modality: Modality?
+  var marking = ""
+  var bpm = ""
+  var notes = ""
+  var tags: [String] = []
+  var formError: String?
+
+  init(kind: ItemKind = .piece) {
+    self.kind = kind
+  }
+
+  init(item: LibraryItemView) {
+    kind = item.itemType
+    title = item.title
+    composer = item.subtitle
+    tags = item.tags
+    // Normalise on load so editing self-heals legacy combined values
+    // ("F# major") into tonic + modality even if the user never re-taps a spoke.
+    let selection = KeyHelper.selection(key: item.key ?? "", modality: item.modality)
+    key = selection?.spelling ?? item.key ?? ""
+    modality = selection?.mode ?? item.modality
+    marking = item.tempoMarking ?? ""
+    bpm = item.tempoBpm.map(String.init) ?? ""
+    notes = item.notes ?? ""
+  }
+
+  var canSubmit: Bool {
+    !title.trimmingCharacters(in: .whitespaces).isEmpty
+  }
+
+  func createInput() -> CreateItem {
+    CreateItem(
+      title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+      kind: kind,
+      composer: emptyToNil(composer),
+      key: emptyToNil(key),
+      modality: modality,
+      tempo: buildTempo(),
+      notes: emptyToNil(notes),
+      tags: tags)
+  }
+
+  func updateInput() -> UpdateItem {
+    UpdateItem(
+      title: title,
+      kind: kind,
+      composer: .some(emptyToNil(composer)),
+      key: .some(emptyToNil(key)),
+      modality: .some(modality),
+      tempo: .some(buildTempo()),
+      notes: .some(emptyToNil(notes)),
+      tags: tags,
+      priority: nil)
+  }
+
+  private func emptyToNil(_ value: String) -> String? {
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private func buildTempo() -> Tempo? {
+    let mark = emptyToNil(marking)
+    let beats = UInt16(bpm.trimmingCharacters(in: .whitespaces))
+    if mark == nil && beats == nil { return nil }
+    return Tempo(marking: mark, bpm: beats)
+  }
+}

--- a/ios/Intrada/Views/Screens/ItemFormScaffold.swift
+++ b/ios/Intrada/Views/Screens/ItemFormScaffold.swift
@@ -1,0 +1,95 @@
+import SharedTypes
+import SwiftUI
+
+/// Shared body for the add/edit item sheets: the field cards plus the
+/// confirm/cancel toolbar and the error-reconcile flow. `send` dispatches the
+/// add/update event; the scaffold owns the "don't celebrate until the core
+/// confirms" handling so both screens behave identically.
+struct ItemFormScaffold: View {
+  @Environment(Store.self) private var store
+  @Environment(\.dismiss) private var dismiss
+
+  @Bindable var form: ItemFormModel
+  let title: String
+  let confirmLabel: String
+  let composerSuggestions: [String]
+  let tagSuggestions: [String]
+  let send: () -> Void
+
+  var body: some View {
+    NavigationStack {
+      ZStack {
+        PaperBackground()
+        VStack(spacing: 0) {
+          if let formError = form.formError {
+            FormErrorBanner(message: formError)
+              .padding(.horizontal, 16)
+              .padding(.top, 12)
+              .transition(.move(edge: .top).combined(with: .opacity))
+          }
+          ScrollView {
+            VStack(spacing: 16) {
+              KindSegment(selection: $form.kind)
+
+              VStack(spacing: 0) {
+                FormField(label: "Title", text: $form.title, placeholder: "Required")
+                divider
+                AutocompleteField(
+                  label: "Composer", text: $form.composer, suggestions: composerSuggestions)
+                divider
+                KeyPicker(label: "Key", key: $form.key, modality: $form.modality)
+              }
+              .cardSurface()
+
+              VStack(spacing: 0) {
+                FormField(label: "Tempo marking", text: $form.marking, placeholder: "e.g. Allegro")
+                divider
+                FormField(label: "Beats per minute", text: $form.bpm, keyboard: .numberPad)
+              }
+              .cardSurface()
+
+              FormField(label: "Notes", text: $form.notes, axis: .vertical)
+                .cardSurface()
+
+              VStack(spacing: 0) {
+                TagChipInput(label: "Tags", tags: $form.tags, suggestions: tagSuggestions)
+              }
+              .cardSurface()
+            }
+            .padding(16)
+          }
+        }
+      }
+      .navigationTitle(title)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button(confirmLabel, action: confirm)
+            .disabled(!form.canSubmit)
+        }
+      }
+    }
+  }
+
+  private var divider: some View {
+    Rectangle().fill(IntradaColor.hairline).frame(height: 1)
+  }
+
+  // Don't celebrate or dismiss until the core confirms: a validation reject or
+  // failed local write surfaces in viewModel.error, which we keep on screen.
+  private func confirm() {
+    form.formError = nil
+    send()
+    if let error = store.viewModel?.error {
+      withAnimation { form.formError = error }
+      UINotificationFeedbackGenerator().notificationOccurred(.error)
+      UIAccessibility.post(notification: .announcement, argument: "Error: \(error)")
+    } else {
+      UINotificationFeedbackGenerator().notificationOccurred(.success)
+      dismiss()
+    }
+  }
+}

--- a/ios/Intrada/Views/Screens/LibraryAddScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryAddScreen.swift
@@ -6,134 +6,30 @@ import SwiftUI
 /// ulid; the shell only collects field values.
 struct LibraryAddScreen: View {
   @Environment(Store.self) private var store
-  @Environment(\.dismiss) private var dismiss
-
-  @State private var kind: ItemKind
-  @State private var title = ""
-  @State private var composer = ""
-  @State private var key = ""
-  @State private var modality: Modality?
-  @State private var marking = ""
-  @State private var bpm = ""
-  @State private var notes = ""
-  @State private var tags: [String] = []
-  @State private var formError: String?
+  @State private var form: ItemFormModel
 
   init(defaultKind: ItemKind = .piece) {
-    _kind = State(initialValue: defaultKind)
+    _form = State(initialValue: ItemFormModel(kind: defaultKind))
   }
 
   #if DEBUG
     init(previewError: String) {
-      _kind = State(initialValue: .piece)
-      _formError = State(initialValue: previewError)
+      let form = ItemFormModel(kind: .piece)
+      form.formError = previewError
+      _form = State(initialValue: form)
     }
   #endif
 
   var body: some View {
-    NavigationStack {
-      ZStack {
-        PaperBackground()
-        VStack(spacing: 0) {
-          if let formError {
-            FormErrorBanner(message: formError)
-              .padding(.horizontal, 16)
-              .padding(.top, 12)
-              .transition(.move(edge: .top).combined(with: .opacity))
-          }
-          ScrollView {
-            VStack(spacing: 16) {
-              KindSegment(selection: $kind)
-
-              VStack(spacing: 0) {
-                FormField(label: "Title", text: $title, placeholder: "Required")
-                divider
-                AutocompleteField(
-                  label: "Composer", text: $composer, suggestions: composerSuggestions)
-                divider
-                KeyPicker(label: "Key", key: $key, modality: $modality)
-              }
-              .cardSurface()
-
-              VStack(spacing: 0) {
-                FormField(label: "Tempo marking", text: $marking, placeholder: "e.g. Allegro")
-                divider
-                FormField(label: "Beats per minute", text: $bpm, keyboard: .numberPad)
-              }
-              .cardSurface()
-
-              FormField(label: "Notes", text: $notes, axis: .vertical)
-                .cardSurface()
-
-              VStack(spacing: 0) {
-                TagChipInput(label: "Tags", tags: $tags, suggestions: availableTags)
-              }
-              .cardSurface()
-            }
-            .padding(16)
-          }
-        }
-      }
-      .navigationTitle("New \(kind.label)")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") { dismiss() }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Button("Add", action: add)
-            .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty)
-        }
-      }
+    ItemFormScaffold(
+      form: form,
+      title: "New \(form.kind.label)",
+      confirmLabel: "Add",
+      composerSuggestions: store.viewModel?.availableComposers ?? [],
+      tagSuggestions: store.viewModel?.availableTags ?? []
+    ) {
+      store.send(.item(.add(form.createInput())))
     }
-  }
-
-  private var divider: some View {
-    Rectangle().fill(IntradaColor.hairline).frame(height: 1)
-  }
-
-  private var composerSuggestions: [String] {
-    store.viewModel?.availableComposers ?? []
-  }
-
-  private var availableTags: [String] {
-    store.viewModel?.availableTags ?? []
-  }
-
-  private func add() {
-    let input = CreateItem(
-      title: title.trimmingCharacters(in: .whitespacesAndNewlines),
-      kind: kind,
-      composer: emptyToNil(composer),
-      key: emptyToNil(key),
-      modality: modality,
-      tempo: buildTempo(),
-      notes: emptyToNil(notes),
-      tags: tags)
-    // Don't celebrate or dismiss until the core confirms: a validation reject
-    // or failed local write surfaces in viewModel.error, which we keep on screen.
-    formError = nil
-    store.send(.item(.add(input)))
-    if let error = store.viewModel?.error {
-      withAnimation { formError = error }
-      UINotificationFeedbackGenerator().notificationOccurred(.error)
-      UIAccessibility.post(notification: .announcement, argument: "Error: \(error)")
-    } else {
-      UINotificationFeedbackGenerator().notificationOccurred(.success)
-      dismiss()
-    }
-  }
-
-  private func emptyToNil(_ value: String) -> String? {
-    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
-  }
-
-  private func buildTempo() -> Tempo? {
-    let mark = emptyToNil(marking)
-    let beats = UInt16(bpm.trimmingCharacters(in: .whitespaces))
-    if mark == nil && beats == nil { return nil }
-    return Tempo(marking: mark, bpm: beats)
   }
 }
 

--- a/ios/Intrada/Views/Screens/LibraryEditScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryEditScreen.swift
@@ -6,147 +6,32 @@ import SwiftUI
 struct LibraryEditScreen: View {
   let item: LibraryItemView
   @Environment(Store.self) private var store
-  @Environment(\.dismiss) private var dismiss
-
-  @State private var kind: ItemKind
-  @State private var title: String
-  @State private var composer: String
-  @State private var key: String
-  @State private var modality: Modality?
-  @State private var marking: String
-  @State private var bpm: String
-  @State private var notes: String
-  @State private var tags: [String]
-  @State private var formError: String?
+  @State private var form: ItemFormModel
 
   init(item: LibraryItemView) {
     self.item = item
-    _kind = State(initialValue: item.itemType)
-    _tags = State(initialValue: item.tags)
-    _title = State(initialValue: item.title)
-    _composer = State(initialValue: item.subtitle)
-    // Normalise on load so editing self-heals legacy combined values
-    // ("F# major") into tonic + modality even if the user never re-taps a spoke.
-    let selection = KeyHelper.selection(key: item.key ?? "", modality: item.modality)
-    _key = State(initialValue: selection?.spelling ?? item.key ?? "")
-    _modality = State(initialValue: selection?.mode ?? item.modality)
-    _marking = State(initialValue: item.tempoMarking ?? "")
-    _bpm = State(initialValue: item.tempoBpm.map(String.init) ?? "")
-    _notes = State(initialValue: item.notes ?? "")
+    _form = State(initialValue: ItemFormModel(item: item))
   }
 
   #if DEBUG
     init(item: LibraryItemView, previewError: String) {
-      self.init(item: item)
-      _formError = State(initialValue: previewError)
+      self.item = item
+      let form = ItemFormModel(item: item)
+      form.formError = previewError
+      _form = State(initialValue: form)
     }
   #endif
 
   var body: some View {
-    NavigationStack {
-      ZStack {
-        PaperBackground()
-        VStack(spacing: 0) {
-          if let formError {
-            FormErrorBanner(message: formError)
-              .padding(.horizontal, 16)
-              .padding(.top, 12)
-              .transition(.move(edge: .top).combined(with: .opacity))
-          }
-          ScrollView {
-            VStack(spacing: 16) {
-              KindSegment(selection: $kind)
-
-              VStack(spacing: 0) {
-                FormField(label: "Title", text: $title, placeholder: "Required")
-                divider
-                AutocompleteField(
-                  label: "Composer", text: $composer, suggestions: composerSuggestions)
-                divider
-                KeyPicker(label: "Key", key: $key, modality: $modality)
-              }
-              .cardSurface()
-
-              VStack(spacing: 0) {
-                FormField(label: "Tempo marking", text: $marking, placeholder: "e.g. Allegro")
-                divider
-                FormField(label: "Beats per minute", text: $bpm, keyboard: .numberPad)
-              }
-              .cardSurface()
-
-              FormField(label: "Notes", text: $notes, axis: .vertical)
-                .cardSurface()
-
-              VStack(spacing: 0) {
-                TagChipInput(label: "Tags", tags: $tags, suggestions: availableTags)
-              }
-              .cardSurface()
-            }
-            .padding(16)
-          }
-        }
-      }
-      .navigationTitle("Edit")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") { dismiss() }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Button("Save", action: save)
-            .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty)
-        }
-      }
+    ItemFormScaffold(
+      form: form,
+      title: "Edit",
+      confirmLabel: "Save",
+      composerSuggestions: store.viewModel?.availableComposers ?? [],
+      tagSuggestions: store.viewModel?.availableTags ?? []
+    ) {
+      store.send(.item(.update(id: item.id, input: form.updateInput())))
     }
-  }
-
-  private var divider: some View {
-    Rectangle().fill(IntradaColor.hairline).frame(height: 1)
-  }
-
-  private var composerSuggestions: [String] {
-    store.viewModel?.availableComposers ?? []
-  }
-
-  private var availableTags: [String] {
-    store.viewModel?.availableTags ?? []
-  }
-
-  private func save() {
-    let input = UpdateItem(
-      title: title,
-      kind: kind,
-      composer: .some(emptyToNil(composer)),
-      key: .some(emptyToNil(key)),
-      modality: .some(modality),
-      tempo: .some(buildTempo()),
-      notes: .some(emptyToNil(notes)),
-      tags: tags,
-      priority: nil)
-    // Don't celebrate or dismiss until the core confirms: a validation reject
-    // or failed local write surfaces in viewModel.error, which we keep on screen.
-    formError = nil
-    store.send(.item(.update(id: item.id, input: input)))
-    if let error = store.viewModel?.error {
-      withAnimation { formError = error }
-      UINotificationFeedbackGenerator().notificationOccurred(.error)
-      UIAccessibility.post(notification: .announcement, argument: "Error: \(error)")
-    } else {
-      UINotificationFeedbackGenerator().notificationOccurred(.success)
-      dismiss()
-    }
-  }
-
-  private func emptyToNil(_ value: String) -> String? {
-    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
-  }
-
-  private func buildTempo() -> Tempo? {
-    let mark = emptyToNil(marking)
-    let beats = UInt16(bpm.trimmingCharacters(in: .whitespaces))
-    if mark == nil && beats == nil { return nil }
-    return Tempo(marking: mark, bpm: beats)
   }
 }
 

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -317,7 +317,7 @@ final class StoreEffectLoopTests: XCTestCase {
       "add should land: count=\(afterAdd.items.count) err=\(afterAdd.error ?? "nil")")
     let id = try XCTUnwrap(afterAdd.items.first?.id)
 
-    // Mirrors LibraryEditScreen.save(): every PATCH field set, type flipped.
+    // Mirrors ItemFormModel.updateInput(): every PATCH field set, type flipped.
     _ = try bridge.update(
       .item(
         .update(


### PR DESCRIPTION
From the iOS review (**H1** — flagged as the single largest maintenance liability). `LibraryAddScreen` and `LibraryEditScreen` were ~110 lines of near-verbatim duplication (body, the three field cards, `divider`, composer/tag suggestions, `emptyToNil`/`buildTempo`, and the error-reconcile flow), so every new field had to be added in two places in sync.

## Changes

- **`ItemFormModel`** (`@Observable`): the nine field values + `formError`, the `emptyToNil`/`buildTempo` helpers, and `createInput()` / `updateInput()` builders.
- **`ItemFormScaffold`**: the shared sheet body (field cards + Cancel/confirm toolbar) and the "don't celebrate until the core confirms" reconcile, parameterised by a `send` closure (add vs update).
- **Add/Edit screens** become thin wrappers (~30 lines each) differing only in seed, title, button label, and the dispatched event.

Net: the two screens drop ~220 lines; the logic lives once.

## Pure refactor — no behaviour change

All six Add/Edit snapshots (`testLibraryAddScreen` / `…Exercise` / `…WithError`, and the Edit trio) pass **unchanged**, proving the view tree is identical. Done now, before Practice/Track clone the Library screens — the captured principle *"consolidate before you template."*

## Testing
Full `IntradaTests` suite green on the pinned sim; snapshots unchanged.
**Coverage:** Swift/`ios` is Codecov-ignored; behaviour is unchanged and snapshot-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)