### PR TITLE
fix(ci): include justfile in the native paths filter (fixes #1055)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
               - 'crates/intrada-ffi/**'
               - 'ios/**'
               - 'scripts/ios-run-sim.sh'
+              - 'justfile'
               - '.github/workflows/ci.yml'
 
   test:


### PR DESCRIPTION
Tier-1 CI fix: the `native` filter didn't list `justfile`, so a justfile-only PR skipped the Native iOS job that executes its recipes (`ios-fmt-check`, `ios-gen`, `ios-test`). One static path added. The Tauri `mobile` filter has the same theoretical exposure but that lane is paused — left as-is deliberately.

This PR touches only `ci.yml` itself, which is already in every filter, so all lanes run and exercise the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)