### PR TITLE
tooling(ios): per-worktree snapshot sim so parallel worktrees don't block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,15 @@ before kicking off a fresh test run — check for another live session
 `pgrep -x Xcode`). If anything you didn't start is active, **pause and ask the
 user** rather than risk killing their running sim/tests.
 
+`just ios-test` already follows this rule: it names its sim per worktree
+(`intrada-test-26-5-<worktree-basename>`), so parallel worktrees run snapshot
+tests on **distinct** devices instead of serializing on one shared device. The
+device model is irrelevant to snapshot output (swift-snapshot-testing pins
+`.iPhone13`; only the iOS 26.5 runtime affects the pixels). `just
+ios-test-sim-clean` deletes only the current worktree's sim. Removing blocking
+isn't free of resource limits — N booted sims + N Swift builds is heavy, so the
+practical ceiling is how many parallel agents the host can take, not the sim.
+
 **Demo data vs. real on-device data.** A plain launch (`just ios` → Cmd+R on the
 default **Intrada** scheme, or any build with no launch args) runs
 **local-first**: the Library hydrates from the on-device GRDB store, so items

--- a/docs/ios-testing.md
+++ b/docs/ios-testing.md
@@ -47,6 +47,8 @@ SEED=0 just ios-run # …against your real on-device data, not the demo seed
 just ios-gen        # force-regenerate the Swift bindings (after a core change)
 just ios-snapshots-optimize   # oxipng -o max every reference (run before commit)
 just ios-snapshots-check      # orphan + 200 KB-ceiling guard (same as CI)
+just ios-test                 # full IntradaTests suite on a per-worktree sim (CI parity)
+just ios-test-sim-clean       # delete this worktree's ios-test sim
 ```
 
 ## Snapshot tests (the per-PR UI regression gate)
@@ -100,7 +102,8 @@ gesture (e.g. pull-to-reveal) never fired.
 - **Stale bindings after pulling/rebasing** onto a main with core changes →
   `extra argument` / `cannot find type` Swift errors. Run `just ios-gen`
   (see CLAUDE.md → Native iOS Shell, and the memory note on rebase+regen).
-- **Clean up** the throwaway sims you create: `xcrun simctl delete <udid>`.
+- **Clean up** the throwaway sims you create: `xcrun simctl delete <udid>`
+  (or `just ios-test-sim-clean` for the sim `just ios-test` made in this worktree).
 
 ## Running alongside another checkout (worktrees)
 
@@ -118,15 +121,28 @@ checkout is using**.
 
 Rules to keep two checkouts from colliding:
 
-- **Don't run two iOS test/sim sessions at once** — serialize them. It's the sim
-  contention (not disk/CPU) that produces the pty errors above.
-- **Use a worktree-scoped sim**, created once and targeted by UDID, instead of a
-  bare `"iPhone 16"` both checkouts might grab:
+- **`just ios-test` is safe to run in parallel across worktrees.** It names its
+  sim per worktree (`intrada-test-26-5-<worktree-basename>`), so each checkout
+  with a distinct basename gets its own device — no serialization. (Two
+  worktree dirs that sanitise to the same name — e.g. `foo.1` and `foo-1` —
+  would share a sim; slug-like worktree names avoid this.) The device model is irrelevant to
+  snapshot output (swift-snapshot-testing pins `.iPhone13`; only the iOS 26.5
+  runtime affects the pixels), so per-worktree devices change nothing about
+  pass/fail. `just ios-test-sim-clean` deletes only the current worktree's sim.
+  This removes *blocking*, not resource load — N booted sims + N Swift builds is
+  heavy, so the practical ceiling is how many parallel agents the host can take.
+- **Ad-hoc `xcodebuild` / `simctl` sessions that share one device still
+  serialize.** If you run the raw `xcodebuild test` snippets above (not via
+  `just ios-test`), give each session a **worktree-scoped sim** targeted by
+  UDID, instead of a bare `"iPhone 16"` both checkouts might grab:
   ```bash
   UDID=$(xcrun simctl create "snap-$(basename "$PWD")" "iPhone 16" "iOS26.5")
   ```
-- **Only touch sims you created.** Delete *your* UDID when done; never
-  `shutdown all` / `delete unavailable` / restart `CoreSimulatorService` blind.
+  Two sessions pointed at the *same* device produce the pty contention errors
+  above; distinct devices run concurrently.
+- **Only touch sims you created.** Delete *your* UDID (or `just
+  ios-test-sim-clean` for the recipe's sim) when done; never `shutdown all` /
+  `delete unavailable` / restart `CoreSimulatorService` blind.
 - **Check before any global op or a fresh test run** whether another session is
   live:
   ```bash

--- a/justfile
+++ b/justfile
@@ -385,13 +385,44 @@ ios-test: _ios-sync
     set -euo pipefail
     cd ios
     xcodegen generate
