### PR TITLE
Native iOS: local-first session persistence — player Phase A (#948)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -112,6 +112,9 @@ pub enum Event {
     StoreLoaded(PersistenceOutput),
     /// Write result (split from `StoreLoaded` so a failed write reloads without looping — #825).
     StoreWritten(PersistenceOutput),
+    SessionsStoreLoaded(PersistenceOutput),
+    /// Session write result, kept separate so a failed save reloads sessions (not items).
+    SessionStoreWritten(PersistenceOutput),
 }
 
 /// Side effects the core requests from shells.
@@ -166,8 +169,7 @@ impl App for Intrada {
                 model.api_base_url = api_base_url;
                 model.local_first = local_first;
                 if local_first {
-                    // Sessions/sets aren't on the native shell yet — migrated later.
-                    persistence::load_items()
+                    Command::all([persistence::load_items(), persistence::load_sessions()])
                 } else {
                     Command::all([
                         http::fetch_items(&model.api_base_url),
@@ -300,7 +302,7 @@ impl App for Intrada {
                     model.items = items;
                     crux_core::render::render()
                 }
-                PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Ack | PersistenceOutput::Sessions(_) => Command::done(),
                 // Failed read: surface only — no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -309,11 +311,32 @@ impl App for Intrada {
             },
             Event::StoreWritten(output) => match output {
                 PersistenceOutput::Ack => Command::done(),
-                PersistenceOutput::Items(_) => Command::done(),
+                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
                 // Failed write → reload to roll back the un-persisted change (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     persistence::load_items()
+                }
+            },
+            Event::SessionsStoreLoaded(output) => match output {
+                PersistenceOutput::Sessions(sessions) => {
+                    model.sessions = sessions;
+                    model.practice_summaries = build_practice_summaries(&model.sessions);
+                    crux_core::render::render()
+                }
+                PersistenceOutput::Items(_) | PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    crux_core::render::render()
+                }
+            },
+            Event::SessionStoreWritten(output) => match output {
+                PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
+                // Failed save → reload sessions to roll back the optimistic push (#825).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    persistence::load_sessions()
                 }
             },
         }

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -1061,11 +1061,22 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             model.session_status = SessionStatus::Idle;
             model.last_error = None;
 
-            Command::all([
-                crate::http::create_session(&model.api_base_url, &practice_session),
-                Command::notify_shell(AppEffect::ClearSessionInProgress).into(),
-                crux_core::render::render(),
-            ])
+            let clear = Command::notify_shell(AppEffect::ClearSessionInProgress).into();
+            if model.local_first {
+                // No server callback to clear the dismiss-mute, so record success here.
+                model.record_success();
+                Command::all([
+                    crate::persistence::save_session(practice_session),
+                    clear,
+                    crux_core::render::render(),
+                ])
+            } else {
+                Command::all([
+                    crate::http::create_session(&model.api_base_url, &practice_session),
+                    clear,
+                    crux_core::render::render(),
+                ])
+            }
         }
 
         SessionEvent::DiscardSession => {
@@ -1830,6 +1841,45 @@ mod tests {
         assert_eq!(
             model.sessions[0].completion_status,
             CompletionStatus::Completed
+        );
+    }
+
+    #[test]
+    fn local_first_save_session_persists_and_skips_http() {
+        let mut model = model_with_summary();
+        model.local_first = true;
+        let app = Intrada;
+        let mut cmd = app.update(
+            Event::Session(SessionEvent::SaveSession { now: Utc::now() }),
+            &mut model,
+        );
+        let id = model.sessions[0].id.clone();
+        assert!(
+            cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+                if matches!(&req.operation, crate::persistence::PersistenceOperation::SaveSession(s) if s.id == id))),
+            "local-first save persists the session locally"
+        );
+        assert!(
+            !cmd.effects().any(|e| matches!(e, Effect::Http(_))),
+            "local-first save makes no HTTP request"
+        );
+    }
+
+    #[test]
+    fn online_save_session_uses_http_not_persistence() {
+        let mut model = model_with_summary();
+        let app = Intrada;
+        let mut cmd = app.update(
+            Event::Session(SessionEvent::SaveSession { now: Utc::now() }),
+            &mut model,
+        );
+        assert!(
+            cmd.effects().any(|e| matches!(e, Effect::Http(_))),
+            "online save POSTs to the server"
+        );
+        assert!(
+            !cmd.effects().any(|e| matches!(e, Effect::Persistence(_))),
+            "online save makes no local persistence write"
         );
     }
 

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -392,4 +392,43 @@ mod tests {
             entries,
         });
     }
