### PR TITLE
docs: fix stale iOS-shell claim in roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,8 +29,9 @@ issues disagree, the issues are right.
 Capture, Plan, Space (manual), and Show (analytics) all have working
 surfaces. Auth, library, sessions, routines, scoring, focus mode, tempo
 tracking, design system, multi-device shell, E2E tests — all done. The
-Tauri/Leptos iOS shell is the active iOS path; the SwiftUI shell has been
-removed.
+native SwiftUI iOS app (on the Crux core — see
+[`specs/native-ios.md`](../specs/native-ios.md)) is the active iOS path;
+the Tauri/Leptos shells are paused.
 
 The active gaps are deeper Layer-1 capture (multi-key, sections, archive),
 the Space layer (mastery decay, spaced repetition), and parts of Show


### PR DESCRIPTION
## Summary
- `docs/roadmap.md` ("Where the product is today") claimed the Tauri/Leptos shell was the active iOS path and the SwiftUI shell had been removed — the inverse of reality since 2026-06.
- Updated to match the CLAUDE.md CURRENT FOCUS banner: native SwiftUI on the Crux core ([`specs/native-ios.md`](https://github.com/jonyardley/intrada/blob/main/specs/native-ios.md)) is the active path; the Tauri/Leptos shells are paused.

Tier 1 doc-only change; no code touched, no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)