-    name="intrada-test-26-5"
-    udid=$(xcrun simctl list devices --json | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; print(next((x['udid'] for v in d.values() for x in v if x['name']=='$name'), ''))")
+    name="$(just _ios-test-sim-name)"
+    udid="$(just _ios-test-sim-udid)"
     [ -n "$udid" ] || udid=$(xcrun simctl create "$name" "iPhone 16" "iOS26.5")
     xcodebuild test -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
         -destination "id=$udid" -derivedDataPath build/dd \
         -clonedSourcePackagesDirPath build/spm -quiet \
         COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
+
+# Per-worktree sim name (basename of the checkout, sanitised to simctl-safe
+# chars) so parallel worktrees don't share one device. The device model is
+# irrelevant to snapshot output — swift-snapshot-testing pins `.iPhone13`; only
+# the iOS 26.5 runtime affects the pixels — so any distinct device is safe.
+[private]
+_ios-test-sim-name:
+    @printf 'intrada-test-26-5-%s\n' "$(basename "$(git rev-parse --show-toplevel)" | tr -c 'A-Za-z0-9_-' '-' | sed 's/-*$//')"
+
+# UDID of THIS worktree's snapshot sim, or empty if it doesn't exist yet.
+[private]
+_ios-test-sim-udid:
+    @xcrun simctl list devices --json | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; print(next((x['udid'] for v in d.values() for x in v if x['name']=='$(just _ios-test-sim-name)'), ''))"
+
+# Delete THIS worktree's snapshot sim (created by `ios-test`). Only ever removes
+# the device named for the current worktree — never another worktree's or the
+# main checkout's, and never a global reset (see the shared-simulator rule).
+[group('iOS')]
+ios-test-sim-clean:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    name="$(just _ios-test-sim-name)"
+    udid="$(just _ios-test-sim-udid)"
+    if [ -n "$udid" ]; then
+        # `simctl delete` refuses a booted device, and `ios-test` leaves its sim
+        # booted — shut it down first (ignore "already shutdown").
+        xcrun simctl shutdown "$udid" 2>/dev/null || true
+        xcrun simctl delete "$udid" && echo "✓ deleted $name ($udid)"
+    else
+        echo "✓ no sim named $name — nothing to clean"
+    fi
 
 # Facet typegen → ios/generated/SharedTypes (Event/Effect/ViewModel + bincode).
 [group('iOS')]


### PR DESCRIPTION
## Problem

Running parallel work across git worktrees, `just ios-test` was a bottleneck: it hardcoded a single shared simulator name (`intrada-test-26-5`), so concurrent worktrees all targeted the **same** device. A simulator hosts one `xcodebuild test` session at a time, so the runs serialized (and tripped the "device busy / Unable to lookup in current state" class).

The build side was already isolated per worktree (`build/dd`, `build/spm` are path-relative); only the device was shared.

## Change

Name the snapshot sim **per worktree** — `intrada-test-26-5-<worktree-basename>` — so each checkout creates/reuses its own iOS 26.5 device and runs concurrently. Safe because the device model is irrelevant to snapshot output: swift-snapshot-testing pins `.iPhone13`/`displayScale 2`, and only the **iOS 26.5 runtime** affects the rendered pixels. So per-worktree devices change nothing about pass/fail or recorded references.

- `_ios-test-sim-name` / `_ios-test-sim-udid` private helpers; `ios-test` uses them.
- New `just ios-test-sim-clean` — deletes **only** the current worktree's sim (shuts it down first, since `ios-test` leaves it booted and `simctl delete` refuses a booted device). Never touches another worktree's sim; no global reset.
- Docs: `docs/ios-testing.md` (the stale "Don't run two iOS test/sim sessions at once — serialize them" rule now scopes only to **ad-hoc** raw `xcodebuild`/`simctl` that share a device) + a CLAUDE.md note under the shared-simulator rule.

CI is untouched — it already creates its own throwaway `snap-26-5` sim per run.

## Behavior

- First `ios-test` per worktree: one-time create + boot. Subsequent runs reuse by name.
- N agents → N distinct booted sims, N independent test sessions, no serialization.
- Removes *blocking*, not resource load — N booted sims + N Swift builds is heavy, so the practical ceiling is how many parallel agents the host can take.
- One-time orphan cleanup once all worktrees adopt this: `xcrun simctl delete intrada-test-26-5`.

## Testing

Build-tooling + docs only — no Rust, no Swift, no files under `ios/`. `cargo fmt --check` passes; clippy/test/`just ios-test` are N/A (no code paths changed). Recipe logic verified: name resolves clean per worktree, `_ios-test-sim-udid` returns empty when no sim exists, `ios-test-sim-clean` no-ops gracefully. I did **not** run a full `just ios-test` end-to-end (multi-minute cold build while parallel sims were booted); the `xcodebuild test` invocation itself is byte-for-byte unchanged — only the targeted sim name differs.

**Coverage:** N/A — build tooling + docs, no testable code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)