### PR TITLE
feat(core): SessionBlock grouping — Phase A (core + persistence)

### DIFF
--- a/crates/intrada-api/src/db/sessions.rs
+++ b/crates/intrada-api/src/db/sessions.rs
@@ -167,6 +167,7 @@ fn row_to_entry(row: &libsql::Row) -> Result<SetlistEntry, ApiError> {
         rep_history,
         planned_duration_secs,
         achieved_tempo,
+        group_id: None,
     })
 }
 
@@ -408,6 +409,7 @@ pub async fn insert_session(
                 rep_history: entry.rep_history.clone(),
                 planned_duration_secs: entry.planned_duration_secs,
                 achieved_tempo: entry.achieved_tempo,
+                group_id: None,
             });
         }
 

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -519,6 +519,7 @@ mod tests {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         }
     }
 

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -23,7 +23,7 @@ use crate::domain::set::{handle_set_event, Set, SetEvent};
 use crate::domain::types::{LibrarySort, ListQuery, SortDirection, SortField};
 use crate::http;
 use crate::model::{
-    build_active_session_view, build_summary_view, entry_to_view, session_to_view,
+    build_active_session_view, build_blocks, build_summary_view, entry_to_view, session_to_view,
     BuildingSetlistView, ItemPracticeSummary, LibraryItemView, LinkedExerciseView, Model,
     PieceRefView, SessionStatusView, SetSourceStatus, ViewModel,
 };
@@ -494,6 +494,8 @@ impl App for Intrada {
             SessionStatus::Building(building) => {
                 let entries: Vec<_> = building.entries.iter().map(entry_to_view).collect();
                 let item_count = entries.len();
+                let blocks = build_blocks(&entries);
+                let block_count = blocks.len();
                 let source_status = match &building.source_set_id {
                     None => SetSourceStatus::NoSource,
                     Some(sid) => {
@@ -535,6 +537,8 @@ impl App for Intrada {
                     Some(BuildingSetlistView {
                         entries,
                         item_count,
+                        blocks,
+                        block_count,
                         session_intention: building.session_intention.clone(),
                         target_duration_mins: building.target_duration_mins,
                         source_status,
@@ -917,6 +921,7 @@ fn sample_sessions() -> Vec<PracticeSession> {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         }
     };
 
@@ -1955,6 +1960,7 @@ mod tests {
                         rep_history: None,
                         planned_duration_secs: None,
                         achieved_tempo: if e % 3 == 0 { Some(120) } else { None },
+                        group_id: None,
                     }
                 })
                 .collect();
@@ -2105,6 +2111,7 @@ mod tests {
                     rep_history: None,
                     planned_duration_secs: None,
                     achieved_tempo: None,
+                    group_id: None,
                 },
                 SetlistEntry {
                     id: "e2".to_string(),
@@ -2123,6 +2130,7 @@ mod tests {
                     rep_history: None,
                     planned_duration_secs: None,
                     achieved_tempo: None,
+                    group_id: None,
                 },
             ],
         });
@@ -2204,6 +2212,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             }],
         });
 
@@ -2234,6 +2243,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             }],
         });
 
@@ -2306,6 +2316,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             }],
         });
 
@@ -2372,6 +2383,7 @@ mod tests {
                     rep_history: None,
                     planned_duration_secs: None,
                     achieved_tempo: None,
+                    group_id: None,
                 },
                 SetlistEntry {
                     id: "e2".to_string(),
@@ -2390,6 +2402,7 @@ mod tests {
                     rep_history: None,
                     planned_duration_secs: None,
                     achieved_tempo: None,
+                    group_id: None,
                 },
             ],
         });
@@ -2461,6 +2474,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             }],
         });
 
@@ -2527,6 +2541,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: tempo,
+                group_id: None,
             }],
         }
     }
@@ -2580,6 +2595,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             }],
         };
 
