### PR TITLE
fix(ios): bleed Library filter pills to the screen edge when scrolled

### DIFF
--- a/ios/Intrada/Views/Components/LibraryFilterTabs.swift
+++ b/ios/Intrada/Views/Components/LibraryFilterTabs.swift
@@ -35,6 +35,7 @@ enum LibraryFilter: CaseIterable, Identifiable {
 
 struct LibraryFilterTabs: View {
   @Binding var selection: LibraryFilter
+  var edgeInset: CGFloat = 0
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @Namespace private var pill
 
@@ -70,6 +71,8 @@ struct LibraryFilterTabs: View {
         }
       }
     }
+    .contentMargins(.leading, edgeInset, for: .scrollContent)
+    .padding(.leading, -edgeInset)
   }
 }
 

--- a/ios/Intrada/Views/Screens/LibraryScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryScreen.swift
@@ -36,7 +36,7 @@ struct LibraryScreen: View {
     ) {
       VStack(spacing: 0) {
         HStack(spacing: IntradaSpacing.controlGap) {
-          LibraryFilterTabs(selection: filterBinding)
+          LibraryFilterTabs(selection: filterBinding, edgeInset: IntradaSpacing.card)
             .frame(maxWidth: .infinity, alignment: .leading)
           LibrarySortMenu(
             current: store.viewModel?.activeSort


### PR DESCRIPTION
## What

On the Library screen, the horizontal filter pills (**All / Pieces / Exercises**) clipped 16pt from the screen edge when scrolled — a pill appeared "cut off" mid-air instead of sliding off the edge.

The pills live in a horizontal `ScrollView` nested inside an HStack inset by `IntradaSpacing.card` (16pt), so the viewport's leading edge inherited that inset.

## Fix

- Bleed the viewport to the screen's leading edge with `.padding(.leading, -edgeInset)`.
- Restore the resting inset with `.contentMargins(.leading, edgeInset, for: .scrollContent)`.

Net effect: **at-rest layout is pixel-identical** (snapshots unaffected — the standalone `LibraryFilterTabs` snapshot uses the default `edgeInset: 0`, making both modifiers no-ops there), but scrolled pills now slide cleanly off the screen edge.

`edgeInset` is passed from `LibraryScreen` as `IntradaSpacing.card` (no raw literal); defaults to `0` for the "no bleed" case.

## Testing

- `cargo fmt --check` ✓ · `cargo clippy --workspace -- -D warnings` ✓ (no Rust changed)
- `just ios-test` ✓ — full `IntradaTests` suite passes on the pinned iPhone 16 / iOS 26.5 sim; no snapshot regressions.
- Self-review via `superpowers:code-reviewer`: Ship it — no Blockers/Important.

**Coverage:** n/a — UI-only change in the native iOS shell (`ios/` is outside Codecov scope); snapshot suite is the gate and passes.

## On-device check
The static at-rest visual is unchanged and tested. The *pull animation* feel (pills sliding off the leading screen edge rather than clipping at a 16pt seam) can't be captured by snapshots — worth an eyeball on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)