### PR TITLE
CI/iOS: exact-pin SPM deps (deterministic snapshot renderer)

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -20,15 +20,19 @@ packages:
     path: generated/IntradaCoreFFI
   SharedTypes:
     path: generated/SharedTypes
+  # Exact-pinned (not `from:`) so SPM can't drift to a newer release on a
+  # cache-miss resolve — snapshot references are renderer-specific, and
+  # swift-snapshot-testing's version is part of that renderer. Bump deliberately
+  # (edit the version here + re-record snapshots if the renderer changed).
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa
-    from: "8.0.0"
+    exactVersion: "8.58.3"
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
-    from: "1.18.0"
+    exactVersion: "1.19.2"
   GRDB:
     url: https://github.com/groue/GRDB.swift
-    from: "7.0.0"
+    exactVersion: "7.11.0"
 
 targets:
   Intrada:


### PR DESCRIPTION
From the iOS review (C / checks & balances — the `Package.resolved` item).

## Problem
SPM deps used `from:` (minimum-version) ranges, so a **cache-miss resolve could pull a newer release**. swift-snapshot-testing's version is part of the snapshot **renderer**, so a silent bump breaks the committed PNG references with no lockfile to explain the drift. (It was already at 1.19.2, *above* the `from: 1.18.0` floor.)

## Why exact-pin in project.yml (not a committed Package.resolved)
`ios/Intrada.xcodeproj` is **gitignored and regenerated by xcodegen** every build, and `Package.resolved` lives inside it — so a committed lockfile would need fragile copy-into-place plumbing in both the justfile and CI. `project.yml` is committed and **is** xcodegen's input, so an exact pin there survives regeneration with zero plumbing and pins the renderer.

## Change
Pin the three direct deps to their currently-resolved exact versions:
- Sentry `8.0.0+` → **8.58.3**
- swift-snapshot-testing `1.18.0+` → **1.19.2** (the renderer-critical one)
- GRDB `7.0.0+` → **7.11.0**

Bumps are now deliberate (edit the version + re-record snapshots if the renderer moved).

## Verification
No behaviour change — resolves to the same versions already in use; `Package.resolved` confirms swift-snapshot-testing pinned at exactly 1.19.2; full `IntradaTests` suite green, all snapshots unchanged. (`project.yml` is YAML, so not subject to the comment-density gate.)

**Left open for your review — not merged.** Second C-leftover (Swift coverage) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)