### PR TITLE
Native iOS: extract HairlineDivider + InlineSuggestionList primitives

### DIFF
--- a/ios/Intrada/DesignSystem/HairlineDivider.swift
+++ b/ios/Intrada/DesignSystem/HairlineDivider.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+struct HairlineDivider: View {
+  var body: some View {
+    Rectangle().fill(IntradaColor.hairline).frame(height: 1)
+  }
+}

--- a/ios/Intrada/Views/Components/AutocompleteField.swift
+++ b/ios/Intrada/Views/Components/AutocompleteField.swift
@@ -65,37 +65,14 @@ struct AutocompleteField: View {
   }
 
   private var suggestionList: some View {
-    VStack(spacing: 0) {
-      Rectangle().fill(IntradaColor.hairline).frame(height: 1)
-      ForEach(matches, id: \.self) { suggestion in
-        Button {
-          text = suggestion
-          focused = false
-          UISelectionFeedbackGenerator().selectionChanged()
-        } label: {
-          HStack(spacing: 10) {
-            Image(systemName: "arrow.up.left")
-              .font(IntradaFont.meta)
-              .foregroundStyle(IntradaColor.inkFaint)
-            Text(suggestion)
-              .font(IntradaFont.body)
-              .foregroundStyle(IntradaColor.ink)
-            Spacer(minLength: 0)
-          }
-          .padding(.vertical, 10)
-          .padding(.horizontal, 16)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityHint("Fills \(label) with \(suggestion)")
-
-        if suggestion != matches.last {
-          Rectangle().fill(IntradaColor.hairline).frame(height: 1).padding(.leading, 16)
-        }
-      }
-    }
-    .background(IntradaColor.surfaceSunken.opacity(0.6))
+    InlineSuggestionList(
+      matches: matches,
+      systemImage: "arrow.up.left",
+      accessibilityHint: { "Fills \(label) with \($0)" },
+      onPick: {
+        text = $0
+        focused = false
+      })
   }
 }
 

--- a/ios/Intrada/Views/Components/InlineSuggestionList.swift
+++ b/ios/Intrada/Views/Components/InlineSuggestionList.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// The inline reveal list shared by `AutocompleteField` and `TagChipInput`:
+/// a hairline-topped column of tappable suggestions over a sunken fill. The
+/// owner supplies the matches, leading glyph, pick action, and a11y hint.
+struct InlineSuggestionList: View {
+  let matches: [String]
+  let systemImage: String
+  let accessibilityHint: (String) -> String
+  let onPick: (String) -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      HairlineDivider()
+      ForEach(matches, id: \.self) { suggestion in
+        Button {
+          onPick(suggestion)
+          UISelectionFeedbackGenerator().selectionChanged()
+        } label: {
+          HStack(spacing: 10) {
+            Image(systemName: systemImage)
+              .font(IntradaFont.meta)
+              .foregroundStyle(IntradaColor.inkFaint)
+            Text(suggestion)
+              .font(IntradaFont.body)
+              .foregroundStyle(IntradaColor.ink)
+            Spacer(minLength: 0)
+          }
+          .padding(.vertical, 10)
+          .padding(.horizontal, 16)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(accessibilityHint(suggestion))
+
+        if suggestion != matches.last {
+          HairlineDivider().padding(.leading, 16)
+        }
+      }
+    }
+    .background(IntradaColor.surfaceSunken.opacity(0.6))
+  }
+}

