### PR TITLE
chore: group crux crate bumps, pin facet + uniffi in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,27 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # The crux crates are a matched set (shared `Operation` trait + facet
+    # reflection): crux_core, crux_http, crux_macros must move in lockstep, or
+    # the tree ends up with two crux_core versions and trait bounds break (#970).
+    # Group them so dependabot proposes one coordinated, jointly-resolved PR
+    # instead of skewed single-crate bumps.
+    groups:
+      crux:
+        patterns:
+          - "crux*"
     # iOS-pivot focus mode: pause bumps for the web/Tauri shells (on hold).
     # Core + API deps still auto-update. Remove this ignore list at parity.
     ignore:
+      # Manually pinned to versions other tooling dictates — never auto-bump:
+      #   facet  -> must match crux_core's `facet =0.44` pin (typegen reflection)
+      #   uniffi -> must match cargo-swift's bundled bindgen (=0.29.4 guard in
+      #             intrada-ffi/src/lib.rs). Both broke main when bumped (#966/#968).
+      - dependency-name: "facet"
+      - dependency-name: "facet-*"
+      - dependency-name: "uniffi"
+      - dependency-name: "uniffi-*"
+      - dependency-name: "uniffi_*"
       - dependency-name: "tauri"
       - dependency-name: "tauri-*"
       - dependency-name: "leptos"


### PR DESCRIPTION
## Why

Follow-up to #970. The skew that broke `main` happened because dependabot bumps matched-set crates one at a time. This config stops it recurring.

## Changes to `.github/dependabot.yml` (cargo)

- **Group `crux*`** — `crux_core` + `crux_http` + `crux_macros` now come as one jointly-resolved PR, so they can't drift apart (the cause of the `Operation` trait errors when crux_http was left on 0.17).
- **Ignore `facet` / `uniffi`** — both are manually pinned to versions other tooling dictates:
  - `facet` must match crux_core's `facet =0.44` pin (typegen reflection)
  - `uniffi` must match cargo-swift's bundled bindgen (`=0.29.4` guard in `intrada-ffi/src/lib.rs`)

  Bumping either is a manual, coordinated step alongside the tool that dictates it — exactly the bumps (#966, #968) that broke `main`.

## Note on CI

This PR touches only `.github/dependabot.yml`, so the path-gated Rust/native checks (Test, Clippy, Native iOS) will **skip** — they have nothing to build. That's expected for a config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)