### PR TITLE
ios: surface unknown stored enum strings on decode (#949)

### DIFF
--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -178,6 +178,16 @@ final class LibraryStore: ItemStore {
 
   // ── Row ↔ Item codec ─────────────────────────────────────────────────
 
+  // Surface (don't silently default) a stored enum string we don't recognise —
+  // e.g. an older binary reading a row a newer version wrote (#949).
+  private static let decodeContext = "LibraryStore decode"
+
+  private struct UnknownStoredEnum: Error, CustomStringConvertible {
+    let kind: String
+    let raw: String
+    var description: String { "unknown \(kind) on decode: \"\(raw)\"" }
+  }
+
   private static func item(from row: Row) -> Item {
     let marking: String? = row["tempo_marking"]
     let bpm: UInt16? = (row["tempo_bpm"] as Int?).map { UInt16($0) }
@@ -207,14 +217,23 @@ final class LibraryStore: ItemStore {
 
   private static func modality(from raw: String?) -> Modality? {
     switch raw {
-    case "major": .major
-    case "minor": .minor
-    default: nil
+    case "major": return .major
+    case "minor": return .minor
+    case nil: return nil
+    case .some(let other):
+      report(UnknownStoredEnum(kind: "Modality", raw: other), decodeContext)
+      return nil
     }
   }
 
   private static func kind(from raw: String) -> ItemKind {
-    raw == "exercise" ? .exercise : .piece
+    switch raw {
+    case "piece": return .piece
+    case "exercise": return .exercise
+    default:
+      report(UnknownStoredEnum(kind: "ItemKind", raw: raw), decodeContext)
+      return .piece
+    }
   }
 
   private static func encodeTags(_ tags: [String]) -> String {
@@ -298,7 +317,13 @@ final class LibraryStore: ItemStore {
   }
 
   private static func completionStatus(from raw: String) -> CompletionStatus {
-    raw == "ended_early" ? .endedEarly : .completed
+    switch raw {
+    case "completed": return .completed
+    case "ended_early": return .endedEarly
+    default:
+      report(UnknownStoredEnum(kind: "CompletionStatus", raw: raw), decodeContext)
+      return .completed
+    }
   }
 
   private static func entryStatusString(_ status: EntryStatus) -> String {
@@ -311,9 +336,12 @@ final class LibraryStore: ItemStore {
 
   private static func entryStatus(from raw: String) -> EntryStatus {
     switch raw {
-    case "skipped": .skipped
-    case "not_attempted": .notAttempted
-    default: .completed
+    case "completed": return .completed
+    case "skipped": return .skipped
+    case "not_attempted": return .notAttempted
+    default:
+      report(UnknownStoredEnum(kind: "EntryStatus", raw: raw), decodeContext)
+      return .notAttempted  // conservative: an unknown status must not inflate stats (#949)
     }
   }
 
@@ -325,7 +353,13 @@ final class LibraryStore: ItemStore {
   }
 
   private static func repAction(from raw: String) -> RepAction {
-    raw == "missed" ? .missed : .success
+    switch raw {
+    case "missed": return .missed
+    case "success": return .success
+    default:
+      report(UnknownStoredEnum(kind: "RepAction", raw: raw), decodeContext)
+      return .missed  // conservative: an unknown rep must not inflate achievement (#949)
+    }
   }
 
 }

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -190,6 +190,36 @@ final class LibraryStoreTests: XCTestCase {
     XCTAssertTrue(columns.contains("deleted_at"), "session needs deleted_at; has \(columns)")
   }
 
+  /// Unknown stored enum strings (an older binary reading a newer row) fall back
+  /// to conservative defaults rather than silently mis-categorising (#949).
+  func testUnknownStoredEnumStringsFallBackToConservativeDefaults() throws {
+    let entries =
+      #"[{"id":"e1","itemId":"i1","itemTitle":"X","itemType":"klingon","position":0,"durationSecs":0,"status":"quantum","repHistory":["warp"]}]"#
+    let store = try LibraryStore.upgradeTestStore(
+      migratedTo: "v3_session",
+      seed: """
+        INSERT INTO item
+          (id, title, kind, composer, key, modality, tempo_marking, tempo_bpm, notes, tags,
+           created_at, updated_at, priority, deleted_at)
+        VALUES ('i1', 'X', 'piece', NULL, NULL, 'lydian', NULL, NULL, NULL, '[]',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 0, NULL);
+        INSERT INTO session
+          (id, started_at, completed_at, total_duration_secs, completion_status,
+           session_notes, session_intention, entries, updated_at, deleted_at)
+        VALUES ('s1', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 0, 'enlightenment',
+                NULL, NULL, '\(entries)', '2026-01-01T00:00:00Z', NULL)
+        """)
+    XCTAssertNil(try XCTUnwrap(try store.loadItems().first).modality, "unknown modality → nil")
+
+    let got = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(got.completionStatus, .completed, "unknown completion status → completed")
+    let e = try XCTUnwrap(got.entries.first)
+    XCTAssertEqual(
+      e.status, .notAttempted, "unknown entry status → conservative notAttempted, not completed")
+    XCTAssertEqual(e.itemType, .piece, "unknown kind → piece")
+    XCTAssertEqual(e.repHistory, [.missed], "unknown rep action → conservative missed")
+  }
+
   /// Upgrade path: a pre-existing v2 item row survives the v3 session migration.
   func testV2ItemSurvivesSessionMigration() throws {
     let store = try LibraryStore.upgradeTestStore(


### PR DESCRIPTION
Closes #949.

`LibraryStore`'s enum decoders (`kind`, `modality`, `completionStatus`, `entryStatus`, `repAction`) silently fell through to a safe default on an unrecognised string. Unreachable today (we only decode what we wrote, same schema version), but an older binary reading a row a newer version wrote would silently **mis-categorise** — e.g. unknown `entryStatus` → `.completed` inflates practice stats vs the more conservative `.notAttempted`. That's the surface-don't-swallow class one level down.

## Change
- Route every unrecognised string through `report(_:)` (the established swallowed-error surface from `Logging.swift`) so the anomaly is logged (and Sentry-captured when a DSN is set) instead of vanishing.
- Pick **conservative defaults** where the choice affects stats: `entryStatus → .notAttempted`, `repAction → .missed` — an unknown value can no longer pad practice stats or achievement counts. `kind → .piece`, `completionStatus → .completed`, `modality → nil` retain their natural defaults but now log.

Pure decode-side change: no network, no schema change, no `try!`/force-unwrap — offline-first and dumb-pipe invariants intact.

## Tests
`testUnknownStoredEnumStringsFallBackToConservativeDefaults` seeds a row at HEAD schema with unknown strings for all five enums and asserts each conservative default (incl. `repAction → .missed` and `modality → nil`).

`just ios-test` gate passed (full IntradaTests on the pinned iPhone 16 / iOS 26.5 sim); the new test ran + passed explicitly.

**Coverage:** ignored path (`ios/` is Codecov-excluded). The new behaviour is unit-pinned by the test above; the `report()` log side-effect is not assertable in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)