### PR TITLE
Native iOS: fix the UITest idle-trap — static week-strip under UI tests (#941)

### DIFF
--- a/ios/Intrada/Core/UITestFlags.swift
+++ b/ios/Intrada/Core/UITestFlags.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum UITestFlags {
+  /// Animations off — the Practice week-strip's paging TabView otherwise defeats
+  /// XCUITest's wait-for-idle (#941).
+  static var animationsDisabled: Bool { has("--disable-animations") }
+
+  static var seedSampleData: Bool { has("--seed-sample-data") }
+
+  private static func has(_ flag: String) -> Bool {
+    ProcessInfo.processInfo.arguments.contains(flag)
+  }
+}

--- a/ios/Intrada/IntradaApp.swift
+++ b/ios/Intrada/IntradaApp.swift
@@ -27,9 +27,7 @@ struct IntradaApp: App {
   init() {
     IntradaFonts.register()
 
-    // The Practice week-strip's paging TabView defeats XCUITest's idle wait;
-    // UI tests pass --disable-animations to run deterministically (#935).
-    if ProcessInfo.processInfo.arguments.contains("--disable-animations") {
+    if UITestFlags.animationsDisabled {
       UIView.setAnimationsEnabled(false)
     }
 

--- a/ios/Intrada/Views/RootView.swift
+++ b/ios/Intrada/Views/RootView.swift
@@ -53,9 +53,7 @@ struct RootView: View {
     }
   }
 
-  private var seedSampleData: Bool {
-    ProcessInfo.processInfo.arguments.contains("--seed-sample-data")
-  }
+  private var seedSampleData: Bool { UITestFlags.seedSampleData }
 
   private static func applyTabBarAppearance() {
     let appearance = UITabBarAppearance()

--- a/ios/Intrada/Views/Screens/PracticeScreen.swift
+++ b/ios/Intrada/Views/Screens/PracticeScreen.swift
@@ -96,20 +96,7 @@ struct PracticeScreen: View {
         systemImage: "metronome.fill",
         message: "Your practice sessions will appear here.")
     } else {
-      TabView(selection: weekBinding) {
-        ForEach(Array(weeks.enumerated()), id: \.offset) { index, days in
-          WeekStrip(
-            days: days, today: referenceDate, practiceDays: practiceDays,
-            selected: Binding(get: { effectiveSelection }, set: { selectedDay = $0 }),
-            calendar: calendar
-          )
-          .padding(.horizontal, IntradaSpacing.cardCompact)
-          .tag(index)
-        }
-      }
-      .tabViewStyle(.page(indexDisplayMode: .never))
-      .frame(height: 64)
-      .padding(.top, IntradaSpacing.row)
+      weekStrips
       Text(dayLabel)
         .font(IntradaFont.bodyMedium)
         .foregroundStyle(IntradaColor.inkSecondary)
@@ -119,6 +106,34 @@ struct PracticeScreen: View {
         .padding(.bottom, 6)
       dayContent
     }
+  }
+
+  // Under UI tests the paging TabView's animation never lets the app idle, so
+  // XCUITest stalls (#941) — show the current week statically instead.
+  @ViewBuilder private var weekStrips: some View {
+    Group {
+      if UITestFlags.animationsDisabled {
+        weekStripView(selectedWeek)
+      } else {
+        TabView(selection: weekBinding) {
+          ForEach(Array(weeks.enumerated()), id: \.offset) { index, days in
+            weekStripView(days).tag(index)
+          }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+      }
+    }
+    .frame(height: 64)
+    .padding(.top, IntradaSpacing.row)
+  }
+
+  private func weekStripView(_ days: [Date]) -> some View {
+    WeekStrip(
+      days: days, today: referenceDate, practiceDays: practiceDays,
+      selected: Binding(get: { effectiveSelection }, set: { selectedDay = $0 }),
+      calendar: calendar
+    )
+    .padding(.horizontal, IntradaSpacing.cardCompact)
   }
 
   @ViewBuilder private var dayContent: some View {


### PR DESCRIPTION
Closes #941.

## Problem

The Practice week-strip uses a paging `TabView` (`.tabViewStyle(.page)`) whose **SwiftUI** animation never lets the app reach idle. `UIView.setAnimationsEnabled(false)` (set under `--disable-animations`) only stops **UIKit** animations, so XCUITest's wait-for-idle stalls on the slow CI sim — the builder UITest ran **~460s** there (vs ~20s locally), making every CI run slow and fragile.

## Fix

Under `--disable-animations`, PracticeScreen renders the **current week statically** (no paging `TabView`), so the app idles. Production is untouched (no normal launch passes the flag → always the paging view). Snapshot tests host views in-process without the flag, so they keep the paging view and their references are **unchanged** (no re-records).

Also adds a small `UITestFlags` helper and migrates the inline `--disable-animations` / `--seed-sample-data` argument checks (IntradaApp + RootView) onto it.

## Verification

- Full `IntradaTests` + `IntradaUITests` green locally; **no snapshot re-records** (paging view preserved for snapshots).
- The idle-trap only manifests on CI's slow sim, so the real proof is the **CI UITest duration dropping from ~460s toward ~60s** — I'll confirm on this PR's run.
- `cargo fmt --check` clean (no Rust); comment density under the gate.

## Self-review

Code-reviewer: 1 Blocker (comment density 0.17 — two `///` docs restated WHAT) **fixed**; production-unchanged, snapshot-isolation, and the static-branch equivalence all verified sound. 0 other findings.

## Coverage

N/A — Swift-only; native shell isn't in Codecov's (Rust) scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)