### PR TITLE
test(core): end-to-end failed-delete rollback at the core seam (#834)

### DIFF
--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -297,6 +297,51 @@ mod tests {
     }
 
     #[test]
+    fn local_first_failed_delete_rolls_back_via_store_reload() {
+        // End-to-end rollback (#834): an optimistic delete whose store write
+        // fails must never be a silent success (invariant #5) — it surfaces an
+        // error and reloads from the store, which still holds the row the
+        // failed write never removed.
+        use crate::domain::item::ItemEvent;
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.local_first = true;
+        model.items = vec![sample_item("p1")];
+
+        let mut cmd = app.update(
+            Event::Item(ItemEvent::Delete { id: "p1".into() }),
+            &mut model,
+        );
+        assert!(
+            model.items.is_empty(),
+            "delete optimistically removes the row"
+        );
+        assert!(has_delete(&mut cmd, "p1"));
+
+        let mut cmd = app.update(Event::StoreWritten(PersistenceOutput::Failed), &mut model);
+        assert!(
+            model.last_error.is_some(),
+            "a failed delete must surface an error, not vanish silently"
+        );
+        assert!(
+            cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+                if req.operation == PersistenceOperation::LoadItems)),
+            "a failed write reloads from the store to roll back"
+        );
+
+        let _ = app.update(
+            Event::StoreLoaded(PersistenceOutput::Items(vec![sample_item("p1")])),
+            &mut model,
+        );
+        assert_eq!(
+            model.items.len(),
+            1,
+            "the rolled-back delete restores the row"
+        );
+        assert_eq!(model.items[0].id, "p1");
+    }
+
+    #[test]
     fn online_add_uses_http_not_persistence() {
         use crate::domain::item::ItemEvent;
         let app = crate::app::Intrada;


### PR DESCRIPTION
## What

Adds an end-to-end **failed-delete rollback** test at the core seam (#834). The existing guard (`store_written_failed_surfaces_and_rehydrates`) only fed `StoreWritten(Failed)` to a blank model — it never exercised the full delete→fail→restore sequence.

The new test drives the whole local-first path:
1. `ItemEvent::Delete` optimistically removes the row + emits a delete persistence write.
2. `StoreWritten(Failed)` surfaces an error **and** reloads from the store (the rollback).
3. `StoreLoaded` returns the row the failed write never deleted → it's restored.

This locks **offline invariant #5** (a failed local write is never a silent success) end-to-end through the core.

## Scope

This covers the **core** seam. The issue also names the **Swift store-loop seam** (`StoreEffectLoopTests`) — that half needs the iOS test target / simulator, so #834 stays open to track it; this PR is the core-side coverage.

## Testing

Test-only. Verified the guard is meaningful by dropping the reload from the `StoreWritten(Failed)` handler and watching the test fail on the rollback assertion; reverted, green. `cargo test -p intrada-core` → 392 passed. fmt + clippy clean.

Coverage: this PR *is* coverage for the rollback path.

Refs #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
