### PR TITLE
ios(test): await HTTP resolve deterministically, kill the CI flake (#956)

### DIFF
--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -362,13 +362,30 @@ final class StoreEffectLoopTests: XCTestCase {
     return bridge
   }
 
-  /// Run `action`, then await the bridge's first `resolve` — the HTTP leg hops
-  /// through a detached `Task`, so the assertion must wait for it.
-  private func whenResolved(_ bridge: FakeBridge, _ action: () -> Void) async {
-    let resolved = expectation(description: "bridge resolved")
-    bridge.onResolve = { resolved.fulfill() }
-    action()
-    await fulfillment(of: [resolved], timeout: 5)  // generous ceiling; absorbs CI scheduling jitter (#861)
+  /// Resume on the bridge's `resolve` callback, not a wall-clock `fulfillment`
+  /// — a loaded CI runner starves the detached HTTP Task; a tight ceiling flakes
+  /// (#956, #861). The 30s net is a fail-bounded backstop, not the happy path.
+  private func whenResolved(
+    _ bridge: FakeBridge, _ action: () -> Void,
+    file: StaticString = #filePath, line: UInt = #line
+  ) async {
+    let gate = ResolveGate()
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      let timeout = Task {
+        try? await Task.sleep(for: .seconds(30))
+        if gate.claim() {
+          XCTFail("bridge never resolved within the 30s safety ceiling", file: file, line: line)
+          continuation.resume()
+        }
+      }
+      bridge.onResolve = {
+        if gate.claim() {
+          timeout.cancel()
+          continuation.resume()
+        }
+      }
+      action()
+    }
   }
 
   static let sampleItem = Item(
@@ -432,6 +449,19 @@ private final class FakeBridge: CoreBridge {
     if let throwOnView { throw throwOnView }
     if let nextViewModel { return try nextViewModel() }
     return try emptyViewModel()
+  }
+}
+
+/// One-shot: only the first of {resolve, timeout} resumes (double-resume traps).
+private final class ResolveGate {
+  private let lock = NSLock()
+  private var claimed = false
+  func claim() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    if claimed { return false }
+    claimed = true
+    return true
   }
 }
 


### PR DESCRIPTION
## What
`StoreEffectLoopTests`' 6 async HTTP tests waited on the bridge resolve via a wall-clock `fulfillment(of:timeout: 5)`. The HTTP leg hops through a detached `Task`; on a loaded GitHub macOS runner (one failing run took **446s** for a suite that's ~80s locally) that `Task` is starved and the resolve — which *does* eventually fire — misses the 5s ceiling, reddening CI on unrelated PRs. Second recurrence (#861 already bumped 2s→5s).

Closes #956.

## Fix
Replace the wall-clock race with a `CheckedContinuation` resumed on the resolve callback:
- **Success path waits exactly as long as the resolve takes** — no load-sensitive ceiling, so it can't flake under runner load.
- A **30s safety net** (~600x the local resolve time, so load jitter can't trip it) **fails** — rather than hangs the job or silently passes — if a real regression means resolve never fires.
- A one-shot `ResolveGate` (`NSLock`-guarded bool) guarantees exactly one of `{resolve, timeout}` resumes the continuation — resuming a `CheckedContinuation` twice traps. On success it cancels the timeout `Task`, so no lingering work.

`onResolve` fires *after* `resolved.append(...)` in `FakeBridge`, so resuming on it keeps the tests' `bridge.resolved.first` assertions correct (no read-before-write race).

## Verification
`just ios-test` green locally — all 6 async tests (`testHttpEffectMaps*`, `testHttpRequestMapsMethodAndHeaders`, `testResolveChainedRenderRefreshesView`) pass on the new helper. The fix is test-infra only; no product/core code touched.

## Coverage
N/A — test-only change; Swift shell is in Codecov's ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)