### PR TITLE
test(core): round-trip ItemEvent::Update across the FFI bincode wire (#777)

### DIFF
--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -324,6 +324,27 @@ mod tests {
     }
 
     #[test]
+    fn update_event_round_trips_on_ffi_bincode_wire() {
+        // Wraps the DTO in the event that actually crosses the bridge, so
+        // enum/struct framing is covered too (#777). See the bare-DTO test above.
+        use crate::domain::item::ItemEvent;
+        assert_round_trips(ItemEvent::Update {
+            id: "01HX0000000000000000000000".to_string(),
+            input: UpdateItem {
+                title: Some("Renamed".to_string()),
+                kind: Some(ItemKind::Exercise),
+                composer: Some(Some("Bach".to_string())),
+                key: Some(None),
+                modality: Some(Some(Modality::Minor)),
+                tempo: Some(None),
+                notes: Some(Some("phrasing".to_string())),
+                tags: Some(vec!["etude".to_string()]),
+                priority: Some(true),
+            },
+        });
+    }
+
+    #[test]
     fn create_item_round_trips_on_ffi_bincode_wire() {
         assert_round_trips(CreateItem {
             title: "Clair de Lune".to_string(),


### PR DESCRIPTION
## What

Phase A3 deferred test from #777 (refs #775). Adds an FFI bincode round-trip for `ItemEvent::Update` — the event that *actually* crosses the Swift↔Rust bridge — over crux's real `BincodeFfiFormat`.

The bare `UpdateItem` already had a round-trip guard (`update_item_round_trips_on_ffi_bincode_wire`). This wraps it in `ItemEvent::Update { id, input }` so a misalignment in the enum/struct framing is caught too, not just the inner DTO.

## On the "absent field" case

The issue asked to also cover an *absent* (outer-`None`) double-option field. Verifying rather than assuming: the facet-generated Swift serializer writes **every** field positionally (it has no notion of serde's `skip_serializing_if`), so an outer-`None` never crosses the bincode wire — the three-state skip/clear/set distinction is the **JSON-API path only**. The faithful wire shape is all-fields-present, which the test models. (A naive Rust→Rust round-trip of an outer-`None` field *does* misalign, because Rust's serialize honors `skip_serializing_if` — but that asymmetry is a test-harness artifact, not a path the real bridge takes, since Rust never serializes events onto the FFI wire.)

## Testing

Test-only change. Confirmed the guard is meaningful by temporarily forcing `double_option` to its `is_human_readable()` (JSON) branch — the exact #846 regression — and watching the new test fail; reverted, all green. `cargo test -p intrada-core` → 391 passed. fmt + clippy clean.

Coverage: full — this PR *is* test coverage for the bridge-crossing `ItemEvent::Update`.

Closes #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
