### PR TITLE
Native iOS: don't start Sentry under XCTest (stop test pollution)

### DIFF
--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -27,7 +27,10 @@ struct IntradaApp: App {
     IntradaFonts.register()
 
     // `hasPrefix` gates out empty (CI) and an unexpanded `${…}` literal alike.
-    if let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String,
+    let runningUnderXCTest =
+      ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    if !runningUnderXCTest,
+      let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String,
       dsn.hasPrefix("https://")
     {
       SentrySDK.start { options in


### PR DESCRIPTION
## Problem

Three `TestError` events reached the **live** `intrada-mobile` Sentry project (issues `INTRADA-MOBILE-1/2`). They're not real bugs — `StoreEffectLoopTests` deliberately makes the fake bridge/store throw `TestError` to exercise the `guarded → report()` error path, and `report()` calls `SentrySDK.capture()`. When a DSN is baked into the test build (a dev with `SENTRY_DSN_NATIVE` in their env running `just ios-test`), those test errors get sent to production.

## Fix

Skip `SentrySDK.start` when running under the XCTest unit-test host (`XCTestConfigurationFilePath` env var present). With the SDK not started, `report()`'s `SentrySDK.capture()` is a no-op, so nothing ships. CI is unaffected (no DSN there anyway).

## Verification

Ran `just ios-test` **with the DSN exported** (the scenario that previously polluted) → full suite green **and zero new `TestError` events reached Sentry** (issue event counts unchanged: 2 + 1, last seen unchanged). Before this guard, the same run sent them.

## Known residual (minor)

This guards the **unit-test** host. **UI tests** (`LibrarySearchUITests`) launch the app in a separate process where `XCTestConfigurationFilePath` is *not* set, so a DSN-baked UI-test run could still emit a session/transaction (but **not** `TestError` — UI tests don't drive `report()`). Lower-noise and only when a dev runs `just ios-test` locally with a DSN; CI never has one. Can be tightened later via a launch argument if it proves noisy.

## Coverage
N/A — native-iOS Swift shell untracked by Codecov (#897); no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
