### PR TITLE
core(session): derive Default for BuildingSession and use it (#748)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -2776,11 +2776,8 @@ mod tests {
         let app = Intrada;
         let model = Model {
             session_status: SessionStatus::Building(BuildingSession {
-                entries: vec![],
                 session_intention: Some("Focus on dynamics".to_string()),
-                target_duration_mins: None,
-                source_set_id: None,
-                source_set_entry_snapshot: vec![],
+                ..Default::default()
             }),
             ..Model::test_default()
         };
@@ -3225,13 +3222,8 @@ mod tests {
     fn view_set_source_status_no_source() {
         let app = Intrada;
         let mut model = Model::test_default();
-        model.session_status = SessionStatus::Building(crate::domain::session::BuildingSession {
-            entries: vec![],
-            source_set_id: None,
-            source_set_entry_snapshot: vec![],
-            session_intention: None,
-            target_duration_mins: None,
-        });
+        model.session_status =
+            SessionStatus::Building(crate::domain::session::BuildingSession::default());
         let vm = app.view(&model);
         let building = vm.building_setlist.unwrap();
         assert_eq!(building.source_status, SetSourceStatus::NoSource);
@@ -3270,8 +3262,7 @@ mod tests {
             entries: vec![entry],
             source_set_id: Some("set-1".to_string()),
             source_set_entry_snapshot: vec!["item-a".to_string()],
-            session_intention: None,
-            target_duration_mins: None,
+            ..Default::default()
         });
         let vm = app.view(&model);
         let building = vm.building_setlist.unwrap();
@@ -3314,8 +3305,7 @@ mod tests {
             entries: vec![entry],
             source_set_id: Some("set-1".to_string()),
             source_set_entry_snapshot: vec!["item-a".to_string()],
-            session_intention: None,
-            target_duration_mins: None,
+            ..Default::default()
         });
         let vm = app.view(&model);
         let building = vm.building_setlist.unwrap();

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -98,7 +98,7 @@ pub struct PracticeSession {
 // ── Transient State Types ──────────────────────────────────────────────
 
 /// State during setlist assembly (Building phase).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BuildingSession {
     pub entries: Vec<SetlistEntry>,
     pub session_intention: Option<String>,
@@ -413,13 +413,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 model.last_error = Some("A practice is already in progress".to_string());
                 return crux_core::render::render();
             }
-            model.session_status = SessionStatus::Building(BuildingSession {
-                entries: vec![],
-                session_intention: None,
-                target_duration_mins: None,
-                source_set_id: None,
-                source_set_entry_snapshot: vec![],
-            });
+            model.session_status = SessionStatus::Building(BuildingSession::default());
             model.last_error = None;
             crux_core::render::render()
         }
@@ -442,11 +436,8 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 return crux_core::render::render();
             }
             model.session_status = SessionStatus::Building(BuildingSession {
-                entries: vec![],
-                session_intention: None,
                 target_duration_mins: Some(target_duration_mins),
-                source_set_id: None,
-                source_set_entry_snapshot: vec![],
+                ..Default::default()
             });
             model.last_error = None;
             crux_core::render::render()

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -346,10 +346,7 @@ mod tests {
             api_base_url: "http://localhost:3001".to_string(),
             session_status: SessionStatus::Building(BuildingSession {
                 entries,
-                session_intention: None,
-                target_duration_mins: None,
-                source_set_id: None,
-                source_set_entry_snapshot: vec![],
+                ..Default::default()
             }),
             ..Default::default()
         }


### PR DESCRIPTION
## What

`BuildingSession` had no `Default`, so every construction spelled out all five fields. `StartBuilding` listed five empty/None values; `StartBuildingWithTarget` repeated four just to set `target_duration_mins`; five more literals lived in tests (#748).

Derive `Default` and use it:
- `StartBuilding` → `BuildingSession::default()`
- `StartBuildingWithTarget` → `BuildingSession { target_duration_mins: Some(…), ..Default::default() }`
- Test sites → `::default()` / `{ <field>, ..Default::default() }`

Net −22 lines, and adding a future field no longer means editing every call site.

> The issue mentioned `EnterBuildingFromGoal` too, but that handler was removed with the goals feature — `StartBuilding` / `StartBuildingWithTarget` are the remaining production sites.

## Why it's safe

Behaviour-preserving: `Vec::default()` is `vec![]` and `Option::default()` is `None`, matching every explicit value. The `StartBuilding` / `StartBuildingWithTarget` handler tests (which assert `target_duration_mins` and the resulting state) still pass. `BuildingSession` is internal `Model` state — not a bridge-crossing / `facet_typegen` type — so deriving `Default` has no FFI/bincode-wire impact.

## Testing

`cargo test -p intrada-core` → 391 passed. fmt + clippy clean. No new tests: pure refactor, fully covered by the existing `StartBuilding*` handler tests.

Coverage: full — no new behaviour.

Closes #748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
