### PR TITLE
codecov: document that the native-iOS Swift shell is untracked

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,12 @@ comment:
   require_head: true
 
 ignore:
+  # Native iOS Swift shell — intentionally not coverage-tracked. The coverage
+  # job is Rust-only (cargo-llvm-cov); the shell is a dumb pipe whose logic
+  # lives in the Crux core (covered above). Swift unit tests exist but aren't
+  # measured. Wiring xccov→Codecov is tracked in #896 (horizon:later).
+  - "ios/**"
+
   # Leptos web shell — UI code compiled to WASM, not covered by
   # cargo-llvm-cov (excluded from the coverage job entirely).
   - "crates/intrada-web/**"


### PR DESCRIPTION
From the iOS review (C / checks & balances — the Swift-coverage item, scoped to **document + defer** per your call).

The coverage job is Rust-only (`cargo llvm-cov`), so `ios/**` Swift never reaches Codecov and the 70% patch target silently ignores it. Rather than leave that gap unexplained, this adds an `ignore` entry + comment to `codecov.yml` noting the shell is a dumb pipe whose logic is covered by the Crux core (Rust job), Swift unit tests exist but aren't measured, and the full `xccov`→Codecov wiring is tracked in **#896** (`horizon:later`).

Config-only (YAML); no build/behaviour impact. **Left open for your review — not merged.**

This closes the **C-leftovers**: exact-pin SPM deps (#895) + this. Remaining review backlog: #881 (global error surface), #869 (core tag dedupe), #874 (flaky test — likely closeable by #886), #849/#888/#896 (horizon:later), G (TestFlight, parked for your dev account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)