### PR TITLE
fix(core+ios): error_seq replaces the message-compare haptic pattern (fixes #1056)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -160,6 +160,20 @@ impl App for Intrada {
         event: Self::Event,
         model: &mut Self::Model,
     ) -> Command<Self::Effect, Self::Event> {
+        let command = self.handle_event(event, model);
+        if model.last_error.is_some() {
+            model.error_seq = model.error_seq.wrapping_add(1);
+        }
+        command
+    }
+
+    fn view(&self, model: &Self::Model) -> Self::ViewModel {
+        self.build_view(model)
+    }
+}
+
+impl Intrada {
+    fn handle_event(&self, event: Event, model: &mut Model) -> Command<Effect, Event> {
         match event {
             // ── Lifecycle ────────────────────────────────────────────
             Event::StartApp {
@@ -342,7 +356,7 @@ impl App for Intrada {
         }
     }
 
-    fn view(&self, model: &Self::Model) -> Self::ViewModel {
+    fn build_view(&self, model: &Model) -> ViewModel {
         use std::collections::HashMap;
 
         // Build an id→item index for O(1) linked-exercise lookup.
@@ -627,6 +641,7 @@ impl App for Intrada {
             summary,
             session_status,
             error: model.last_error.clone(),
+            error_seq: model.error_seq,
             analytics,
             sets,
             account_preferences: model.account_preferences.clone(),
@@ -3519,6 +3534,35 @@ mod tests {
             achieved_tempo: None,
             group_id: None,
         }
+    }
+
+    #[test]
+    fn error_seq_bumps_on_each_failed_update_even_with_identical_message() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+        let fail = || {
+            Event::Session(SessionEvent::AddToSetlist {
+                item_id: "x".to_string(),
+            })
+        };
+        let _ = app.update(fail(), &mut model);
+        let seq1 = app.view(&model).error_seq;
+        let _ = app.update(fail(), &mut model);
+        let seq2 = app.view(&model).error_seq;
+        assert!(seq1 > 0);
+        assert!(
+            seq2 > seq1,
+            "a repeated identical failure must still advance the sequence"
+        );
+    }
+
+    #[test]
+    fn error_seq_stable_across_successful_updates() {
+        let app = Intrada;
+        let mut model = Model::test_default();
+        let before = app.view(&model).error_seq;
+        let _ = app.update(Event::Session(SessionEvent::StartBuilding), &mut model);
+        assert_eq!(app.view(&model).error_seq, before);
     }
 
     #[test]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -74,6 +74,9 @@ pub struct Model {
     /// Set from the confirmed `SetSaveSucceeded { request_id }`; per-form
     /// id-matching isolates concurrent `SetSaveForm` instances (#663).
     pub last_set_save_request_id: Option<String>,
+    /// Bumped by every update that concludes with `last_error` present, so
+    /// shells can tell a repeated identical failure from a success (#1056).
+    pub error_seq: u64,
 }
 
 impl Model {
@@ -182,6 +185,8 @@ pub struct ViewModel {
     pub summary: Option<SummaryView>,
     pub session_status: SessionStatusView,
     pub error: Option<String>,
+    /// See `Model::error_seq` — compare around a send instead of the message.
+    pub error_seq: u64,
     pub analytics: Option<AnalyticsView>,
     pub sets: Vec<SetView>,
     pub account_preferences: Option<AccountPreferences>,

--- a/ios/Intrada/Views/Components/AddToSessionSheet.swift
+++ b/ios/Intrada/Views/Components/AddToSessionSheet.swift
@@ -62,14 +62,14 @@ struct AddToSessionSheet: View {
   }
 
   private func toggle(_ item: LibraryItemView) {
-    let before = store.viewModel?.error
+    let before = store.viewModel?.errorSeq
     if let entryId = entryByItem[item.id] {
       store.send(.session(.removeFromSetlist(entryId: entryId)))
     } else {
       store.send(.session(.addToSetlist(itemId: item.id)))
     }
     // Only ack once the core confirms — errors surface in RootView's banner (#846).
-    if store.viewModel?.error == before {
+    if store.viewModel?.errorSeq == before {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
   }

--- a/ios/Intrada/Views/Screens/FocusPlayerScreen.swift
+++ b/ios/Intrada/Views/Screens/FocusPlayerScreen.swift
@@ -211,9 +211,9 @@ struct FocusPlayerScreen: View {
   // Completed). Errors surface on RootView's banner, so dismiss only on success.
   private func handleReflection(_ target: ReflectionTarget, score: UInt8?, note: String) {
     if !note.isEmpty {
-      let before = store.viewModel?.error
+      let before = store.viewModel?.errorSeq
       store.send(.session(.updateEntryNotes(entryId: target.id, notes: note)))
-      if store.viewModel?.error != before { return }
+      if store.viewModel?.errorSeq != before { return }
     }
     store.send(.session(.nextItem(now: SessionClock.nowRFC3339())))
     if let score {

--- a/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
+++ b/ios/Intrada/Views/Screens/LibraryDetailScreen.swift
@@ -303,9 +303,9 @@ struct LibraryDetailScreen: View {
   }
 
   private func practiseThis() {
-    let before = store.viewModel?.error
+    let before = store.viewModel?.errorSeq
     store.send(.session(.startBuildingWith(itemId: item.id)))
-    if store.viewModel?.error == before {
+    if store.viewModel?.errorSeq == before {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
   }
@@ -336,14 +336,14 @@ struct LibraryDetailScreen: View {
     let toUnlink = current.subtracting(selected)
     var ok = true
     for id in toLink {
-      let before = store.viewModel?.error
+      let before = store.viewModel?.errorSeq
       store.send(.item(.linkExercise(pieceId: item.id, exerciseId: id)))
-      if store.viewModel?.error != before { ok = false }
+      if store.viewModel?.errorSeq != before { ok = false }
     }
     for id in toUnlink {
-      let before = store.viewModel?.error
+      let before = store.viewModel?.errorSeq
       store.send(.item(.unlinkExercise(pieceId: item.id, exerciseId: id)))
-      if store.viewModel?.error != before { ok = false }
+      if store.viewModel?.errorSeq != before { ok = false }
     }
     if ok && !(toLink.isEmpty && toUnlink.isEmpty) {
       UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -355,9 +355,9 @@ struct LibraryDetailScreen: View {
     let dest = index + delta
     guard dest >= 0, dest < ids.count else { return }
     ids.swapAt(index, dest)
-    let before = store.viewModel?.error
+    let before = store.viewModel?.errorSeq
     store.send(.item(.reorderLinkedExercises(pieceId: item.id, orderedIds: ids)))
-    if store.viewModel?.error == before {
+    if store.viewModel?.errorSeq == before {
       UISelectionFeedbackGenerator().selectionChanged()
     }
   }

--- a/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
+++ b/ios/Intrada/Views/Screens/SessionBuilderScreen.swift
@@ -321,13 +321,13 @@ struct SessionBuilderScreen: View {
   // ── Actions ──────────────────────────────────────────────────────────
 
   private func removeUnit(_ block: SetlistBlockView) {
-    let before = store.viewModel?.error
+    let before = store.viewModel?.errorSeq
     if let groupId = block.groupId {
       store.send(.session(.removeBlock(groupId: groupId)))
     } else if let entryId = block.entries.first?.id {
       store.send(.session(.removeFromSetlist(entryId: entryId)))
     }
-    if store.viewModel?.error == before {
+    if store.viewModel?.errorSeq == before {
       UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
   }
@@ -338,7 +338,7 @@ struct SessionBuilderScreen: View {
     let target = from < destination ? destination - 1 : destination
     guard target != from else { return }
     let unit = units[from]
-    let before = store.viewModel?.error
+    let before = store.viewModel?.errorSeq
     if let groupId = unit.block.groupId {
       store.send(.session(.reorderBlock(groupId: groupId, newPosition: UInt64(target))))
     } else if let entryId = unit.block.entries.first?.id {
@@ -350,7 +350,7 @@ struct SessionBuilderScreen: View {
         store.send(.session(.reorderSetlist(entryId: entryId, newPosition: UInt64(newIndex))))
       }
     }
-    if store.viewModel?.error == before {
+    if store.viewModel?.errorSeq == before {
       UISelectionFeedbackGenerator().selectionChanged()
     }
   }


### PR DESCRIPTION
## Summary

Shells confirmed a core write by comparing `ViewModel.error` before/after `store.send` — a repeated identical failure compared equal and fired a success haptic. Now:

- **Core**: `Model.error_seq`/`ViewModel.error_seq`. `App::update` wraps the (unchanged) handler match in a new inherent `handle_event` and bumps the sequence whenever an update concludes with `last_error` present — one seam catching all ~81 direct error-set sites, including `surface_error`'s identical-message dedupe (the exact #1056 hole).
- **Swift**: all eight snapshot/compare sites converted to sequence compares (`AddToSessionSheet.toggle` covers both its events through one comparison); the three display reads of `.error` (banners, form) are untouched.

**Accepted trade-off (fail-safe by construction):** the seq bumps on any update ending in an errored state, so a successful send made while an unrelated stale error is still displayed can suppress a haptic. It can never fire a false success — the failure direction of the original bug.

## Coverage

Coverage: full — TDD tests pin that a repeated identical failure advances the sequence and a successful update leaves it stable.

## Test plan

- `cargo test` (455 core), `fmt`, `clippy --workspace -D warnings` — green
- `just ios-test` full suite + `ios-fmt-check` — green post-rebase (bindings regenerated; no snapshot impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)