### PR TITLE
core: idempotent CancelBuilding + UpdateItem bincode landmine guard (#944, #908)

### DIFF
--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -695,12 +695,16 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
         }
 
         SessionEvent::CancelBuilding => {
-            if !matches!(model.session_status, SessionStatus::Building(_)) {
-                model.last_error = Some("Not in building state".to_string());
-                return crux_core::render::render();
+            // Idempotent: already-Idle cancel is a no-op success, not a silent error (#944).
+            match model.session_status {
+                SessionStatus::Building(_) | SessionStatus::Idle => {
+                    model.session_status = SessionStatus::Idle;
+                    model.last_error = None;
+                }
+                _ => {
+                    model.last_error = Some("Not in building state".to_string());
+                }
             }
-            model.session_status = SessionStatus::Idle;
-            model.last_error = None;
             crux_core::render::render()
         }
 
@@ -1555,6 +1559,37 @@ mod tests {
 
         assert!(model.last_error.is_none());
         assert!(matches!(model.session_status, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn test_cancel_building_when_idle_is_noop_success() {
+        let mut model = model_with_library();
+        update(&mut model, Event::Session(SessionEvent::CancelBuilding));
+
+        assert!(model.last_error.is_none());
+        assert!(matches!(model.session_status, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn test_cancel_building_is_idempotent_when_called_twice() {
+        let mut model = model_with_library();
+        update(&mut model, Event::Session(SessionEvent::StartBuilding));
+        update(&mut model, Event::Session(SessionEvent::CancelBuilding));
+        update(&mut model, Event::Session(SessionEvent::CancelBuilding));
+
+        assert!(model.last_error.is_none());
+        assert!(matches!(model.session_status, SessionStatus::Idle));
+    }
+
+    #[test]
+    fn test_cancel_building_from_active_is_a_wrong_state_error() {
+        // Cancelling the builder must not silently nuke an Active session (#944).
+        let (mut model, _) = model_with_active_session(2);
+
+        update(&mut model, Event::Session(SessionEvent::CancelBuilding));
+
+        assert_eq!(model.last_error.as_deref(), Some("Not in building state"));
+        assert!(matches!(model.session_status, SessionStatus::Active(_)));
     }
 
     // --- Active Phase Tests ---

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -324,6 +324,41 @@ mod tests {
     }
 
     #[test]
+    fn update_item_absent_field_does_not_round_trip_on_rust_bincode_serialize() {
+        // LANDMINE GUARD (#908): `skip_serializing_if` omits an outer-`None`
+        // field on the bincode serialize path while deserialize reads it
+        // positionally — asymmetric on the FFI wire (#846 silent-decode class),
+        // safe today only because Swift serializes and Rust only deserializes.
+        // Pins the asymmetry: making bincode serialize field-complete flips this.
+        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
+
+        let with_absent_field = UpdateItem {
+            title: Some("Renamed".to_string()),
+            kind: None,
+            composer: Some(Some("Bach".to_string())),
+            key: Some(None),
+            modality: Some(Some(Modality::Minor)),
+            tempo: Some(None),
+            notes: Some(Some("phrasing".to_string())),
+            tags: Some(vec!["etude".to_string()]),
+            priority: Some(true),
+        };
+
+        let mut bytes = Vec::new();
+        BincodeFfiFormat::serialize(&mut bytes, &with_absent_field).expect("serialize");
+        let decoded: Result<UpdateItem, _> = BincodeFfiFormat::deserialize(&bytes);
+
+        if let Ok(back) = decoded {
+            assert_ne!(
+                back, with_absent_field,
+                "bincode serialize became field-complete — if you fixed the \
+                 skip_serializing_if asymmetry (#908), update this guard to \
+                 assert a clean round-trip"
+            );
+        }
+    }
+
+    #[test]
     fn update_event_round_trips_on_ffi_bincode_wire() {
         // Wraps the DTO in the event that actually crosses the bridge, so
         // enum/struct framing is covered too (#777). See the bare-DTO test above.


### PR DESCRIPTION
Two small `intrada-core` fixes, grouped by area.

## #944 — `CancelBuilding` idempotent
`SessionEvent::CancelBuilding` set `last_error = "Not in building state"` when it arrived while already `Idle`. That error reaches `viewModel.error` but no Practice/Builder screen surfaces it — the silent-no-op / surface-don't-swallow pattern. `Idle` is the user's intended end state, so cancelling an already-Idle (or double-cancelled) session is now a **no-op success**.

A genuinely wrong-state cancel — from `Active`/`Summary` — still errors (cancelling the *builder* must never silently nuke an in-progress or just-finished session). That preserved branch is now covered by a test.

Abandon/discard idempotency is **deferred to #932** per the issue body (and to keep the intentional `test_abandon_session_not_active` contract).

## #908 — `UpdateItem` bincode serialize asymmetry guard
`UpdateItem`'s `skip_serializing_if` is correct for the JSON-API PATCH path (omit-unchanged) but asymmetric on the positional bincode FFI wire: Rust *serialize* omits an outer-`None` field while *deserialize* reads positionally (the #846 silent-decode class). Safe today only because the bridge is one-directional (Swift serializes → Rust deserializes). Added a guard test that pins the asymmetry so a future Rust-side bincode producer can't reintroduce it silently.

## Tests
TDD: failing tests written first for #944 (watched fail, then implemented). 4 `cancel_building` tests + 1 bincode guard. Full workspace: 594 pass, clippy + fmt clean.

**Coverage:** full — both changes are pure `intrada-core` logic/test with unit coverage (idempotent + wrong-state branches; serialize-asymmetry guard).

Closes #944
Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)