### PR TITLE
Native iOS: fix screen transactions never finishing (no APM data) — #912

### DIFF
--- a/ios/Intrada/Core/ScreenTransaction.swift
+++ b/ios/Intrada/Core/ScreenTransaction.swift
@@ -1,0 +1,22 @@
+import Sentry
+import SwiftUI
+
+extension View {
+  // `.onAppear` fires only for the visible tab, so this names the transaction after the
+  // on-screen view — unlike SentryTracedView, whose root mis-binds across a TabView's eager body eval (#912).
+  func screenTransaction(_ name: String) -> some View {
+    modifier(ScreenTransactionModifier(name: name))
+  }
+}
+
+private struct ScreenTransactionModifier: ViewModifier {
+  let name: String
+
+  func body(content: Content) -> some View {
+    content.onAppear {
+      let transaction = SentrySDK.startTransaction(
+        name: name, operation: "ui.load", bindToScope: false)
+      DispatchQueue.main.async { transaction.finish() }
+    }
+  }
+}

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -1,5 +1,3 @@
-import Sentry
-import SentrySwiftUI
 import SharedTypes
 import SwiftUI
 
@@ -16,14 +14,14 @@ struct RootView: View {
   var body: some View {
     TabView {
       NavigationStack {
-        SentryTracedView("Library", waitForFullDisplay: true) { LibraryScreen() }
+        LibraryScreen().screenTransaction("Library")
       }
       .tabItem { Label("Library", systemImage: "books.vertical") }
-      SentryTracedView("Practice") { PracticeScreen() }
+      PracticeScreen().screenTransaction("Practice")
         .tabItem { Label("Practice", systemImage: "metronome.fill") }
-      SentryTracedView("Routines") { RoutinesScreen() }
+      RoutinesScreen().screenTransaction("Routines")
         .tabItem { Label("Routines", systemImage: "music.note.list") }
-      SentryTracedView("Progress") { AnalyticsScreen() }
+      AnalyticsScreen().screenTransaction("Progress")
         .tabItem { Label("Progress", systemImage: "chart.line.uptrend.xyaxis") }
     }
     .tint(IntradaColor.accent)
@@ -50,8 +48,6 @@ struct RootView: View {
         store.send(.startApp(apiBaseUrl: apiBaseURL, localFirst: true))
         store.restorePersistedSort()
       }
-      // Closes Library's TTFD span — hydration is synchronous (else the span would hang to DeadlineExceeded).
-      SentrySDK.reportFullyDisplayed()
     }
   }
 


### PR DESCRIPTION
## Problem (#912)

No transactions or profiling ever reached Sentry from the native app — Traces and Profiling were empty (errors/crashes/sessions were fine). **Not** a quota/plan issue: envelopes return HTTP 200.

Root cause (verified via the SDK transport log): the 4 per-tab `SentryTracedView`s each try to own a **single** root `ui.load` transaction (it guards on `activeSpanId == nil`). In a `TabView`, all 4 tab bodies evaluate **eagerly**, so the first body claims the root transaction — it bound to **`Practice`**, not the visible **`Library`** — and `SentryTracedView` only finishes its root in **`viewDidAppear`**. A non-visible tab's `.onAppear` never fires, so the transaction **hung open forever and was never sent**.

## Fix

New `.screenTransaction(_:)` modifier (`ios/Intrada/Core/ScreenTransaction.swift`): starts a `ui.load` transaction in `.onAppear` (which fires **only for the visible tab**) and finishes it on the next runloop. Applied to each pillar screen in `RootView`; removed the 4 `SentryTracedView`s, the now-unused `Sentry`/`SentrySwiftUI` imports, and the `reportFullyDisplayed()` call. `bindToScope: false` (the transaction has no children and finishes next-runloop, so binding would only thrash the scope against the auto UIViewController tracker).

## Verified end-to-end

- Sim launch: transaction now created as **`Library`** (correct tab), `Finished trace … status: ok`, envelopes **200**.
- Sentry query after: **`Library` transaction = 20 events** (was 0 for days).
- `just ios-test` (full suite, built without a DSN → Sentry off in tests) green.

## Known limitations (tracked on #912)

- **Durations are near-instant** (`appear → next runloop`), so these are "screen viewed" markers, not load-time measurements. Meaningful per-screen **TTFD** durations are the remaining #912 work (the old `waitForFullDisplay`/`reportFullyDisplayed` is removed since it never fired).
- `.onAppear` re-fires on tab re-selection → a fresh short transaction each time (bounded; no leak; sampled at `tracesSampleRate`).
- **Profiling**: the profiler runs and uploads (continuous/UI profiling), but data lands in the Profiling UI / trace view rather than the legacy `profiles` dataset — verify in the **Profiling** section; may need UI Profiling enabled on the org.

## Coverage
N/A — native-iOS Swift shell untracked by Codecov (#897); no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
