### PR TITLE
Native iOS: CI-stable real-bridge UITest for the setlist builder (#935)

### DIFF
--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -1,5 +1,6 @@
 import Sentry
 import SwiftUI
+import UIKit
 
 @main
 struct IntradaApp: App {
@@ -25,6 +26,12 @@ struct IntradaApp: App {
 
   init() {
     IntradaFonts.register()
+
+    // The Practice week-strip's paging TabView defeats XCUITest's idle wait;
+    // UI tests pass --disable-animations to run deterministically (#935).
+    if ProcessInfo.processInfo.arguments.contains("--disable-animations") {
+      UIView.setAnimationsEnabled(false)
+    }
 
     // `hasPrefix` gates out empty (CI) and an unexpanded `${…}` literal alike.
     let runningUnderXCTest =

--- a/ios/IntradaUITests/SessionBuilderUITests.swift
+++ b/ios/IntradaUITests/SessionBuilderUITests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+/// Real-bridge UITest for the builder (#935). `--disable-animations` stops the
+/// Practice week-strip's paging TabView defeating XCUITest idle (pulled from #933).
+@MainActor
+final class SessionBuilderUITests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    continueAfterFailure = false
+  }
+
+  private func launchSeeded() -> XCUIApplication {
+    let app = XCUIApplication()
+    app.launchArguments = ["--seed-sample-data", "--disable-animations"]
+    app.launch()
+    return app
+  }
+
+  func testBuildSetlistAddThenRemove() {
+    let app = launchSeeded()
+
+    let practiceTab = app.tabBars.buttons["Practice"]
+    XCTAssertTrue(practiceTab.waitForExistence(timeout: 10), "Practice tab")
+    practiceTab.tap()
+
+    let startButton = app.buttons["Start practising"]
+    XCTAssertTrue(startButton.waitForExistence(timeout: 5), "Start practising button")
+    startButton.tap()
+
+    let addItems = app.buttons["Add items"]
+    XCTAssertTrue(addItems.waitForExistence(timeout: 5), "Builder's Add items action")
+    addItems.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Add to session"].waitForExistence(timeout: 5), "Picker sheet title")
+    tapButton(in: app, containing: "Clair de Lune")
+    tapButton(in: app, containing: "Hanon No. 1")
+    let done = app.buttons["Done"]
+    XCTAssertTrue(done.waitForExistence(timeout: 5), "Picker Done button")
+    done.tap()
+
+    XCTAssertTrue(
+      row(in: app, containing: "Clair de Lune").waitForExistence(timeout: 5),
+      "Clair de Lune added to setlist")
+    XCTAssertTrue(
+      row(in: app, containing: "Hanon No. 1").waitForExistence(timeout: 5),
+      "Hanon No. 1 added to setlist")
+
+    revealSwipeActions(on: row(in: app, containing: "Clair de Lune"))
+    let remove = app.buttons["Remove"]
+    XCTAssertTrue(remove.waitForExistence(timeout: 5), "Swipe reveals Remove")
+    remove.tap()
+
+    XCTAssertTrue(
+      row(in: app, containing: "Clair de Lune").waitForNonExistence(timeout: 5),
+      "Removed entry leaves the setlist")
+    XCTAssertTrue(row(in: app, containing: "Hanon No. 1").exists, "Untouched entry remains")
+  }
+
+  // Cards/rows combine into one a11y element ("<type>, <title>"); match by CONTAINS.
+  private func tapButton(in app: XCUIApplication, containing label: String) {
+    let button = app.buttons.matching(NSPredicate(format: "label CONTAINS %@", label)).firstMatch
+    XCTAssertTrue(button.waitForExistence(timeout: 5), "Picker button for \(label)")
+    button.tap()
+  }
+
+  private func row(in app: XCUIApplication, containing label: String) -> XCUIElement {
+    app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", label)).firstMatch
+  }
+
+  // Partial drag reveals the actions without a full swipe committing the delete.
+  private func revealSwipeActions(on element: XCUIElement) {
+    let start = element.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5))
+    let end = element.coordinate(withNormalizedOffset: CGVector(dx: 0.2, dy: 0.5))
+    start.press(forDuration: 0.05, thenDragTo: end)
+  }
+}


### PR DESCRIPTION
## What

The CI-stable, real-bridge **XCUITest for the setlist builder** that was pulled from #933. It drives the actual running app through the build flow — Practice → **Start practising** → builder → **Add items** → pick two library items → swipe-to-remove — exercising the real Swift↔Rust bincode bridge that snapshot + core unit tests can't reach.

## The hardening (why the first attempt failed CI)

The Practice tab mounts a paging week-strip `TabView(.page)` whenever there are sessions (the seeded case). It animates continuously, defeating XCUITest's "wait for app idle" — every interaction burned the ~60s idle timeout (one run hit **381s** before failing), so the test was pulled from #933 to unblock it.

Fix: a `--disable-animations` launch arg in `IntradaApp` → `UIView.setAnimationsEnabled(false)`. It's **general-purpose** (any future UITest can opt in, including ones that need seeded data) and attacks the root cause directly, rather than the narrower "launch unseeded so there's no week-strip" path. The flag is gated behind the arg, so it can't bleed into the snapshot suite or `simctl launch` smoke runs.

## Scope (deliberately test-only)

- Covers the builder **add / remove** flow over the real bridge.
- The Active player (#932) and the full **build → practise** loop coverage are **deferred** — they need the player to exist first (tracked: #938).

## Test plan / verification

- New `SessionBuilderUITests.testBuildSetlistAddThenRemove` — **passed in ~40s** on the pinned iPhone 16 / iOS 26.5 sim (vs the 381s timeout before).
- Full `just ios-test` suite: **90/90 passed, 0 failed, 0 skipped** (snapshots + both UITests).
- `cargo fmt --check` clean (no Rust changed).

## Coverage

N/A — Swift-only diff; the native iOS shell isn't in Codecov's (Rust) scope. Verified via the real-bridge run + the green suite.

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)