+
+    #[test]
+    fn save_session_persistence_op_round_trips_on_ffi_bincode_wire() {
+        // PracticeSession crosses the bridge as a SaveSession persistence Effect;
+        // its optional-heavy SetlistEntry + rep_history is exactly the #846 risk.
+        use crate::domain::session::{
+            CompletionStatus, EntryStatus, PracticeSession, RepAction, SetlistEntry,
+        };
+        use crate::persistence::PersistenceOperation;
+        let now = chrono::Utc::now();
+        let entry = SetlistEntry {
+            id: "e1".to_string(),
+            item_id: "p1".to_string(),
+            item_title: "Clair de Lune".to_string(),
+            item_type: ItemKind::Piece,
+            position: 0,
+            duration_secs: 300,
+            status: EntryStatus::Completed,
+            notes: Some("phrasing".to_string()),
+            score: Some(4),
+            intention: Some("evenness".to_string()),
+            rep_target: Some(5),
+            rep_count: Some(5),
+            rep_target_reached: Some(true),
+            rep_history: Some(vec![RepAction::Success, RepAction::Missed]),
+            planned_duration_secs: Some(300),
+            achieved_tempo: Some(120),
+        };
+        assert_round_trips(PersistenceOperation::SaveSession(PracticeSession {
+            id: "s1".to_string(),
+            entries: vec![entry],
+            session_notes: Some("solid".to_string()),
+            session_intention: Some("warm up".to_string()),
+            started_at: now,
+            completed_at: now,
+            total_duration_secs: 300,
+            completion_status: CompletionStatus::Completed,
+        }));
+    }
 }

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::{Effect, Event};
 use crate::domain::item::Item;
+use crate::domain::session::PracticeSession;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
@@ -22,6 +23,8 @@ pub enum PersistenceOperation {
         id: String,
         deleted_at: DateTime<Utc>,
     },
+    LoadSessions,
+    SaveSession(PracticeSession),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -29,6 +32,7 @@ pub enum PersistenceOperation {
 #[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum PersistenceOutput {
     Items(Vec<Item>),
+    Sessions(Vec<PracticeSession>),
     Ack,
     /// Local store failed the op — surfaced, not trusted as success (#816).
     Failed,
@@ -49,6 +53,16 @@ pub fn save_item(item: Item) -> Command<Effect, Event> {
 pub fn delete_item(id: String, deleted_at: DateTime<Utc>) -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::DeleteItem { id, deleted_at })
         .then_send(Event::StoreWritten)
+}
+
+pub fn load_sessions() -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::LoadSessions)
+        .then_send(Event::SessionsStoreLoaded)
+}
+
+pub fn save_session(session: PracticeSession) -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::SaveSession(session))
+        .then_send(Event::SessionStoreWritten)
 }
 
 #[cfg(test)]
