### PR TITLE
Native iOS: `just ios-release` for on-device performance builds

### DIFF
--- a/justfile
+++ b/justfile
@@ -372,7 +372,7 @@ ios-gen: ios-typegen (ios-package "debug")
 ios-release: ios-typegen (ios-package "release")
     cd ios && xcodegen generate
     rm -f ios/generated/.gen-stamp
-    @echo "✓ release core ready — in Xcode: select your device, then Product → Profile (⌘I)"
+    @echo "✓ release core ready — in Xcode: select your device, then Product → Profile (⌘I). Next 'just ios' rebuilds the debug core."
 
 # Losslessly shrink snapshot references — drops Xcode's redundant all-opaque
 # alpha channel (keeps pixels + sRGB), ~75% smaller. Run after (re)recording

--- a/justfile
+++ b/justfile
@@ -356,10 +356,23 @@ ios-logs:
 
 # Force a full regenerate of both Swift packages + refresh the change-stamp.
 [group('iOS')]
-ios-gen: ios-typegen ios-package
+ios-gen: ios-typegen (ios-package "debug")
     @mkdir -p ios/generated
     @just _ios-src-hash > ios/generated/.gen-stamp
     @echo "✓ bindings regenerated"
+
+# Prep an on-device PERFORMANCE build: regenerate the Crux core optimized for
+# release, then in Xcode select your device and Profile (⌘I). `ios`/`ios-gen`
+# build the core in debug (cargo-swift's default) — 10–100× slower in hot paths,
+# so misleading for perf work; this rebuilds it with `--release`. ⌘I builds the
+# Swift app Release, signs with project.yml's team, and opens Instruments.
+# Clears the gen-stamp so the next plain `just ios` rebuilds the debug core
+# (never link a release core into a routine debug run).
+[group('iOS')]
+ios-release: ios-typegen (ios-package "release")
+    cd ios && xcodegen generate
+    rm -f ios/generated/.gen-stamp
+    @echo "✓ release core ready — in Xcode: select your device, then Product → Profile (⌘I)"
 
 # Losslessly shrink snapshot references — drops Xcode's redundant all-opaque
 # alpha channel (keeps pixels + sRGB), ~75% smaller. Run after (re)recording
@@ -434,11 +447,12 @@ ios-typegen:
 
 # cargo-swift → ios/generated/IntradaCoreFFI (CoreFFI + RustFramework.xcframework).
 [group('iOS')]
-ios-package:
+ios-package profile="debug":
     #!/usr/bin/env bash
     set -euo pipefail
     cd crates/intrada-ffi
-    cargo swift package --name IntradaCoreFFI --platforms ios --lib-type static --features uniffi --accept-all
+    if [ "{{profile}}" = "release" ]; then rel="--release"; else rel=""; fi
+    cargo swift package --name IntradaCoreFFI --platforms ios --lib-type static --features uniffi $rel --accept-all
     rm -rf ../../ios/generated/IntradaCoreFFI
     mkdir -p ../../ios/generated
     mv IntradaCoreFFI ../../ios/generated/IntradaCoreFFI


### PR DESCRIPTION
## What

Adds `just ios-release`: regenerates the Crux core optimized for **release**, regenerates the Xcode project, then hands off to Xcode for the on-device run/profile. Also parameterizes `ios-package` with a `profile` arg (default `debug`, behaviour unchanged).

## Why

`just ios`/`ios-gen` build the Rust core via cargo-swift's **default debug profile** (verified: `cargo swift package` defaults to debug, `-r/--release` is opt-in). Debug Rust is 10–100× slower in hot paths, so an on-device performance test is misleading even if the Swift app is built Release. Xcode can flip the Swift side (Release/Profile config) but **can't change how the core xcframework was compiled** — that's driven by our recipe. So the recipe does the one thing Xcode can't, and leaves signing + Instruments to Xcode (more reliable than a CLI device-signing path).

## Usage

```bash
just ios-release   # release core + project regen
```
Then in Xcode: select your device → **Product → Profile (⌘I)** → builds Swift Release, signs with the team in `project.yml`, opens Instruments. The recipe clears the gen-stamp so the next plain `just ios` rebuilds the debug core automatically.

## Notes

- Tier 1 (dev-tooling). No Rust/Swift source touched — `cargo fmt`/`clippy`/`test` are no-ops for this diff.
- Verified: justfile parses; `ios-release` injects `--release`, `ios-gen` does not (`just --dry-run`). The full release compile + on-device profiling weren't run here (no device attached) — recipe logic confirmed, first device run is the user's to exercise.
- Rebased on top of #915 (per-worktree sim); independent of #910 (seeded scheme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)