### PR TITLE
Native iOS: unify tag chips into one TagChip primitive

### DIFF
--- a/ios/Intrada/DesignSystem/TagChip.swift
+++ b/ios/Intrada/DesignSystem/TagChip.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// A tag chip. `.sunken` (recessed fill) is for chips inside a card; `.outlined`
+/// (card fill + hairline) is for chips on bare paper, where they need their own
+/// definition. Pass `onRemove` for an editable chip with a ✕.
+struct TagChip: View {
+  enum Style { case sunken, outlined }
+
+  let text: String
+  var style: Style = .sunken
+  var onRemove: (() -> Void)?
+
+  init(_ text: String, style: Style = .sunken, onRemove: (() -> Void)? = nil) {
+    self.text = text
+    self.style = style
+    self.onRemove = onRemove
+  }
+
+  var body: some View {
+    if let onRemove {
+      chip
+        .contentShape(Capsule())
+        .onTapGesture(perform: onRemove)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+        // `.isButton` so VoiceOver advertises the tap as activatable — a bare
+        // onTapGesture isn't surfaced reliably (matches the KeyPicker convention).
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Double tap to remove")
+    } else {
+      chip
+    }
+  }
+
+  private var chip: some View {
+    let removable = onRemove != nil
+    return HStack(spacing: 5) {
+      Text(text)
+        .font(IntradaFont.metaMedium)
+        .foregroundStyle(IntradaColor.inkSecondary)
+        .lineLimit(1)
+      if removable {
+        Image(systemName: "xmark")
+          .font(.system(size: 9, weight: .semibold))
+          .foregroundStyle(IntradaColor.inkFaint)
+      }
+    }
+    .padding(.vertical, style == .outlined ? 5 : (removable ? 4 : 3))
+    .padding(.horizontal, style == .outlined ? 10 : (removable ? 9 : 8))
+    .background(
+      style == .sunken ? IntradaColor.surfaceSunken : IntradaColor.cardFill, in: Capsule()
+    )
+    .overlay {
+      if style == .outlined {
+        Capsule().stroke(IntradaColor.hairline, lineWidth: 1)
+      }
+    }
+  }
+}

--- a/ios/Intrada/Views/Components/TagChipInput.swift
+++ b/ios/Intrada/Views/Components/TagChipInput.swift
@@ -42,7 +42,7 @@ struct TagChipInput: View {
         if !tags.isEmpty {
           FlowLayout(spacing: 6) {
             ForEach(tags, id: \.self) { tag in
-              RemovableChip(text: tag) { remove(tag) }
+              TagChip(tag, onRemove: { remove(tag) })
             }
           }
         }
@@ -92,33 +92,6 @@ struct TagChipInput: View {
       systemImage: "plus",
       accessibilityHint: { "Adds the tag \($0)" },
       onPick: { add($0) })
-  }
-}
-
-private struct RemovableChip: View {
-  let text: String
-  let onRemove: () -> Void
-
-  var body: some View {
-    HStack(spacing: 5) {
-      Text(text)
-        .font(IntradaFont.metaMedium)
-        .foregroundStyle(IntradaColor.inkSecondary)
-      Image(systemName: "xmark")
-        .font(.system(size: 9, weight: .semibold))
-        .foregroundStyle(IntradaColor.inkFaint)
-    }
-    .padding(.vertical, 4)
-    .padding(.horizontal, 9)
-    .background(IntradaColor.surfaceSunken, in: Capsule())
-    .contentShape(Capsule())
-    .onTapGesture(perform: onRemove)
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(text)
-    // `.isButton` so VoiceOver advertises the tap as activatable (matches the
-    // KeyPicker convention); a bare onTapGesture isn't surfaced reliably.
-    .accessibilityAddTraits(.isButton)
-    .accessibilityHint("Double tap to remove")
   }
 }
 

--- a/ios/Intrada/Views/Components/TagPills.swift
+++ b/ios/Intrada/Views/Components/TagPills.swift
@@ -10,27 +10,13 @@ struct TagPills: View {
     let shown = Array(tags.prefix(limit))
     let overflow = tags.count - shown.count
     HStack(spacing: 6) {
-      ForEach(shown, id: \.self) { TagChip(text: $0) }
+      ForEach(shown, id: \.self) { TagChip($0) }
       if overflow > 0 {
-        TagChip(text: "+\(overflow)")
+        TagChip("+\(overflow)")
       }
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel("Tags: \(tags.joined(separator: ", "))")
-  }
-}
-
-private struct TagChip: View {
-  let text: String
-
-  var body: some View {
-    Text(text)
-      .font(IntradaFont.metaMedium)
-      .foregroundStyle(IntradaColor.inkSecondary)
-      .lineLimit(1)
-      .padding(.vertical, 3)
-      .padding(.horizontal, 8)
-      .background(IntradaColor.surfaceSunken, in: Capsule())
   }
 }
 

--- a/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
@@ -102,13 +102,7 @@ struct LibraryDetailScreen: View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: 8) {
         ForEach(item.tags, id: \.self) { tag in
-          Text(tag)
-            .font(IntradaFont.metaMedium)
-            .foregroundStyle(IntradaColor.inkSecondary)
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .background(IntradaColor.cardFill, in: Capsule())
-            .overlay(Capsule().stroke(IntradaColor.hairline, lineWidth: 1))
+          TagChip(tag, style: .outlined)
         }
       }
     }


### PR DESCRIPTION
From the iOS review (**F4**). Three hand-rolled chip views existed: `TagPills`' private `TagChip` (read-only list pills), `TagChipInput`'s `RemovableChip` (editable), and an inline outlined chip on `LibraryDetailScreen` (the "drift").

Collapsed into one **`TagChip(_:style:onRemove:)`** primitive:
- **`.sunken`** (recessed fill) for chips inside a card; **`.outlined`** (card fill + hairline) for chips on bare paper where they need their own definition. Per your call (keep both looks), the detail-screen difference is now an **intentional, named variant** rather than unflagged drift.
- **`onRemove`** adds the ✕ + tap + VoiceOver "double tap to remove".

## Pure refactor — both looks preserved exactly
All snapshots pass **unchanged** (detail = outlined, edit = sunken+✕, list pills = sunken). The primitive reproduces each original's exact metrics (the padding differences are derived from style/removable).

## Stacked PR
Based on `claude/ios-designsystem-primitives` (#893) since both touch `TagChipInput`/`LibraryDetailScreen`. GitHub will auto-retarget this to `main` when #893 merges. **Left open for your review — not merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)