### PR TITLE
Native iOS: extract shared BrowseControlsBar header (#942)

### DIFF
--- a/ios/Intrada/Views/Components/BrowseControlsBar.swift
+++ b/ios/Intrada/Views/Components/BrowseControlsBar.swift
@@ -1,0 +1,136 @@
+import SharedTypes
+import SwiftUI
+
+/// The shared Library/builder browse header: type pills, sort menu, tag filter,
+/// and a button-revealed search bar — all writing the core's shared `activeQuery`
+/// / `activeSort` (#792). Extracted from LibraryScreen so the builder reuses it
+/// instead of cloning the orchestration (#942).
+struct BrowseControlsBar: View {
+  @Environment(Store.self) private var store
+  private let elevated: Bool
+  @State private var filtering = false
+  @State private var searchText: String
+  @State private var searchRevealed: Bool
+  @FocusState private var searchFocused: Bool
+
+  init(elevated: Bool = false, previewSearch: String? = nil) {
+    self.elevated = elevated
+    _searchText = State(initialValue: previewSearch ?? "")
+    _searchRevealed = State(initialValue: previewSearch != nil)
+  }
+
+  private var activeTags: [String] { store.viewModel?.activeQuery?.tags ?? [] }
+
+  private var filterBinding: Binding<LibraryFilter> {
+    Binding(
+      get: { LibraryFilter(kind: store.viewModel?.activeQuery?.itemType) },
+      set: { sendQuery(kind: $0.kind, text: searchText) })
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      // Shadow + zIndex stay on the header alone so the revealed search bar
+      // slides out from *under* it rather than sharing its elevation.
+      elevatedHeader
+        .zIndex(1)
+      if searchRevealed {
+        LibrarySearchBar(text: $searchText, focused: $searchFocused, onCancel: cancelSearch)
+          .padding(.horizontal, IntradaSpacing.card)
+          .padding(.bottom, IntradaSpacing.cardCompact)
+          .background(IntradaColor.paperTop)
+          .transition(.move(edge: .top).combined(with: .opacity))
+      }
+    }
+    .sensoryFeedback(.selection, trigger: searchRevealed)
+    .sheet(isPresented: $filtering) {
+      TagFilterSheet(
+        available: store.viewModel?.availableTags ?? [],
+        selected: activeTags, onChange: sendTagFilter)
+    }
+    .onChange(of: searchText) { _, newValue in
+      sendQuery(kind: store.viewModel?.activeQuery?.itemType, text: newValue)
+    }
+  }
+
+  @ViewBuilder private var elevatedHeader: some View {
+    if elevated {
+      header.cardShadow()
+    } else {
+      header
+    }
+  }
+
+  private var header: some View {
+    HStack(spacing: IntradaSpacing.controlGap) {
+      LibraryFilterTabs(selection: filterBinding, edgeInset: IntradaSpacing.card)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      LibrarySortMenu(
+        current: store.viewModel?.activeSort
+          ?? LibrarySort(field: .dateAdded, direction: .descending),
+        onChange: { store.send(.setSort($0)) })
+      Button {
+        filtering = true
+      } label: {
+        Image(
+          systemName: activeTags.isEmpty
+            ? "line.3.horizontal.decrease.circle"
+            : "line.3.horizontal.decrease.circle.fill"
+        )
+        .font(IntradaFont.tab)
+        .foregroundStyle(activeTags.isEmpty ? IntradaColor.inkFaint : IntradaColor.accent)
+        .padding(IntradaSpacing.controlGap)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Filter by tag")
+      .accessibilityValue(activeTags.isEmpty ? "Off" : "\(activeTags.count) selected")
+      Button(action: toggleSearch) {
+        Image(systemName: "magnifyingglass")
+          .font(IntradaFont.tab)
+          .foregroundStyle(searchRevealed ? IntradaColor.accent : IntradaColor.inkFaint)
+          .padding(IntradaSpacing.controlGap)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Search")
+    }
+    .padding(.horizontal, IntradaSpacing.card)
+    .padding(.top, IntradaSpacing.cardCompact)
+    .padding(.bottom, IntradaSpacing.row)
+    // Opaque + on top so the bar emerges from behind the pills rather than
+    // ghosting over them (see Design System Rules → animated reveals).
+    .background(IntradaColor.paperTop)
+  }
+
+  private func toggleSearch() {
+    if searchRevealed {
+      cancelSearch()
+    } else {
+      withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { searchRevealed = true }
+      searchFocused = true
+    }
+  }
+
+  private func cancelSearch() {
+    searchText = ""
+    searchFocused = false
+    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { searchRevealed = false }
+  }
+
+  // Change one dimension while preserving the others, so the three filters
+  // (type / search / tags) don't reset each other.
+  private func sendQuery(kind: ItemKind?, text: String) {
+    applyQuery(kind: kind, text: text, tags: activeTags)
+  }
+
+  private func sendTagFilter(_ tags: [String]) {
+    applyQuery(kind: store.viewModel?.activeQuery?.itemType, text: searchText, tags: tags)
+  }
+
+  private func applyQuery(kind: ItemKind?, text: String, tags: [String]) {
+    let trimmed = text.trimmingCharacters(in: .whitespaces)
+    let query =
+      (kind == nil && trimmed.isEmpty && tags.isEmpty)
+      ? nil
+      : ListQuery(text: trimmed.isEmpty ? nil : trimmed, itemType: kind, key: nil, tags: tags)
+    store.send(.setQuery(query))
+  }
+}

--- a/ios/Intrada/Views/Screens/LibraryScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryScreen.swift
@@ -4,30 +4,16 @@ import SwiftUI
 struct LibraryScreen: View {
   @Environment(Store.self) private var store
   @State private var adding = false
-  @State private var filtering = false
-  @State private var searchText = ""
-  @State private var searchRevealed = false
-  @FocusState private var searchFocused: Bool
+  private let previewSearch: String?
 
-  init() {}
+  init() { previewSearch = nil }
 
   #if DEBUG
-    /// Preview/snapshot seed: render with the search bar already revealed and a
-    /// query in flight, so the searching state has its own visual regression test.
-    init(previewSearch: String) {
-      _searchText = State(initialValue: previewSearch)
-      _searchRevealed = State(initialValue: true)
-    }
+    /// Preview/snapshot seed: render with the search bar already revealed.
+    init(previewSearch: String) { self.previewSearch = previewSearch }
   #endif
 
   private var items: [LibraryItemView] { store.viewModel?.items ?? [] }
-
-  // Core owns the filter: read `activeQuery`, write back via `setQuery` (#792).
-  private var filterBinding: Binding<LibraryFilter> {
-    Binding(
-      get: { LibraryFilter(kind: store.viewModel?.activeQuery?.itemType) },
-      set: { sendQuery(kind: $0.kind, text: searchText) })
-  }
 
   var body: some View {
     ScreenScaffold(
@@ -35,67 +21,16 @@ struct LibraryScreen: View {
       trailing: .init(label: "Add item", action: { adding = true })
     ) {
       VStack(spacing: 0) {
-        HStack(spacing: IntradaSpacing.controlGap) {
-          LibraryFilterTabs(selection: filterBinding, edgeInset: IntradaSpacing.card)
-            .frame(maxWidth: .infinity, alignment: .leading)
-          LibrarySortMenu(
-            current: store.viewModel?.activeSort
-              ?? LibrarySort(field: .dateAdded, direction: .descending),
-            onChange: { store.send(.setSort($0)) })
-          Button {
-            filtering = true
-          } label: {
-            Image(
-              systemName: activeTags.isEmpty
-                ? "line.3.horizontal.decrease.circle"
-                : "line.3.horizontal.decrease.circle.fill"
-            )
-            .font(IntradaFont.tab)
-            .foregroundStyle(activeTags.isEmpty ? IntradaColor.inkFaint : IntradaColor.accent)
-            .padding(IntradaSpacing.controlGap)
-          }
-          .buttonStyle(.plain)
-          .accessibilityLabel("Filter by tag")
-          .accessibilityValue(activeTags.isEmpty ? "Off" : "\(activeTags.count) selected")
-          Button(action: toggleSearch) {
-            Image(systemName: "magnifyingglass")
-              .font(IntradaFont.tab)
-              .foregroundStyle(searchRevealed ? IntradaColor.accent : IntradaColor.inkFaint)
-              .padding(IntradaSpacing.controlGap)
-          }
-          .buttonStyle(.plain)
-          .accessibilityLabel("Search")
-        }
-        .padding(.horizontal, IntradaSpacing.card)
-        .padding(.top, IntradaSpacing.cardCompact)
-        .padding(.bottom, IntradaSpacing.row)
-        // Opaque + on top so the bar emerges from behind the pills rather than
-        // ghosting over them (see Design System Rules → animated reveals).
-        .background(IntradaColor.paperTop)
-        .zIndex(1)
-        if searchRevealed {
-          LibrarySearchBar(text: $searchText, focused: $searchFocused, onCancel: cancelSearch)
-            .padding(.horizontal, IntradaSpacing.card)
-            .padding(.bottom, IntradaSpacing.cardCompact)
-            .background(IntradaColor.paperTop)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
+        BrowseControlsBar(previewSearch: previewSearch)
         content
       }
     }
     // The list draws its own serif header, so suppress the nav bar here; the
     // detail keeps it for the back chevron.
     .toolbar(.hidden, for: .navigationBar)
-    .sensoryFeedback(.selection, trigger: searchRevealed)
     .sheet(isPresented: $adding) {
       LibraryAddScreen(defaultKind: store.viewModel?.activeQuery?.itemType ?? .piece)
         .environment(store)
-    }
-    .sheet(isPresented: $filtering) {
-      TagFilterSheet(
-        available: store.viewModel?.availableTags ?? [],
-        selected: activeTags,
-        onChange: sendTagFilter)
     }
     // Key on the id (not the value) so an edit — which changes the item's hash —
     // doesn't break the pushed destination; the detail re-reads the fresh item.
@@ -103,9 +38,6 @@ struct LibraryScreen: View {
       if let found = items.first(where: { $0.id == id }) {
         LibraryDetailScreen(item: found)
       }
-    }
-    .onChange(of: searchText) { _, newValue in
-      sendQuery(kind: store.viewModel?.activeQuery?.itemType, text: newValue)
     }
   }
 
@@ -133,25 +65,6 @@ struct LibraryScreen: View {
     }
   }
 
-  private func toggleSearch() {
-    if searchRevealed {
-      cancelSearch()
-    } else {
-      withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-        searchRevealed = true
-      }
-      searchFocused = true
-    }
-  }
-
-  private func cancelSearch() {
-    searchText = ""
-    searchFocused = false
-    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
-      searchRevealed = false
-    }
-  }
-
   private var isSearching: Bool {
     !(store.viewModel?.activeQuery?.text ?? "").isEmpty
   }
@@ -165,32 +78,6 @@ struct LibraryScreen: View {
     case .pieces: return "No pieces yet."
     case .exercises: return "No exercises yet."
     }
-  }
-
-  /// The currently active tag filter (OR-matched in the core).
-  private var activeTags: [String] {
-    store.viewModel?.activeQuery?.tags ?? []
-  }
-
-  /// Change the type filter / search text while preserving the active tag
-  /// filter, so the three dimensions don't reset each other.
-  private func sendQuery(kind: ItemKind?, text: String) {
-    applyQuery(kind: kind, text: text, tags: activeTags)
-  }
-
-  /// Change the tag filter while preserving the active type filter + search.
-  private func sendTagFilter(_ tags: [String]) {
-    applyQuery(kind: store.viewModel?.activeQuery?.itemType, text: searchText, tags: tags)
-  }
-
-  /// Build the combined query from all three dimensions; all-empty clears it.
-  private func applyQuery(kind: ItemKind?, text: String, tags: [String]) {
-    let trimmed = text.trimmingCharacters(in: .whitespaces)
-    let query =
-      (kind == nil && trimmed.isEmpty && tags.isEmpty)
-      ? nil
-      : ListQuery(text: trimmed.isEmpty ? nil : trimmed, itemType: kind, key: nil, tags: tags)
-    store.send(.setQuery(query))
   }
 
   private var subtitle: String? {

--- a/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
+++ b/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
@@ -8,31 +8,20 @@ struct SessionBuilderScreen: View {
   @Environment(Store.self) private var store
   @Environment(\.dismiss) private var dismiss
   @State private var confirmingCancel = false
-  @State private var filtering = false
-  @State private var searchText = ""
-  @State private var searchRevealed = false
-  @FocusState private var searchFocused: Bool
 
   private var items: [LibraryItemView] { store.viewModel?.items ?? [] }
   private var entries: [SetlistEntryView] { store.viewModel?.buildingSetlist?.entries ?? [] }
-  private var activeTags: [String] { store.viewModel?.activeQuery?.tags ?? [] }
 
   private var entryByItem: [String: String] {
     let entries = store.viewModel?.buildingSetlist?.entries ?? []
     return Dictionary(entries.map { ($0.itemId, $0.id) }, uniquingKeysWith: { first, _ in first })
   }
 
-  private var filterBinding: Binding<LibraryFilter> {
-    Binding(
-      get: { LibraryFilter(kind: store.viewModel?.activeQuery?.itemType) },
-      set: { sendQuery(kind: $0.kind, text: searchText) })
-  }
-
   var body: some View {
     ZStack {
       PaperBackground()
       VStack(spacing: 0) {
-        browseControls
+        BrowseControlsBar(elevated: true)
         library
         queueTray
       }
@@ -45,15 +34,6 @@ struct SessionBuilderScreen: View {
         Button("Cancel") { cancel() }
       }
     }
-    .sensoryFeedback(.selection, trigger: searchRevealed)
-    .sheet(isPresented: $filtering) {
-      TagFilterSheet(
-        available: store.viewModel?.availableTags ?? [],
-        selected: activeTags, onChange: sendTagFilter)
-    }
-    .onChange(of: searchText) { _, newValue in
-      sendQuery(kind: store.viewModel?.activeQuery?.itemType, text: newValue)
-    }
     .alert("Discard session plan?", isPresented: $confirmingCancel) {
       Button("Discard", role: .destructive) { dismiss() }
       Button("Keep editing", role: .cancel) {}
@@ -63,53 +43,6 @@ struct SessionBuilderScreen: View {
   }
 
   // ── Library (browse + add) ───────────────────────────────────────────
-
-  private var browseControls: some View {
-    VStack(spacing: 0) {
-      HStack(spacing: IntradaSpacing.controlGap) {
-        LibraryFilterTabs(selection: filterBinding, edgeInset: IntradaSpacing.card)
-          .frame(maxWidth: .infinity, alignment: .leading)
-        LibrarySortMenu(
-          current: store.viewModel?.activeSort
-            ?? LibrarySort(field: .dateAdded, direction: .descending),
-          onChange: { store.send(.setSort($0)) })
-        Button {
-          filtering = true
-        } label: {
-          Image(
-            systemName: activeTags.isEmpty
-              ? "line.3.horizontal.decrease.circle" : "line.3.horizontal.decrease.circle.fill"
-          )
-          .font(IntradaFont.tab)
-          .foregroundStyle(activeTags.isEmpty ? IntradaColor.inkFaint : IntradaColor.accent)
-          .padding(IntradaSpacing.controlGap)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Filter by tag")
-        Button(action: toggleSearch) {
-          Image(systemName: "magnifyingglass")
-            .font(IntradaFont.tab)
-            .foregroundStyle(searchRevealed ? IntradaColor.accent : IntradaColor.inkFaint)
-            .padding(IntradaSpacing.controlGap)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Search")
-      }
-      .padding(.horizontal, IntradaSpacing.card)
-      .padding(.top, IntradaSpacing.cardCompact)
-      .padding(.bottom, IntradaSpacing.row)
-      .background(IntradaColor.paperTop)
-      .cardShadow()
-      .zIndex(1)
-      if searchRevealed {
-        LibrarySearchBar(text: $searchText, focused: $searchFocused, onCancel: cancelSearch)
-          .padding(.horizontal, IntradaSpacing.card)
-          .padding(.bottom, IntradaSpacing.cardCompact)
-          .background(IntradaColor.paperTop)
-          .transition(.move(edge: .top).combined(with: .opacity))
-      }
-    }
-  }
 
   @ViewBuilder private var library: some View {
     if items.isEmpty {
@@ -246,21 +179,6 @@ struct SessionBuilderScreen: View {
     if entries.isEmpty { dismiss() } else { confirmingCancel = true }
   }
 
-  private func toggleSearch() {
-    if searchRevealed {
-      cancelSearch()
-    } else {
-      withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { searchRevealed = true }
-      searchFocused = true
-    }
-  }
-
-  private func cancelSearch() {
-    searchText = ""
-    searchFocused = false
-    withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) { searchRevealed = false }
-  }
-
   private var isSearching: Bool { !(store.viewModel?.activeQuery?.text ?? "").isEmpty }
 
   private var emptyMessage: String {
@@ -268,23 +186,6 @@ struct SessionBuilderScreen: View {
       return "No items match “\(text)”."
     }
     return "Your library is empty — add pieces and exercises first."
-  }
-
-  private func sendQuery(kind: ItemKind?, text: String) {
-    applyQuery(kind: kind, text: text, tags: activeTags)
-  }
-
-  private func sendTagFilter(_ tags: [String]) {
-    applyQuery(kind: store.viewModel?.activeQuery?.itemType, text: searchText, tags: tags)
-  }
-
-  private func applyQuery(kind: ItemKind?, text: String, tags: [String]) {
-    let trimmed = text.trimmingCharacters(in: .whitespaces)
-    let query =
-      (kind == nil && trimmed.isEmpty && tags.isEmpty)
-      ? nil
-      : ListQuery(text: trimmed.isEmpty ? nil : trimmed, itemType: kind, key: nil, tags: tags)
-    store.send(.setQuery(query))
   }
 }
 


### PR DESCRIPTION
## What
Extracts the shared Library/builder browse header — type-filter pills, sort
menu, tag-filter sheet, and the button-revealed search bar — into one
`BrowseControlsBar` component (`ios/Intrada/Views/Components/BrowseControlsBar.swift`).
`LibraryScreen` and `SessionBuilderScreen` now render it instead of each
cloning the identical orchestration (the `activeQuery`/`activeSort` writes,
the `toggle`/`cancel`/`applyQuery` funcs, and the `@State`/`@FocusState`).

Closes #942.

## Why
The two screens carried byte-identical browse orchestration. CLAUDE.md's
"consolidate before you template" principle: the Library screens are the
template the other pillars clone, so duplication here multiplies.

## Behaviour-preserving
- `just ios-test` green with **zero snapshot PNG churn**.
- Net −150ish lines across the two screens (one shared component replaces two clones).
- The builder passes `elevated: true`, which applies `.cardShadow()` to the
  **header HStack only** — exactly the pre-refactor scope, so the revealed
  search bar still slides out from *under* the header's elevation. The Library
  renders it bare (`elevated: false`, no shadow), unchanged.
- `previewSearch` (DEBUG-only seam) seeds the revealed-search state for snapshots.

## Minor a11y unification
The builder's tag-filter button previously had only an `accessibilityLabel`;
the extracted component adds the `accessibilityValue` ("Off" / "N selected")
the Library button already carried. Strict improvement — both screens now
expose the richer value.

## Coverage
N/A for line coverage — Swift/iOS shell is in Codecov's ignore list. Quality
gate is the snapshot suite (zero churn) + the existing screen snapshots.
Builder search-revealed snapshot gap tracked in #957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)