### PR TITLE
Native iOS: fix Sentry DSN never reaching Info.plist (SDK never started)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,9 +409,13 @@ in prod), `ALLOWED_ORIGIN` (default `http://localhost:8080`), `PORT` (default 30
 ### Native iOS (optional)
 `SENTRY_DSN_NATIVE` — put in `.env` to capture crash/error events from local dev
 builds (reports to the `intrada-mobile` Sentry project, tagged
-`environment=development`). `xcodegen` bakes it into the app's `Info.plist`; the
-justfile's `set dotenv-load` feeds it in. **Unset in CI**, so test/smoke runs send
-nothing. The app only starts Sentry on a real `https://` DSN, so an empty or
+`environment=development`). `xcodegen` writes it to the `SENTRY_DSN` build
+setting; the target's partial `Info.plist` (`ios/Intrada/Info.plist`) carries
+`SENTRY_DSN = $(SENTRY_DSN)` so the value lands in the built plist — a custom key
+**can't** ride `INFOPLIST_KEY_*`, which `GENERATE_INFOPLIST_FILE` only honours for
+Apple-recognised keys (that gap meant Sentry silently never started). The
+justfile's `set dotenv-load` feeds the var in. **Unset in CI**, so test/smoke runs
+send nothing. The app only starts Sentry on a real `https://` DSN, so an empty or
 unexpanded value is a safe no-op.
 
 ## Design System Rules

--- a/ios/Intrada/Info.plist
+++ b/ios/Intrada/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SENTRY_DSN</key>
+	<string>$(SENTRY_DSN)</string>
+</dict>
+</plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -47,10 +47,14 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.intrada.native
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
-        # DSN from the SENTRY_DSN_NATIVE env var (xcodegen expands ${...}; the
-        # justfile's `set dotenv-load` feeds it from .env). Unset in CI → empty →
-        # Sentry stays disabled there. Reports to the intrada-mobile project.
-        INFOPLIST_KEY_SENTRY_DSN: "${SENTRY_DSN_NATIVE}"
+        # Custom Info.plist keys (SENTRY_DSN) are dropped by GENERATE_INFOPLIST_FILE —
+        # it only injects Apple-recognised INFOPLIST_KEY_* — so they go through this
+        # partial plist, which the build system merges with the generated keys.
+        INFOPLIST_FILE: Intrada/Info.plist
+        # xcodegen expands ${...} from the env (justfile `set dotenv-load` feeds .env);
+        # the plist's $(SENTRY_DSN) resolves this at build. Unset → empty → the
+        # hasPrefix("https://") start gate keeps Sentry off (CI). intrada-mobile project.
+        SENTRY_DSN: "${SENTRY_DSN_NATIVE}"
     dependencies:
       - package: IntradaCoreFFI
         product: IntradaCoreFFI


### PR DESCRIPTION
## The bug

Sentry **never initialised on any native-iOS build** — crash reporting, errors, and the recently-added APM all silently did nothing. No event has ever reached the `intrada-mobile` project.

`IntradaApp.init()` gates `SentrySDK.start` on `Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN")`, and the DSN was wired through `INFOPLIST_KEY_SENTRY_DSN: "${SENTRY_DSN_NATIVE}"`. But Xcode's `GENERATE_INFOPLIST_FILE = YES` only injects **Apple-recognised** `INFOPLIST_KEY_*` settings into the built `Info.plist`. `SENTRY_DSN` is a **custom** key → silently dropped. So the key never existed at runtime, `hasPrefix("https://")` always failed, and the SDK was never started.

Confirmed empirically: the pbxproj had `INFOPLIST_KEY_SENTRY_DSN` with the real value, but the built `Info.plist` had no `SENTRY_DSN` key at all.

## The fix

Route the custom key through a **partial `Info.plist`** that the build merges with the generated keys:

- `ios/Intrada/Info.plist` (new): `SENTRY_DSN = $(SENTRY_DSN)` — a build-setting reference, **no secret committed**.
- `project.yml`: add `INFOPLIST_FILE: Intrada/Info.plist` + a `SENTRY_DSN: "${SENTRY_DSN_NATIVE}"` build setting; drop the broken `INFOPLIST_KEY_SENTRY_DSN`. Keep `GENERATE_INFOPLIST_FILE` + the launch-screen key.
- `CLAUDE.md`: correct the env-var doc to describe the real mechanism.

## Verification

- Rebuilt with the DSN exported → `SENTRY_DSN` **now present** in the built `Info.plist`, with `UILaunchScreen`, `CFBundleShortVersionString=0.1.0`, `CFBundleVersion=1`, `CFBundleIdentifier` all preserved (merge works; no duplicate-plist build error).
- Launched on the simulator with debug logging: the SDK **fully initialises** (DSN parsed, HTTP transport, all integrations installed) and **opens a TLS connection to the EU ingest endpoint** (`o…ingest.de.sentry.io`). Before the fix: zero Sentry network activity.
- Empty/CI: with `SENTRY_DSN_NATIVE` unset, `$(SENTRY_DSN)` resolves to an empty string → start gate stays off. `IntradaApp.swift` unchanged (its `https://` gate is the backstop).
- `just ios-test` (build + snapshots + unit + UI) green.
- Self-review (`superpowers:code-reviewer`): clean, no blockers; independently verified the no-duplicate-resource and empty-DSN-safety concerns.

## After merge
Rebuild on device with `just ios` (the DSN is baked at xcodegen-generate time). Events land under **Traces / Performance**, environment **development**.

## Coverage
N/A — native-iOS Swift shell untracked by Codecov (#897); no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
