### PR TITLE
docs(spec): note Practice pillar Phase C progress

### DIFF
--- a/specs/native-ios.md
+++ b/specs/native-ios.md
@@ -188,6 +188,12 @@ sync-agnostic now; defer the engine; lean roll-our-own LWW when we build sync.**
   (Pencil + HIG, reconsidering vs. web) *starts* each pillar, then local-first
   data, then per-screen quality (snapshot + accessibility) and iPad `SplitView`
   built *with* the screen. A redesign on a stable core, not a port.
+  - **C-Practice (in progress):** the *session-history* surface shipped first —
+    Practice home with seeded demo sessions (#902), the duration summary, the
+    week calendar strip with day filtering (#905), and swipe paging between
+    weeks (#911); plus an `IntradaSpacing`/`IntradaRadius` token system (#922).
+    Next: the **setlist builder** (the `SessionStatus::Building` flow that makes
+    "Start practising" real), then the active player and post-session summary.
 - **Phase D (sync = the paid tier):** LWW sync to the Axum API (server-
   authoritative `updated_at`, tombstones, deterministic tiebreak — designed
   above); account/sign-in gates sync; StoreKit subscription + entitlement


### PR DESCRIPTION
Tier 1 doc-only change. Records native Practice-pillar progress in `specs/native-ios.md` Phase C — the session-history surface that shipped today (home #902, week strip #905, swipe paging #911, spacing tokens #922) and what's next (the setlist builder). `roadmap.md` stays vision-level by design, so the spec is the right place for build tracking.

No code change; no tests affected.