### PR TITLE
Native iOS: drop Sentry profiling config (paid feature, deferred)

### DIFF
--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -44,11 +44,6 @@ struct IntradaApp: App {
         #endif
         options.enablePerformanceV2 = true
         options.enableAppHangTrackingV2 = true
-        // `sessionSampleRate` is relative to `tracesSampleRate` — prod profiling rides the 0.2 trace rate.
-        options.configureProfiling = {
-          $0.lifecycle = .trace
-          $0.sessionSampleRate = 1.0
-        }
       }
     }
   }


### PR DESCRIPTION
## What

Remove the Sentry **continuous/UI profiling** config (`configureProfiling`) — it requires a **paid** profiling quota we're not on yet.

Left enabled, the profiler still samples the main thread on every sampled trace (`tracesSampleRate` 1.0 dev / 0.2 prod) — real CPU/battery cost — and uploads profile chunks that Sentry **rejects** (no quota). Overhead with zero payoff.

## Kept (works on the current plan)
Tracing/transactions, warm app-start, slow/frozen frames, `enablePerformanceV2`, `enableAppHangTrackingV2`.

## Re-enabling later
When we subscribe to profiling, it's just the 4-line block back:
```swift
options.configureProfiling = {
  $0.lifecycle = .trace
  $0.sessionSampleRate = 1.0
}
```

## Testing
`cargo fmt --check` ✓ · `just ios-test` (full suite) ✓ green. Pure deletion (5 lines), no behavior change beyond not starting the profiler.

## Coverage
N/A — native-iOS Swift shell untracked by Codecov (#897); no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
