### PR TITLE
fix(security): ignore quick-xml DoS advisories (RUSTSEC-2026-0194/0195)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,17 @@ ignore = [
     { id = "RUSTSEC-2026-0098", reason = "transitive via libsql; tracked in #568" },
     { id = "RUSTSEC-2026-0099", reason = "transitive via libsql; tracked in #568" },
     { id = "RUSTSEC-2026-0104", reason = "transitive via libsql; tracked in #568" },
+
+    # quick-xml DoS advisories (quadratic duplicate-attr check; unbounded
+    # namespace-declaration allocation). Transitive via rust-s3 0.37.2 →
+    # aws-creds → quick-xml 0.38 (the R2/S3 client, intrada-api only). Fixed in
+    # quick-xml >=0.41, but rust-s3 0.37.2 (latest) still pins ^0.38 — no
+    # upstream bump exists. DoS only, and quick-xml here parses XML *responses*
+    # from Cloudflare R2 (a trusted first-party endpoint), never attacker-
+    # controlled input. Clear when rust-s3 ships a quick-xml >=0.41 release.
+    # Tracked in #1032.
+    { id = "RUSTSEC-2026-0194", reason = "transitive via rust-s3; DoS on trusted R2 XML; no upstream fix; tracked in #1032" },
+    { id = "RUSTSEC-2026-0195", reason = "transitive via rust-s3; DoS on trusted R2 XML; no upstream fix; tracked in #1032" },
 ]
 
 # ── Licenses ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #1032. Unblocks the **Security** CI check, which currently fails on `main` and every branch.

## Problem

Two DoS advisories were published for **quick-xml 0.38.4**, failing `cargo-deny` repo-wide:
- **RUSTSEC-2026-0194** — quadratic runtime checking a start tag for duplicate attribute names.
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader`.

Transitive and **`intrada-api`-only**: `rust-s3 0.37.2 → aws-creds 0.39.1 → quick-xml 0.38` (the R2/S3 client). Not used by the core or the iOS shell.

## Why an ignore (not an upgrade)

Fixed only in **quick-xml ≥ 0.41**, but `aws-creds` pins `quick-xml = "0.38"` and `rust-s3 0.37.2` is the latest release — `cargo update` locks 0 packages, so there's **no upstream bump available**. Forcing quick-xml 0.41 via `[patch]` would break `aws-creds`' 0.38-era API usage.

So this adds a justified, tracked `deny.toml` ignore — the same pattern the repo already uses for the rsa Marvin advisory and the libsql/webpki advisories (#568). The risk is low: these are **DoS-only**, and `quick-xml` here parses XML **responses from Cloudflare R2** (a trusted first-party endpoint), never attacker-controlled input. #1032 tracks clearing it when `rust-s3` ships a quick-xml ≥0.41 release.

## Verification

`cargo deny check` locally: **advisories ok, bans ok, licenses ok, sources ok**. Config-only change — no Rust, no behaviour change.

## Note on the redesign stack

This must land on `main` first; the open redesign PRs (#1026, #1030) then need a rebase onto the updated `main` to pick up the `deny.toml` change and clear their own Security check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)