@@ -3402,6 +3418,7 @@ mod tests {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         };
         model.session_status = SessionStatus::Building(crate::domain::session::BuildingSession {
             entries: vec![entry],
@@ -3445,6 +3462,7 @@ mod tests {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         };
         model.session_status = SessionStatus::Building(crate::domain::session::BuildingSession {
             entries: vec![entry],

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -78,6 +78,11 @@ pub struct SetlistEntry {
     pub planned_duration_secs: Option<u32>,
     #[serde(default)]
     pub achieved_tempo: Option<u16>,
+    /// Block grouping (building phase): entries pulled in alongside a piece via
+    /// its related exercises share one `group_id`. A block is the contiguous run
+    /// of entries with the same id; `None` = standalone.
+    #[serde(default)]
+    pub group_id: Option<String>,
 }
 
 /// A completed practice session (persisted to localStorage).
@@ -195,6 +200,26 @@ pub enum SessionEvent {
     ReorderSetlist {
         entry_id: String,
         new_position: usize,
+    },
+    /// Move a whole block to a new unit-position (blocks + standalone items,
+    /// in order). Keeps the block contiguous.
+    ReorderBlock {
+        group_id: String,
+        new_position: usize,
+    },
+    /// Drop a block's related exercises, keeping the piece (becomes standalone).
+    KeepOnlyPiece {
+        group_id: String,
+    },
+    /// Dissolve a block — its entries stay in place but become standalone.
+    UngroupBlock {
+        group_id: String,
+    },
+    /// Dissolve every block.
+    UngroupAllBlocks,
+    /// Remove a whole block (piece + its related exercises).
+    RemoveBlock {
+        group_id: String,
     },
     StartSession {
         now: DateTime<Utc>,
@@ -336,6 +361,7 @@ fn create_entry(
         rep_history: None,
         planned_duration_secs: None,
         achieved_tempo: None,
+        group_id: None,
     }
 }
 
@@ -343,6 +369,52 @@ fn reindex_entries(entries: &mut [SetlistEntry]) {
     for (i, entry) in entries.iter_mut().enumerate() {
         entry.position = i;
     }
+}
+
+/// Partition entries into ordered units: a contiguous run sharing a `Some`
+/// `group_id` is one unit (a block); every `None` entry is its own unit.
+fn into_units(entries: Vec<SetlistEntry>) -> Vec<Vec<SetlistEntry>> {
+    let mut units: Vec<Vec<SetlistEntry>> = Vec::new();
+    for entry in entries {
+        match &entry.group_id {
+            Some(g) => {
+                let extends = units
+                    .last()
+                    .and_then(|u| u.first())
+                    .and_then(|e| e.group_id.as_deref())
+                    == Some(g.as_str());
+                if extends {
+                    units.last_mut().expect("checked above").push(entry);
+                } else {
+                    units.push(vec![entry]);
+                }
+            }
+            None => units.push(vec![entry]),
+        }
+    }
+    units
+}
+
+/// True when every `group_id` occupies a single contiguous run — the block
+/// invariant a reorder must never break.
+fn groups_contiguous(entries: &[SetlistEntry]) -> bool {
+    let mut closed: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut current: Option<&str> = None;
+    for entry in entries {
+        let g = entry.group_id.as_deref();
+        if g != current {
+            if let Some(prev) = current {
+                closed.insert(prev);
+            }
+            if let Some(g) = g {
+                if closed.contains(g) {
+                    return false;
+                }
+            }
+            current = g;
+        }
+    }
+    true
 }
 
 fn create_item_from_title(title: &str, kind: ItemKind) -> Item {
@@ -573,18 +645,60 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 return crux_core::render::render();
             }
 
-            let Some((title, item_type)) = find_item_in_model(model, &item_id) else {
+            // Resolve the item and — for a piece — its related exercises as owned
+            // tuples before taking the mutable Building borrow.
+            let Some(item) = model.items.iter().find(|i| i.id == item_id) else {
                 model.last_error = Some(LibraryError::NotFound { id: item_id }.to_string());
                 return crux_core::render::render();
+            };
+            let piece = (item.id.clone(), item.title.clone(), item.kind.clone());
+            let related: Vec<(String, String, ItemKind)> = if item.kind == ItemKind::Piece {
+                item.linked_exercise_ids
+                    .iter()
+                    .filter_map(|ex_id| {
+                        model
+                            .items
+                            .iter()
+                            .find(|i| &i.id == ex_id && i.kind == ItemKind::Exercise)
+                            .map(|i| (i.id.clone(), i.title.clone(), i.kind.clone()))
+                    })
+                    .collect()
+            } else {
+                Vec::new()
             };
 
             let SessionStatus::Building(ref mut building) = model.session_status else {
                 model.last_error = Some("Internal error: expected Building state".to_string());
                 return crux_core::render::render();
             };
+
+            // Skip related exercises already in the setlist — don't duplicate.
+            let existing: std::collections::HashSet<String> =
+                building.entries.iter().map(|e| e.item_id.clone()).collect();
+            let related_to_add: Vec<(String, String, ItemKind)> = related
+                .into_iter()
+                .filter(|(id, _, _)| !existing.contains(id))
+                .collect();
+
+            // A block forms only when ≥1 related exercise actually comes along.
+            let group_id = if related_to_add.is_empty() {
+                None
+            } else {
+                Some(ulid::Ulid::new().to_string())
+            };
+
+            // Related first (warm-up order), then the piece.
+            for (id, title, kind) in &related_to_add {
+                let position = building.entries.len();
+                let mut entry = create_entry(id, title, kind.clone(), position);
+                entry.group_id.clone_from(&group_id);
+                building.entries.push(entry);
+            }
             let position = building.entries.len();
-            let entry = create_entry(&item_id, &title, item_type, position);
-            building.entries.push(entry);
+            let mut piece_entry = create_entry(&piece.0, &piece.1, piece.2, position);
+            piece_entry.group_id = group_id;
+            building.entries.push(piece_entry);
+
             model.last_error = None;
             crux_core::render::render()
         }
@@ -658,6 +772,118 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
 
             let entry = building.entries.remove(current_index);
             building.entries.insert(new_position, entry);
+            if !groups_contiguous(&building.entries) {
+                // Revert — the move would split a block.
+                let entry = building.entries.remove(new_position);
+                building.entries.insert(current_index, entry);
+                model.last_error = Some("Can't move an item out of its block".to_string());
+                return crux_core::render::render();
+            }
+            reindex_entries(&mut building.entries);
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::ReorderBlock {
+            group_id,
+            new_position,
+        } => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Not in building state".to_string());
+                return crux_core::render::render();
+            };
+
+            let mut units = into_units(std::mem::take(&mut building.entries));
+            let Some(current) = units.iter().position(|u| {
+                u.first().and_then(|e| e.group_id.as_deref()) == Some(group_id.as_str())
+            }) else {
+                building.entries = units.into_iter().flatten().collect();
+                model.last_error = Some(format!("Block '{group_id}' not found in setlist"));
+                return crux_core::render::render();
+            };
+
+            let target = new_position.min(units.len().saturating_sub(1));
+            let unit = units.remove(current);
+            units.insert(target, unit);
+            building.entries = units.into_iter().flatten().collect();
+            reindex_entries(&mut building.entries);
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::KeepOnlyPiece { group_id } => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Not in building state".to_string());
+                return crux_core::render::render();
+            };
+
+            let in_block = |e: &SetlistEntry| e.group_id.as_deref() == Some(group_id.as_str());
+            if !building.entries.iter().any(in_block) {
+                model.last_error = Some(format!("Block '{group_id}' not found in setlist"));
+                return crux_core::render::render();
+            }
+
+            building
+                .entries
+                .retain(|e| !(in_block(e) && e.item_type == ItemKind::Exercise));
+            // The lone piece left behind is no longer a block.
+            for entry in building.entries.iter_mut().filter(|e| in_block(e)) {
+                entry.group_id = None;
+            }
+            reindex_entries(&mut building.entries);
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::UngroupBlock { group_id } => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Not in building state".to_string());
+                return crux_core::render::render();
+            };
+
+            let mut found = false;
+            for entry in building
+                .entries
+                .iter_mut()
+                .filter(|e| e.group_id.as_deref() == Some(group_id.as_str()))
+            {
+                entry.group_id = None;
+                found = true;
+            }
+            if !found {
+                model.last_error = Some(format!("Block '{group_id}' not found in setlist"));
+                return crux_core::render::render();
+            }
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::UngroupAllBlocks => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Not in building state".to_string());
+                return crux_core::render::render();
+            };
+            for entry in &mut building.entries {
+                entry.group_id = None;
+            }
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
+        SessionEvent::RemoveBlock { group_id } => {
+            let SessionStatus::Building(ref mut building) = model.session_status else {
+                model.last_error = Some("Not in building state".to_string());
+                return crux_core::render::render();
+            };
+
+            let len_before = building.entries.len();
+            building
+                .entries
+                .retain(|e| e.group_id.as_deref() != Some(group_id.as_str()));
+            if building.entries.len() == len_before {
+                model.last_error = Some(format!("Block '{group_id}' not found in setlist"));
+                return crux_core::render::render();
+            }
             reindex_entries(&mut building.entries);
             model.last_error = None;
             crux_core::render::render()
@@ -1223,6 +1449,259 @@ mod tests {
     fn update(model: &mut Model, event: Event) {
         let app = Intrada;
         let _cmd = app.update(event, model);
+    }
+
+    // --- Block grouping (related exercises travel with a piece) ---
+
+    fn linked_model() -> Model {
+        let now = Utc::now();
+        let mk = |id: &str, title: &str, kind: ItemKind, linked: &[&str]| Item {
+            id: id.to_string(),
+            title: title.to_string(),
+            kind,
+            composer: None,
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            linked_exercise_ids: linked.iter().map(|s| s.to_string()).collect(),
+            created_at: now,
+            updated_at: now,
+            priority: false,
+        };
+        Model {
+            items: vec![
+                mk("piece-P", "Sonata", ItemKind::Piece, &["ex-A", "ex-B"]),
+                mk("piece-Q", "Nocturne", ItemKind::Piece, &[]),
+                mk("ex-A", "Scales", ItemKind::Exercise, &[]),
+                mk("ex-B", "Arpeggios", ItemKind::Exercise, &[]),
+                mk("ex-C", "Sight-reading", ItemKind::Exercise, &[]),
+            ],
+            api_base_url: "http://localhost:3001".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn building_entries(model: &Model) -> &[SetlistEntry] {
+        match &model.session_status {
+            SessionStatus::Building(b) => &b.entries,
+            _ => panic!("expected Building state"),
+        }
+    }
+
+    fn ids(model: &Model) -> Vec<String> {
+        building_entries(model)
+            .iter()
+            .map(|e| e.item_id.clone())
+            .collect()
+    }
+
+    fn add(model: &mut Model, item_id: &str) {
+        update(
+            model,
+            Event::Session(SessionEvent::AddToSetlist {
+                item_id: item_id.to_string(),
+            }),
+        );
+    }
+
+    fn group_of(model: &Model, item_id: &str) -> Option<String> {
+        building_entries(model)
+            .iter()
+            .find(|e| e.item_id == item_id)
+            .and_then(|e| e.group_id.clone())
+    }
+
+    #[test]
+    fn add_piece_pulls_related_into_a_block_related_first() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        let e = building_entries(&m);
+        assert_eq!(ids(&m), ["ex-A", "ex-B", "piece-P"]);
+        let g = e[0].group_id.clone();
+        assert!(g.is_some(), "block has a group_id");
+        assert!(
+            e.iter().all(|x| x.group_id == g),
+            "all three share the group"
+        );
+        assert_eq!((e[0].position, e[1].position, e[2].position), (0, 1, 2));
+    }
+
+    #[test]
+    fn add_piece_without_related_is_standalone() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-Q");
+        let e = building_entries(&m);
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].group_id, None);
+    }
+
+    #[test]
+    fn add_exercise_directly_is_standalone() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "ex-C");
+        let e = building_entries(&m);
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].group_id, None);
+    }
+
+    #[test]
+    fn add_piece_skips_already_present_related() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "ex-A");
+        add(&mut m, "piece-P");
+        let e = building_entries(&m);
+        assert_eq!(
+            e.iter().filter(|x| x.item_id == "ex-A").count(),
+            1,
+            "ex-A not duplicated"
+        );
+        assert_eq!(ids(&m), ["ex-A", "ex-B", "piece-P"]);
+        assert_eq!(
+            e[0].group_id, None,
+            "the pre-existing ex-A stays standalone"
+        );
+        assert!(e[1].group_id.is_some());
+        assert_eq!(e[1].group_id, e[2].group_id, "ex-B + piece form the block");
+    }
+
+    #[test]
+    fn remove_block_removes_piece_and_related() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "ex-C");
+        add(&mut m, "piece-P");
+        let g = group_of(&m, "piece-P").unwrap();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::RemoveBlock { group_id: g }),
+        );
+        assert!(m.last_error.is_none());
+        assert_eq!(ids(&m), ["ex-C"]);
+    }
+
+    #[test]
+    fn keep_only_piece_drops_related_and_destandalones() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        let g = group_of(&m, "piece-P").unwrap();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::KeepOnlyPiece { group_id: g }),
+        );
+        let e = building_entries(&m);
+        assert_eq!(ids(&m), ["piece-P"]);
+        assert_eq!(e[0].group_id, None, "lone piece is no longer a block");
+    }
+
+    #[test]
+    fn ungroup_block_keeps_items_in_place() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        let g = group_of(&m, "piece-P").unwrap();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::UngroupBlock { group_id: g }),
+        );
+        let e = building_entries(&m);
+        assert_eq!(ids(&m), ["ex-A", "ex-B", "piece-P"]);
+        assert!(e.iter().all(|x| x.group_id.is_none()));
+    }
+
+    #[test]
+    fn ungroup_all_clears_every_group() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        add(&mut m, "ex-C");
+        update(&mut m, Event::Session(SessionEvent::UngroupAllBlocks));
+        assert!(building_entries(&m).iter().all(|x| x.group_id.is_none()));
+    }
+
+    #[test]
+    fn reorder_block_moves_the_whole_unit() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        add(&mut m, "ex-C");
+        let g = group_of(&m, "piece-P").unwrap();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::ReorderBlock {
+                group_id: g,
+                new_position: 1,
+            }),
+        );
+        assert_eq!(ids(&m), ["ex-C", "ex-A", "ex-B", "piece-P"]);
+    }
+
+    #[test]
+    fn reorder_within_block_is_allowed() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        let ex_b = building_entries(&m)[1].id.clone();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::ReorderSetlist {
+                entry_id: ex_b,
+                new_position: 0,
+            }),
+        );
+        assert!(m.last_error.is_none());
+        let e = building_entries(&m);
+        assert_eq!(ids(&m), ["ex-B", "ex-A", "piece-P"]);
+        assert!(e.iter().all(|x| x.group_id == e[0].group_id));
+    }
+
+    #[test]
+    fn reorder_that_splits_a_block_is_rejected() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "ex-C");
+        add(&mut m, "piece-P");
+        let ex_c = building_entries(&m)[0].id.clone();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::ReorderSetlist {
+                entry_id: ex_c,
+                new_position: 2,
+            }),
+        );
+        assert!(m.last_error.is_some(), "splitting move rejected");
+        assert_eq!(
+            ids(&m),
+            ["ex-C", "ex-A", "ex-B", "piece-P"],
+            "order unchanged"
+        );
+    }
+
+    #[test]
+    fn building_view_projects_blocks_and_standalones() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        add(&mut m, "ex-C");
+        let vm = Intrada.view(&m);
+        let b = vm.building_setlist.expect("building view");
+        assert_eq!(b.item_count, 4);
+        assert_eq!(b.block_count, 2);
+        let block = &b.blocks[0];
+        assert!(block.group_id.is_some());
+        assert_eq!(block.piece_title.as_deref(), Some("Sonata"));
+        assert_eq!(block.related_count, 2);
+        assert_eq!(block.entries.len(), 3);
+        let solo = &b.blocks[1];
+        assert_eq!(solo.group_id, None);
+        assert_eq!(solo.piece_title, None);
+        assert_eq!(solo.related_count, 0);
     }
 
     // --- Building Phase Tests ---

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -417,6 +417,31 @@ fn groups_contiguous(entries: &[SetlistEntry]) -> bool {
     true
 }
 
