### PR TITLE
Native iOS: APM follow-ups — report() Sentry tag + Library TTFD

### DIFF
--- a/ios/Intrada/Core/Logging.swift
+++ b/ios/Intrada/Core/Logging.swift
@@ -13,5 +13,9 @@ func report(_ error: Error, _ context: String? = nil) {
   } else {
     logger.error("\(String(describing: error), privacy: .public)")
   }
-  SentrySDK.capture(error: error)
+  SentrySDK.capture(error: error) { scope in
+    guard let context else { return }
+    scope.setTag(value: context, key: "report_context")
+    scope.setFingerprint(["{{ default }}", context])
+  }
 }

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -1,3 +1,4 @@
+import Sentry
 import SentrySwiftUI
 import SharedTypes
 import SwiftUI
@@ -15,7 +16,7 @@ struct RootView: View {
   var body: some View {
     TabView {
       NavigationStack {
-        SentryTracedView("Library") { LibraryScreen() }
+        SentryTracedView("Library", waitForFullDisplay: true) { LibraryScreen() }
       }
       .tabItem { Label("Library", systemImage: "books.vertical") }
       SentryTracedView("Practice") { PracticeScreen() }
@@ -49,6 +50,8 @@ struct RootView: View {
         store.send(.startApp(apiBaseUrl: apiBaseURL, localFirst: true))
         store.restorePersistedSort()
       }
+      // Closes Library's TTFD span — hydration is synchronous (else the span would hang to DeadlineExceeded).
+      SentrySDK.reportFullyDisplayed()
     }
   }
 


### PR DESCRIPTION
## What

Two tracked follow-ups to the merged Sentry APM PR (#914).

### #913 — `report()` Sentry context (closes #913)
`report(_:_:)` previously sent only the `Error` to Sentry, so the `context` string (`store-open` / `persistence` / `bridge`) was logged to the unified log only and lost in Sentry. Now it captures with a per-event scope that sets:
- a `report_context` **tag** → filterable/distinguishable in Sentry
- a **fingerprint** `["{{ default }}", context]` → groups *separately by site*

The fingerprint is the load-bearing bit: `store-open` and `persistence` both throw **GRDB** errors, so a tag alone wouldn't split their issue groups (same default fingerprint). `{{ default }}` preserves Sentry's stacktrace grouping while `context` splits same-typed sites. (`bridge` is bincode/FFI, already a distinct type.) No-context calls behave exactly as before.

### #912 — Library Time-to-Full-Display (advances #912)
Library's `SentryTracedView` opts into `waitForFullDisplay: true`, and `SentrySDK.reportFullyDisplayed()` fires at the end of `RootView`'s hydration `.task`.

This is safe because **local-first hydration is synchronous** — `Store.process()` handles the `loadItems` persistence effect *inline* within `store.send(.startApp)` (no `Task`/`await`), so by the time `.task` returns the Library is loaded and rendered. The TTFD span closes immediately; no 30s `DeadlineExceeded`. Only **Library** opts into TTFD — the other three pillars stay TTID-only (plain `SentryTracedView`), so none of them can hang on a missing report call.

## Scope / what's left on #912
Staged per the issue: this wires **Library only**. Replicating `waitForFullDisplay` + `reportFullyDisplayed()` to Practice/Routines/Progress, and **verifying in Sentry that the TTFD spans close with `OK` (not `DeadlineExceeded`)**, remains on #912 — that verification needs a live DSN + Sentry observation (handed off).

## Testing
- `cargo fmt --check` ✓
- `just ios-test` (build + full `IntradaTests`: snapshots + unit + UI) ✓ — green
- Self-review (`superpowers:code-reviewer`): **clean, no blockers**; traced the synchronous-hydration claim through the core and verified all Sentry APIs against the pinned 8.58.3 checkout.

## Coverage
N/A — the native-iOS Swift shell is untracked by Codecov (#897). No Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