--- a/ios/Intrada/Views/Components/TagChipInput.swift
+++ b/ios/Intrada/Views/Components/TagChipInput.swift
@@ -87,36 +87,11 @@ struct TagChipInput: View {
   }
 
   private var suggestionList: some View {
-    VStack(spacing: 0) {
-      Rectangle().fill(IntradaColor.hairline).frame(height: 1)
-      ForEach(matches, id: \.self) { suggestion in
-        Button {
-          add(suggestion)
-          UISelectionFeedbackGenerator().selectionChanged()
-        } label: {
-          HStack(spacing: 10) {
-            Image(systemName: "plus")
-              .font(IntradaFont.meta)
-              .foregroundStyle(IntradaColor.inkFaint)
-            Text(suggestion)
-              .font(IntradaFont.body)
-              .foregroundStyle(IntradaColor.ink)
-            Spacer(minLength: 0)
-          }
-          .padding(.vertical, 10)
-          .padding(.horizontal, 16)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityHint("Adds the tag \(suggestion)")
-
-        if suggestion != matches.last {
-          Rectangle().fill(IntradaColor.hairline).frame(height: 1).padding(.leading, 16)
-        }
-      }
-    }
-    .background(IntradaColor.surfaceSunken.opacity(0.6))
+    InlineSuggestionList(
+      matches: matches,
+      systemImage: "plus",
+      accessibilityHint: { "Adds the tag \($0)" },
+      onPick: { add($0) })
   }
 }
 

--- a/ios/Intrada/Views/Components/TagFilterSheet.swift
+++ b/ios/Intrada/Views/Components/TagFilterSheet.swift
@@ -47,7 +47,7 @@ struct TagFilterSheet: View {
                 .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
 
                 if tag != available.last {
-                  Rectangle().fill(IntradaColor.hairline).frame(height: 1).padding(.leading, 16)
+                  HairlineDivider().padding(.leading, 16)
                 }
               }
             }

--- a/ios/Intrada/Views/Screens/ItemFormScaffold.swift
+++ b/ios/Intrada/Views/Screens/ItemFormScaffold.swift
@@ -33,17 +33,17 @@ struct ItemFormScaffold: View {
 
               VStack(spacing: 0) {
                 FormField(label: "Title", text: $form.title, placeholder: "Required")
-                divider
+                HairlineDivider()
                 AutocompleteField(
                   label: "Composer", text: $form.composer, suggestions: composerSuggestions)
-                divider
+                HairlineDivider()
                 KeyPicker(label: "Key", key: $form.key, modality: $form.modality)
               }
               .cardSurface()
 
               VStack(spacing: 0) {
                 FormField(label: "Tempo marking", text: $form.marking, placeholder: "e.g. Allegro")
-                divider
+                HairlineDivider()
                 FormField(label: "Beats per minute", text: $form.bpm, keyboard: .numberPad)
               }
               .cardSurface()
@@ -72,10 +72,6 @@ struct ItemFormScaffold: View {
         }
       }
     }
-  }
-
-  private var divider: some View {
-    Rectangle().fill(IntradaColor.hairline).frame(height: 1)
   }
 
   // Don't celebrate or dismiss until the core confirms: a validation reject or

--- a/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
@@ -20,7 +20,7 @@ struct LibraryDetailScreen: View {
             VStack(spacing: 0) {
               ForEach(Array(detailRows.enumerated()), id: \.offset) { index, row in
                 if index > 0 {
-                  Rectangle().fill(IntradaColor.hairline).frame(height: 1)
+                  HairlineDivider()
                 }
                 DetailRow(label: row.label, value: row.value)
               }


### PR DESCRIPTION
From the iOS review (F2/F3, DesignSystem consolidation). Two UI primitives that were hand-inlined across many sites:

- **`HairlineDivider`** — the `Rectangle().fill(IntradaColor.hairline).frame(height: 1)` row separator. Now one primitive used at all 6 call sites (`ItemFormScaffold` ×3, `LibraryDetailScreen`, `TagFilterSheet`, and inside the suggestion list).
- **`InlineSuggestionList`** — the inline reveal list that `AutocompleteField` and `TagChipInput` had **verbatim-duplicated**; they differed only in leading glyph (`arrow.up.left` vs `plus`), pick action, and a11y hint, which are now parameters.

## Pure refactor — no behaviour change
All snapshots pass **unchanged** (incl. `LibraryDetailScreen` which renders a divider, and the Add/Edit screens). Rendering is identical.

## Testing
Full `IntradaTests` suite green on the pinned sim; snapshots unchanged. (Self-review posted as a comment.)

**Not auto-merged — left open for your review.** Completes F2/F3; F4 (unify the 3–4 `TagChip` styles, incl. the detail-screen drift fix) is a separate PR since it changes rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)