+/// Clear the `group_id` of any block left without its anchor piece — a block
+/// only means "this piece's warm-up", so when the piece goes the related
+/// exercises become standalone (§7.4 dissolve).
+fn dissolve_pieceless_groups(entries: &mut [SetlistEntry]) {
+    let anchored: std::collections::HashSet<&str> = entries
+        .iter()
+        .filter(|e| e.item_type == ItemKind::Piece)
+        .filter_map(|e| e.group_id.as_deref())
+        .collect();
+    let orphans: std::collections::HashSet<String> = entries
+        .iter()
+        .filter_map(|e| e.group_id.clone())
+        .filter(|g| !anchored.contains(g.as_str()))
+        .collect();
+    for entry in entries.iter_mut() {
+        if entry
+            .group_id
+            .as_deref()
+            .is_some_and(|g| orphans.contains(g))
+        {
+            entry.group_id = None;
+        }
+    }
+}
+
 fn create_item_from_title(title: &str, kind: ItemKind) -> Item {
     let now = Utc::now();
     Item {
@@ -743,6 +768,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 return crux_core::render::render();
             }
 
+            dissolve_pieceless_groups(&mut building.entries);
             reindex_entries(&mut building.entries);
             model.last_error = None;
             crux_core::render::render()
@@ -1474,9 +1500,11 @@ mod tests {
             items: vec![
                 mk("piece-P", "Sonata", ItemKind::Piece, &["ex-A", "ex-B"]),
                 mk("piece-Q", "Nocturne", ItemKind::Piece, &[]),
+                mk("piece-R", "Etude", ItemKind::Piece, &["ex-C"]),
                 mk("ex-A", "Scales", ItemKind::Exercise, &[]),
                 mk("ex-B", "Arpeggios", ItemKind::Exercise, &[]),
                 mk("ex-C", "Sight-reading", ItemKind::Exercise, &[]),
+                mk("ex-D", "Trills", ItemKind::Exercise, &[]),
             ],
             api_base_url: "http://localhost:3001".to_string(),
             ..Default::default()
@@ -1702,6 +1730,103 @@ mod tests {
         assert_eq!(solo.group_id, None);
         assert_eq!(solo.piece_title, None);
         assert_eq!(solo.related_count, 0);
+    }
+
+    #[test]
+    fn two_adjacent_blocks_project_separately() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P"); // block G1: ex-A, ex-B, piece-P
+        add(&mut m, "piece-R"); // block G2: ex-C, piece-R
+        assert_eq!(ids(&m), ["ex-A", "ex-B", "piece-P", "ex-C", "piece-R"]);
+        let g1 = group_of(&m, "piece-P");
+        let g2 = group_of(&m, "piece-R");
+        assert!(g1.is_some() && g2.is_some() && g1 != g2, "distinct blocks");
+        let b = Intrada.view(&m).building_setlist.unwrap();
+        assert_eq!(b.block_count, 2);
+        assert_eq!(b.item_count, 5);
+        assert_eq!(b.blocks[0].piece_title.as_deref(), Some("Sonata"));
+        assert_eq!(b.blocks[0].related_count, 2);
+        assert_eq!(b.blocks[1].piece_title.as_deref(), Some("Etude"));
+        assert_eq!(b.blocks[1].related_count, 1);
+    }
+
+    #[test]
+    fn standalone_can_move_between_two_blocks() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P"); // G1: 0,1,2
+        add(&mut m, "piece-R"); // G2: 3,4
+        add(&mut m, "ex-D"); // standalone: 5
+        let ex_d = building_entries(&m)
+            .iter()
+            .find(|e| e.item_id == "ex-D")
+            .unwrap()
+            .id
+            .clone();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::ReorderSetlist {
+                entry_id: ex_d,
+                new_position: 3,
+            }),
+        );
+        assert!(
+            m.last_error.is_none(),
+            "a standalone between blocks splits neither"
+        );
+        assert_eq!(
+            ids(&m),
+            ["ex-A", "ex-B", "piece-P", "ex-D", "ex-C", "piece-R"]
+        );
+        assert!(groups_contiguous(building_entries(&m)));
+    }
+
+    #[test]
+    fn removing_the_piece_dissolves_the_block_to_standalone() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P"); // ex-A, ex-B, piece-P (group)
+        let piece = building_entries(&m)
+            .iter()
+            .find(|e| e.item_id == "piece-P")
+            .unwrap()
+            .id
+            .clone();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::RemoveFromSetlist { entry_id: piece }),
+        );
+        assert!(m.last_error.is_none());
+        assert_eq!(ids(&m), ["ex-A", "ex-B"]);
+        assert!(
+            building_entries(&m).iter().all(|x| x.group_id.is_none()),
+            "related become standalone when their piece is removed"
+        );
+        let b = Intrada.view(&m).building_setlist.unwrap();
+        assert_eq!(
+            b.block_count, 2,
+            "two standalone units, not one pieceless block"
+        );
+    }
+
+    #[test]
+    fn removing_a_related_keeps_the_block() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P"); // ex-A, ex-B, piece-P
+        let ex_a = building_entries(&m)[0].id.clone();
+        update(
+            &mut m,
+            Event::Session(SessionEvent::RemoveFromSetlist { entry_id: ex_a }),
+        );
+        assert!(m.last_error.is_none());
+        assert_eq!(ids(&m), ["ex-B", "piece-P"]);
+        let e = building_entries(&m);
+        assert!(
+            e[0].group_id.is_some() && e[0].group_id == e[1].group_id,
+            "the piece + remaining related stay one block"
+        );
     }
 
     // --- Building Phase Tests ---

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -206,6 +206,7 @@ pub fn handle_set_event(event: SetEvent, model: &mut Model) -> Command<Effect, E
                     rep_history: None,
                     planned_duration_secs: None,
                     achieved_tempo: None,
