### PR TITLE
Native iOS: unify KindSegment + LibraryFilterTabs into SegmentedPills (#807)

### DIFF
--- a/ios/Intrada/Views/Components/KindSegment.swift
+++ b/ios/Intrada/Views/Components/KindSegment.swift
@@ -5,38 +5,11 @@ import SwiftUI
 /// `LibraryFilterTabs`, shared by the add and edit forms.
 struct KindSegment: View {
   @Binding var selection: ItemKind
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @Namespace private var pill
 
   var body: some View {
-    HStack(spacing: 4) {
-      ForEach([ItemKind.piece, ItemKind.exercise], id: \.self) { kind in
-        let isSelected = kind == selection
-        Button {
-          withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.8)) {
-            selection = kind
-          }
-        } label: {
-          Text(kind.label)
-            .font(IntradaFont.segment)
-            .foregroundStyle(isSelected ? IntradaColor.onAccent : IntradaColor.inkSecondary)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, IntradaSpacing.controlGap)
-            .background {
-              if isSelected {
-                Capsule()
-                  .fill(IntradaColor.accent)
-                  .matchedGeometryEffect(id: "kindPill", in: pill)
-              }
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(kind.label)
-        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-      }
-    }
-    .padding(4)
-    .background(IntradaColor.cardFill, in: Capsule())
-    .overlay(Capsule().stroke(IntradaColor.hairline, lineWidth: 1))
+    SegmentedPills(
+      options: [.piece, .exercise], selection: $selection, label: \.label,
+      font: IntradaFont.segment, unselectedColor: IntradaColor.inkSecondary,
+      layout: .fullWidthTrack)
   }
 }

--- a/ios/Intrada/Views/Components/LibraryFilterTabs.swift
+++ b/ios/Intrada/Views/Components/LibraryFilterTabs.swift
@@ -36,43 +36,11 @@ enum LibraryFilter: CaseIterable, Identifiable {
 struct LibraryFilterTabs: View {
   @Binding var selection: LibraryFilter
   var edgeInset: CGFloat = 0
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
-  @Namespace private var pill
 
   var body: some View {
-    // Horizontal scroll so the pills slide rather than wrap mid-word once the
-    // labels grow past the width at large Dynamic Type (#810).
-    ScrollView(.horizontal, showsIndicators: false) {
-      HStack(spacing: IntradaSpacing.controlGap) {
-        ForEach(LibraryFilter.allCases) { filter in
-          let isSelected = filter == selection
-          Button {
-            withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.8)) {
-              selection = filter
-            }
-          } label: {
-            Text(filter.label)
-              .font(IntradaFont.tab)
-              .lineLimit(1)
-              .foregroundStyle(isSelected ? IntradaColor.onAccent : IntradaColor.inkFaint)
-              .padding(.vertical, 6)
-              .padding(.horizontal, IntradaSpacing.row)
-              .background {
-                if isSelected {
-                  Capsule()
-                    .fill(IntradaColor.accent)
-                    .matchedGeometryEffect(id: "selectedPill", in: pill)
-                }
-              }
-          }
-          .buttonStyle(.plain)
-          .accessibilityLabel(filter.label)
-          .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-        }
-      }
-    }
-    .contentMargins(.leading, edgeInset, for: .scrollContent)
-    .padding(.leading, -edgeInset)
+    SegmentedPills(
+      options: LibraryFilter.allCases, selection: $selection, label: \.label,
+      layout: .inlineScrolling(edgeInset: edgeInset))
   }
 }
 