@@ -447,5 +461,77 @@ mod tests {
 
         let mut delete = app.update(Event::Item(ItemEvent::Delete { id }), &mut model);
         assert!(!has_http(&mut delete), "delete");
+    }
+
+    // ── Sessions ────────────────────────────────────────────────────────
+
+    fn sample_session(id: &str) -> PracticeSession {
+        let now = chrono::Utc::now();
+        PracticeSession {
+            id: id.to_string(),
+            entries: vec![],
+            session_notes: None,
+            session_intention: None,
+            started_at: now,
+            completed_at: now,
+            total_duration_secs: 0,
+            completion_status: crate::domain::session::CompletionStatus::Completed,
+        }
+    }
+
+    #[test]
+    fn save_session_requests_a_save_op() {
+        let mut cmd = save_session(sample_session("s1"));
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if matches!(&req.operation, PersistenceOperation::SaveSession(s) if s.id == "s1"))));
+    }
+
+    #[test]
+    fn load_sessions_requests_the_load_operation() {
+        let mut cmd = load_sessions();
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::LoadSessions)));
+    }
+
+    #[test]
+    fn sessions_store_loaded_replaces_model_sessions() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        model.sessions = vec![sample_session("stale")];
+        let _ = app.update(
+            Event::SessionsStoreLoaded(PersistenceOutput::Sessions(vec![sample_session("fresh")])),
+            &mut model,
+        );
+        assert_eq!(model.sessions.len(), 1);
+        assert_eq!(model.sessions[0].id, "fresh");
+    }
+
+    #[test]
+    fn start_app_local_first_also_loads_sessions() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(
+            Event::StartApp {
+                api_base_url: "http://x".into(),
+                local_first: true,
+            },
+            &mut model,
+        );
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::LoadSessions)));
+        assert!(!has_http(&mut cmd), "local-first launch makes no HTTP");
+    }
+
+    #[test]
+    fn session_store_written_failed_reloads_sessions() {
+        let app = crate::app::Intrada;
+        let mut model = Model::test_default();
+        let mut cmd = app.update(
+            Event::SessionStoreWritten(PersistenceOutput::Failed),
+            &mut model,
+        );
+        assert!(model.last_error.is_some());
+        assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+            if req.operation == PersistenceOperation::LoadSessions)));
     }
 }

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -7,6 +7,8 @@ protocol ItemStore {
   func loadItems() throws -> [Item]
   func save(_ item: Item) throws
   func delete(id: String, deletedAt: String) throws
+  func loadSessions() throws -> [PracticeSession]
+  func saveSession(_ session: PracticeSession) throws
 }
 
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
@@ -86,6 +88,41 @@ final class LibraryStore: ItemStore {
     }
   }
 
+  func loadSessions() throws -> [PracticeSession] {
+    try dbQueue.read { db in
+      try Row.fetchAll(
+        db, sql: "SELECT * FROM session WHERE deleted_at IS NULL ORDER BY completed_at DESC"
+      )
+      .map(Self.session(from:))
+    }
+  }
+
+  /// Insert or update by id. A session is immutable once completed, so
+  /// `updated_at` simply tracks `completed_at` — the column exists for sync LWW.
+  func saveSession(_ session: PracticeSession) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO session
+            (id, started_at, completed_at, total_duration_secs, completion_status,
+             session_notes, session_intention, entries, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+          ON CONFLICT(id) DO UPDATE SET
+            started_at = excluded.started_at, completed_at = excluded.completed_at,
+            total_duration_secs = excluded.total_duration_secs,
+            completion_status = excluded.completion_status,
+            session_notes = excluded.session_notes, session_intention = excluded.session_intention,
+            entries = excluded.entries, updated_at = excluded.updated_at, deleted_at = NULL
+          """,
+        arguments: [
+          session.id, session.startedAt, session.completedAt,
+          Int(session.totalDurationSecs), Self.completionString(session.completionStatus),
+          session.sessionNotes, session.sessionIntention,
+          Self.encodeEntries(session.entries), session.completedAt,
+        ])
+    }
+  }
+
   /// Column names of a table (for the schema-invariant test). `[String]` not
   /// `Set` — `SharedTypes`' domain `Set` shadows `Swift.Set` here.
   func columnNames(ofTable table: String) throws -> [String] {
@@ -118,6 +155,23 @@ final class LibraryStore: ItemStore {
     }
     migrator.registerMigration("v2_add_modality") { db in
       try db.execute(sql: "ALTER TABLE item ADD COLUMN modality TEXT")
+    }
+    migrator.registerMigration("v3_session") { db in
+      try db.execute(
+        sql: """
+          CREATE TABLE session (
+            id TEXT PRIMARY KEY NOT NULL,
+            started_at TEXT NOT NULL,
+            completed_at TEXT NOT NULL,
+            total_duration_secs INTEGER NOT NULL,
+            completion_status TEXT NOT NULL,
+            session_notes TEXT,
+            session_intention TEXT,
+            entries TEXT NOT NULL DEFAULT '[]',
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
     }
     return migrator
   }