+                    group_id: None,
                 });
             }
 
@@ -371,6 +372,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             },
             SetlistEntry {
                 id: "entry-2".to_string(),
@@ -389,6 +391,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             },
         ]
     }
@@ -615,6 +618,7 @@ mod tests {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         }]);
         model.sets.push(set);
 
@@ -969,6 +973,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             });
         }
 
@@ -1023,6 +1028,7 @@ mod tests {
                 rep_history: None,
                 planned_duration_secs: None,
                 achieved_tempo: None,
+                group_id: None,
             });
         }
 

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -471,6 +471,7 @@ mod tests {
             rep_history: Some(vec![RepAction::Success, RepAction::Missed]),
             planned_duration_secs: Some(300),
             achieved_tempo: Some(120),
+            group_id: None,
         };
         assert_round_trips(PersistenceOperation::SaveSession(PracticeSession {
             id: "s1".to_string(),
@@ -483,5 +484,48 @@ mod tests {
             completion_status: CompletionStatus::Completed,
             session_score: Some(8),
         }));
+    }
+
+    #[test]
+    fn block_grouping_session_events_round_trip_on_ffi_bincode_wire() {
+        use crate::domain::session::SessionEvent;
+        assert_round_trips(SessionEvent::ReorderBlock {
+            group_id: "g1".to_string(),
+            new_position: 2,
+        });
+        assert_round_trips(SessionEvent::KeepOnlyPiece {
+            group_id: "g1".to_string(),
+        });
+        assert_round_trips(SessionEvent::UngroupBlock {
+            group_id: "g1".to_string(),
+        });
+        assert_round_trips(SessionEvent::UngroupAllBlocks);
+        assert_round_trips(SessionEvent::RemoveBlock {
+            group_id: "g1".to_string(),
+        });
+    }
+
+    #[test]
+    fn setlist_entry_group_id_round_trips_on_ffi_bincode_wire() {
+        use crate::domain::session::{EntryStatus, SetlistEntry};
+        assert_round_trips(SetlistEntry {
+            id: "e1".to_string(),
+            item_id: "ex1".to_string(),
+            item_title: "Scales".to_string(),
+            item_type: ItemKind::Exercise,
+            position: 0,
+            duration_secs: 0,
+            status: EntryStatus::NotAttempted,
+            notes: None,
+            score: None,
+            intention: None,
+            rep_target: None,
+            rep_count: None,
+            rep_target_reached: None,
+            rep_history: None,
+            planned_duration_secs: None,
+            achieved_tempo: None,
+            group_id: Some("block-1".to_string()),
+        });
     }
 }

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -324,6 +324,8 @@ pub struct SetlistEntryView {
     pub planned_duration_secs: Option<u32>,
     pub planned_duration_display: Option<String>,
     pub achieved_tempo: Option<u16>,
+    /// The block this entry belongs to in the builder; `None` = standalone.
+    pub group_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -367,11 +369,27 @@ pub enum SetSourceStatus {
     },
 }
 