--- a/ios/Intrada/Views/Components/SegmentedPills.swift
+++ b/ios/Intrada/Views/Components/SegmentedPills.swift
@@ -1,0 +1,106 @@
+import SharedTypes
+import SwiftUI
+
+/// Shared accent-pill segmented control: a sliding `matchedGeometryEffect`
+/// capsule across `options`. Backs both `LibraryFilterTabs` (inline-scrolling
+/// tabs) and `KindSegment` (full-width bordered track) so the pill language
+/// lives in one place (#807).
+struct SegmentedPills<Option: Hashable>: View {
+  enum Layout: Equatable {
+    /// Leading, horizontally-scrollable tabs that hug their labels.
+    case inlineScrolling(edgeInset: CGFloat)
+    /// Equal-width segments on a bordered card track.
+    case fullWidthTrack
+  }
+
+  let options: [Option]
+  @Binding var selection: Option
+  let label: (Option) -> String
+  var font: Font = IntradaFont.tab
+  var unselectedColor: Color = IntradaColor.inkFaint
+  var layout: Layout = .inlineScrolling(edgeInset: 0)
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Namespace private var pill
+
+  var body: some View {
+    switch layout {
+    case .inlineScrolling(let edgeInset):
+      // Horizontal scroll so the pills slide rather than wrap mid-word once the
+      // labels grow past the width at large Dynamic Type (#810).
+      ScrollView(.horizontal, showsIndicators: false) { track }
+        .contentMargins(.leading, edgeInset, for: .scrollContent)
+        .padding(.leading, -edgeInset)
+    case .fullWidthTrack:
+      track
+        .padding(4)
+        .background(IntradaColor.cardFill, in: Capsule())
+        .overlay(Capsule().stroke(IntradaColor.hairline, lineWidth: 1))
+    }
+  }
+
+  private var track: some View {
+    HStack(spacing: layout == .fullWidthTrack ? 4 : IntradaSpacing.controlGap) {
+      ForEach(options, id: \.self) { option in
+        pillButton(option)
+      }
+    }
+  }
+
+  private func pillButton(_ option: Option) -> some View {
+    let isSelected = option == selection
+    return Button {
+      withAnimation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.8)) {
+        selection = option
+      }
+    } label: {
+      pillLabel(option, isSelected: isSelected)
+        .background {
+          if isSelected {
+            Capsule()
+              .fill(IntradaColor.accent)
+              .matchedGeometryEffect(id: "selectedPill", in: pill)
+          }
+        }
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(label(option))
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+  }
+
+  @ViewBuilder private func pillLabel(_ option: Option, isSelected: Bool) -> some View {
+    let text = Text(label(option))
+      .font(font)
+      .foregroundStyle(isSelected ? IntradaColor.onAccent : unselectedColor)
+    switch layout {
+    case .inlineScrolling:
+      text.lineLimit(1).padding(.vertical, 6).padding(.horizontal, IntradaSpacing.row)
+    case .fullWidthTrack:
+      text.frame(maxWidth: .infinity).padding(.vertical, IntradaSpacing.controlGap)
+    }
+  }
+}
+
+#if DEBUG
+  private struct SegmentedPillsPreview: View {
+    @State private var tab: LibraryFilter = .pieces
+    @State private var kind: ItemKind = .piece
+    var body: some View {
+      ZStack {
+        PaperBackground()
+        VStack(spacing: IntradaSpacing.card) {
+          SegmentedPills(
+            options: LibraryFilter.allCases, selection: $tab, label: \.label,
+            layout: .inlineScrolling(edgeInset: 0))
+          SegmentedPills(
+            options: [.piece, .exercise], selection: $kind, label: \.label,
+            font: IntradaFont.segment, unselectedColor: IntradaColor.inkSecondary,
+            layout: .fullWidthTrack)
+        }
+        .padding(IntradaSpacing.card)
+      }
+    }
+  }
+
+  #Preview { SegmentedPillsPreview() }
+#endif


### PR DESCRIPTION
## What
Folds the two near-identical accent-pill segmented controls — `KindSegment` (full-width Piece/Exercise selector) and `LibraryFilterTabs` (inline All/Pieces/Exercises tabs) — into one parameterised `SegmentedPills` primitive. Both become thin configurations of it.

Closes #807.

## Why
They shared the entire pill language — `matchedGeometryEffect` slide, the `spring(response: 0.35, dampingFraction: 0.8)`, the `onAccent`/unselected token pairing, the a11y `.isSelected` trait — and differed only in:
- option set (binary `ItemKind` vs tri-state `LibraryFilter`)
- font (`segment` 14 vs `tab` 13) and unselected colour (`inkSecondary` vs `inkFaint`)
- layout (`.fullWidthTrack` — equal segments on a bordered card — vs `.inlineScrolling(edgeInset:)` — leading, horizontally-scrollable tabs)

Per CLAUDE.md's "extend, don't clone" rule, consolidating now (before a third copy appears) keeps the pill language in one place.

## Behaviour-preserving
`just ios-test` green with **zero snapshot PNG churn**:
- `testLibraryFilterTabs` / `testLibraryFilterTabsAccessibility` (direct component snapshots, all three states) — unchanged.
- Item add/edit form snapshots (exercise the `KindSegment` path) — unchanged.

The `SegmentedPills` `@Namespace` is per-instance, so collapsing the two distinct `matchedGeometryEffect` ids (`selectedPill`/`kindPill`) into one has no rendering effect.

## Coverage
N/A for line coverage — Swift shell is in Codecov's ignore list. Quality gate is the snapshot suite (zero churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)