### PR TITLE
Native iOS: "Intrada (Seeded)" Xcode scheme for demo data on Cmd+R

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,15 +98,17 @@ before kicking off a fresh test run — check for another live session
 `pgrep -x Xcode`). If anything you didn't start is active, **pause and ask the
 user** rather than risk killing their running sim/tests.
 
-**Demo data vs. real on-device data.** A plain launch (`just ios` → Cmd+R, or
-any build with no launch args) runs **local-first**: the Library hydrates from
-the on-device GRDB store, so items you add survive restarts. The 6 sample
-pieces are **opt-in** via the `--seed-sample-data` launch arg — in Xcode:
-Edit Scheme → Run → Arguments → Arguments Passed On Launch. `just ios-run`
-passes it by default (`SEED=1`); use `SEED=0 just ios-run` to launch against
-your real data. Seed mode (`Event::LoadSampleData`) replaces the model with
-demo items and **skips store hydration**, so don't use it when testing
-persistence — your saved rows are still on disk but won't be read back.
+**Demo data vs. real on-device data.** A plain launch (`just ios` → Cmd+R on the
+default **Intrada** scheme, or any build with no launch args) runs
+**local-first**: the Library hydrates from the on-device GRDB store, so items
+you add survive restarts. The 6 sample pieces are **opt-in** via the
+`--seed-sample-data` launch arg. In Xcode, pick the **Intrada (Seeded)** scheme
+from the scheme dropdown (defined in `ios/project.yml`) and Cmd+R — the
+selection persists across `just ios` regenerations. `just ios-run` passes the
+same arg by default (`SEED=1`); use `SEED=0 just ios-run` to launch against your
+real data. Seed mode (`Event::LoadSampleData`) replaces the model with demo
+items and **skips store hydration**, so don't use it when testing persistence —
+your saved rows are still on disk but won't be read back.
 
 Run `cargo fmt --check` and `cargo clippy -- -D warnings` *locally before pushing* —
 not just before committing. Pushing then watching CI fail wastes a full ~3-minute

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -90,3 +90,18 @@ targets:
         product: SharedTypes
       - package: IntradaCoreFFI
         product: IntradaCoreFFI
+
+# Extra scheme for Cmd+R against the demo dataset (the 6 sample pieces +
+# practice history). Pick "Intrada (Seeded)" from Xcode's scheme dropdown to
+# develop against populated content before add/edit exists; the default
+# "Intrada" scheme runs local-first against real on-device data. The arg is the
+# same one `just ios-run`'s SEED passes on the headless path. Selection persists
+# across `just ios` regenerations (it lives in xcuserdata, untouched by xcodegen).
+schemes:
+  Intrada (Seeded):
+    build:
+      targets:
+        Intrada: all
+    run:
+      commandLineArguments:
+        "--seed-sample-data": true


### PR DESCRIPTION
## What

Adds a dedicated **`Intrada (Seeded)`** Xcode scheme (in `ios/project.yml`) that bakes the `--seed-sample-data` launch arg into its Run action. Pick it from Xcode's scheme dropdown to Cmd+R against the demo dataset (6 sample pieces + practice history); the default **`Intrada`** scheme stays clean and runs local-first against real on-device data.

## Why

The sample data was only reachable via `just ios-run` (`SEED=1`, headless) or a manual *Edit Scheme → Arguments* hand-edit — so `just ios` + Cmd+R always launched against real data, with no easy way to develop against populated content before add/edit exists.

xcodegen doesn't expand `${...}` env vars inside `commandLineArguments`, so a single env-gated scheme silently drops the arg. Two schemes is the clean path. The scheme choice lives in `xcuserdata`, so it persists across `just ios` regenerations.

## Notes

- Seed mode (`Event::LoadSampleData`) is in-memory and skips store hydration — real on-device rows are untouched, and seeded items aren't persisted. Intended for developing against demo content, not testing persistence.
- Also updates the "Demo data vs. real on-device data" note in `CLAUDE.md` to point at the scheme instead of the old hand-edit.

## Tier / review

Tier 1 (dev-tooling config + doc). No Rust touched — `cargo fmt`/`clippy`/`test` are no-ops for this diff. Verified both schemes generate via `xcodegen generate` (seed arg present + `isEnabled = YES` only on the seeded scheme). No domain/persistence/FFI/auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)