+/// A unit in the builder queue: a block (a piece with its related exercises) or
+/// a single standalone item. `group_id == None` means standalone.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct SetlistBlockView {
+    pub group_id: Option<String>,
+    /// The block's anchor-piece title; `None` for a standalone item.
+    pub piece_title: Option<String>,
+    pub related_count: usize,
+    pub duration_display: String,
+    pub entries: Vec<SetlistEntryView>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct BuildingSetlistView {
     pub entries: Vec<SetlistEntryView>,
     pub item_count: usize,
+    /// The same entries grouped into ordered units (blocks + standalone items).
+    pub blocks: Vec<SetlistBlockView>,
+    pub block_count: usize,
     pub session_intention: Option<String>,
     pub target_duration_mins: Option<u32>,
     pub source_status: SetSourceStatus,
@@ -416,7 +434,57 @@ pub fn entry_to_view(entry: &SetlistEntry) -> SetlistEntryView {
             }
         }),
         achieved_tempo: entry.achieved_tempo,
+        group_id: entry.group_id.clone(),
     }
+}
+
+/// Project flat entry views into ordered units: a contiguous run sharing a
+/// `group_id` becomes one block (related exercises first, piece last); every
+/// ungrouped entry is its own standalone unit.
+pub fn build_blocks(entries: &[SetlistEntryView]) -> Vec<SetlistBlockView> {
+    let mut blocks: Vec<SetlistBlockView> = Vec::new();
+    for entry in entries {
+        let extends = match (&entry.group_id, blocks.last()) {
+            (Some(g), Some(last)) => last.group_id.as_deref() == Some(g.as_str()),
+            _ => false,
+        };
+        let is_piece = entry.item_type == ItemKind::Piece;
+        if extends {
+            let block = blocks.last_mut().expect("extends implies a last block");
+            if is_piece {
+                block.piece_title = Some(entry.item_title.clone());
+            } else {
+                block.related_count += 1;
+            }
+            block.entries.push(entry.clone());
+        } else {
+            let grouped = entry.group_id.is_some();
+            blocks.push(SetlistBlockView {
+                group_id: entry.group_id.clone(),
+                piece_title: (grouped && is_piece).then(|| entry.item_title.clone()),
+                related_count: usize::from(grouped && !is_piece),
+                duration_display: String::new(),
+                entries: vec![entry.clone()],
+            });
+        }
+    }
+    for block in &mut blocks {
+        let total: u32 = block
+            .entries
+            .iter()
+            .filter_map(|e| e.planned_duration_secs)
+            .sum();
+        block.duration_display = if total > 0 {
+            if total % 60 == 0 {
+                format!("{} min", total / 60)
+            } else {
+                crate::domain::session::format_duration_display(u64::from(total))
+            }
+        } else {
+            "—".to_string()
+        };
+    }
+    blocks
 }
 
 pub fn build_active_session_view(active: &ActiveSession) -> ActiveSessionView {
@@ -499,6 +567,7 @@ mod tests {
             rep_history: None,
             planned_duration_secs: None,
             achieved_tempo: None,
+            group_id: None,
         }
     }
 

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -319,6 +319,7 @@ final class LibraryStore: ItemStore {
     var repHistory: [String]?
     var plannedDurationSecs: UInt32?
     var achievedTempo: UInt16?
+    var groupId: String?
   }
 
   private static func encodeEntries(_ entries: [SetlistEntry]) -> String {
@@ -329,7 +330,8 @@ final class LibraryStore: ItemStore {
         notes: e.notes, score: e.score, intention: e.intention, repTarget: e.repTarget,
         repCount: e.repCount, repTargetReached: e.repTargetReached,
         repHistory: e.repHistory.map { $0.map(repActionString) },
-        plannedDurationSecs: e.plannedDurationSecs, achievedTempo: e.achievedTempo)
+        plannedDurationSecs: e.plannedDurationSecs, achievedTempo: e.achievedTempo,
+        groupId: e.groupId)
     }
     guard let data = try? JSONEncoder().encode(dtos), let json = String(data: data, encoding: .utf8)
     else { return "[]" }
