### PR TITLE
Native iOS: confirm before discarding a session plan (#936 increment 3)

### DIFF
--- a/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
+++ b/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
@@ -1,11 +1,12 @@
 import SharedTypes
 import SwiftUI
 
-// Cancel/back isn't handled here: PracticeScreen's navigation binding sends
-// `cancelBuilding` when this screen pops.
+// `cancelBuilding` fires from PracticeScreen's navigation binding on dismiss.
 struct SessionBuilderScreen: View {
   @Environment(Store.self) private var store
+  @Environment(\.dismiss) private var dismiss
   @State private var picking = false
+  @State private var confirmingCancel = false
 
   private var entries: [SetlistEntryView] { store.viewModel?.buildingSetlist?.entries ?? [] }
 
@@ -27,8 +28,30 @@ struct SessionBuilderScreen: View {
       }
     }
     .navigationBarTitleDisplayMode(.inline)
+    // Hiding the back chevron also disables the swipe-back that bypasses cancel().
+    .navigationBarBackButtonHidden(true)
+    .toolbar {
+      ToolbarItem(placement: .topBarLeading) {
+        Button("Cancel") { cancel() }
+      }
+    }
     .sheet(isPresented: $picking) {
       SessionItemPickerSheet().environment(store)
+    }
+    // Alert (not confirmationDialog) so the buttons show on iPad/regular width.
+    .alert("Discard session plan?", isPresented: $confirmingCancel) {
+      Button("Discard", role: .destructive) { dismiss() }
+      Button("Keep editing", role: .cancel) {}
+    } message: {
+      Text("The items you've added will be cleared.")
+    }
+  }
+
+  private func cancel() {
+    if entries.isEmpty {
+      dismiss()
+    } else {
+      confirmingCancel = true
     }
   }
 

--- a/ios/IntradaUITests/SessionBuilderUITests.swift
+++ b/ios/IntradaUITests/SessionBuilderUITests.swift
@@ -16,7 +16,7 @@ final class SessionBuilderUITests: XCTestCase {
     return app
   }
 
-  func testBuildSetlistAddThenRemove() {
+  func testBuildSetlistAddRemoveThenCancel() {
     let app = launchSeeded()
 
     let practiceTab = app.tabBars.buttons["Practice"]
@@ -56,6 +56,23 @@ final class SessionBuilderUITests: XCTestCase {
       row(in: app, containing: "Clair de Lune").waitForNonExistence(timeout: 5),
       "Removed entry leaves the setlist")
     XCTAssertTrue(row(in: app, containing: "Hanon No. 1").exists, "Untouched entry remains")
+
+    let addItems2 = app.buttons["Add items"]
+    app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
+      .press(
+        forDuration: 0.05,
+        thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)))
+    XCTAssertTrue(addItems2.exists, "Edge-swipe does not bypass the cancel guard")
+
+    app.buttons["Cancel"].tap()
+    XCTAssertTrue(
+      app.buttons["Discard"].waitForExistence(timeout: 5), "Cancel asks before discarding")
+    app.buttons["Keep editing"].tap()
+    XCTAssertTrue(addItems2.waitForExistence(timeout: 5), "Keep editing stays in the builder")
+
+    app.buttons["Cancel"].tap()
+    app.buttons["Discard"].tap()
+    XCTAssertTrue(startButton.waitForExistence(timeout: 5), "Discard returns to Practice")
   }
 
   // Cards/rows combine into one a11y element ("<type>, <title>"); match by CONTAINS.


### PR DESCRIPTION
Final increment of session builder v2 (#936): leaving the builder with a non-empty setlist now warns before discarding.

## What

- System back chevron hidden (`navigationBarBackButtonHidden(true)`), which also **disables the interactive swipe-back** that would bypass the guard.
- A **Cancel** toolbar button → `.alert("Discard session plan?")` with **Discard** (destructive) / **Keep editing** (cancel) when the setlist is non-empty; an empty builder cancels straight away.
- `cancelBuilding` still fires from PracticeScreen's navigation binding on `dismiss()` — the shell stays a dumb pipe.

## Self-review (both Important findings resolved)

- **Edge-swipe guard — empirically verified, not just asserted.** I temporarily removed `navigationBarBackButtonHidden` and confirmed the UITest goes **red** ("Edge-swipe does not bypass the cancel guard" fails) — so the synthetic swipe really triggers the back gesture and the guard really stops it. The test constrains the regression; restored after.
- **Redundant `cancelBuilding` records an unsurfaced core error** → tracked **#944** (make the core handler idempotent; happy path sends it exactly once and the swipe is now disabled, so it's benign today — but a core change belongs in its own TDD'd PR, not a UI increment).
- Alert roles correct (`.destructive` / `.cancel`); tab-switch/backgrounding confirmed not to silently discard.

## Test plan

- `SessionBuilderUITests` extended (renamed `testBuildSetlistAddRemoveThenCancel`) to cover the swipe-disable + confirm/keep/discard flow; passes on the sim.
- Builder snapshots re-recorded (no pixel change — the Cancel item renders in the *pushed* nav bar, which the root-hosted snapshot doesn't surface; behavior covered by the UITest).
- Full `IntradaTests` + `IntradaUITests` green; `cargo fmt --check` clean (no Rust); comment density under the gate.

## Coverage

N/A — Swift-only; native shell isn't in Codecov's (Rust) scope. Verified via the UITest + snapshot suite.

This completes #936 (toggle → browse controls → cancel-confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)