### PR TITLE
feat(core+ios): composer subtitle on PieceRefView breadcrumb menu rows (fixes #1049)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -366,6 +366,7 @@ impl App for Intrada {
                             .push(PieceRefView {
                                 id: item.id.clone(),
                                 title: item.title.clone(),
+                                subtitle: item.composer.clone(),
                             });
                     }
                 }
@@ -3849,6 +3850,52 @@ mod tests {
             &mut model,
         );
         assert_eq!(model.items[0].kind, ItemKind::Exercise);
+    }
+
+    #[test]
+    fn linked_from_piece_ref_carries_composer_subtitle() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let piece = Item {
+            id: "piece-1".to_string(),
+            title: "Sonata".to_string(),
+            kind: ItemKind::Piece,
+            composer: Some("Debussy".to_string()),
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+            linked_exercise_ids: vec!["ex-1".to_string()],
+            priority: false,
+        };
+        let ex = Item {
+            id: "ex-1".to_string(),
+            title: "Scales".to_string(),
+            kind: ItemKind::Exercise,
+            composer: None,
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+            linked_exercise_ids: vec![],
+            priority: false,
+        };
+        let model = Model {
+            items: vec![piece, ex],
+            ..Model::test_default()
+        };
+        let vm = app.view(&model);
+        let exercise = vm.items.iter().find(|i| i.id == "ex-1").unwrap();
+        assert_eq!(
+            exercise.linked_from_pieces[0].subtitle.as_deref(),
+            Some("Debussy")
+        );
     }
 
     #[test]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -233,6 +233,9 @@ pub struct LinkedExerciseView {
 pub struct PieceRefView {
     pub id: String,
     pub title: String,
+    /// Composer, when the piece has one — disambiguates identically titled
+    /// pieces in provenance UI (#1049).
+    pub subtitle: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -393,8 +393,8 @@
           latestTempo: 108, tempoHistory: [], lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false, linkedExercises: [],
         linkedFromPieces: [
-          PieceRefView(id: "piece-1", title: "Clair de Lune"),
-          PieceRefView(id: "piece-2", title: "Gymnopédie No. 1"),
+          PieceRefView(id: "piece-1", title: "Clair de Lune", subtitle: "Claude Debussy"),
+          PieceRefView(id: "piece-2", title: "Gymnopédie No. 1", subtitle: "Erik Satie"),
         ])
     }
 

--- a/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
@@ -245,7 +245,12 @@ struct LibraryDetailScreen: View {
       } else {
         Menu {
           ForEach(item.linkedFromPieces, id: \.id) { piece in
-            NavigationLink(value: piece.id) { Text(piece.title) }
+            NavigationLink(value: piece.id) {
+              Text(piece.title)
+              if let subtitle = piece.subtitle {
+                Text(subtitle)
+              }
+            }
           }
         } label: {
           breadcrumbRow(first, discloses: true)


### PR DESCRIPTION
## Summary

Two linking pieces with the same title produced indistinguishable rows in the exercise breadcrumb menu (#1050). `PieceRefView` gains `subtitle: Option<String>` (the piece's composer, when set), populated in `view()` and rendered as the standard SwiftUI menu-row subtitle. Bindings regenerated; preview fixtures updated.

## Verification

Core: TDD — red-first test pinning composer → subtitle resolution. The menu open/push path was live-verified on-sim in #1050; the subtitle is a second `Text` in the menu row (SwiftUI's native title+subtitle menu treatment) and is not re-driven here — worth an eyeball on your next sim run. Closed menus render identically, so no snapshot changes.

## Coverage

Coverage: full for the core change (subtitle resolution test); the field is a plain `Option<String>` (positional-bincode safe, core→Swift read).

## Test plan

- `cargo test` (450 core on this base), `fmt`, `clippy --workspace` — green
- `just ios-test` + `ios-fmt-check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)