### PR TITLE
Native iOS: full Sentry APM — tracing + profiling

### DIFF
--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -34,9 +34,18 @@ struct IntradaApp: App {
         options.dsn = dsn
         #if DEBUG
           options.environment = "development"
+          options.tracesSampleRate = 1.0
         #else
           options.environment = "production"
+          options.tracesSampleRate = 0.2
         #endif
+        options.enablePerformanceV2 = true
+        options.enableAppHangTrackingV2 = true
+        // `sessionSampleRate` is relative to `tracesSampleRate` — prod profiling rides the 0.2 trace rate.
+        options.configureProfiling = {
+          $0.lifecycle = .trace
+          $0.sessionSampleRate = 1.0
+        }
       }
     }
   }

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -1,3 +1,4 @@
+import SentrySwiftUI
 import SharedTypes
 import SwiftUI
 
@@ -14,14 +15,14 @@ struct RootView: View {
   var body: some View {
     TabView {
       NavigationStack {
-        LibraryScreen()
+        SentryTracedView("Library") { LibraryScreen() }
       }
       .tabItem { Label("Library", systemImage: "books.vertical") }
-      PracticeScreen()
+      SentryTracedView("Practice") { PracticeScreen() }
         .tabItem { Label("Practice", systemImage: "metronome.fill") }
-      RoutinesScreen()
+      SentryTracedView("Routines") { RoutinesScreen() }
         .tabItem { Label("Routines", systemImage: "music.note.list") }
-      AnalyticsScreen()
+      SentryTracedView("Progress") { AnalyticsScreen() }
         .tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
     }
     .tint(IntradaColor.accent)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -58,6 +58,8 @@ targets:
         product: SharedTypes
       - package: Sentry
         product: Sentry
+      - package: Sentry
+        product: SentrySwiftUI
       - package: GRDB
         product: GRDB
     scheme:


### PR DESCRIPTION
## What

Expands the native-iOS Sentry integration from crash/error reporting to **full APM** (tracing + profiling). Answers a "is Sentry set up for local dev?" check that turned into "can we add full APM?".

### Changes
- **`IntradaApp.swift`** — `SentrySDK.start` now sets:
  - `tracesSampleRate` — **1.0 in DEBUG, 0.2 in release** (full signal locally, controlled prod volume)
  - `configureProfiling` with **trace lifecycle** — profiles every sampled trace; prod profiling rides the 0.2 trace rate (sessionSampleRate is relative)
  - `enablePerformanceV2` (app-start finishes at first frame) and `enableAppHangTrackingV2` (fully/non-fully-blocking + fatal hangs, App Hang Rate)
- **`RootView.swift`** — wrap each of the 4 pillar screens in `SentryTracedView`. Load-bearing: auto UIViewController tracing is a **no-op in pure SwiftUI**, so without this there'd be no per-screen transactions and no app-start data.
- **`project.yml`** — add the `SentrySwiftUI` product (same already-pinned Sentry 8.58.3 package, no new version).

All gated behind the existing `https://` DSN check, so CI / no-DSN dev remains a no-op.

## Why

`report(_:)` already routed swallowed errors to Sentry, but there was no performance/tracing/profiling. This adds it for local dev (simulator + device) and production. APIs verified against the sentry-cocoa 8.58.3 docs.

## What you'll see in Sentry
Per-screen transactions (`Library`/`Practice`/`Routines`/`Progress`, op `ui.load`), app-start spans, slow/frozen frames, network + file I/O spans, profiles (flame charts), and app-hang events with durations. Local dev tags `environment=development`.

## Testing
- `cargo fmt --check` ✓
- `just ios-test` (build + full `IntradaTests`: snapshots + unit + UI) ✓ — green. (One run hit a pre-existing flaky UI test, `LibrarySearchUITests.testSearchButtonRevealsFiltersAndCancels`, which passes on retry; the documented animated-reveal/`typeText` timing flake, unrelated to this change.)
- `SentryTracedView` adds no layout, so snapshot references are unaffected.

## Coverage
N/A — the native-iOS Swift shell is untracked by Codecov (see #897). No Rust changed.

## Follow-ups (tracked)
- #912 — wire per-screen Time-to-Full-Display (TTFD) spans (deliberately deferred; needs `reportFullyDisplayed()` wiring or it emits noisy `DeadlineExceeded` spans)
- #913 — attach `report()` context as a Sentry tag for issue grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