@@ -171,6 +225,107 @@ final class LibraryStore: ItemStore {
 
   private static func decodeTags(_ json: String) -> [String] {
     (try? JSONDecoder().decode([String].self, from: Data(json.utf8))) ?? []
+  }
+
+  // ── Row ↔ PracticeSession codec ──────────────────────────────────────
+
+  private static func session(from row: Row) -> PracticeSession {
+    PracticeSession(
+      id: row["id"], entries: decodeEntries(row["entries"]),
+      sessionNotes: row["session_notes"], sessionIntention: row["session_intention"],
+      startedAt: row["started_at"], completedAt: row["completed_at"],
+      totalDurationSecs: UInt64(row["total_duration_secs"] as Int64),
+      completionStatus: completionStatus(from: row["completion_status"]))
+  }
+
+  // Entries (a nested, optional-heavy aggregate) go to JSON via a Codable DTO,
+  // not bincode: bincode is positional, so a future field change would fail to
+  // decode old rows — unacceptable when the device is the only copy.
+  private struct StoredEntry: Codable {
+    var id: String
+    var itemId: String
+    var itemTitle: String
+    var itemType: String
+    var position: UInt64
+    var durationSecs: UInt64
+    var status: String
+    var notes: String?
+    var score: UInt8?
+    var intention: String?
+    var repTarget: UInt8?
+    var repCount: UInt8?
+    var repTargetReached: Bool?
+    var repHistory: [String]?
+    var plannedDurationSecs: UInt32?
+    var achievedTempo: UInt16?
+  }
+
+  private static func encodeEntries(_ entries: [SetlistEntry]) -> String {
+    let dtos = entries.map { e in
+      StoredEntry(
+        id: e.id, itemId: e.itemId, itemTitle: e.itemTitle, itemType: kindString(e.itemType),
+        position: e.position, durationSecs: e.durationSecs, status: entryStatusString(e.status),
+        notes: e.notes, score: e.score, intention: e.intention, repTarget: e.repTarget,
+        repCount: e.repCount, repTargetReached: e.repTargetReached,
+        repHistory: e.repHistory.map { $0.map(repActionString) },
+        plannedDurationSecs: e.plannedDurationSecs, achievedTempo: e.achievedTempo)
+    }
+    guard let data = try? JSONEncoder().encode(dtos), let json = String(data: data, encoding: .utf8)
+    else { return "[]" }
+    return json
+  }
+
+  private static func decodeEntries(_ json: String) -> [SetlistEntry] {
+    guard let dtos = try? JSONDecoder().decode([StoredEntry].self, from: Data(json.utf8)) else {
+      return []
+    }
+    return dtos.map { d in
+      SetlistEntry(
+        id: d.id, itemId: d.itemId, itemTitle: d.itemTitle, itemType: kind(from: d.itemType),
+        position: d.position, durationSecs: d.durationSecs, status: entryStatus(from: d.status),
+        notes: d.notes, score: d.score, intention: d.intention, repTarget: d.repTarget,
+        repCount: d.repCount, repTargetReached: d.repTargetReached,
+        repHistory: d.repHistory.map { $0.map(repAction(from:)) },
+        plannedDurationSecs: d.plannedDurationSecs, achievedTempo: d.achievedTempo)
+    }
+  }
+
+  private static func completionString(_ status: CompletionStatus) -> String {
+    switch status {
+    case .completed: "completed"
+    case .endedEarly: "ended_early"
+    }
+  }
+
+  private static func completionStatus(from raw: String) -> CompletionStatus {
+    raw == "ended_early" ? .endedEarly : .completed
+  }
+
+  private static func entryStatusString(_ status: EntryStatus) -> String {
+    switch status {
+    case .completed: "completed"
+    case .skipped: "skipped"
+    case .notAttempted: "not_attempted"
+    }
+  }
+
+  private static func entryStatus(from raw: String) -> EntryStatus {
+    switch raw {
+    case "skipped": .skipped
+    case "not_attempted": .notAttempted
+    default: .completed
+    }
+  }
+
+  private static func repActionString(_ action: RepAction) -> String {
+    switch action {
+    case .missed: "missed"
+    case .success: "success"
+    }
+  }
+
+  private static func repAction(from raw: String) -> RepAction {
+    raw == "missed" ? .missed : .success
   }
 
 }

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -103,6 +103,10 @@ final class Store {
       case .deleteItem(let id, let deletedAt):
         try store.delete(id: id, deletedAt: deletedAt)
         return .ack
+      case .loadSessions: return .sessions(try store.loadSessions())
+      case .saveSession(let session):
+        try store.saveSession(session)
+        return .ack
       }
     } catch {
       report(error, "persistence")

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -115,4 +115,93 @@ final class LibraryStoreTests: XCTestCase {
     XCTAssertTrue(
       columns.contains("deleted_at"), "item table must carry deleted_at; has \(columns)")
   }
+
+  // ── Sessions ──────────────────────────────────────────────────────────
+
+  private func entry(_ id: String) -> SetlistEntry {
+    SetlistEntry(
+      id: id, itemId: "item-\(id)", itemTitle: "Etude", itemType: .exercise, position: 0,
+      durationSecs: 300, status: .completed, notes: "good", score: 4, intention: "evenness",
+      repTarget: 5, repCount: 5, repTargetReached: true,
+      repHistory: [.success, .missed, .success], plannedDurationSecs: 300, achievedTempo: 120)
+  }
+
+  private func session(_ id: String, completedAt: String = "2026-01-01T00:00:00Z")
+    -> PracticeSession
+  {
+    PracticeSession(
+      id: id, entries: [entry("a"), entry("b")], sessionNotes: "solid",
+      sessionIntention: "warm up", startedAt: "2026-01-01T00:00:00Z", completedAt: completedAt,
+      totalDurationSecs: 600, completionStatus: .completed)
+  }
+
+  func testSaveThenLoadSessionRoundTrips() throws {
+    let store = try makeStore()
+    try store.saveSession(session("s1"))
+    let got = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(got.id, "s1")
+    XCTAssertEqual(got.totalDurationSecs, 600)
+    XCTAssertEqual(got.completionStatus, .completed)
+    XCTAssertEqual(got.sessionNotes, "solid")
+    XCTAssertEqual(got.sessionIntention, "warm up")
+    XCTAssertEqual(got.entries.count, 2)
+    let e = try XCTUnwrap(got.entries.first)
+    XCTAssertEqual(e.itemType, .exercise)
+    XCTAssertEqual(e.status, .completed)
+    XCTAssertEqual(e.score, 4)
+    XCTAssertEqual(e.repTarget, 5)
+    XCTAssertEqual(e.repHistory, [.success, .missed, .success])
+    XCTAssertEqual(e.achievedTempo, 120)
+  }
+
+  func testEndedEarlyAndEmptyEntriesRoundTrip() throws {
+    let store = try makeStore()
+    var s = session("s2")
+    s.entries = []
+    s.completionStatus = .endedEarly
+    s.sessionNotes = nil
+    try store.saveSession(s)
+    let got = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(got.completionStatus, .endedEarly)
+    XCTAssertTrue(got.entries.isEmpty)
+    XCTAssertNil(got.sessionNotes)
+  }
+
+  func testSkippedAndNotAttemptedEntryStatusRoundTrip() throws {
+    let store = try makeStore()
+    var s = session("s3")
+    s.entries[0].status = .skipped
+    s.entries[1].status = .notAttempted
+    try store.saveSession(s)
+    let got = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(got.entries.map(\.status), [.skipped, .notAttempted])
+  }
+
+  func testSessionsLoadNewestFirst() throws {
+    let store = try makeStore()
+    try store.saveSession(session("old", completedAt: "2026-01-01T00:00:00Z"))
+    try store.saveSession(session("new", completedAt: "2026-02-01T00:00:00Z"))
+    XCTAssertEqual(try store.loadSessions().map(\.id), ["new", "old"])
+  }
+
+  func testSessionSchemaHasSyncColumns() throws {
+    let columns = try makeStore().columnNames(ofTable: "session")
+    XCTAssertTrue(columns.contains("updated_at"), "session needs updated_at; has \(columns)")
+    XCTAssertTrue(columns.contains("deleted_at"), "session needs deleted_at; has \(columns)")
+  }
+
+  /// Upgrade path: a pre-existing v2 item row survives the v3 session migration.
+  func testV2ItemSurvivesSessionMigration() throws {
+    let store = try LibraryStore.upgradeTestStore(
+      migratedTo: "v2_add_modality",
+      seed: """
+        INSERT INTO item
+          (id, title, kind, composer, key, modality, tempo_marking, tempo_bpm, notes, tags,
+           created_at, updated_at, priority, deleted_at)
+        VALUES ('p1', 'Legacy', 'piece', 'Bach', 'C', 'major', 'Allegro', 120, 'x',
+                '["scale"]', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 0, NULL)
+        """)
+    XCTAssertEqual(try store.loadItems().count, 1, "the v2 item survives the v3 migration")
+    XCTAssertTrue(try store.loadSessions().isEmpty, "the new session table starts empty")
+  }
 }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -442,6 +442,8 @@ private struct FailingStore: ItemStore {
   func loadItems() throws -> [Item] { throw TestError() }
   func save(_ item: Item) throws { throw TestError() }
   func delete(id: String, deletedAt: String) throws { throw TestError() }
+  func loadSessions() throws -> [PracticeSession] { throw TestError() }
+  func saveSession(_ session: PracticeSession) throws { throw TestError() }
 }
 
 final class MockURLProtocol: URLProtocol {

--- a/specs/native-ios-player.md
+++ b/specs/native-ios-player.md
@@ -1,0 +1,97 @@
+# Native iOS practice player
+
+> Status: Phase A in progress. Last updated 2026-06-04.
+
+## Problem
+
+The native iOS builder (#936) assembles a setlist but "Start session" dead-ends.
+The player closes the **Plan → Practise → Track** loop: build → practise each
+item → finish → a session lands in the Practice history. The core's
+`SessionStatus` machine (`Building → Active → Summary → Idle`) already drives all
+of this; the gap is (1) completed sessions don't persist on-device, and (2) there
+are no Active/Summary screens.
+
+The app is offline-first: a finished session **must** survive a restart with no
+network. Today it doesn't — `SaveSession` only POSTs to the API, and `StartApp`
+in local-first mode loads items only (`app.rs` comment: "Sessions/sets aren't on
+the native shell yet"). So the player needs a persistence foundation *before* the
+UI is worth shipping.
+
+## Approach — phased
+
+- **Phase A — session persistence (this spec / #948).** Make completed sessions
+  persist locally and reload on launch. No UI; pure core + GRDB. The foundation
+  everything else sits on.
+- **Phase B — player spine (#932).** Pre-start review → focus screen (current
+  item, next/skip) → finish → Summary, wired to Phase A. In-memory state is the
+  core's; finishing persists. Flow designed in Pencil first.
+- **Phase C — layers.** Timer, rep counter / scoring, the interstitial reflection
+  between items, resume/discard of a crash-recovered session.
+
+Phases B/C carry the interaction design (the "spend friction deliberately" split:
+a calm focus screen, with scoring/reps in the between-item interstitial rather
+than on top of the timer). Those are settled in a Pencil pass before Phase B.
+
+## Phase A — design
+
+Mirror the **Items** local-first pipeline exactly (`domain/item.rs` +
+`persistence.rs` + `LibraryStore.swift`), so sessions follow the proven path.
+
+**Core (`intrada-core`):**
+- `PersistenceOperation` gains `LoadSessions` and `SaveSession(PracticeSession)`;
+  `PersistenceOutput` gains `Sessions(Vec<PracticeSession>)`.
+- `persistence::load_sessions()` / `save_session()` helpers (→ `Event::Sessions…`).
+- `SaveSession` handler branches on `model.local_first`: local → `save_session`
+  (+ `record_success`, keep the `ClearSessionInProgress` notify); online →
+  `http::create_session` (unchanged). The optimistic `model.sessions.push` stays
+  in both.
+- `StartApp { local_first: true }` issues `load_items()` **and** `load_sessions()`.
+- A `SessionsStoreLoaded` handler sets `model.sessions` from the output (mirrors
+  `StoreLoaded` for items); rebuilds `practice_summaries`.
+
+**iOS (GRDB):**
+- New `v3_session` migration: a `session` table keyed by `id`, top-level fields as
+  columns (`started_at`, `completed_at`, `total_duration_secs`,
+  `completion_status`, `session_notes`, `session_intention`), the nested
+  `entries` as a JSON `TEXT` column, plus sync columns `updated_at` +
+  `deleted_at` (invariant 2). `updated_at` is stamped to `completed_at` on save
+  (sessions are immutable once completed).
+- `entries` JSON via a Swift `Codable` storage DTO mirroring `SetlistEntry`
+  (+ `RepAction`). **Not** a bincode blob: bincode is positional, so any future
+  field change would fail to decode old rows — unacceptable when the device is
+  the only copy of the data. JSON + optional fields evolves additively.
+- Store gains `loadSessions()` / `saveSession(_:)`; `Store.persistenceOutput(for:)`
+  handles the new ops.
+
+### Key decisions
+
+- **JSON column for entries, not a junction table or bincode blob.** Sessions are
+  read/written whole (history display), so a relational `session_entry` table
+  (with its own nested `rep_history`) is over-normalisation; the Items table's
+  `tags`-as-JSON sets the denormalise-collections-as-JSON precedent. JSON over
+  bincode for evolution safety.
+- **No `updated_at` on the `PracticeSession` domain type.** The sync column lives
+  on the table only; a completed session is immutable, so `updated_at` =
+  `completed_at`. Avoids a domain-type/ViewModel/API change for no behavioural gain.
+- **`DeleteSession` persistence deferred.** No native delete-session UI yet; the
+  table ships `deleted_at` so it's sync-ready, but the soft-delete op lands with
+  the UI that needs it (tracked separately).
+
+### Offline-first invariant check (Phase A)
+
+1. No-network local path — `SaveSession`/load go through the persistence Effect, not HTTP. ✓
+2. Sync-ready schema — `updated_at` + `deleted_at`; no hard delete. ✓
+3. Client-owned id — the session's ulid is canonical (no temp-id). ✓
+4. Reconciliation in the core — the `local_first` branch + load handler are Rust. ✓
+5. Failed write surfaces — reuse `StoreWritten`/`Failed` handling (no fake Ack). ✓
+6. Both modes — `SaveSession` + `StartApp` tested local-first **and** online. ✓
+7. No account gate. ✓
+8. Relational data in GRDB (not `crux_kv`). ✓
+
+## Testing (Phase A)
+
+- Core (TDD): `SaveSession` in `local_first` emits the persistence save (not HTTP)
+  and keeps the optimistic `model.sessions`; `StartApp { local_first }` loads
+  sessions; online mode still POSTs. Both modes.
+- GRDB: a migration **upgrade-path** test (populate at v2, migrate to v3, items
+  intact) and a session **round-trip** (save → load → equal, entries preserved).


### PR DESCRIPTION
The player's foundation (#948). Completed practice sessions now persist on-device and reload on launch, so build → practise → finish survives a restart **offline**. Closes the gap where `SaveSession` only POSTed to the API. Spec rides with this phase: `specs/native-ios-player.md`.

## What

Mirrors the Items local-first pipeline.

**Core (TDD):**
- `PersistenceOperation::{LoadSessions, SaveSession(PracticeSession)}`, `PersistenceOutput::Sessions`, `load_sessions()`/`save_session()`.
- `SaveSession` branches on `local_first` (persist locally + record success + keep `ClearSessionInProgress`) vs the existing HTTP POST.
- `StartApp { local_first }` loads sessions alongside items; `SessionsStoreLoaded` sets `model.sessions` (+ summaries); `SessionStoreWritten` rolls a failed save back by reloading.

**iOS (GRDB):**
- `v3_session` migration — top-level fields as columns, nested `entries` as JSON via a Codable `StoredEntry` DTO, sync columns `updated_at` + `deleted_at` (no hard delete). JSON not bincode: bincode is positional and would fail to decode old rows on any field change — unacceptable when the device is the only copy.
- `loadSessions`/`saveSession` + the `PracticeSession`↔row codec; `Store` resolves the new ops.

## Offline-first invariants
All 8 upheld (no-network local path, sync-ready schema + no hard delete, client ulid, reconciliation in core, `Failed` not fake-`Ack`, both modes tested, no account gate, GRDB not crux_kv) — see the spec's checklist.

## Tests
- Core: `SaveSession` persists-not-POSTs local-first / POSTs online; `StartApp` loads sessions; failed save reloads. **Plus the FFI bincode round-trip** for `SaveSession(PracticeSession)` — the #846 build-precondition guard for the optional-heavy payload.
- GRDB: session round-trip (entries + rep history + skipped/not-attempted statuses preserved), the **v2→v3 upgrade path** (items intact), sync-column schema invariant.
- 401 core tests + full `IntradaTests` suite green; fmt + clippy clean.

## Self-review (code-reviewer)
0 Blockers after fixes. The one Important — a missing FFI bridge round-trip test for the new write payload (a CLAUDE.md build precondition / #846 class) — **added** and green. Two nits handled: `.skipped`/`.notAttempted` round-trip coverage added; forward-compat enum decode tracked (#949).

## Coverage
Core has unit + round-trip + GRDB tests. The iOS shell isn't in Codecov's (Rust) scope.

## Deferred
- **#950** — `DeleteSession` persistence (no native delete UI yet; table already ships `deleted_at`).
- **#949** — surface unknown enum strings on decode (forward-compat; unreachable today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)