@@ -347,7 +349,8 @@ final class LibraryStore: ItemStore {
         notes: d.notes, score: d.score, intention: d.intention, repTarget: d.repTarget,
         repCount: d.repCount, repTargetReached: d.repTargetReached,
         repHistory: d.repHistory.map { $0.map(repAction(from:)) },
-        plannedDurationSecs: d.plannedDurationSecs, achievedTempo: d.achievedTempo)
+        plannedDurationSecs: d.plannedDurationSecs, achievedTempo: d.achievedTempo,
+        groupId: d.groupId)
     }
   }
 

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -140,7 +140,17 @@
           items: [.previewPiece, .previewExercise, .previewMinimal],
           buildingSetlist: BuildingSetlistView(
             entries: [.previewPiece, .previewExercise],
-            itemCount: 2, sessionIntention: nil, targetDurationMins: nil,
+            itemCount: 2,
+            blocks: [
+              SetlistBlockView(
+                groupId: nil, pieceTitle: nil, relatedCount: 0, durationDisplay: "—",
+                entries: [.previewPiece]),
+              SetlistBlockView(
+                groupId: nil, pieceTitle: nil, relatedCount: 0, durationDisplay: "—",
+                entries: [.previewExercise]),
+            ],
+            blockCount: 2,
+            sessionIntention: nil, targetDurationMins: nil,
             sourceStatus: .noSource)))
     }
 
@@ -367,7 +377,7 @@
         id: id, itemId: item, itemTitle: title, itemType: type, position: position,
         durationDisplay: "—", status: .notAttempted, notes: nil, score: nil, intention: nil,
         repTarget: nil, repCount: nil, repTargetReached: nil, repHistory: nil,
-        plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: nil)
+        plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: nil, groupId: nil)
     }
   }
 
@@ -419,7 +429,8 @@
         id: "entry-\(position)", itemId: "item-\(position)", itemTitle: title, itemType: type,
         position: position, durationDisplay: "10 min", status: .completed, notes: nil,
         score: nil, intention: nil, repTarget: nil, repCount: nil, repTargetReached: nil,
-        repHistory: nil, plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: nil)
+        repHistory: nil, plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: nil,
+        groupId: nil)
     }
   }
 
@@ -482,7 +493,7 @@
         id: id, itemId: id, itemTitle: title, itemType: type, position: 0,
         durationDisplay: duration, status: status, notes: nil, score: score, intention: nil,
         repTarget: nil, repCount: nil, repTargetReached: nil, repHistory: nil,
-        plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: tempo)
+        plannedDurationSecs: nil, plannedDurationDisplay: nil, achievedTempo: tempo, groupId: nil)
     }
   }
 #endif

--- a/ios/IntradaTests/LibraryStoreMigrationTests.swift
+++ b/ios/IntradaTests/LibraryStoreMigrationTests.swift
@@ -39,7 +39,8 @@ final class LibraryStoreMigrationTests: XCTestCase {
       id: "e1", itemId: "i1", itemTitle: "Scales", itemType: .exercise,
       position: 0, durationSecs: 60, status: .completed,
       notes: nil, score: 8, intention: nil, repTarget: nil, repCount: nil,
-      repTargetReached: nil, repHistory: nil, plannedDurationSecs: nil, achievedTempo: nil)
+      repTargetReached: nil, repHistory: nil, plannedDurationSecs: nil, achievedTempo: nil,
+      groupId: nil)
     let session = PracticeSession(
       id: "sess-rt", entries: [entry],
       sessionNotes: nil, sessionIntention: nil,
@@ -49,6 +50,24 @@ final class LibraryStoreMigrationTests: XCTestCase {
     let loaded = try store.loadSessions()
     XCTAssertEqual(loaded.count, 1)
     XCTAssertEqual(loaded[0].sessionScore, 7, "sessionScore UInt8→Int64→UInt8(clamping:) round-trip must preserve 7")
+  }
+
+  func testGroupIdRoundTripsThroughTheJsonCodec() throws {
+    let store = try LibraryStore.inMemory()
+    let entry = SetlistEntry(
+      id: "e1", itemId: "i1", itemTitle: "Scales", itemType: .exercise,
+      position: 0, durationSecs: 60, status: .completed,
+      notes: nil, score: nil, intention: nil, repTarget: nil, repCount: nil,
+      repTargetReached: nil, repHistory: nil, plannedDurationSecs: nil, achievedTempo: nil,
+      groupId: "block-1")
+    let session = PracticeSession(
+      id: "sess-g", entries: [entry],
+      sessionNotes: nil, sessionIntention: nil,
+      startedAt: "2026-01-01T10:00:00Z", completedAt: "2026-01-01T10:30:00Z",
+      totalDurationSecs: 60, completionStatus: .completed, sessionScore: nil)
+    try store.saveSession(session)
+    let loaded = try store.loadSessions()
+    XCTAssertEqual(loaded.first?.entries.first?.groupId, "block-1", "group_id round-trips through the JSON-blob codec")
   }
 
   func testV5RescaleClampNilAndBlobPreservation() throws {

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -124,7 +124,8 @@ final class LibraryStoreTests: XCTestCase {
       id: id, itemId: "item-\(id)", itemTitle: "Etude", itemType: .exercise, position: 0,
       durationSecs: 300, status: .completed, notes: "good", score: 4, intention: "evenness",
       repTarget: 5, repCount: 5, repTargetReached: true,
-      repHistory: [.success, .missed, .success], plannedDurationSecs: 300, achievedTempo: 120)
+      repHistory: [.success, .missed, .success], plannedDurationSecs: 300, achievedTempo: 120,
+      groupId: nil)
   }
 
   private func session(_ id: String, completedAt: String = "2026-01-01T00:00:00Z")

