### PR TITLE
fix(ci): setup_ci in TestFlight lane (codesign keychain hang)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,11 @@ PROFILE_NAME = "match AppStore #{APP_IDENTIFIER}".freeze
 platform :ios do
   desc "Build a signed Release .ipa and upload it to TestFlight (internal testing)."
   lane :beta do
+    # On CI, create an unlocked temporary keychain for match to import the cert
+    # into — otherwise codesign blocks on a keychain UI prompt that never comes
+    # and the job hangs to the timeout. No-op locally.
+    setup_ci
+
     api_key = app_store_connect_api_key(
       key_id: ENV.fetch("ASC_KEY_ID"),
       issuer_id: ENV.fetch("ASC_ISSUER_ID"),


### PR DESCRIPTION
The first successful-signing TestFlight run hung for an hour on `codesign` and hit the 60-min job timeout. Root cause: the `beta` lane was missing `setup_ci`, so `match` imported the Apple Distribution cert into the default keychain and `codesign` blocked on a keychain UI prompt that never comes in headless CI.

`setup_ci` creates an unlocked temporary keychain (no-op locally). One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)