### PR TITLE
fix(core): AddToSetlist is idempotent by item id (fixes #939)

### DIFF
--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -1654,6 +1654,22 @@ mod tests {
     }
 
     #[test]
+    fn re_adding_present_piece_is_a_full_no_op_even_with_new_relateds() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-Q");
+        if let Some(piece) = m.items.iter_mut().find(|i| i.id == "piece-Q") {
+            piece.linked_exercise_ids = vec!["ex-C".to_string()];
+        }
+        add(&mut m, "piece-Q");
+        assert_eq!(
+            ids(&m),
+            ["piece-Q"],
+            "membership no-op wins; newly linked relateds come in by removing and re-adding"
+        );
+    }
+
+    #[test]
     fn add_piece_pulls_related_into_a_block_related_first() {
         let mut m = linked_model();
         update(&mut m, Event::Session(SessionEvent::StartBuilding));

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -688,6 +688,15 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 return crux_core::render::render();
             }
 
+            // Membership is binary (the picker/sheet toggle relies on it):
+            // re-adding a present item is an idempotent no-op, not a duplicate (#939).
+            if let SessionStatus::Building(ref building) = model.session_status {
+                if building.entries.iter().any(|e| e.item_id == item_id) {
+                    model.last_error = None;
+                    return crux_core::render::render();
+                }
+            }
+
             // Resolve the item and — for a piece — its related exercises as owned
             // tuples before taking the mutable Building borrow.
             let Some(item) = model.items.iter().find(|i| i.id == item_id) else {
@@ -1625,6 +1634,26 @@ mod tests {
     }
 
     #[test]
+    fn add_to_setlist_is_idempotent_by_item_id() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "ex-C");
+        add(&mut m, "ex-C");
+        assert_eq!(ids(&m), ["ex-C"], "second add of the same item is a no-op");
+        assert_eq!(m.last_error, None);
+    }
+
+    #[test]
+    fn add_piece_twice_does_not_duplicate_block() {
+        let mut m = linked_model();
+        update(&mut m, Event::Session(SessionEvent::StartBuilding));
+        add(&mut m, "piece-P");
+        add(&mut m, "piece-P");
+        assert_eq!(ids(&m), ["ex-A", "ex-B", "piece-P"]);
+        assert_eq!(m.last_error, None);
+    }
+
+    #[test]
     fn add_piece_pulls_related_into_a_block_related_first() {
         let mut m = linked_model();
         update(&mut m, Event::Session(SessionEvent::StartBuilding));
@@ -2109,33 +2138,6 @@ mod tests {
         );
 
         assert!(model.last_error.is_some());
-    }
-
-    #[test]
-    fn test_add_duplicate_items_to_setlist() {
-        let mut model = model_with_library();
-        update(&mut model, Event::Session(SessionEvent::StartBuilding));
-        update(
-            &mut model,
-            Event::Session(SessionEvent::AddToSetlist {
-                item_id: "piece-1".to_string(),
-            }),
-        );
-        update(
-            &mut model,
-            Event::Session(SessionEvent::AddToSetlist {
-                item_id: "piece-1".to_string(),
-            }),
-        );
-
-        assert!(model.last_error.is_none());
-        if let SessionStatus::Building(ref b) = model.session_status {
-            assert_eq!(b.entries.len(), 2);
-            // Each entry has a unique ID
-            assert_ne!(b.entries[0].id, b.entries[1].id);
-        } else {
-            panic!("Expected Building state");
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Setlist membership is binary in every shell surface (picker toggle, AddToSessionSheet), but that was only a shell convention — the core unconditionally pushed a fresh-ulid entry, so a duplicate (legacy data, a future second writer) left the extra entry unreachable from the UI. `AddToSetlist` now no-ops when the item is already present, putting the reconciliation in the core where it belongs.

- Replaces `test_add_duplicate_items_to_setlist`, which pinned the superseded duplicates-allowed behaviour; #939 is the decision record.
- Behaviour notes (deliberate): the membership guard wins over the item-existence check, so re-adding a deleted-but-listed item is a silent no-op rather than NotFound; and re-adding a piece that has since gained new linked exercises is a full no-op (remove + re-add pulls the new block) — the latter is pinned by a test.

## Coverage

Coverage: full — idempotent exercise re-add, piece-block no-duplication, and the new-relateds no-op edge all have tests (first two written red-first).

## Test plan

- `cargo test` (451 core), `cargo fmt --check`, `clippy --workspace -D warnings`, `cargo test -p intrada-api` — green
- `just ios-test` full suite — green (behaviour-only core change; no bridge shape change, no snapshot impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)