### PR TITLE
core: dedupe tags case-insensitively on create/update (parity with AddTags)

### DIFF
--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -39,9 +39,14 @@ fn trimmed_nonempty(value: Option<String>) -> Option<String> {
 }
 
 fn normalize_tags(tags: Vec<String>) -> Vec<String> {
+    // Case-insensitive dedupe keeping first-seen casing, matching the AddTags
+    // handler's case-fold and the available_tags vocabulary — so create/update
+    // can't store "Jazz" + "jazz" as two tags.
+    let mut seen = std::collections::HashSet::new();
     tags.into_iter()
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
+        .filter(|t| seen.insert(t.to_lowercase()))
         .collect()
 }
 
@@ -393,6 +398,38 @@ mod tests {
         assert_eq!(out.notes, None, "whitespace-only notes collapses to None");
         assert_eq!(out.tempo, None, "blank marking + no bpm drops the tempo");
         assert_eq!(out.tags, vec!["warm-up".to_string(), "scales".to_string()]);
+    }
+
+    #[test]
+    fn normalize_dedupes_tags_case_insensitively_keeping_first_casing() {
+        let input = CreateItem {
+            title: "Etude".to_string(),
+            kind: ItemKind::Exercise,
+            composer: None,
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![
+                "Jazz".to_string(),
+                "jazz".to_string(),
+                "  JAZZ  ".to_string(),
+                "blues".to_string(),
+            ],
+        };
+        assert_eq!(
+            normalize_create_item(input).tags,
+            vec!["Jazz".to_string(), "blues".to_string()]
+        );
+
+        let update = UpdateItem {
+            tags: Some(vec!["Recital".to_string(), "recital".to_string()]),
+            ..Default::default()
+        };
+        assert_eq!(
+            normalize_update_item(update).tags,
+            Some(vec!["Recital".to_string()])
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #869.

## Problem
The `AddTags` handler and the `available_tags` vocabulary dedupe tags case-insensitively, but `normalize_tags` (used by create + update) only **trimmed and dropped blanks** — so creating or editing an item with `["Jazz", "jazz"]` stored both. Inconsistent across the tag-writing paths.

## Fix
Add the same case-insensitive dedupe (keeping first-seen casing) to `normalize_tags`, so every path — Add, Update, AddTags — agrees. Applies to **both iOS and web** (shared core; invariant 6).

Core-internal change — no FFI/type change, no bindings regen, no iOS surface touched.

## Testing
TDD: `normalize_dedupes_tags_case_insensitively_keeping_first_casing` (red→green) covers create *and* update. 386 core tests pass; `cargo fmt`/`clippy --all-targets` clean; workspace compiles.

**Self-review to follow as a comment. Left open for your review — not merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)