### PR TITLE
Native iOS: `just ios-release` opens Xcode after prepping the release core

### DIFF
--- a/justfile
+++ b/justfile
@@ -372,7 +372,8 @@ ios-gen: ios-typegen (ios-package "debug")
 ios-release: ios-typegen (ios-package "release")
     cd ios && xcodegen generate
     rm -f ios/generated/.gen-stamp
-    @echo "✓ release core ready — in Xcode: select your device, then Product → Profile (⌘I). Next 'just ios' rebuilds the debug core."
+    @echo "✓ release core ready — opening Xcode. Select your device, then Product → Profile (⌘I). Next 'just ios' rebuilds the debug core."
+    xed ios/Intrada.xcodeproj
 
 # Losslessly shrink snapshot references — drops Xcode's redundant all-opaque
 # alpha channel (keeps pixels + sRGB), ~75% smaller. Run after (re)recording


### PR DESCRIPTION
## What

Appends `xed ios/Intrada.xcodeproj` to the `ios-release` recipe so it opens Xcode after regenerating the release core — parity with `just ios`.

## Why

After #917, `just ios-release` regenerated the release core but left you to open Xcode by hand. Now it's one command: prep release core → open Xcode ready to **Product → Profile (⌘I)**.

Follow-up to #917 (which merged before this small ergonomic addition).

## Notes

Tier 1 dev-tooling. No Rust/Swift touched. `just --dry-run ios-release` confirms it parses; diff is a single added line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)