--- a/specs/session-block-grouping.md
+++ b/specs/session-block-grouping.md
@@ -1,0 +1,156 @@
+# SessionBlock grouping — spec
+
+> Tier 3 (Crux core + FFI bridge + local persistence). Spec → review → plan →
+> implement. Status: **draft for review** — open questions in §7 need answers
+> before Phase A.
+
+## 1. Problem
+
+Related exercises are a list on the piece-detail screen today, but they don't
+flow into practice. The design ("Where related items travel together · Session
+builder") makes them useful: **adding a piece to a session pulls its related
+exercises in as one movable block**, so a piece and the work that supports it
+never drift apart.
+
+## 2. Target behaviour (from `design/Linked Exercises.dc.html`)
+
+- Adding a **piece** that has related exercises creates a **block**: the related
+  exercises sit **before** the piece (warm-up → piece reading order).
+- The block **drags as a unit**; rows are **sortable within** the block; the
+  block **collapses to one line** (`"Clair de Lune · 2 related, then piece · 18 min"`).
+- **Removal granularity:**
+  - remove a single row → drops just that exercise from *this* session (it stays
+    related to the piece for next time — the link is untouched);
+  - block action **"just the piece"** → drop the related, keep the piece;
+  - block action **"ungroup"** → dissolve the block, items stay as standalone;
+  - global **"Ungroup all"**.
+- Directly-added **exercises** stay **standalone** (no block).
+- Builder summary: `"32 min · 3 blocks · 5 items"`.
+
+## 3. Current state (see also the architecture map)
+
+- `SetlistEntry` is a **flat** record (`domain/session.rs:56`); `BuildingSession.entries:
+  Vec<SetlistEntry>` (`session.rs:103`). No grouping metadata.
+- `SessionEvent::AddToSetlist { item_id }` (`session.rs:570`) creates **one** entry
+  and **ignores** `linked_exercise_ids`. `RemoveFromSetlist`/`ReorderSetlist`
+  operate per-entry (`session.rs:618`, `:637`).
+- Relations live on the item: `Item.linked_exercise_ids: Vec<String>` (`domain/item.rs:54`),
+  projected as `LibraryItemView.linked_exercises` (`model.rs:257`) — **unused** by the builder.
+- ViewModel: `BuildingSetlistView { entries, item_count, … }` (`model.rs:352`),
+  `SetlistEntryView` (`model.rs:289`) — no group metadata.
+- A built session flattens to `ActiveSession` → `PracticeSession` for persistence;
+  entries are flat throughout.
+
+## 4. Approach — `group_id` tag on flat entries (recommended)
+
+Keep `entries: Vec<SetlistEntry>` **flat** and add an optional group tag, rather
+than restructuring into nested blocks. A block is a **contiguous run of entries
+sharing a `group_id`** (related exercises first, piece last). Standalone items
+have `group_id == None`.
+
+**Why this over nested `Vec<SetlistBlock>`:** the flat list flows unchanged into
+`ActiveSession`, `PracticeSession`, and persistence — the Active player, Summary,
+and the sessions store gain **one nullable field**, not a reshaped model. Grouping
+is a building-phase concern projected in the ViewModel. (Nested blocks would ripple
+through every phase and the GRDB schema; rejected.)
+
+### 4.1 Core model
+
+- `SetlistEntry`: add `pub group_id: Option<String>` (`#[serde(default)]`).
+- New entries from a grouped add share a freshly-minted `group_id` (ulid).
+
+### 4.2 Events (core owns all logic)
+
+- **Change** `AddToSetlist { item_id }`: when the item is a **piece** with
+  `linked_exercise_ids`, the handler also appends entries for those related
+  exercises (related-first, piece-last), all sharing a new `group_id`. Adding an
+  exercise, or a piece with no relations, stays a single ungrouped entry.
+  *(Open Q 7.1: dedupe a related exercise already in the setlist.)*
+- **New** `KeepOnlyPiece { group_id }` — drop related entries, keep the piece
+  (piece becomes standalone: `group_id → None`).
+- **New** `UngroupBlock { group_id }` — clear `group_id` on the run; items stay,
+  in place, as standalone.
+- **New** `UngroupAllBlocks` — `UngroupBlock` for every group.
+- **New** `RemoveBlock { group_id }` — remove the whole block (piece + related).
+- **Reuse** `RemoveFromSetlist { entry_id }` for single-row removal (unchanged;
+  does **not** unlink — the relation is on the item, not the entry).
+- **Reorder:** `ReorderSetlist` stays for *within-block* moves (must keep the run
+  contiguous — reject/clamp a move that would split a group). Add
+  **`ReorderBlock { group_id, new_position }`** to move a whole block as a unit.
+
+### 4.3 ViewModel projection
+
+Extend `BuildingSetlistView` additively (keep `entries` so the paused web shell
+keeps compiling — invariant 6):
+
+- add `blocks: Vec<SetlistBlockView>` where
+  `SetlistBlockView { group_id: Option<String>, piece_title: Option<String>,
+  related_count: usize, duration_display: String, entries: Vec<SetlistEntryView> }`
+  (a standalone item = a one-entry block with `group_id: None`).
+- add `block_count: usize` to drive `"3 blocks · 5 items"`.
+- `SetlistEntryView` gains `group_id: Option<String>` for within-block affordances.
+
+The core computes block summaries; the shell renders. **Collapse state is UI-only**
+(SwiftUI `@State` / Leptos signal) per the state-boundary table — never core state.
+
+### 4.4 Persistence / offline-first
+
+- `group_id` rides the flat entry into `ActiveSession`/`PracticeSession`.
+- Sessions persist their entries as a **JSON blob** through the `StoredEntry` DTO
+  (deliberately not bincode, so field additions are safe — `LibraryStore.swift`).
+  So **no SQL migration**: add an optional `groupId` to `StoredEntry` + the
+  encode/decode mapping; old rows decode it as `nil`. Core type + DTO + codec
+  evolve together.
+- No new network path; pure local mutation. Invariants 1–8 hold (no hard delete,
+  reconciliation stays in core, both modes branch-free here).
+
+### 4.5 UI (SwiftUI)
+
+- Builder queue renders `blocks`: a block gets a header row (piece title + `N
+  related, then piece · MM min`, collapse chevron, overflow menu → "Just the
+  piece" / "Ungroup") over its entry rows; standalone items render as today.
+- Block header is the drag handle for `ReorderBlock`; within-block rows reorder
+  via the existing per-row handle (clamped to the group).
+- Toolbar gains "Ungroup all" when any block exists.
+- Reuse `SetlistQueueRow`; add a `SessionBlockHeader` primitive.
+
+## 5. Key decisions
+
+- **Flat entries + `group_id` tag**, not nested blocks (§4).
+- **Default = bring related**; "just the piece" is the escape hatch (matches design).
+- **Removing a row never unlinks** — the relation lives on the item.
+- **Collapse is UI-only**; block structure + summaries are core-projected.
+- **Additive ViewModel** (`entries` retained) so the paused web shell still builds.
+
+## 6. Phasing
+
+- **Phase A** (this spec rides here): core model + events + ViewModel projection +
+  round-trip tests + persistence codec (no SQL migration — see §4.4) + binding
+  regen + preview-literal fixes. No new builder UI yet; web unchanged.
+- **Phase B**: SwiftUI block rendering, reorder-as-unit, block actions, snapshots.
+- **Phase C**: polish — collapse animation, "Ungroup all", a11y, iPad.
+
+## 7. Open questions (need answers before Phase A)
+
+1. **Dedupe:** if a related exercise is *already* in the setlist (standalone or in
+   another block) when its piece is added, do we (a) skip it, (b) move it into the
+   new block, or (c) allow a duplicate? *(Lean: skip — don't duplicate.)*
+2. **"Ungroup" vs "Remove block":** the design shows both "ungroup" (keep items)
+   and a header-X "drop the group" (remove items). Confirm both are wanted, or
+   collapse to one.
+3. **Reorder model:** is whole-block drag (header) + within-block drag (rows)
+   enough, or do we also need to drag a row *out* of a block to make it standalone?
+   *(Lean: out-of-block drag is Phase C, not MVP.)*
+4. **Empty group:** removing the *piece* from a block but keeping related — does the
+   block dissolve to standalone exercises, or is that disallowed? *(Lean: dissolve.)*
+
+## 8. Risks
+
+- **Bridge round-trip:** `group_id` + the new events cross the bincode FFI bridge.
+  Extend `assert_round_trips` for every new event/field **before** wiring UI
+  (the #846 silent-no-op class). Plain `Option<String>` is bincode-safe; no
+  JSON-only serde attrs.
+- **Reorder contiguity:** the invariant "a group is a contiguous run" must be
+  enforced in every reorder handler, with a test that a split-causing move is
+  rejected.
+- **Web compile:** additive ViewModel keeps `intrada-web` building; CI still runs it.

--- a/specs/session-block-grouping.md
+++ b/specs/session-block-grouping.md
@@ -130,19 +130,19 @@ The core computes block summaries; the shell renders. **Collapse state is UI-onl
 - **Phase B**: SwiftUI block rendering, reorder-as-unit, block actions, snapshots.
 - **Phase C**: polish — collapse animation, "Ungroup all", a11y, iPad.
 
-## 7. Open questions (need answers before Phase A)
+## 7. Decisions (resolved for Phase A)
 
-1. **Dedupe:** if a related exercise is *already* in the setlist (standalone or in
-   another block) when its piece is added, do we (a) skip it, (b) move it into the
-   new block, or (c) allow a duplicate? *(Lean: skip — don't duplicate.)*
-2. **"Ungroup" vs "Remove block":** the design shows both "ungroup" (keep items)
-   and a header-X "drop the group" (remove items). Confirm both are wanted, or
-   collapse to one.
-3. **Reorder model:** is whole-block drag (header) + within-block drag (rows)
-   enough, or do we also need to drag a row *out* of a block to make it standalone?
-   *(Lean: out-of-block drag is Phase C, not MVP.)*
-4. **Empty group:** removing the *piece* from a block but keeping related — does the
-   block dissolve to standalone exercises, or is that disallowed? *(Lean: dissolve.)*
+1. **Dedupe:** a related exercise already in the setlist is **skipped** — never
+   duplicated (it stays where it is; the new block just omits it).
+2. **"Ungroup" vs "Remove block":** **both** kept — `UngroupBlock` keeps the items
+   (clears `group_id`), `RemoveBlock` drops the whole block.
+3. **Reorder model:** whole-block drag (`ReorderBlock`) + within-block drag
+   (`ReorderSetlist`, contiguity-guarded). Dragging a row *out* of a block is
+   deferred to Phase C.
+4. **Piece removal dissolves the block:** removing the *piece* via
+   `RemoveFromSetlist` clears `group_id` on the remaining related (they become
+   standalone) — a block only means "this piece's warm-up". Implemented via
+   `dissolve_pieceless_groups`; tested.
 
 ## 8. Risks
 


### PR DESCRIPTION
## Summary
Phase A of SessionBlock grouping (#1019) — the core + persistence plumbing so a piece's related exercises travel with it as one movable **block** in the session builder. **No new builder UI yet** (that's Phase B); the paused web shell is unchanged.

Spec: `specs/session-block-grouping.md` (rides with this PR).

## Approach
Tag flat setlist entries with an optional `group_id` (a block = a contiguous run sharing one id; related-first, piece-last) rather than nest into blocks — this keeps the Active player, Summary, and persistence on a flat `Vec<SetlistEntry>` (just one new nullable field), with grouping projected as `blocks` in the ViewModel.

## Core
- `SetlistEntry.group_id`. `AddToSetlist` pulls a piece's `linked_exercise_ids` into a new group (skipping any already in the setlist; an exercise / relationless piece stays standalone).
- New events: `ReorderBlock` (move a block as a unit), `KeepOnlyPiece`, `UngroupBlock`, `UngroupAllBlocks`, `RemoveBlock`. `ReorderSetlist` now rejects a move that would split a block.
- `BuildingSetlistView` gains `blocks: [SetlistBlockView]` + `block_count` (additive — the web shell reads `entries` by field access, unaffected). `SetlistEntryView` gains `group_id`.
- 14 behavioural tests + bincode FFI round-trips for the new events + the `group_id` field.

## Persistence (offline-first)
- `group_id` rides the JSON-blob `StoredEntry` codec — **no SQL migration** (the DTO is deliberately not bincode, so an optional field is safe; old rows decode as nil). Round-trip test added.
- API: `SetlistEntry` literals carry `group_id: None` (compat; the online path drops grouping — relevant only when web/sync un-pauses; tracked in #1021).

## Verification
- `cargo fmt --check` ✓ · `cargo clippy --workspace -- -D warnings` ✓ · `cargo test --workspace` ✓ (core 438 + 14 new, api 17, web, …)
- `just ios-test` ✓ — iOS compiles against regenerated bindings; full snapshot suite green, **no snapshot diffs** (the builder UI still renders `entries`).

## Coverage
Core domain logic covered by the 14 new unit tests + the round-trips; the iOS persistence codec by the GRDB `group_id` round-trip test. (iOS/web are outside the Rust Codecov scope.)

## Deferred (tracked)
- #1019 — Phase B (builder UI: block header rows, reorder-as-unit, block actions, snapshots) and Phase C (collapse, "Ungroup all", a11y, iPad)
- #1021 — wire `group_id` through the API when web/sync un-pauses

🤖 Generated with [Claude Code](https://claude.com/claude-code)