### PR TITLE
fix(ios): declare supported interface orientations (App Store 90474)

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -53,6 +53,10 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.intrada.native
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        # Orientations must be declared or App Store upload rejects the binary
+        # (90474); iPad multitasking requires all four. iPhone stays portrait.
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         # App icon = the Icon Composer AppIcon.icon bundle (no asset catalog).
         # actool rasterises back-compat PNGs for iOS 17/18; iOS 26 gets the
         # layered Liquid Glass rendering.


### PR DESCRIPTION
The TestFlight upload built + signed + uploaded fine, but Apple rejected the binary: `Invalid bundle. No orientations were specified… (90474)`. The generated Info.plist had no `UISupportedInterfaceOrientations`.

Declares iPhone = portrait, iPad = all four (required for iPad multitasking) via `INFOPLIST_KEY_*` build settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)