### PR TITLE
chore: add graphify knowledge graph of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ ios/build/
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/test_output/
+# graphify knowledge-graph tool — machine-local interpreter path + incremental
+# extraction cache (embeds absolute paths, not portable across clones).
+# graph.json / GRAPH_REPORT.md / manifest.json / cost.json are committed.
+graphify-out/.graphify_python
+graphify-out/.graphify_root
+graphify-out/cache/

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,124 @@
+# Graph Report - .  (2026-07-13)
+
+## Corpus Check
+- Large corpus: 710 files · ~873,283 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder.
+
+## Summary
+- 6040 nodes · 12714 edges · 1 communities
+- Extraction: 95% EXTRACTED · 5% INFERRED · 0% AMBIGUOUS · INFERRED: 665 edges (avg confidence: 0.71)
+- Token cost: 0 input · 2,626,283 output
+
+## Community Hubs (Navigation)
+- Whole repo (no clustering)
+
+## God Nodes (most connected - your core abstractions)
+1. `e5` - 166 edges
+2. `ApiError` - 158 edges
+3. `update()` - 127 edges
+4. `AppState` - 79 edges
+5. `u()` - 75 edges
+6. `i()` - 74 edges
+7. `n()` - 68 edges
+8. `s()` - 67 edges
+9. `SwiftUI` - 66 edges
+10. `Model` - 63 edges
+
+## Surprising Connections (you probably didn't know these)
+- `Principle II: Testing Standards` --semantically_similar_to--> `Offline-First Invariants`  [INFERRED] [semantically similar]
+  .specify/memory/constitution.md → CLAUDE.md
+- `Principle V: Architecture Integrity` --semantically_similar_to--> `Crux Capabilities Pattern`  [INFERRED] [semantically similar]
+  .specify/memory/constitution.md → CLAUDE.md
+- `SaveLibrarySort AppEffect` --semantically_similar_to--> `StorageEffect`  [INFERRED] [semantically similar]
+  docs/superpowers/plans/2026-06-01-library-sort.md → specs/_archive/001-music-library/contracts/library-api.md
+- `Principle IV: Performance Requirements` --conceptually_related_to--> `intrada Development Guidelines (CLAUDE.md)`  [INFERRED]
+  .specify/memory/constitution.md → CLAUDE.md
+- `Light-mode 'paper' exploration — design notes` --conceptually_related_to--> `Native SwiftUI iOS pivot (Crux core, local-first, retiring Tauri)`  [INFERRED]
+  design/light-mode-exploration.md → docs/roadmap.md
+
+## Import Cycles
+- 2-file cycle: `crates/intrada-api/src/rate_limit.rs -> crates/intrada-api/src/state.rs -> crates/intrada-api/src/rate_limit.rs`
+- 2-file cycle: `crates/intrada-api/src/auth.rs -> crates/intrada-api/src/state.rs -> crates/intrada-api/src/auth.rs`
+- 2-file cycle: `crates/intrada-core/src/app.rs -> crates/intrada-core/src/http.rs -> crates/intrada-core/src/app.rs`
+- 2-file cycle: `crates/intrada-core/src/domain/session.rs -> crates/intrada-core/src/model.rs -> crates/intrada-core/src/domain/session.rs`
+- 2-file cycle: `crates/intrada-core/src/domain/mcp_audit.rs -> crates/intrada-core/src/model.rs -> crates/intrada-core/src/domain/mcp_audit.rs`
+- 3-file cycle: `crates/intrada-api/src/auth.rs -> crates/intrada-api/src/state.rs -> crates/intrada-api/src/rate_limit.rs -> crates/intrada-api/src/auth.rs`
+
+## Hyperedges (group relationships)
+- **iOS-Only Pivot Governance** — claude_dev_guidelines_ios_only_focus, github_dependabot_ios_pivot_ignore, github_workflows_ci_ios_pivot_disabled_jobs [INFERRED 0.85]
+- **Offline-First Data Integrity Guarantees** — claude_dev_guidelines_offline_first_invariants, claude_dev_guidelines_local_data_migrations, claude_dev_guidelines_json_bincode_ffi_bug [EXTRACTED 0.90]
+- **Native iOS TestFlight Release Pipeline** — github_workflows_release_testflight, github_workflows_ci_native_ios_job, setup_testflight_bootstrap [EXTRACTED 0.90]
+- **Design file sync & single-ownership process** — design_design_process_md, design_claude_md, design_handover_md, concept_single_ownership_per_surface, concept_fold_in_ratchet [INFERRED 0.85]
+- **dc-import shared-screen pattern across design files** — design_intrada_design_system_dc_html, design_linked_exercises_dc_html, design_focus_player_dc_html, design_session_summary_dc_html, concept_dc_import_pattern [EXTRACTED 0.95]
+- **Self-Determination Theory evidence supporting autonomy-first design** — docs_research_foundation_md, ryan_deci_2000, valenzuela_codina_pestana_2018, bonneville_roussy_evans_2024, concept_spend_friction_deliberately [INFERRED 0.75]
+- **001-music-library SpecKit Document Bundle** — specs__archive_001_music_library_checklists_requirements, specs__archive_001_music_library_contracts_library_api, specs__archive_001_music_library_data_model, specs__archive_001_music_library_plan, specs__archive_001_music_library_quickstart, specs__archive_001_music_library_research, specs__archive_001_music_library_spec, specs__archive_001_music_library_tasks [INFERRED 0.90]
+- **002-ci-cd SpecKit Document Bundle** — specs__archive_002_ci_cd_checklists_requirements, specs__archive_002_ci_cd_plan, specs__archive_002_ci_cd_quickstart, specs__archive_002_ci_cd_research, specs__archive_002_ci_cd_spec, specs__archive_002_ci_cd_tasks [INFERRED 0.90]
+- **003-leptos-app-mvp SpecKit Document Bundle (partial, this chunk)** — specs__archive_003_leptos_app_mvp_checklists_requirements, specs__archive_003_leptos_app_mvp_data_model, specs__archive_003_leptos_app_mvp_plan, specs__archive_003_leptos_app_mvp_quickstart, specs__archive_003_leptos_app_mvp_research [INFERRED 0.90]
+- **Feature 004 documentation set (spec/plan/tasks/data-model/events/research/quickstart/checklist)** — specs_archive_004_library_detail_editing_spec, specs_archive_004_library_detail_editing_plan, specs_archive_004_library_detail_editing_tasks, specs_archive_004_library_detail_editing_data_model, specs_archive_004_library_detail_editing_contracts_events, specs_archive_004_library_detail_editing_research, specs_archive_004_library_detail_editing_quickstart, specs_archive_004_library_detail_editing_checklists_requirements [EXTRACTED 1.00]
+- **Feature 005 documentation set (spec/plan/tasks/research/quickstart/checklist)** — specs_archive_005_component_architecture_spec, specs_archive_005_component_architecture_plan, specs_archive_005_component_architecture_tasks, specs_archive_005_component_architecture_research, specs_archive_005_component_architecture_quickstart, specs_archive_005_component_architecture_checklists_requirements [EXTRACTED 1.00]
+- **Feature 006 documentation set (spec/plan/tasks/research/quickstart/checklist)** — specs_archive_006_ui_primitives_spec, specs_archive_006_ui_primitives_plan, specs_archive_006_ui_primitives_tasks, specs_archive_006_ui_primitives_research, specs_archive_006_ui_primitives_quickstart, specs_archive_006_ui_primitives_checklists_requirements [EXTRACTED 1.00]
+- **007 Crux & Leptos Upgrade — archived spec doc set** — specs_archive_007_crux_leptos_upgrade_spec, specs_archive_007_crux_leptos_upgrade_plan, specs_archive_007_crux_leptos_upgrade_research, specs_archive_007_crux_leptos_upgrade_quickstart, specs_archive_007_crux_leptos_upgrade_tasks, specs_archive_007_crux_leptos_upgrade_checklists_requirements [EXTRACTED 1.00]
+- **008 URL Routing — archived spec doc set** — specs_archive_008_url_routing_spec, specs_archive_008_url_routing_plan, specs_archive_008_url_routing_research, specs_archive_008_url_routing_quickstart, specs_archive_008_url_routing_tasks, specs_archive_008_url_routing_checklists_requirements [EXTRACTED 1.00]
+- **009 Unified Library Item Form — archived spec doc set** — specs_archive_009_unified_library_form_spec, specs_archive_009_unified_library_form_plan, specs_archive_009_unified_library_form_research, specs_archive_009_unified_library_form_quickstart, specs_archive_009_unified_library_form_tasks, specs_archive_009_unified_library_form_checklists_requirements, specs_archive_009_unified_library_form_data_model [EXTRACTED 1.00]
+- **011 JSON File Persistence — Spec-Kit Document Set** — specs_archive_011_json_persistence_research, specs_archive_011_json_persistence_spec, specs_archive_011_json_persistence_tasks [INFERRED 0.85]
+- **012 Practice Sessions — Spec-Kit Document Set** — specs_archive_012_practice_sessions_checklists_requirements, specs_archive_012_practice_sessions_data_model, specs_archive_012_practice_sessions_plan, specs_archive_012_practice_sessions_quickstart, specs_archive_012_practice_sessions_research, specs_archive_012_practice_sessions_spec, specs_archive_012_practice_sessions_tasks [INFERRED 0.85]
+- **013 Web UI Testing & E2E Infrastructure — Spec-Kit Document Set** — specs_archive_013_web_testing_checklists_requirements, specs_archive_013_web_testing_data_model, specs_archive_013_web_testing_plan, specs_archive_013_web_testing_quickstart, specs_archive_013_web_testing_research, specs_archive_013_web_testing_spec, specs_archive_013_web_testing_tasks [INFERRED 0.85]
+- **015 Rework Sessions Spec Bundle** — specs_archive_015_rework_sessions_spec, specs_archive_015_rework_sessions_plan, specs_archive_015_rework_sessions_data_model, specs_archive_015_rework_sessions_tasks, specs_archive_015_rework_sessions_research, specs_archive_015_rework_sessions_contracts_session_events, specs_archive_015_rework_sessions_quickstart, specs_archive_015_rework_sessions_checklists_requirements [EXTRACTED 1.00]
+- **016 Glassmorphism Responsive Spec Bundle** — specs_archive_016_glassmorphism_responsive_spec, specs_archive_016_glassmorphism_responsive_plan, specs_archive_016_glassmorphism_responsive_quickstart, specs_archive_016_glassmorphism_responsive_research, specs_archive_016_glassmorphism_responsive_tasks, specs_archive_016_glassmorphism_responsive_checklists_requirements [EXTRACTED 1.00]
+- **019 Improve CI/CD Spec Bundle** — specs_archive_019_improve_cicd_spec, specs_archive_019_improve_cicd_plan, specs_archive_019_improve_cicd_quickstart, specs_archive_019_improve_cicd_research, specs_archive_019_improve_cicd_tasks, specs_archive_019_improve_cicd_checklists_requirements [EXTRACTED 1.00]
+- **Archived Feature Spec 020: API Server document set** — specs_archive_020_api_server_plan, specs_archive_020_api_server_spec, specs_archive_020_api_server_research, specs_archive_020_api_server_data_model, specs_archive_020_api_server_quickstart, specs_archive_020_api_server_tasks, specs_archive_020_api_server_contracts_pieces, specs_archive_020_api_server_contracts_exercises, specs_archive_020_api_server_contracts_sessions, specs_archive_020_api_server_contracts_health [EXTRACTED 1.00]
+- **Archived Feature Spec 021: API Sync document set** — specs_archive_021_api_sync_plan, specs_archive_021_api_sync_spec, specs_archive_021_api_sync_research, specs_archive_021_api_sync_data_model, specs_archive_021_api_sync_quickstart, specs_archive_021_api_sync_tasks, specs_archive_021_api_sync_contracts_api_client, specs_archive_021_api_sync_checklists_requirements [EXTRACTED 1.00]
+- **Archived Feature Spec 022: Session Item Scoring document set (partial — chunk 8)** — specs_archive_022_session_scoring_plan, specs_archive_022_session_scoring_data_model, specs_archive_022_session_scoring_contracts_api_changes, specs_archive_022_session_scoring_checklists_requirements [EXTRACTED 1.00]
+- **022-session-scoring feature spec bundle** — specs_archive_022_session_scoring_spec_doc, specs_archive_022_session_scoring_research_doc, specs_archive_022_session_scoring_quickstart_doc, specs_archive_022_session_scoring_tasks_doc [EXTRACTED 1.00]
+- **023-analytics-dashboard feature spec bundle** — specs_archive_023_analytics_dashboard_spec_doc, specs_archive_023_analytics_dashboard_plan_doc, specs_archive_023_analytics_dashboard_research_doc, specs_archive_023_analytics_dashboard_data_model_doc, specs_archive_023_analytics_dashboard_quickstart_doc, specs_archive_023_analytics_dashboard_contracts_api_changes_doc, specs_archive_023_analytics_dashboard_checklists_requirements_doc, specs_archive_023_analytics_dashboard_tasks_doc [EXTRACTED 1.00]
+- **024-form-autocomplete feature spec bundle** — specs_archive_024_form_autocomplete_spec_doc, specs_archive_024_form_autocomplete_plan_doc, specs_archive_024_form_autocomplete_research_doc, specs_archive_024_form_autocomplete_data_model_doc, specs_archive_024_form_autocomplete_quickstart_doc, specs_archive_024_form_autocomplete_contracts_components_doc, specs_archive_024_form_autocomplete_checklists_requirements_doc, specs_archive_024_form_autocomplete_tasks_doc [EXTRACTED 1.00]
+- **025-reusable-routines archived feature spec bundle** — specs__archive_025_reusable_routines_spec, specs__archive_025_reusable_routines_plan, specs__archive_025_reusable_routines_research, specs__archive_025_reusable_routines_data_model, specs__archive_025_reusable_routines_quickstart, specs__archive_025_reusable_routines_tasks [EXTRACTED 1.00]
+- **026-drag-drop-builder archived feature spec bundle** — specs__archive_026_drag_drop_builder_spec, specs__archive_026_drag_drop_builder_plan, specs__archive_026_drag_drop_builder_research, specs__archive_026_drag_drop_builder_data_model, specs__archive_026_drag_drop_builder_quickstart, specs__archive_026_drag_drop_builder_tasks, specs__archive_026_drag_drop_builder_checklists_requirements, specs__archive_026_drag_drop_builder_contracts_readme [EXTRACTED 1.00]
+- **048-focus-mode archived feature spec bundle** — specs__archive_048_focus_mode_spec, specs__archive_048_focus_mode_plan, specs__archive_048_focus_mode_research, specs__archive_048_focus_mode_data_model, specs__archive_048_focus_mode_quickstart, specs__archive_048_focus_mode_tasks, specs__archive_048_focus_mode_checklists_requirements, specs__archive_048_focus_mode_contracts_api_changes [EXTRACTED 1.00]
+- **095-user-auth Archived Feature Spec Document Set** — specs_archive_095_user_auth_checklists_requirements_doc, specs_archive_095_user_auth_contracts_auth_changes_doc, specs_archive_095_user_auth_data_model_doc, specs_archive_095_user_auth_plan_doc, specs_archive_095_user_auth_quickstart_doc, specs_archive_095_user_auth_research_doc, specs_archive_095_user_auth_spec_doc, specs_archive_095_user_auth_tasks_doc [EXTRACTED 1.00]
+- **103-repetition-counter Archived Feature Spec Document Set** — specs_archive_103_repetition_counter_checklists_requirements_doc, specs_archive_103_repetition_counter_contracts_api_changes_doc, specs_archive_103_repetition_counter_data_model_doc, specs_archive_103_repetition_counter_plan_doc, specs_archive_103_repetition_counter_quickstart_doc, specs_archive_103_repetition_counter_research_doc, specs_archive_103_repetition_counter_spec_doc, specs_archive_103_repetition_counter_tasks_doc [EXTRACTED 1.00]
+- **104-rep-history Archived Feature Spec Document Set** — specs_archive_104_rep_history_checklists_requirements_doc, specs_archive_104_rep_history_contracts_api_changes_doc, specs_archive_104_rep_history_data_model_doc, specs_archive_104_rep_history_plan_doc, specs_archive_104_rep_history_quickstart_doc, specs_archive_104_rep_history_research_doc [EXTRACTED 1.00]
+- **105-tempo-tracking archived feature spec bundle** — specs_archive_105_tempo_tracking_spec, specs_archive_105_tempo_tracking_plan, specs_archive_105_tempo_tracking_research, specs_archive_105_tempo_tracking_data_model, specs_archive_105_tempo_tracking_contracts_api, specs_archive_105_tempo_tracking_quickstart, specs_archive_105_tempo_tracking_tasks, specs_archive_105_tempo_tracking_checklists_requirements [EXTRACTED 1.00]
+- **151-tempo-progress-charts archived feature spec bundle** — specs_archive_151_tempo_progress_charts_spec, specs_archive_151_tempo_progress_charts_plan, specs_archive_151_tempo_progress_charts_research, specs_archive_151_tempo_progress_charts_data_model, specs_archive_151_tempo_progress_charts_contracts_readme, specs_archive_151_tempo_progress_charts_quickstart, specs_archive_151_tempo_progress_charts_tasks, specs_archive_151_tempo_progress_charts_checklists_requirements [EXTRACTED 1.00]
+- **104-rep-history archived feature spec bundle** — specs_archive_104_rep_history_spec, specs_archive_104_rep_history_tasks, 104_rep_history_repaction, 104_rep_history_hide_show_preserve [INFERRED 0.85]
+- **153 Weekly Practice Summary archived SpecKit bundle** — specs__archive_153_weekly_practice_summary_quickstart, specs__archive_153_weekly_practice_summary_research, specs__archive_153_weekly_practice_summary_spec, specs__archive_153_weekly_practice_summary_tasks [EXTRACTED 0.95]
+- **154 Session Week Strip archived SpecKit bundle** — specs__archive_154_session_week_strip_checklists_requirements, specs__archive_154_session_week_strip_contracts_readme, specs__archive_154_session_week_strip_data_model, specs__archive_154_session_week_strip_plan, specs__archive_154_session_week_strip_quickstart, specs__archive_154_session_week_strip_research, specs__archive_154_session_week_strip_spec, specs__archive_154_session_week_strip_tasks [EXTRACTED 0.95]
+- **269 Teacher Capture archived SpecKit bundle** — specs__archive_269_teacher_capture_checklists_requirements, specs__archive_269_teacher_capture_contracts_api, specs__archive_269_teacher_capture_data_model, specs__archive_269_teacher_capture_plan, specs__archive_269_teacher_capture_quickstart, specs__archive_269_teacher_capture_research, specs__archive_269_teacher_capture_spec, specs__archive_269_teacher_capture_tasks [EXTRACTED 0.95]
+- **Native SwiftUI + Crux practice-player architecture (Phase A persistence -> player spine -> shell)** — specs_native_ios_doc, specs_native_ios_player_doc, specs_native_player_doc [EXTRACTED 1.00]
+- **iOS lock-screen session-presence plugins (background audio + Live Activity) on the native shell** — specs_background_audio_plugin_doc, specs_live_activity_plugin_doc, specs_native_ios_doc [EXTRACTED 1.00]
+- **Shared design-token/utility system (input.css tokens, card family, typography utilities)** — specs_design_system_doc, specs_design_refresh_2026_doc, specs_onboarding_welcome_doc [INFERRED 0.85]
+
+## Communities (1 total, 0 thin omitted)
+
+### Community 0 - "Whole repo (no clustering)"
+Cohesion: 1.00
+Nodes (4219): $schema, hooks, PostToolUse, pre-push script, xcodebuild, npx, check-prerequisites.sh script, common.sh script (+4211 more)
+
+## Ambiguous Edges - Review These
+- `Indigo · Refined — locked light-paper palette` → `Type colour-coding (Piece vs Exercise colour + icon pair)`  [AMBIGUOUS]
+  docs/design-principles.md · relation: semantically_similar_to
+- `Library Add/Detail/Editing - Tasks` → `LibraryItemView ViewModel`  [AMBIGUOUS]
+  specs/_archive/004-library-detail-editing/tasks.md · relation: conceptually_related_to
+- `Weekly Practice Summary Requirements Checklist` → `153 Weekly Practice Summary - Spec`  [AMBIGUOUS]
+  specs/_archive/153-weekly-practice-summary/checklists/requirements.md · relation: references
+- `compute_neglected_items computation approach` → `Decision 5: Lesson as standalone entity, no item relationships yet`  [AMBIGUOUS]
+  specs/_archive/153-weekly-practice-summary/research.md · relation: semantically_similar_to
+
+## Knowledge Gaps
+- **446 isolated node(s):** `$schema`, `PostToolUse`, `npx`, `check-prerequisites.sh script`, `common.sh script` (+441 more)
+  These have ≤1 connection - possible missing edges or undocumented components.
+
+## Suggested Questions
+_Questions this graph is uniquely positioned to answer:_
+
+- **What is the exact relationship between `Indigo · Refined — locked light-paper palette` and `Type colour-coding (Piece vs Exercise colour + icon pair)`?**
+  _Edge tagged AMBIGUOUS (relation: semantically_similar_to) - confidence is low._
+- **What is the exact relationship between `Library Add/Detail/Editing - Tasks` and `LibraryItemView ViewModel`?**
+  _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
+- **What is the exact relationship between `Weekly Practice Summary Requirements Checklist` and `153 Weekly Practice Summary - Spec`?**
+  _Edge tagged AMBIGUOUS (relation: references) - confidence is low._
+- **What is the exact relationship between `compute_neglected_items computation approach` and `Decision 5: Lesson as standalone entity, no item relationships yet`?**
+  _Edge tagged AMBIGUOUS (relation: semantically_similar_to) - confidence is low._
+- **What connects `$schema`, `PostToolUse`, `npx` to the rest of the system?**
+  _446 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Should `Whole repo (no clustering)` be split into smaller, more focused modules?**
+  _Cohesion score 0.0006971243210522333 - nodes in this community are weakly interconnected._

--- a/graphify-out/cost.json
+++ b/graphify-out/cost.json
@@ -1,7 +1,7 @@
 {
   "runs": [
     {
-      "date": "placeholder",
+      "date": "2026-07-13T15:04:08Z",
       "input_tokens": 0,
       "output_tokens": 2626283,
       "files": 710

--- a/graphify-out/cost.json
+++ b/graphify-out/cost.json
@@ -1,0 +1,12 @@
+{
+  "runs": [
+    {
+      "date": "placeholder",
+      "input_tokens": 0,
+      "output_tokens": 2626283,
+      "files": 710
+    }
+  ],
+  "total_input_tokens": 0,
+  "total_output_tokens": 2626283
+}

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,0 +1,3552 @@
+{
+  ".claude/settings.json": {
+    "mtime": 1783501819.5685124,
+    "ast_hash": "d9ae0d661e9f88585814f892549f4e77",
+    "semantic_hash": "d9ae0d661e9f88585814f892549f4e77"
+  },
+  ".githooks/pre-push": {
+    "mtime": 1783501819.5982056,
+    "ast_hash": "debf7c487cea5624c304bab4e295a24e",
+    "semantic_hash": "debf7c487cea5624c304bab4e295a24e"
+  },
+  ".mcp.json": {
+    "mtime": 1783501819.568579,
+    "ast_hash": "1edbe889b72e0e1ae598e0df90a6b654",
+    "semantic_hash": "1edbe889b72e0e1ae598e0df90a6b654"
+  },
+  ".specify/scripts/bash/check-prerequisites.sh": {
+    "mtime": 1783501819.6015303,
+    "ast_hash": "a8738d6f126b60481413b0e9ef6ef4ae",
+    "semantic_hash": "a8738d6f126b60481413b0e9ef6ef4ae"
+  },
+  ".specify/scripts/bash/common.sh": {
+    "mtime": 1783501819.6016216,
+    "ast_hash": "9221ae87db6704d4d532718f4424dd00",
+    "semantic_hash": "9221ae87db6704d4d532718f4424dd00"
+  },
+  ".specify/scripts/bash/create-new-feature.sh": {
+    "mtime": 1783501819.6017215,
+    "ast_hash": "eb8c4468ab330f53daa53b3c6a785637",
+    "semantic_hash": "eb8c4468ab330f53daa53b3c6a785637"
+  },
+  ".specify/scripts/bash/setup-plan.sh": {
+    "mtime": 1783501819.6017938,
+    "ast_hash": "4ce206b50f766fbf36a2d69e448356e9",
+    "semantic_hash": "4ce206b50f766fbf36a2d69e448356e9"
+  },
+  ".specify/scripts/bash/update-agent-context.sh": {
+    "mtime": 1783501819.6019015,
+    "ast_hash": "7593ba8c83a162ca6a9ad214d084948f",
+    "semantic_hash": "7593ba8c83a162ca6a9ad214d084948f"
+  },
+  "crates/intrada-api/build.rs": {
+    "mtime": 1783501819.6074376,
+    "ast_hash": "86ba34e78005e3b4175913844e3312c5",
+    "semantic_hash": "86ba34e78005e3b4175913844e3312c5"
+  },
+  "crates/intrada-api/src/auth.rs": {
+    "mtime": 1783501819.607601,
+    "ast_hash": "ea54298bdc44d00fc741ce454a168a84",
+    "semantic_hash": "ea54298bdc44d00fc741ce454a168a84"
+  },
+  "crates/intrada-api/src/clerk.rs": {
+    "mtime": 1783501819.6076782,
+    "ast_hash": "ef1b3ae2e00bcd4c416cc5b3c22b124d",
+    "semantic_hash": "ef1b3ae2e00bcd4c416cc5b3c22b124d"
+  },
+  "crates/intrada-api/src/db/account.rs": {
+    "mtime": 1783501819.607785,
+    "ast_hash": "c63958f037d75aa2d798242bd1f0cde2",
+    "semantic_hash": "c63958f037d75aa2d798242bd1f0cde2"
+  },
+  "crates/intrada-api/src/db/audit.rs": {
+    "mtime": 1783501819.6078537,
+    "ast_hash": "53b1d8b6369bb5dd0c2ea9ba45a63284",
+    "semantic_hash": "53b1d8b6369bb5dd0c2ea9ba45a63284"
+  },
+  "crates/intrada-api/src/db/items.rs": {
+    "mtime": 1783501819.6083155,
+    "ast_hash": "91a93b505ac348da3ac0a32b366df04a",
+    "semantic_hash": "91a93b505ac348da3ac0a32b366df04a"
+  },
+  "crates/intrada-api/src/db/mod.rs": {
+    "mtime": 1783501819.6083982,
+    "ast_hash": "263605e73749ff814bfba84d18eed7c9",
+    "semantic_hash": "263605e73749ff814bfba84d18eed7c9"
+  },
+  "crates/intrada-api/src/db/oauth.rs": {
+    "mtime": 1783501819.6084886,
+    "ast_hash": "f95c52676c04931a943020b29d703af6",
+    "semantic_hash": "f95c52676c04931a943020b29d703af6"
+  },
+  "crates/intrada-api/src/db/sessions.rs": {
+    "mtime": 1783501819.6089766,
+    "ast_hash": "11fb5805e3adac2cf4baf530da1c279a",
+    "semantic_hash": "11fb5805e3adac2cf4baf530da1c279a"
+  },
+  "crates/intrada-api/src/db/sets.rs": {
+    "mtime": 1783501819.6091223,
+    "ast_hash": "df5c62c28cbbb81f7fc0c7ac6e26eb4b",
+    "semantic_hash": "df5c62c28cbbb81f7fc0c7ac6e26eb4b"
+  },
+  "crates/intrada-api/src/db/tokens.rs": {
+    "mtime": 1783501819.6092093,
+    "ast_hash": "6ce6e4c2bc923ba738776a823b7b4fd8",
+    "semantic_hash": "6ce6e4c2bc923ba738776a823b7b4fd8"
+  },
+  "crates/intrada-api/src/error.rs": {
+    "mtime": 1783501819.6095333,
+    "ast_hash": "2f1ab9a3d8895a2a102ed21c1b265c80",
+    "semantic_hash": "2f1ab9a3d8895a2a102ed21c1b265c80"
+  },
+  "crates/intrada-api/src/lib.rs": {
+    "mtime": 1783501819.6096034,
+    "ast_hash": "c8d12e3608fea9b593e1a6d5260b425d",
+    "semantic_hash": "c8d12e3608fea9b593e1a6d5260b425d"
+  },
+  "crates/intrada-api/src/main.rs": {
+    "mtime": 1783501819.6096973,
+    "ast_hash": "e9f4815593bab8a0f890cdcadb083986",
+    "semantic_hash": "e9f4815593bab8a0f890cdcadb083986"
+  },
+  "crates/intrada-api/src/mcp/handlers.rs": {
+    "mtime": 1783501819.6098235,
+    "ast_hash": "7d8a4dc09d181a15b672db94a74f35a2",
+    "semantic_hash": "7d8a4dc09d181a15b672db94a74f35a2"
+  },
+  "crates/intrada-api/src/mcp/mod.rs": {
+    "mtime": 1783501819.6099184,
+    "ast_hash": "06dbd4cdbd52b82b9a4a52320268181f",
+    "semantic_hash": "06dbd4cdbd52b82b9a4a52320268181f"
+  },
+  "crates/intrada-api/src/mcp/protocol.rs": {
+    "mtime": 1783501819.6099937,
+    "ast_hash": "1da4f78b430201625e33b13cf3994b4b",
+    "semantic_hash": "1da4f78b430201625e33b13cf3994b4b"
+  },
+  "crates/intrada-api/src/mcp/server.rs": {
+    "mtime": 1783501819.6100953,
+    "ast_hash": "b1ab113754e21646938d202eb5763043",
+    "semantic_hash": "b1ab113754e21646938d202eb5763043"
+  },
+  "crates/intrada-api/src/mcp/tools.rs": {
+    "mtime": 1783501819.6101995,
+    "ast_hash": "9ea3536c6626d827951b7f9e92f5bdfc",
+    "semantic_hash": "9ea3536c6626d827951b7f9e92f5bdfc"
+  },
+  "crates/intrada-api/src/migrations.rs": {
+    "mtime": 1783501819.610426,
+    "ast_hash": "25599dbb536473d21ca81a4cef89c2e0",
+    "semantic_hash": "25599dbb536473d21ca81a4cef89c2e0"
+  },
+  "crates/intrada-api/src/rate_limit.rs": {
+    "mtime": 1783501819.6105425,
+    "ast_hash": "4e9f9e207f3b1005d8cb192d21884900",
+    "semantic_hash": "4e9f9e207f3b1005d8cb192d21884900"
+  },
+  "crates/intrada-api/src/routes/account.rs": {
+    "mtime": 1783501819.6106467,
+    "ast_hash": "3f659c2cc19cfe6492006d020bc6f4b2",
+    "semantic_hash": "3f659c2cc19cfe6492006d020bc6f4b2"
+  },
+  "crates/intrada-api/src/routes/assets.rs": {
+    "mtime": 1783501819.610713,
+    "ast_hash": "b747da3b4a6d622dd31b63fa3eb45de8",
+    "semantic_hash": "b747da3b4a6d622dd31b63fa3eb45de8"
+  },
+  "crates/intrada-api/src/routes/auth_ios.rs": {
+    "mtime": 1783501819.610776,
+    "ast_hash": "a4fbee38050e11d95d0a028a0e837bcb",
+    "semantic_hash": "a4fbee38050e11d95d0a028a0e837bcb"
+  },
+  "crates/intrada-api/src/routes/health.rs": {
+    "mtime": 1783501819.6108437,
+    "ast_hash": "01e51a02c74a40a2af685dff92dba7d9",
+    "semantic_hash": "01e51a02c74a40a2af685dff92dba7d9"
+  },
+  "crates/intrada-api/src/routes/items.rs": {
+    "mtime": 1783501819.6111336,
+    "ast_hash": "f79f6a11e501e3b50f5dee4c1c16d22c",
+    "semantic_hash": "f79f6a11e501e3b50f5dee4c1c16d22c"
+  },
+  "crates/intrada-api/src/routes/mod.rs": {
+    "mtime": 1783501819.6112297,
+    "ast_hash": "892501f3c8780d235671b76587378fd3",
+    "semantic_hash": "892501f3c8780d235671b76587378fd3"
+  },
+  "crates/intrada-api/src/routes/oauth.rs": {
+    "mtime": 1783501819.6113276,
+    "ast_hash": "faeaf9c73eeda6b8e45a5393869e61fb",
+    "semantic_hash": "faeaf9c73eeda6b8e45a5393869e61fb"
+  },
+  "crates/intrada-api/src/routes/sessions.rs": {
+    "mtime": 1783501819.6113968,
+    "ast_hash": "22fb81089779831180c1aa48b310ca34",
+    "semantic_hash": "22fb81089779831180c1aa48b310ca34"
+  },
+  "crates/intrada-api/src/routes/sets.rs": {
+    "mtime": 1783501819.611472,
+    "ast_hash": "b4eff8012afe7b001013e31d28bad18f",
+    "semantic_hash": "b4eff8012afe7b001013e31d28bad18f"
+  },
+  "crates/intrada-api/src/routes/tokens.rs": {
+    "mtime": 1783501819.6115751,
+    "ast_hash": "b27b3955d3f257a0d0768a0b06f81d5f",
+    "semantic_hash": "b27b3955d3f257a0d0768a0b06f81d5f"
+  },
+  "crates/intrada-api/src/services/account.rs": {
+    "mtime": 1783501819.61171,
+    "ast_hash": "e7ff2420bddfbb1ae2fd5db03f09d8ea",
+    "semantic_hash": "e7ff2420bddfbb1ae2fd5db03f09d8ea"
+  },
+  "crates/intrada-api/src/services/audit.rs": {
+    "mtime": 1783501819.61178,
+    "ast_hash": "fba6516d016ef2bfd528db7c60eb4d85",
+    "semantic_hash": "fba6516d016ef2bfd528db7c60eb4d85"
+  },
+  "crates/intrada-api/src/services/items.rs": {
+    "mtime": 1783501819.611841,
+    "ast_hash": "a5440b98dddd168d354688402da667e9",
+    "semantic_hash": "a5440b98dddd168d354688402da667e9"
+  },
+  "crates/intrada-api/src/services/mod.rs": {
+    "mtime": 1783501819.6120045,
+    "ast_hash": "83c693c39991514cfef3a7e432fd79c1",
+    "semantic_hash": "83c693c39991514cfef3a7e432fd79c1"
+  },
+  "crates/intrada-api/src/services/oauth.rs": {
+    "mtime": 1783501819.6120882,
+    "ast_hash": "12fddd959c36c40092d23c4453802de7",
+    "semantic_hash": "12fddd959c36c40092d23c4453802de7"
+  },
+  "crates/intrada-api/src/services/sessions.rs": {
+    "mtime": 1783501819.612147,
+    "ast_hash": "9454e36a13d1740cce46c95753d3d917",
+    "semantic_hash": "9454e36a13d1740cce46c95753d3d917"
+  },
+  "crates/intrada-api/src/services/sets.rs": {
+    "mtime": 1783501819.6122072,
+    "ast_hash": "32bf901b71acac017e5664670a849668",
+    "semantic_hash": "32bf901b71acac017e5664670a849668"
+  },
+  "crates/intrada-api/src/services/tokens.rs": {
+    "mtime": 1783501819.6122744,
+    "ast_hash": "f9da341fccc78364fe12779d1aa26774",
+    "semantic_hash": "f9da341fccc78364fe12779d1aa26774"
+  },
+  "crates/intrada-api/src/state.rs": {
+    "mtime": 1783501819.6123543,
+    "ast_hash": "f1c23cd392c2eef88e404dcdd4994fcd",
+    "semantic_hash": "f1c23cd392c2eef88e404dcdd4994fcd"
+  },
+  "crates/intrada-api/src/storage.rs": {
+    "mtime": 1783501819.6124213,
+    "ast_hash": "7f358cb1f150896f7499b24cd0630702",
+    "semantic_hash": "7f358cb1f150896f7499b24cd0630702"
+  },
+  "crates/intrada-api/src/telemetry.rs": {
+    "mtime": 1783501819.6124763,
+    "ast_hash": "684a34abd48523da4500223259f8cc4e",
+    "semantic_hash": "684a34abd48523da4500223259f8cc4e"
+  },
+  "crates/intrada-api/tests/account_test.rs": {
+    "mtime": 1783501819.6126828,
+    "ast_hash": "c5dd6af15d77e8e044af1b791fd2d602",
+    "semantic_hash": "c5dd6af15d77e8e044af1b791fd2d602"
+  },
+  "crates/intrada-api/tests/auth_ios_test.rs": {
+    "mtime": 1783501819.6127636,
+    "ast_hash": "74d60308ec6b0f1d9b8678ce863dfb0a",
+    "semantic_hash": "74d60308ec6b0f1d9b8678ce863dfb0a"
+  },
+  "crates/intrada-api/tests/auth_test.rs": {
+    "mtime": 1783501819.6128583,
+    "ast_hash": "b91d25d4e6edd3ed275570ee5ee9e833",
+    "semantic_hash": "b91d25d4e6edd3ed275570ee5ee9e833"
+  },
+  "crates/intrada-api/tests/common/mod.rs": {
+    "mtime": 1783501819.6129858,
+    "ast_hash": "0380a353010c25ecf6165b917d5a3ae5",
+    "semantic_hash": "0380a353010c25ecf6165b917d5a3ae5"
+  },
+  "crates/intrada-api/tests/cors_test.rs": {
+    "mtime": 1783501819.6130865,
+    "ast_hash": "4f77cd933c182be4155217ed0698e54b",
+    "semantic_hash": "4f77cd933c182be4155217ed0698e54b"
+  },
+  "crates/intrada-api/tests/health_test.rs": {
+    "mtime": 1783501819.613221,
+    "ast_hash": "1a8ac813d2929568e967a841981d8d17",
+    "semantic_hash": "1a8ac813d2929568e967a841981d8d17"
+  },
+  "crates/intrada-api/tests/items_test.rs": {
+    "mtime": 1783501819.6133127,
+    "ast_hash": "55854a9945aec5093152df481de73be9",
+    "semantic_hash": "55854a9945aec5093152df481de73be9"
+  },
+  "crates/intrada-api/tests/mcp_test.rs": {
+    "mtime": 1783501819.613476,
+    "ast_hash": "6ea63e13c1afb1be575913e88a778a7b",
+    "semantic_hash": "6ea63e13c1afb1be575913e88a778a7b"
+  },
+  "crates/intrada-api/tests/migrations_test.rs": {
+    "mtime": 1783501819.6139433,
+    "ast_hash": "6914e2a4f1c1a882f05b22a5ef633daa",
+    "semantic_hash": "6914e2a4f1c1a882f05b22a5ef633daa"
+  },
+  "crates/intrada-api/tests/oauth_test.rs": {
+    "mtime": 1783501819.6140532,
+    "ast_hash": "0e78ba0ea7689bedc8104253a32a4887",
+    "semantic_hash": "0e78ba0ea7689bedc8104253a32a4887"
+  },
+  "crates/intrada-api/tests/rate_limit_test.rs": {
+    "mtime": 1783501819.6142051,
+    "ast_hash": "4b18e0283dcff8c35ddd1995ba4c7329",
+    "semantic_hash": "4b18e0283dcff8c35ddd1995ba4c7329"
+  },
+  "crates/intrada-api/tests/sessions_test.rs": {
+    "mtime": 1783501819.6145973,
+    "ast_hash": "8ec4c25c922c1441e3a2af37d7f6f3f1",
+    "semantic_hash": "8ec4c25c922c1441e3a2af37d7f6f3f1"
+  },
+  "crates/intrada-api/tests/sets_test.rs": {
+    "mtime": 1783501819.6147182,
+    "ast_hash": "d29bff298ffcdc77206bc844dc0af619",
+    "semantic_hash": "d29bff298ffcdc77206bc844dc0af619"
+  },
+  "crates/intrada-api/tests/tokens_test.rs": {
+    "mtime": 1783501819.6148233,
+    "ast_hash": "807dba6cbc24dd541ac8b0ba695c6897",
+    "semantic_hash": "807dba6cbc24dd541ac8b0ba695c6897"
+  },
+  "crates/intrada-core/src/analytics.rs": {
+    "mtime": 1783501819.6155162,
+    "ast_hash": "bd265e0e3fb1acfa607a3fa29ef33db1",
+    "semantic_hash": "bd265e0e3fb1acfa607a3fa29ef33db1"
+  },
+  "crates/intrada-core/src/app.rs": {
+    "mtime": 1783953660.9262462,
+    "ast_hash": "4abbde21275497c66bea0a38dc8f5d53",
+    "semantic_hash": "4abbde21275497c66bea0a38dc8f5d53"
+  },
+  "crates/intrada-core/src/domain/account.rs": {
+    "mtime": 1783501819.6164043,
+    "ast_hash": "fd2aae6a267963a39237bfa8c894c4cd",
+    "semantic_hash": "fd2aae6a267963a39237bfa8c894c4cd"
+  },
+  "crates/intrada-core/src/domain/item.rs": {
+    "mtime": 1783501819.6167257,
+    "ast_hash": "4260cb6903a46b13210058f211b42b42",
+    "semantic_hash": "4260cb6903a46b13210058f211b42b42"
+  },
+  "crates/intrada-core/src/domain/mcp_audit.rs": {
+    "mtime": 1783501819.6168578,
+    "ast_hash": "f02ed4f2b8dd5c46b20e5095255a4edb",
+    "semantic_hash": "f02ed4f2b8dd5c46b20e5095255a4edb"
+  },
+  "crates/intrada-core/src/domain/mcp_tokens.rs": {
+    "mtime": 1783501819.6169472,
+    "ast_hash": "dc4d0ef62d35dae5e2773a5731a2364e",
+    "semantic_hash": "dc4d0ef62d35dae5e2773a5731a2364e"
+  },
+  "crates/intrada-core/src/domain/mod.rs": {
+    "mtime": 1783501819.6170197,
+    "ast_hash": "b39f907979574aed30b85c822015f8fe",
+    "semantic_hash": "b39f907979574aed30b85c822015f8fe"
+  },
+  "crates/intrada-core/src/domain/oauth.rs": {
+    "mtime": 1783501819.6170933,
+    "ast_hash": "66d6c4d3b8ccad8e02ba232e27f24392",
+    "semantic_hash": "66d6c4d3b8ccad8e02ba232e27f24392"
+  },
+  "crates/intrada-core/src/domain/session.rs": {
+    "mtime": 1783953660.9269633,
+    "ast_hash": "6f9f194ddc57d563bb7bd2c93974aa4b",
+    "semantic_hash": "6f9f194ddc57d563bb7bd2c93974aa4b"
+  },
+  "crates/intrada-core/src/domain/set.rs": {
+    "mtime": 1783501819.617876,
+    "ast_hash": "7c673ebf5470169f24360ec7e399f0bc",
+    "semantic_hash": "7c673ebf5470169f24360ec7e399f0bc"
+  },
+  "crates/intrada-core/src/domain/types.rs": {
+    "mtime": 1783501819.6183658,
+    "ast_hash": "fa68c54fc9a80d98759d9df2302b38d3",
+    "semantic_hash": "fa68c54fc9a80d98759d9df2302b38d3"
+  },
+  "crates/intrada-core/src/error.rs": {
+    "mtime": 1783501819.6184669,
+    "ast_hash": "045dadd7f9a03e71efc8081a5711d266",
+    "semantic_hash": "045dadd7f9a03e71efc8081a5711d266"
+  },
+  "crates/intrada-core/src/http.rs": {
+    "mtime": 1783501819.6188276,
+    "ast_hash": "886ad0e8128fa91df6472bc8d04069cc",
+    "semantic_hash": "886ad0e8128fa91df6472bc8d04069cc"
+  },
+  "crates/intrada-core/src/lib.rs": {
+    "mtime": 1783501819.618941,
+    "ast_hash": "5b973f74460d4987dd42359e99ff17fa",
+    "semantic_hash": "5b973f74460d4987dd42359e99ff17fa"
+  },
+  "crates/intrada-core/src/model.rs": {
+    "mtime": 1783953660.9274194,
+    "ast_hash": "2024bdcd588dab21b3dbe0a349bc3b69",
+    "semantic_hash": "2024bdcd588dab21b3dbe0a349bc3b69"
+  },
+  "crates/intrada-core/src/persistence.rs": {
+    "mtime": 1783501819.619595,
+    "ast_hash": "35e0ec2dc9743e9d7131156252430862",
+    "semantic_hash": "35e0ec2dc9743e9d7131156252430862"
+  },
+  "crates/intrada-core/src/validation.rs": {
+    "mtime": 1783501819.6199706,
+    "ast_hash": "77d3ed4ff30d964f4bf1c480176f4f96",
+    "semantic_hash": "77d3ed4ff30d964f4bf1c480176f4f96"
+  },
+  "crates/intrada-core/tests/typegen_readiness.rs": {
+    "mtime": 1783501819.6201098,
+    "ast_hash": "c2d1f51db80bb1b3ce1c65d4034b48e5",
+    "semantic_hash": "c2d1f51db80bb1b3ce1c65d4034b48e5"
+  },
+  "crates/intrada-ffi/src/bin/codegen.rs": {
+    "mtime": 1783501819.620608,
+    "ast_hash": "7d9e244e5e37e2c5a5c9fae16a9ed749",
+    "semantic_hash": "7d9e244e5e37e2c5a5c9fae16a9ed749"
+  },
+  "crates/intrada-ffi/src/ffi.rs": {
+    "mtime": 1783501819.620693,
+    "ast_hash": "71aa6c1055dac121e804fa544b4046b6",
+    "semantic_hash": "71aa6c1055dac121e804fa544b4046b6"
+  },
+  "crates/intrada-ffi/src/lib.rs": {
+    "mtime": 1783501819.620764,
+    "ast_hash": "466fb12b54dbcbee2e90928f82f365cf",
+    "semantic_hash": "466fb12b54dbcbee2e90928f82f365cf"
+  },
+  "crates/intrada-mobile/plugins/auth-session/build.rs": {
+    "mtime": 1783501819.621076,
+    "ast_hash": "2858111c420e47d7670c34568564efb3",
+    "semantic_hash": "2858111c420e47d7670c34568564efb3"
+  },
+  "crates/intrada-mobile/plugins/auth-session/ios/Package.swift": {
+    "mtime": 1783501819.6211941,
+    "ast_hash": "0b25c0a239fc21dbbf6f304e50f61db6",
+    "semantic_hash": "0b25c0a239fc21dbbf6f304e50f61db6"
+  },
+  "crates/intrada-mobile/plugins/auth-session/ios/Sources/AuthSessionPlugin/AuthSessionPlugin.swift": {
+    "mtime": 1783501819.621351,
+    "ast_hash": "6bd4ab8e7b01f047dceaa16d6c45f4fe",
+    "semantic_hash": "6bd4ab8e7b01f047dceaa16d6c45f4fe"
+  },
+  "crates/intrada-mobile/plugins/auth-session/permissions/default.json": {
+    "mtime": 1783501819.6216896,
+    "ast_hash": "e4b832011134580ee8ee8da56e8ad731",
+    "semantic_hash": "e4b832011134580ee8ee8da56e8ad731"
+  },
+  "crates/intrada-mobile/plugins/auth-session/permissions/schemas/schema.json": {
+    "mtime": 1783501819.6218276,
+    "ast_hash": "90a3d1a449e3d7fad8d267f49fdf0b66",
+    "semantic_hash": "90a3d1a449e3d7fad8d267f49fdf0b66"
+  },
+  "crates/intrada-mobile/plugins/auth-session/src/lib.rs": {
+    "mtime": 1783501819.621959,
+    "ast_hash": "2c65cb632c1bf5ba846ad8f67816c9c9",
+    "semantic_hash": "2c65cb632c1bf5ba846ad8f67816c9c9"
+  },
+  "crates/intrada-mobile/plugins/auth-session/src/mobile.rs": {
+    "mtime": 1783501819.6220348,
+    "ast_hash": "7f8b6cc09d4417612ddb29f9d4a32070",
+    "semantic_hash": "7f8b6cc09d4417612ddb29f9d4a32070"
+  },
+  "crates/intrada-mobile/plugins/background-audio/build.rs": {
+    "mtime": 1783501819.6222107,
+    "ast_hash": "80b728e85933e9b052f601e71f87c5e5",
+    "semantic_hash": "80b728e85933e9b052f601e71f87c5e5"
+  },
+  "crates/intrada-mobile/plugins/background-audio/ios/Package.swift": {
+    "mtime": 1783501819.6223178,
+    "ast_hash": "6bca9b78c5ac775b427f58a3b3da8e20",
+    "semantic_hash": "6bca9b78c5ac775b427f58a3b3da8e20"
+  },
+  "crates/intrada-mobile/plugins/background-audio/ios/Sources/BackgroundAudioPlugin/BackgroundAudioPlugin.swift": {
+    "mtime": 1783501819.62252,
+    "ast_hash": "264dde78d9854ac4b448db88b5af8d4e",
+    "semantic_hash": "264dde78d9854ac4b448db88b5af8d4e"
+  },
+  "crates/intrada-mobile/plugins/background-audio/permissions/default.json": {
+    "mtime": 1783501819.6231565,
+    "ast_hash": "fb32721a131e4c59fbde43a2ea923aa6",
+    "semantic_hash": "fb32721a131e4c59fbde43a2ea923aa6"
+  },
+  "crates/intrada-mobile/plugins/background-audio/permissions/schemas/schema.json": {
+    "mtime": 1783501819.623288,
+    "ast_hash": "90a3b2b94fd94c958805bf7ecea84354",
+    "semantic_hash": "90a3b2b94fd94c958805bf7ecea84354"
+  },
+  "crates/intrada-mobile/plugins/background-audio/src/lib.rs": {
+    "mtime": 1783501819.623416,
+    "ast_hash": "f049f2bfae996a07ab987c588cb230c9",
+    "semantic_hash": "f049f2bfae996a07ab987c588cb230c9"
+  },
+  "crates/intrada-mobile/plugins/background-audio/src/mobile.rs": {
+    "mtime": 1783501819.6234803,
+    "ast_hash": "026a46670adfb60e19314a83900f8842",
+    "semantic_hash": "026a46670adfb60e19314a83900f8842"
+  },
+  "crates/intrada-mobile/plugins/live-activity/build.rs": {
+    "mtime": 1783501819.6236455,
+    "ast_hash": "2ae92697a2da8216ba04918287450c27",
+    "semantic_hash": "2ae92697a2da8216ba04918287450c27"
+  },
+  "crates/intrada-mobile/plugins/live-activity/ios/Package.swift": {
+    "mtime": 1783501819.6238763,
+    "ast_hash": "36481f68a68c915d657d22d1cc6dc3ce",
+    "semantic_hash": "36481f68a68c915d657d22d1cc6dc3ce"
+  },
+  "crates/intrada-mobile/plugins/live-activity/ios/Sources/LiveActivityPlugin/LiveActivityPlugin.swift": {
+    "mtime": 1783501819.6240919,
+    "ast_hash": "ea396e72019d5fa50d1c0d19534c8ce1",
+    "semantic_hash": "ea396e72019d5fa50d1c0d19534c8ce1"
+  },
+  "crates/intrada-mobile/plugins/live-activity/permissions/default.json": {
+    "mtime": 1783501819.6245522,
+    "ast_hash": "360729733975eb26f90387e84a859687",
+    "semantic_hash": "360729733975eb26f90387e84a859687"
+  },
+  "crates/intrada-mobile/plugins/live-activity/permissions/schemas/schema.json": {
+    "mtime": 1783501819.624678,
+    "ast_hash": "cfa60b12374d771c228853d165cd4693",
+    "semantic_hash": "cfa60b12374d771c228853d165cd4693"
+  },
+  "crates/intrada-mobile/plugins/live-activity/src/lib.rs": {
+    "mtime": 1783501819.6248012,
+    "ast_hash": "030b7340fc8490d7974d5e209a1b437d",
+    "semantic_hash": "030b7340fc8490d7974d5e209a1b437d"
+  },
+  "crates/intrada-mobile/plugins/live-activity/src/mobile.rs": {
+    "mtime": 1783501819.624862,
+    "ast_hash": "feec037a549aa4f2c926969d8b9df4a9",
+    "semantic_hash": "feec037a549aa4f2c926969d8b9df4a9"
+  },
+  "crates/intrada-mobile/scripts/add-live-activity-target.rb": {
+    "mtime": 1783501819.6249893,
+    "ast_hash": "06dc72e08648cb68692705470621b9e2",
+    "semantic_hash": "06dc72e08648cb68692705470621b9e2"
+  },
+  "crates/intrada-mobile/scripts/fix-ios-build-config.rb": {
+    "mtime": 1783501819.625079,
+    "ast_hash": "b0d688cac98e1e6688a0c663f6d9fb2d",
+    "semantic_hash": "b0d688cac98e1e6688a0c663f6d9fb2d"
+  },
+  "crates/intrada-mobile/shared/IntradaActivityShared/Package.swift": {
+    "mtime": 1783501819.625229,
+    "ast_hash": "5ceff0ebbffdc489440fef5fa0544f42",
+    "semantic_hash": "5ceff0ebbffdc489440fef5fa0544f42"
+  },
+  "crates/intrada-mobile/shared/IntradaActivityShared/Sources/IntradaActivityShared/IntradaActivityAttributes.swift": {
+    "mtime": 1783501819.6253705,
+    "ast_hash": "dedf48e5dabe760ee6292daf8dbab5bd",
+    "semantic_hash": "dedf48e5dabe760ee6292daf8dbab5bd"
+  },
+  "crates/intrada-mobile/src-tauri/build.rs": {
+    "mtime": 1783501819.6256855,
+    "ast_hash": "369270e40cd4d5b802e9971dcff7f524",
+    "semantic_hash": "369270e40cd4d5b802e9971dcff7f524"
+  },
+  "crates/intrada-mobile/src-tauri/capabilities/default.json": {
+    "mtime": 1783501819.625793,
+    "ast_hash": "e4f7eb490ebf6ba38a7b985900d73778",
+    "semantic_hash": "e4f7eb490ebf6ba38a7b985900d73778"
+  },
+  "crates/intrada-mobile/src-tauri/capabilities/mobile.json": {
+    "mtime": 1783501819.6258678,
+    "ast_hash": "ccebb055d084c6a85bbe48a8e49fe7a0",
+    "semantic_hash": "ccebb055d084c6a85bbe48a8e49fe7a0"
+  },
+  "crates/intrada-mobile/src-tauri/src/lib.rs": {
+    "mtime": 1783501819.6264098,
+    "ast_hash": "b7e0d542f9c36a302e6f3727ad36329b",
+    "semantic_hash": "b7e0d542f9c36a302e6f3727ad36329b"
+  },
+  "crates/intrada-mobile/src-tauri/tauri.conf.json": {
+    "mtime": 1783501819.6264808,
+    "ast_hash": "625e37153f16654fda011e3313b286da",
+    "semantic_hash": "625e37153f16654fda011e3313b286da"
+  },
+  "crates/intrada-mobile/widget-extension/Sources/IntradaActivityWidget.swift": {
+    "mtime": 1783501819.6266487,
+    "ast_hash": "ecb1632d9ca5346a3c9bcaf60e6d46f7",
+    "semantic_hash": "ecb1632d9ca5346a3c9bcaf60e6d46f7"
+  },
+  "crates/intrada-mobile/widget-extension/Sources/IntradaWidgetBundle.swift": {
+    "mtime": 1783501819.626823,
+    "ast_hash": "a921e9b43e82577389d5546f6aba6660",
+    "semantic_hash": "a921e9b43e82577389d5546f6aba6660"
+  },
+  "crates/intrada-web/build.rs": {
+    "mtime": 1783501819.6273391,
+    "ast_hash": "970a153b9c73b7c1e91390b91158dee1",
+    "semantic_hash": "970a153b9c73b7c1e91390b91158dee1"
+  },
+  "crates/intrada-web/src/api_client.rs": {
+    "mtime": 1783501819.6290567,
+    "ast_hash": "9d475d418ae7249f0891c5e738c1be38",
+    "semantic_hash": "9d475d418ae7249f0891c5e738c1be38"
+  },
+  "crates/intrada-web/src/app.rs": {
+    "mtime": 1783501819.6291873,
+    "ast_hash": "4025d28ab5c9fc23d3d13365ded91634",
+    "semantic_hash": "4025d28ab5c9fc23d3d13365ded91634"
+  },
+  "crates/intrada-web/src/background_audio.rs": {
+    "mtime": 1783501819.6294234,
+    "ast_hash": "6b3584164dafef0602c1923b000b1e31",
+    "semantic_hash": "6b3584164dafef0602c1923b000b1e31"
+  },
+  "crates/intrada-web/src/components/accent_row.rs": {
+    "mtime": 1783501819.6296036,
+    "ast_hash": "3bdc7481e2a015a4d9e1378943b73ee8",
+    "semantic_hash": "3bdc7481e2a015a4d9e1378943b73ee8"
+  },
+  "crates/intrada-web/src/components/app_footer.rs": {
+    "mtime": 1783501819.629718,
+    "ast_hash": "d53dff2950db3ad7e70cfa1e59a8aaf7",
+    "semantic_hash": "d53dff2950db3ad7e70cfa1e59a8aaf7"
+  },
+  "crates/intrada-web/src/components/app_header.rs": {
+    "mtime": 1783501819.6298182,
+    "ast_hash": "0339b48716e969863a26c00ff4f18e72",
+    "semantic_hash": "0339b48716e969863a26c00ff4f18e72"
+  },
+  "crates/intrada-web/src/components/autocomplete.rs": {
+    "mtime": 1783501819.6299126,
+    "ast_hash": "311e79d73b92584ca2e39b91ed97876b",
+    "semantic_hash": "311e79d73b92584ca2e39b91ed97876b"
+  },
+  "crates/intrada-web/src/components/back_link.rs": {
+    "mtime": 1783501819.629976,
+    "ast_hash": "6c60b9535872ec38cd45afae540b3125",
+    "semantic_hash": "6c60b9535872ec38cd45afae540b3125"
+  },
+  "crates/intrada-web/src/components/bottom_sheet.rs": {
+    "mtime": 1783501819.6300817,
+    "ast_hash": "78f34e2b68d394ab6e396921738ce2a8",
+    "semantic_hash": "78f34e2b68d394ab6e396921738ce2a8"
+  },
+  "crates/intrada-web/src/components/bottom_tab_bar.rs": {
+    "mtime": 1783501819.6301844,
+    "ast_hash": "e11e5b0d7dfd8439216ab57e143ff3f3",
+    "semantic_hash": "e11e5b0d7dfd8439216ab57e143ff3f3"
+  },
+  "crates/intrada-web/src/components/brand_mark.rs": {
+    "mtime": 1783501819.6302469,
+    "ast_hash": "faaf6622cc3410800cb55f7339acd804",
+    "semantic_hash": "faaf6622cc3410800cb55f7339acd804"
+  },
+  "crates/intrada-web/src/components/builder_item_row.rs": {
+    "mtime": 1783501819.6303103,
+    "ast_hash": "16701adfbcf426aed3827a4a5cc0f387",
+    "semantic_hash": "16701adfbcf426aed3827a4a5cc0f387"
+  },
+  "crates/intrada-web/src/components/button.rs": {
+    "mtime": 1783501819.6304038,
+    "ast_hash": "988ef2725823a1d1fe7de0a1c7f3aee7",
+    "semantic_hash": "988ef2725823a1d1fe7de0a1c7f3aee7"
+  },
+  "crates/intrada-web/src/components/card.rs": {
+    "mtime": 1783501819.6304722,
+    "ast_hash": "381b38d3fe5c352f1f05154a013600f2",
+    "semantic_hash": "381b38d3fe5c352f1f05154a013600f2"
+  },
+  "crates/intrada-web/src/components/circular_button.rs": {
+    "mtime": 1783501819.6306539,
+    "ast_hash": "8880df91b03ed6cb93519cf5ec8f59ed",
+    "semantic_hash": "8880df91b03ed6cb93519cf5ec8f59ed"
+  },
+  "crates/intrada-web/src/components/context_menu.rs": {
+    "mtime": 1783501819.6307726,
+    "ast_hash": "02922e16676ff288fba9eaf755906ea2",
+    "semantic_hash": "02922e16676ff288fba9eaf755906ea2"
+  },
+  "crates/intrada-web/src/components/detail_group.rs": {
+    "mtime": 1783501819.630958,
+    "ast_hash": "7c4f0f86facc4ea2e7a7cf4ee42e19a1",
+    "semantic_hash": "7c4f0f86facc4ea2e7a7cf4ee42e19a1"
+  },
+  "crates/intrada-web/src/components/drag_handle.rs": {
+    "mtime": 1783501819.6314034,
+    "ast_hash": "026a60c179463ee9438730be8b4398b7",
+    "semantic_hash": "026a60c179463ee9438730be8b4398b7"
+  },
+  "crates/intrada-web/src/components/empty_state.rs": {
+    "mtime": 1783501819.6314778,
+    "ast_hash": "b65e2673cfc5c63ee5f73a6361a6dc85",
+    "semantic_hash": "b65e2673cfc5c63ee5f73a6361a6dc85"
+  },
+  "crates/intrada-web/src/components/entry_list_editor.rs": {
+    "mtime": 1783501819.631562,
+    "ast_hash": "c8f70f15cc425144e8056dea5b5a546c",
+    "semantic_hash": "c8f70f15cc425144e8056dea5b5a546c"
+  },
+  "crates/intrada-web/src/components/error_banner.rs": {
+    "mtime": 1783501819.6316288,
+    "ast_hash": "5554ab7e1e4339dbba5561ca5900be23",
+    "semantic_hash": "5554ab7e1e4339dbba5561ca5900be23"
+  },
+  "crates/intrada-web/src/components/field_label.rs": {
+    "mtime": 1783501819.63194,
+    "ast_hash": "6924b1fa17c89de9e2d9099d06916617",
+    "semantic_hash": "6924b1fa17c89de9e2d9099d06916617"
+  },
+  "crates/intrada-web/src/components/form_field_error.rs": {
+    "mtime": 1783501819.6324286,
+    "ast_hash": "e15954f2e5cb209877e52b5482a02f77",
+    "semantic_hash": "e15954f2e5cb209877e52b5482a02f77"
+  },
+  "crates/intrada-web/src/components/grouped_list.rs": {
+    "mtime": 1783501819.6326017,
+    "ast_hash": "62268be6aedef876e46c778e7533cca6",
+    "semantic_hash": "62268be6aedef876e46c778e7533cca6"
+  },
+  "crates/intrada-web/src/components/icon.rs": {
+    "mtime": 1783501819.632673,
+    "ast_hash": "beb6946f8b4572ac903f37fcd7e34af6",
+    "semantic_hash": "beb6946f8b4572ac903f37fcd7e34af6"
+  },
+  "crates/intrada-web/src/components/inline_type_indicator.rs": {
+    "mtime": 1783501819.6328213,
+    "ast_hash": "082f57af51cc04e689a2b555826a0c70",
+    "semantic_hash": "082f57af51cc04e689a2b555826a0c70"
+  },
+  "crates/intrada-web/src/components/item_reflection_sheet.rs": {
+    "mtime": 1783501819.632937,
+    "ast_hash": "7a8b1888b1899ae6e32322e7b31cf33e",
+    "semantic_hash": "7a8b1888b1899ae6e32322e7b31cf33e"
+  },
+  "crates/intrada-web/src/components/library_filter_tabs.rs": {
+    "mtime": 1783501819.6330333,
+    "ast_hash": "a1ebae0a78cae08e34549be9fc15e559",
+    "semantic_hash": "a1ebae0a78cae08e34549be9fc15e559"
+  },
+  "crates/intrada-web/src/components/library_item_card.rs": {
+    "mtime": 1783501819.6331189,
+    "ast_hash": "dd493175053d6d24d744c18255f00084",
+    "semantic_hash": "dd493175053d6d24d744c18255f00084"
+  },
+  "crates/intrada-web/src/components/library_set_card.rs": {
+    "mtime": 1783501819.6331868,
+    "ast_hash": "3bb905c6ad8c6cdce6505a6849a4c33b",
+    "semantic_hash": "3bb905c6ad8c6cdce6505a6849a4c33b"
+  },
+  "crates/intrada-web/src/components/library_type_tabs.rs": {
+    "mtime": 1783501819.6332908,
+    "ast_hash": "8edcc017efe0ac8a226f24ecdbb7d6dc",
+    "semantic_hash": "8edcc017efe0ac8a226f24ecdbb7d6dc"
+  },
+  "crates/intrada-web/src/components/line_chart.rs": {
+    "mtime": 1783501819.6337218,
+    "ast_hash": "ecea3abf01443268603e8055fd5ee826",
+    "semantic_hash": "ecea3abf01443268603e8055fd5ee826"
+  },
+  "crates/intrada-web/src/components/mod.rs": {
+    "mtime": 1783501819.6337912,
+    "ast_hash": "2d82164eacf940b2031ea6fdb616f19e",
+    "semantic_hash": "2d82164eacf940b2031ea6fdb616f19e"
+  },
+  "crates/intrada-web/src/components/page_add_button.rs": {
+    "mtime": 1783501819.6338706,
+    "ast_hash": "24c2a8777c9ad3203fab3c0280a80aef",
+    "semantic_hash": "24c2a8777c9ad3203fab3c0280a80aef"
+  },
+  "crates/intrada-web/src/components/page_heading.rs": {
+    "mtime": 1783501819.6340525,
+    "ast_hash": "bb20e279224720b179ec2be197ee8935",
+    "semantic_hash": "bb20e279224720b179ec2be197ee8935"
+  },
+  "crates/intrada-web/src/components/profile_button.rs": {
+    "mtime": 1783501819.6341267,
+    "ast_hash": "d0b5ca2780180844cddadccc654ecede",
+    "semantic_hash": "d0b5ca2780180844cddadccc654ecede"
+  },
+  "crates/intrada-web/src/components/progress_ring.rs": {
+    "mtime": 1783501819.6341934,
+    "ast_hash": "9afcbbc9eb1b4188d8f50023eda27ba6",
+    "semantic_hash": "9afcbbc9eb1b4188d8f50023eda27ba6"
+  },
+  "crates/intrada-web/src/components/pull_to_refresh.rs": {
+    "mtime": 1783501819.6342802,
+    "ast_hash": "1e89b639f4498a52f93b40e3099145d5",
+    "semantic_hash": "1e89b639f4498a52f93b40e3099145d5"
+  },
+  "crates/intrada-web/src/components/rating_chips.rs": {
+    "mtime": 1783501819.6343477,
+    "ast_hash": "5eec7e14da3406501c6462996bd7d2fc",
+    "semantic_hash": "5eec7e14da3406501c6462996bd7d2fc"
+  },
+  "crates/intrada-web/src/components/section_label.rs": {
+    "mtime": 1783501819.6344225,
+    "ast_hash": "66248dfdc4ae51e53ad371ad44734a84",
+    "semantic_hash": "66248dfdc4ae51e53ad371ad44734a84"
+  },
+  "crates/intrada-web/src/components/session_review_sheet.rs": {
+    "mtime": 1783501819.6345582,
+    "ast_hash": "93a3222be413cfc59a8d9bb5613a84eb",
+    "semantic_hash": "93a3222be413cfc59a8d9bb5613a84eb"
+  },
+  "crates/intrada-web/src/components/session_summary.rs": {
+    "mtime": 1783501819.634656,
+    "ast_hash": "727da00a21499c6caefd5bb238b8db85",
+    "semantic_hash": "727da00a21499c6caefd5bb238b8db85"
+  },
+  "crates/intrada-web/src/components/session_timer.rs": {
+    "mtime": 1783501819.634774,
+    "ast_hash": "53985aeb03c97dfb771f5aff0126da06",
+    "semantic_hash": "53985aeb03c97dfb771f5aff0126da06"
+  },
+  "crates/intrada-web/src/components/set_loader.rs": {
+    "mtime": 1783501819.6349964,
+    "ast_hash": "f9f65887bc3e61af7a48585e3b68fb0d",
+    "semantic_hash": "f9f65887bc3e61af7a48585e3b68fb0d"
+  },
+  "crates/intrada-web/src/components/set_save_form.rs": {
+    "mtime": 1783501819.6350987,
+    "ast_hash": "75090e12715b260300b5bee1de3723c9",
+    "semantic_hash": "75090e12715b260300b5bee1de3723c9"
+  },
+  "crates/intrada-web/src/components/setlist_builder.rs": {
+    "mtime": 1783501819.635185,
+    "ast_hash": "b5ee8c5a6436d68ea44b63b035d1c82e",
+    "semantic_hash": "b5ee8c5a6436d68ea44b63b035d1c82e"
+  },
+  "crates/intrada-web/src/components/setlist_entry.rs": {
+    "mtime": 1783501819.6352763,
+    "ast_hash": "39f8cd68ef7c78b8fd43ab2317934200",
+    "semantic_hash": "39f8cd68ef7c78b8fd43ab2317934200"
+  },
+  "crates/intrada-web/src/components/skeleton.rs": {
+    "mtime": 1783501819.6353502,
+    "ast_hash": "ac776679a7d0cf7a585bac12732450b7",
+    "semantic_hash": "ac776679a7d0cf7a585bac12732450b7"
+  },
+  "crates/intrada-web/src/components/stat_card.rs": {
+    "mtime": 1783501819.6354136,
+    "ast_hash": "babee442f60833e09f4d36a1ab40354d",
+    "semantic_hash": "babee442f60833e09f4d36a1ab40354d"
+  },
+  "crates/intrada-web/src/components/status_dot.rs": {
+    "mtime": 1783501819.6354828,
+    "ast_hash": "03beee75fd37f97fd87d4f2b662bb4bb",
+    "semantic_hash": "03beee75fd37f97fd87d4f2b662bb4bb"
+  },
+  "crates/intrada-web/src/components/swipe_actions.rs": {
+    "mtime": 1783501819.635567,
+    "ast_hash": "3f75b8d2490fb5570bec9ab4778a98cc",
+    "semantic_hash": "3f75b8d2490fb5570bec9ab4778a98cc"
+  },
+  "crates/intrada-web/src/components/tag_input.rs": {
+    "mtime": 1783501819.6356437,
+    "ast_hash": "748e05659076d88a05b5db83d4399b4e",
+    "semantic_hash": "748e05659076d88a05b5db83d4399b4e"
+  },
+  "crates/intrada-web/src/components/tempo_progress_chart.rs": {
+    "mtime": 1783501819.6357322,
+    "ast_hash": "8c049f50241cb6990bd8326b6a7a3cde",
+    "semantic_hash": "8c049f50241cb6990bd8326b6a7a3cde"
+  },
+  "crates/intrada-web/src/components/text_area.rs": {
+    "mtime": 1783501819.6358154,
+    "ast_hash": "e37853b758e48b9ddaf9816d6aeb13d7",
+    "semantic_hash": "e37853b758e48b9ddaf9816d6aeb13d7"
+  },
+  "crates/intrada-web/src/components/text_field.rs": {
+    "mtime": 1783501819.6358726,
+    "ast_hash": "14904486ced7a3d4ebeb25863e2bbb76",
+    "semantic_hash": "14904486ced7a3d4ebeb25863e2bbb76"
+  },
+  "crates/intrada-web/src/components/toast.rs": {
+    "mtime": 1783501819.6359293,
+    "ast_hash": "fdd228e4932b60bbf93694fc6745aefa",
+    "semantic_hash": "fdd228e4932b60bbf93694fc6745aefa"
+  },
+  "crates/intrada-web/src/components/transition_prompt.rs": {
+    "mtime": 1783501819.63623,
+    "ast_hash": "04e565cb893f698eb6d5056738576aeb",
+    "semantic_hash": "04e565cb893f698eb6d5056738576aeb"
+  },
+  "crates/intrada-web/src/components/type_badge.rs": {
+    "mtime": 1783501819.6362891,
+    "ast_hash": "75c1f321e425079e3fb890414cc30b54",
+    "semantic_hash": "75c1f321e425079e3fb890414cc30b54"
+  },
+  "crates/intrada-web/src/components/type_tabs.rs": {
+    "mtime": 1783501819.636379,
+    "ast_hash": "dfd924a6192636176532f1625e493917",
+    "semantic_hash": "dfd924a6192636176532f1625e493917"
+  },
+  "crates/intrada-web/src/components/week_strip.rs": {
+    "mtime": 1783501819.636463,
+    "ast_hash": "bf7ab7193c7484390dc073bb851a94e1",
+    "semantic_hash": "bf7ab7193c7484390dc073bb851a94e1"
+  },
+  "crates/intrada-web/src/components/welcome_card.rs": {
+    "mtime": 1783501819.6365376,
+    "ast_hash": "e4d27b8fe579791dc7c1841bf183b3bc",
+    "semantic_hash": "e4d27b8fe579791dc7c1841bf183b3bc"
+  },
+  "crates/intrada-web/src/components/welcome_carousel.rs": {
+    "mtime": 1783501819.636641,
+    "ast_hash": "20c60b78b4169cafb7b573d98eec465c",
+    "semantic_hash": "20c60b78b4169cafb7b573d98eec465c"
+  },
+  "crates/intrada-web/src/components/welcome_mark.rs": {
+    "mtime": 1783501819.6367295,
+    "ast_hash": "662d028eb75dc299dee07b4e7d4128b1",
+    "semantic_hash": "662d028eb75dc299dee07b4e7d4128b1"
+  },
+  "crates/intrada-web/src/core_bridge.rs": {
+    "mtime": 1783501819.6368225,
+    "ast_hash": "9f6b845a394a5f458afc4ee08f43ff2e",
+    "semantic_hash": "9f6b845a394a5f458afc4ee08f43ff2e"
+  },
+  "crates/intrada-web/src/haptics.rs": {
+    "mtime": 1783501819.637112,
+    "ast_hash": "52a6edf2d09a4e1d1b87bfadaf967470",
+    "semantic_hash": "52a6edf2d09a4e1d1b87bfadaf967470"
+  },
+  "crates/intrada-web/src/helpers.rs": {
+    "mtime": 1783501819.6371977,
+    "ast_hash": "41966a743a046c80577dbb023b54d575",
+    "semantic_hash": "41966a743a046c80577dbb023b54d575"
+  },
+  "crates/intrada-web/src/hooks/mod.rs": {
+    "mtime": 1783501819.6375797,
+    "ast_hash": "83a16c071405187dfca1a46efbd31bde",
+    "semantic_hash": "83a16c071405187dfca1a46efbd31bde"
+  },
+  "crates/intrada-web/src/hooks/use_drag_reorder.rs": {
+    "mtime": 1783501819.6376688,
+    "ast_hash": "9953bb2273314605e71a6967710bc543",
+    "semantic_hash": "9953bb2273314605e71a6967710bc543"
+  },
+  "crates/intrada-web/src/js_bridge.rs": {
+    "mtime": 1783501819.6379526,
+    "ast_hash": "3ed388856f6e64d2f0b0f8999db8d63f",
+    "semantic_hash": "3ed388856f6e64d2f0b0f8999db8d63f"
+  },
+  "crates/intrada-web/src/lib.rs": {
+    "mtime": 1783501819.6380157,
+    "ast_hash": "f352ce22c83367fedc1e07127c0722a5",
+    "semantic_hash": "f352ce22c83367fedc1e07127c0722a5"
+  },
+  "crates/intrada-web/src/live_activity.rs": {
+    "mtime": 1783501819.6380847,
+    "ast_hash": "3d96a09ba37ff7ebe557585f897081de",
+    "semantic_hash": "3d96a09ba37ff7ebe557585f897081de"
+  },
+  "crates/intrada-web/src/main.rs": {
+    "mtime": 1783501819.6381495,
+    "ast_hash": "5b8513af88035b5b34c1a55fb10055d3",
+    "semantic_hash": "5b8513af88035b5b34c1a55fb10055d3"
+  },
+  "crates/intrada-web/src/platform.rs": {
+    "mtime": 1783501819.6382124,
+    "ast_hash": "56114f4db2805cec56b79816eb9fe7a6",
+    "semantic_hash": "56114f4db2805cec56b79816eb9fe7a6"
+  },
+  "crates/intrada-web/src/session_lifecycle.rs": {
+    "mtime": 1783501819.6382813,
+    "ast_hash": "ba6a5948bc060a230dbc85cb74516ec7",
+    "semantic_hash": "ba6a5948bc060a230dbc85cb74516ec7"
+  },
+  "crates/intrada-web/src/types.rs": {
+    "mtime": 1783501819.6383512,
+    "ast_hash": "9bf686ac9901214c3c0f690e19e8eef9",
+    "semantic_hash": "9bf686ac9901214c3c0f690e19e8eef9"
+  },
+  "crates/intrada-web/src/validation.rs": {
+    "mtime": 1783501819.6384537,
+    "ast_hash": "5770793fc615d3bd199598f6f68e77ba",
+    "semantic_hash": "5770793fc615d3bd199598f6f68e77ba"
+  },
+  "crates/intrada-web/src/views/account_delete.rs": {
+    "mtime": 1783501819.6385782,
+    "ast_hash": "9a67c2d4f19950946eff62b84f8c0ebc",
+    "semantic_hash": "9a67c2d4f19950946eff62b84f8c0ebc"
+  },
+  "crates/intrada-web/src/views/add_form.rs": {
+    "mtime": 1783501819.6386764,
+    "ast_hash": "b5d0a4f3d4ca17bf6632ea8f393d8ee4",
+    "semantic_hash": "b5d0a4f3d4ca17bf6632ea8f393d8ee4"
+  },
+  "crates/intrada-web/src/views/analytics.rs": {
+    "mtime": 1783501819.6387749,
+    "ast_hash": "1ac75f1f5dbcf017c2048746cfc6dc60",
+    "semantic_hash": "1ac75f1f5dbcf017c2048746cfc6dc60"
+  },
+  "crates/intrada-web/src/views/design_catalogue.rs": {
+    "mtime": 1783501819.6389875,
+    "ast_hash": "4f57dae49619226ab878c4f259d65abe",
+    "semantic_hash": "4f57dae49619226ab878c4f259d65abe"
+  },
+  "crates/intrada-web/src/views/detail.rs": {
+    "mtime": 1783501819.6391172,
+    "ast_hash": "59c7aa742a423fe2e770926d693acba2",
+    "semantic_hash": "59c7aa742a423fe2e770926d693acba2"
+  },
+  "crates/intrada-web/src/views/edit_form.rs": {
+    "mtime": 1783501819.639244,
+    "ast_hash": "2c363342acc369ebf832e0351ca2b76f",
+    "semantic_hash": "2c363342acc369ebf832e0351ca2b76f"
+  },
+  "crates/intrada-web/src/views/library_list.rs": {
+    "mtime": 1783501819.6393332,
+    "ast_hash": "94911bfec810057610d97e0084b0935e",
+    "semantic_hash": "94911bfec810057610d97e0084b0935e"
+  },
+  "crates/intrada-web/src/views/login.rs": {
+    "mtime": 1783501819.639425,
+    "ast_hash": "07876827bf0276fda9cb2375e750bdca",
+    "semantic_hash": "07876827bf0276fda9cb2375e750bdca"
+  },
+  "crates/intrada-web/src/views/mcp_audit.rs": {
+    "mtime": 1783501819.6395106,
+    "ast_hash": "3fe2e22f0abff2e8766069a440f60d0a",
+    "semantic_hash": "3fe2e22f0abff2e8766069a440f60d0a"
+  },
+  "crates/intrada-web/src/views/mcp_tokens.rs": {
+    "mtime": 1783501819.6396067,
+    "ast_hash": "8dd6e6471f624cba6a82ada035965351",
+    "semantic_hash": "8dd6e6471f624cba6a82ada035965351"
+  },
+  "crates/intrada-web/src/views/mod.rs": {
+    "mtime": 1783501819.6396651,
+    "ast_hash": "9aff91af14141e50bcfd3d77789634f6",
+    "semantic_hash": "9aff91af14141e50bcfd3d77789634f6"
+  },
+  "crates/intrada-web/src/views/not_found.rs": {
+    "mtime": 1783501819.6398325,
+    "ast_hash": "6372fa5d0279e2324bc1353b18580760",
+    "semantic_hash": "6372fa5d0279e2324bc1353b18580760"
+  },
+  "crates/intrada-web/src/views/oauth_consent.rs": {
+    "mtime": 1783501819.639916,
+    "ast_hash": "9fcd129a66bf814ef83a8545989228b2",
+    "semantic_hash": "9fcd129a66bf814ef83a8545989228b2"
+  },
+  "crates/intrada-web/src/views/session_active.rs": {
+    "mtime": 1783501819.639994,
+    "ast_hash": "56fd96df4fd2fd1d3af134db2cfbbb87",
+    "semantic_hash": "56fd96df4fd2fd1d3af134db2cfbbb87"
+  },
+  "crates/intrada-web/src/views/session_new.rs": {
+    "mtime": 1783501819.6400654,
+    "ast_hash": "bfe22b163e629c29cf6e74b221adf157",
+    "semantic_hash": "bfe22b163e629c29cf6e74b221adf157"
+  },
+  "crates/intrada-web/src/views/session_summary.rs": {
+    "mtime": 1783501819.640138,
+    "ast_hash": "8dd2603c76b2bba180a63fafc194532c",
+    "semantic_hash": "8dd2603c76b2bba180a63fafc194532c"
+  },
+  "crates/intrada-web/src/views/sessions.rs": {
+    "mtime": 1783501819.6402283,
+    "ast_hash": "b38f78afee8f603c8993e8a9a441b744",
+    "semantic_hash": "b38f78afee8f603c8993e8a9a441b744"
+  },
+  "crates/intrada-web/src/views/sessions_all.rs": {
+    "mtime": 1783501819.6404152,
+    "ast_hash": "581b05fe1aa4dac272367620eedf4cf4",
+    "semantic_hash": "581b05fe1aa4dac272367620eedf4cf4"
+  },
+  "crates/intrada-web/src/views/set_detail.rs": {
+    "mtime": 1783501819.6405,
+    "ast_hash": "20e74a883777f57cd1ffe1c8fa852057",
+    "semantic_hash": "20e74a883777f57cd1ffe1c8fa852057"
+  },
+  "crates/intrada-web/src/views/set_edit.rs": {
+    "mtime": 1783501819.6405797,
+    "ast_hash": "fd6f39799639e5d9d2c1200db42ded04",
+    "semantic_hash": "fd6f39799639e5d9d2c1200db42ded04"
+  },
+  "crates/intrada-web/src/views/settings.rs": {
+    "mtime": 1783501819.640653,
+    "ast_hash": "ce8854ccebd39873a4732cd6939b60c5",
+    "semantic_hash": "ce8854ccebd39873a4732cd6939b60c5"
+  },
+  "crates/intrada-web/src/views/sso_callback.rs": {
+    "mtime": 1783501819.6407197,
+    "ast_hash": "33e8c1971025ed2817923e7fe763ebb6",
+    "semantic_hash": "33e8c1971025ed2817923e7fe763ebb6"
+  },
+  "crates/intrada-web/src/views/welcome.rs": {
+    "mtime": 1783501819.6408145,
+    "ast_hash": "5091d6f93da75a5848c65f91b27ea7ac",
+    "semantic_hash": "5091d6f93da75a5848c65f91b27ea7ac"
+  },
+  "crates/intrada-web/static/clerk/clerk.browser.js": {
+    "mtime": 1783501819.6413698,
+    "ast_hash": "8882efb0478df6596393ae4f069f0e3d",
+    "semantic_hash": "8882efb0478df6596393ae4f069f0e3d"
+  },
+  "crates/intrada-web/static/sentry/bundle.tracing.min.js": {
+    "mtime": 1783501819.6418636,
+    "ast_hash": "a41a78b6e93c42d58c9573092674ef37",
+    "semantic_hash": "a41a78b6e93c42d58c9573092674ef37"
+  },
+  "crates/intrada-web/tests/wasm.rs": {
+    "mtime": 1783501819.6438012,
+    "ast_hash": "98bfbfb596931b9a384579b318490707",
+    "semantic_hash": "98bfbfb596931b9a384579b318490707"
+  },
+  "design/support.js": {
+    "mtime": 1783501819.666933,
+    "ast_hash": "59b552108204bbe9021991fe6f3965fe",
+    "semantic_hash": "59b552108204bbe9021991fe6f3965fe"
+  },
+  "e2e/fixtures/api-mock.ts": {
+    "mtime": 1783501819.6703444,
+    "ast_hash": "52440acec6557343deec2f710a992399",
+    "semantic_hash": "52440acec6557343deec2f710a992399"
+  },
+  "e2e/fixtures/seed-data.ts": {
+    "mtime": 1783501819.6704044,
+    "ast_hash": "022890a74fc102266b02bf964c64a34b",
+    "semantic_hash": "022890a74fc102266b02bf964c64a34b"
+  },
+  "e2e/package.json": {
+    "mtime": 1783501819.6710467,
+    "ast_hash": "4c0783b46f6034e5a28fbf786ec57a76",
+    "semantic_hash": "4c0783b46f6034e5a28fbf786ec57a76"
+  },
+  "e2e/playwright.config.ts": {
+    "mtime": 1783501819.6710975,
+    "ast_hash": "3a13f797ab85139f11b32140074e6328",
+    "semantic_hash": "3a13f797ab85139f11b32140074e6328"
+  },
+  "e2e/tests/add-item.spec.ts": {
+    "mtime": 1783501819.6716714,
+    "ast_hash": "f3a584e300f75ed639dc933247ec6398",
+    "semantic_hash": "f3a584e300f75ed639dc933247ec6398"
+  },
+  "e2e/tests/analytics.spec.ts": {
+    "mtime": 1783501819.6717374,
+    "ast_hash": "7aaf9129d4ddc82fd65ef52f52be3f9e",
+    "semantic_hash": "7aaf9129d4ddc82fd65ef52f52be3f9e"
+  },
+  "e2e/tests/deploy-smoke.spec.ts": {
+    "mtime": 1783501819.6718078,
+    "ast_hash": "32e1e10a4aca4152a41cedb7b1e7fd14",
+    "semantic_hash": "32e1e10a4aca4152a41cedb7b1e7fd14"
+  },
+  "e2e/tests/detail.spec.ts": {
+    "mtime": 1783501819.6718688,
+    "ast_hash": "580fde5a914d34e14d6da5a41db9c32a",
+    "semantic_hash": "580fde5a914d34e14d6da5a41db9c32a"
+  },
+  "e2e/tests/edit-item.spec.ts": {
+    "mtime": 1783501819.6719182,
+    "ast_hash": "fc1f21aa8f9930e04489929f421aff01",
+    "semantic_hash": "fc1f21aa8f9930e04489929f421aff01"
+  },
+  "e2e/tests/navigation.spec.ts": {
+    "mtime": 1783501819.6719666,
+    "ast_hash": "63f330641572f7ade90d903a8db82c55",
+    "semantic_hash": "63f330641572f7ade90d903a8db82c55"
+  },
+  "e2e/tests/sessions.spec.ts": {
+    "mtime": 1783501819.6720448,
+    "ast_hash": "882ccc40df2e48ca4f33dbbed31c3a87",
+    "semantic_hash": "882ccc40df2e48ca4f33dbbed31c3a87"
+  },
+  "e2e/tests/sets.spec.ts": {
+    "mtime": 1783501819.672107,
+    "ast_hash": "289258e899a47f6d853f69b0b6ac1fc9",
+    "semantic_hash": "289258e899a47f6d853f69b0b6ac1fc9"
+  },
+  "e2e/tests/smoke.spec.ts": {
+    "mtime": 1783501819.672168,
+    "ast_hash": "7ee150db08a1af7c90b8d6d2333df0a3",
+    "semantic_hash": "7ee150db08a1af7c90b8d6d2333df0a3"
+  },
+  "e2e/tests/welcome.spec.ts": {
+    "mtime": 1783501819.6722255,
+    "ast_hash": "4e9c4e91116d68accf97aecb9b4625af",
+    "semantic_hash": "4e9c4e91116d68accf97aecb9b4625af"
+  },
+  "ios/Intrada/AppIcon.icon/icon.json": {
+    "mtime": 1783501819.6903641,
+    "ast_hash": "ca5738930af0059f9d04f6b66df7e08d",
+    "semantic_hash": "ca5738930af0059f9d04f6b66df7e08d"
+  },
+  "ios/Intrada/Core/CoreBridge.swift": {
+    "mtime": 1783501819.690454,
+    "ast_hash": "3cd0ea2ec8f3d1187831dd31e54b177c",
+    "semantic_hash": "3cd0ea2ec8f3d1187831dd31e54b177c"
+  },
+  "ios/Intrada/Core/LibraryStore.swift": {
+    "mtime": 1783501819.690862,
+    "ast_hash": "ee4db84da791ffa0d05854a95af25d8c",
+    "semantic_hash": "ee4db84da791ffa0d05854a95af25d8c"
+  },
+  "ios/Intrada/Core/LiveBridge.swift": {
+    "mtime": 1783501819.6909268,
+    "ast_hash": "aff113a885dae5a68620ec6ebc634a50",
+    "semantic_hash": "aff113a885dae5a68620ec6ebc634a50"
+  },
+  "ios/Intrada/Core/Logging.swift": {
+    "mtime": 1783501819.6909773,
+    "ast_hash": "dc3890ccc25496a6ba26fdbd73203a12",
+    "semantic_hash": "dc3890ccc25496a6ba26fdbd73203a12"
+  },
+  "ios/Intrada/Core/ScreenTransaction.swift": {
+    "mtime": 1783501819.6910243,
+    "ast_hash": "3cda89297bc236bd67d9b7241cd53392",
+    "semantic_hash": "3cda89297bc236bd67d9b7241cd53392"
+  },
+  "ios/Intrada/Core/SessionClock.swift": {
+    "mtime": 1783501819.6912313,
+    "ast_hash": "bdca0cf512ae5d89cc6b9ba4d4b8588a",
+    "semantic_hash": "bdca0cf512ae5d89cc6b9ba4d4b8588a"
+  },
+  "ios/Intrada/Core/Store.swift": {
+    "mtime": 1783501819.6915472,
+    "ast_hash": "8f9f5cd1354157bbcb53ead73090e5f6",
+    "semantic_hash": "8f9f5cd1354157bbcb53ead73090e5f6"
+  },
+  "ios/Intrada/Core/UITestFlags.swift": {
+    "mtime": 1783501819.691601,
+    "ast_hash": "f6edc53bdf12b3d224d550adb089894a",
+    "semantic_hash": "f6edc53bdf12b3d224d550adb089894a"
+  },
+  "ios/Intrada/DesignSystem/CardShadow.swift": {
+    "mtime": 1783501819.6919014,
+    "ast_hash": "c6114f3d6c5da00fe34a0d2e7fd2f13b",
+    "semantic_hash": "c6114f3d6c5da00fe34a0d2e7fd2f13b"
+  },
+  "ios/Intrada/DesignSystem/CardSurface.swift": {
+    "mtime": 1783501819.6919522,
+    "ast_hash": "0f7af8fa53d3a1d39651b06cd0856330",
+    "semantic_hash": "0f7af8fa53d3a1d39651b06cd0856330"
+  },
+  "ios/Intrada/DesignSystem/FormErrorBanner.swift": {
+    "mtime": 1783953660.9284883,
+    "ast_hash": "92bc5dccab25578c0f46c81c933055ef",
+    "semantic_hash": "92bc5dccab25578c0f46c81c933055ef"
+  },
+  "ios/Intrada/DesignSystem/GlobalBanner.swift": {
+    "mtime": 1783501819.6920643,
+    "ast_hash": "3a1c118ded70d7288b4425c623992456",
+    "semantic_hash": "3a1c118ded70d7288b4425c623992456"
+  },
+  "ios/Intrada/DesignSystem/HairlineDivider.swift": {
+    "mtime": 1783501819.692111,
+    "ast_hash": "ded854841d29df3b79a7898a0c6ca638",
+    "semantic_hash": "ded854841d29df3b79a7898a0c6ca638"
+  },
+  "ios/Intrada/DesignSystem/IntradaFonts.swift": {
+    "mtime": 1783501819.6921604,
+    "ast_hash": "2c5a3d0a8ced3f4d29528dcb5dbf7955",
+    "semantic_hash": "2c5a3d0a8ced3f4d29528dcb5dbf7955"
+  },
+  "ios/Intrada/DesignSystem/ItemKindStyle.swift": {
+    "mtime": 1783501819.6924973,
+    "ast_hash": "ce402a95f428fc3e4e5fb06ca473e27a",
+    "semantic_hash": "ce402a95f428fc3e4e5fb06ca473e27a"
+  },
+  "ios/Intrada/DesignSystem/LibraryItemView+Display.swift": {
+    "mtime": 1783501819.6928558,
+    "ast_hash": "16989c556eae725140b6ebac46ba3268",
+    "semantic_hash": "16989c556eae725140b6ebac46ba3268"
+  },
+  "ios/Intrada/DesignSystem/Motion.swift": {
+    "mtime": 1783501819.6933393,
+    "ast_hash": "e953851da7861e6befc6467fe5ffe935",
+    "semantic_hash": "e953851da7861e6befc6467fe5ffe935"
+  },
+  "ios/Intrada/DesignSystem/PaperBackground.swift": {
+    "mtime": 1783501819.693401,
+    "ast_hash": "d8476b3ce3f056730be546064660c427",
+    "semantic_hash": "d8476b3ce3f056730be546064660c427"
+  },
+  "ios/Intrada/DesignSystem/PlaceholderContent.swift": {
+    "mtime": 1783501819.6934683,
+    "ast_hash": "f76aa602dd7d4cc19c808dfd2df5c12e",
+    "semantic_hash": "f76aa602dd7d4cc19c808dfd2df5c12e"
+  },
+  "ios/Intrada/DesignSystem/PracticeSessionView+Date.swift": {
+    "mtime": 1783501819.6935241,
+    "ast_hash": "1320c4d8f9b32810094c0d30f6569994",
+    "semantic_hash": "1320c4d8f9b32810094c0d30f6569994"
+  },
+  "ios/Intrada/DesignSystem/PreviewSupport.swift": {
+    "mtime": 1783953660.9288917,
+    "ast_hash": "496ff613df95c9098678f5c8655a4faa",
+    "semantic_hash": "496ff613df95c9098678f5c8655a4faa"
+  },
+  "ios/Intrada/DesignSystem/ScreenScaffold.swift": {
+    "mtime": 1783501819.6943383,
+    "ast_hash": "d8f816065eddf2c6b87c17bb7a880f20",
+    "semantic_hash": "d8f816065eddf2c6b87c17bb7a880f20"
+  },
+  "ios/Intrada/DesignSystem/ScrollEdgeShadow.swift": {
+    "mtime": 1783501819.6944108,
+    "ast_hash": "4c97ba4c26d3c1d51d7216925d75f963",
+    "semantic_hash": "4c97ba4c26d3c1d51d7216925d75f963"
+  },
+  "ios/Intrada/DesignSystem/TagChip.swift": {
+    "mtime": 1783501819.694479,
+    "ast_hash": "0c0ac63c263dee6233f9af532cf1f3b8",
+    "semantic_hash": "0c0ac63c263dee6233f9af532cf1f3b8"
+  },
+  "ios/Intrada/DesignSystem/Theme.swift": {
+    "mtime": 1783501819.6949015,
+    "ast_hash": "7dd41cec03137f158c0f17d10ac7d84b",
+    "semantic_hash": "7dd41cec03137f158c0f17d10ac7d84b"
+  },
+  "ios/Intrada/IntradaApp.swift": {
+    "mtime": 1783501819.6955984,
+    "ast_hash": "bba2ae33d31d956339f3b9e717ba5f6c",
+    "semantic_hash": "bba2ae33d31d956339f3b9e717ba5f6c"
+  },
+  "ios/Intrada/Models/KeyHelper.swift": {
+    "mtime": 1783501819.695716,
+    "ast_hash": "19e99197db9b0994271c8966c50d0cc2",
+    "semantic_hash": "19e99197db9b0994271c8966c50d0cc2"
+  },
+  "ios/Intrada/Views/Components/AddRowButton.swift": {
+    "mtime": 1783501819.7005117,
+    "ast_hash": "0b43194818a9738ffb59511b834485a0",
+    "semantic_hash": "0b43194818a9738ffb59511b834485a0"
+  },
+  "ios/Intrada/Views/Components/AddToSessionSheet.swift": {
+    "mtime": 1783953660.929412,
+    "ast_hash": "7168156a3e551a724900fa1e9d7eb339",
+    "semantic_hash": "7168156a3e551a724900fa1e9d7eb339"
+  },
+  "ios/Intrada/Views/Components/AutocompleteField.swift": {
+    "mtime": 1783501819.7027547,
+    "ast_hash": "f336bceacf88ebbd8798d4cb02e0b975",
+    "semantic_hash": "f336bceacf88ebbd8798d4cb02e0b975"
+  },
+  "ios/Intrada/Views/Components/BottomSheet.swift": {
+    "mtime": 1783953660.9298992,
+    "ast_hash": "c98a3e73667e9dad37ced9847bb81db6",
+    "semantic_hash": "c98a3e73667e9dad37ced9847bb81db6"
+  },
+  "ios/Intrada/Views/Components/BrandBarButton.swift": {
+    "mtime": 1783953660.9302697,
+    "ast_hash": "b2f3314bbdb974a46ecc61541d5193ec",
+    "semantic_hash": "b2f3314bbdb974a46ecc61541d5193ec"
+  },
+  "ios/Intrada/Views/Components/BrowseControlsBar.swift": {
+    "mtime": 1783953660.9306693,
+    "ast_hash": "4d44629f1413be08225d2a6c535a6993",
+    "semantic_hash": "4d44629f1413be08225d2a6c535a6993"
+  },
+  "ios/Intrada/Views/Components/ConsistencyBars.swift": {
+    "mtime": 1783953660.93113,
+    "ast_hash": "c9aa64945527a90f4885880d5d53ea51",
+    "semantic_hash": "c9aa64945527a90f4885880d5d53ea51"
+  },
+  "ios/Intrada/Views/Components/DeleteButton.swift": {
+    "mtime": 1783501819.7052493,
+    "ast_hash": "60a21e1d3be42e8ae2b60bd07f631c7a",
+    "semantic_hash": "60a21e1d3be42e8ae2b60bd07f631c7a"
+  },
+  "ios/Intrada/Views/Components/FlowLayout.swift": {
+    "mtime": 1783501819.7053359,
+    "ast_hash": "ef3cf06a650037d5f3918c458f5e6baa",
+    "semantic_hash": "ef3cf06a650037d5f3918c458f5e6baa"
+  },
+  "ios/Intrada/Views/Components/FormField.swift": {
+    "mtime": 1783501819.7056637,
+    "ast_hash": "5b86ba0be3c499574b30944d84e16b9e",
+    "semantic_hash": "5b86ba0be3c499574b30944d84e16b9e"
+  },
+  "ios/Intrada/Views/Components/InlineSuggestionList.swift": {
+    "mtime": 1783501819.7058794,
+    "ast_hash": "e8995b87c98f2c48bc97556b574f2eb3",
+    "semantic_hash": "e8995b87c98f2c48bc97556b574f2eb3"
+  },
+  "ios/Intrada/Views/Components/KeyPicker.swift": {
+    "mtime": 1783501819.706221,
+    "ast_hash": "47f91c91b27952efedbadbaec81250ba",
+    "semantic_hash": "47f91c91b27952efedbadbaec81250ba"
+  },
+  "ios/Intrada/Views/Components/KindSegment.swift": {
+    "mtime": 1783501819.706403,
+    "ast_hash": "67d64604f24feeea48c39178659ea867",
+    "semantic_hash": "67d64604f24feeea48c39178659ea867"
+  },
+  "ios/Intrada/Views/Components/LibraryFilter.swift": {
+    "mtime": 1783501819.7067122,
+    "ast_hash": "5d8e74b462aa8611776c9039cadd32bd",
+    "semantic_hash": "5d8e74b462aa8611776c9039cadd32bd"
+  },
+  "ios/Intrada/Views/Components/LibraryFilterMenu.swift": {
+    "mtime": 1783501819.7071495,
+    "ast_hash": "29209e6005d7f05e6a1ced05031a9fdc",
+    "semantic_hash": "29209e6005d7f05e6a1ced05031a9fdc"
+  },
+  "ios/Intrada/Views/Components/LibraryItemCard.swift": {
+    "mtime": 1783501819.707405,
+    "ast_hash": "b3237764b3b94fb3f667f6fe57a99215",
+    "semantic_hash": "b3237764b3b94fb3f667f6fe57a99215"
+  },
+  "ios/Intrada/Views/Components/LibrarySearchBar.swift": {
+    "mtime": 1783501819.707472,
+    "ast_hash": "132c31f6d006b007fdbeb0badcaad6be",
+    "semantic_hash": "132c31f6d006b007fdbeb0badcaad6be"
+  },
+  "ios/Intrada/Views/Components/LibrarySortMenu.swift": {
+    "mtime": 1783501819.70753,
+    "ast_hash": "87ec57148c8b7341725aa0e1f2d4e61b",
+    "semantic_hash": "87ec57148c8b7341725aa0e1f2d4e61b"
+  },
+  "ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift": {
+    "mtime": 1783953660.9316711,
+    "ast_hash": "f937bfd50b7ec30ec069c2d743dcd85e",
+    "semantic_hash": "f937bfd50b7ec30ec069c2d743dcd85e"
+  },
+  "ios/Intrada/Views/Components/MasteryDelta.swift": {
+    "mtime": 1783953660.932058,
+    "ast_hash": "d5e0983daca1aeeb804fc8d6e7b66473",
+    "semantic_hash": "d5e0983daca1aeeb804fc8d6e7b66473"
+  },
+  "ios/Intrada/Views/Components/MasteryDial.swift": {
+    "mtime": 1783953660.9324632,
+    "ast_hash": "3a65566124c9d78f9d43991f99d32746",
+    "semantic_hash": "3a65566124c9d78f9d43991f99d32746"
+  },
+  "ios/Intrada/Views/Components/RecentSessions.swift": {
+    "mtime": 1783501819.7088008,
+    "ast_hash": "44a0afb1a7d0dfb165b5704a88c771f4",
+    "semantic_hash": "44a0afb1a7d0dfb165b5704a88c771f4"
+  },
+  "ios/Intrada/Views/Components/RepCounter.swift": {
+    "mtime": 1783953660.9327552,
+    "ast_hash": "c98603a66b51bc285740570d1ac5cb37",
+    "semantic_hash": "c98603a66b51bc285740570d1ac5cb37"
+  },
+  "ios/Intrada/Views/Components/ScoreRing.swift": {
+    "mtime": 1783953660.9330986,
+    "ast_hash": "9b21c3ab717cc46f4310e7976d61daa8",
+    "semantic_hash": "9b21c3ab717cc46f4310e7976d61daa8"
+  },
+  "ios/Intrada/Views/Components/ScoreSelector.swift": {
+    "mtime": 1783953660.9334748,
+    "ast_hash": "5f75a1bd2d4645b8d2387258a2c54d04",
+    "semantic_hash": "5f75a1bd2d4645b8d2387258a2c54d04"
+  },
+  "ios/Intrada/Views/Components/SectionHeader.swift": {
+    "mtime": 1783501819.7100132,
+    "ast_hash": "66e9bd202b318a85ce3d5b557e94650a",
+    "semantic_hash": "66e9bd202b318a85ce3d5b557e94650a"
+  },
+  "ios/Intrada/Views/Components/SegmentedPills.swift": {
+    "mtime": 1783501819.7102425,
+    "ast_hash": "88a3b5ab135c7fe0ab45a69295ced8eb",
+    "semantic_hash": "88a3b5ab135c7fe0ab45a69295ced8eb"
+  },
+  "ios/Intrada/Views/Components/SessionCard.swift": {
+    "mtime": 1783501819.7105656,
+    "ast_hash": "262e3716cc31d979f4b2ad00b603ec4c",
+    "semantic_hash": "262e3716cc31d979f4b2ad00b603ec4c"
+  },
+  "ios/Intrada/Views/Components/TagChipInput.swift": {
+    "mtime": 1783501819.7110891,
+    "ast_hash": "4061c6379f07ccd47c1b381d3e2e57ae",
+    "semantic_hash": "4061c6379f07ccd47c1b381d3e2e57ae"
+  },
+  "ios/Intrada/Views/Components/TagFilterSheet.swift": {
+    "mtime": 1783953660.9338033,
+    "ast_hash": "2e80bdb5523901e6a4b8e84b50b5ea5a",
+    "semantic_hash": "2e80bdb5523901e6a4b8e84b50b5ea5a"
+  },
+  "ios/Intrada/Views/Components/TagPills.swift": {
+    "mtime": 1783501819.7112062,
+    "ast_hash": "45785d56323f1c724f502b614b615478",
+    "semantic_hash": "45785d56323f1c724f502b614b615478"
+  },
+  "ios/Intrada/Views/Components/TypeBadge.swift": {
+    "mtime": 1783953660.9340637,
+    "ast_hash": "ec2a0b76da64cb6902610c4704d0abd4",
+    "semantic_hash": "ec2a0b76da64cb6902610c4704d0abd4"
+  },
+  "ios/Intrada/Views/Components/WeekStrip.swift": {
+    "mtime": 1783501819.7120223,
+    "ast_hash": "52f328a5b84cfeba0ddcda0d1929b301",
+    "semantic_hash": "52f328a5b84cfeba0ddcda0d1929b301"
+  },
+  "ios/Intrada/Views/RootView.swift": {
+    "mtime": 1783953660.934549,
+    "ast_hash": "6e3be9a753853dc694c13bb738e899c2",
+    "semantic_hash": "6e3be9a753853dc694c13bb738e899c2"
+  },
+  "ios/Intrada/Views/Screens/AnalyticsScreen.swift": {
+    "mtime": 1783501819.712725,
+    "ast_hash": "8bb6fdc2711cfcd6308c9dd43e59350f",
+    "semantic_hash": "8bb6fdc2711cfcd6308c9dd43e59350f"
+  },
+  "ios/Intrada/Views/Screens/FocusPlayerScreen.swift": {
+    "mtime": 1783953660.9351053,
+    "ast_hash": "9c00a6d4c76b9061a1992b4ad2a8d412",
+    "semantic_hash": "9c00a6d4c76b9061a1992b4ad2a8d412"
+  },
+  "ios/Intrada/Views/Screens/ItemFormModel.swift": {
+    "mtime": 1783501819.7130387,
+    "ast_hash": "5ac9ce124ed5d66cbe6639a0c4c50e67",
+    "semantic_hash": "5ac9ce124ed5d66cbe6639a0c4c50e67"
+  },
+  "ios/Intrada/Views/Screens/ItemFormScaffold.swift": {
+    "mtime": 1783501819.7130966,
+    "ast_hash": "b084ddb94e2b75948befa14d2c694ba9",
+    "semantic_hash": "b084ddb94e2b75948befa14d2c694ba9"
+  },
+  "ios/Intrada/Views/Screens/LibraryAddScreen.swift": {
+    "mtime": 1783501819.7131503,
+    "ast_hash": "1122f3cb21ce7c35b1b21338f4ba89cd",
+    "semantic_hash": "1122f3cb21ce7c35b1b21338f4ba89cd"
+  },
+  "ios/Intrada/Views/Screens/LibraryDetailScreen.swift": {
+    "mtime": 1783953660.935485,
+    "ast_hash": "0ca286c83de8f3822c58be8ba93fc578",
+    "semantic_hash": "0ca286c83de8f3822c58be8ba93fc578"
+  },
+  "ios/Intrada/Views/Screens/LibraryEditScreen.swift": {
+    "mtime": 1783501819.71343,
+    "ast_hash": "05256abe2fd9fcd319a7470c0e1f404e",
+    "semantic_hash": "05256abe2fd9fcd319a7470c0e1f404e"
+  },
+  "ios/Intrada/Views/Screens/LibraryScreen.swift": {
+    "mtime": 1783953660.9358034,
+    "ast_hash": "d5c33624aaba879e01cc80f188a7aa4d",
+    "semantic_hash": "d5c33624aaba879e01cc80f188a7aa4d"
+  },
+  "ios/Intrada/Views/Screens/LibrarySplitView.swift": {
+    "mtime": 1783501819.713893,
+    "ast_hash": "6542a25c820d86994932abcc0e36ecc7",
+    "semantic_hash": "6542a25c820d86994932abcc0e36ecc7"
+  },
+  "ios/Intrada/Views/Screens/PlayerHost.swift": {
+    "mtime": 1783501819.7144072,
+    "ast_hash": "434f7d419dd4790c03bca64b31b3d4e8",
+    "semantic_hash": "434f7d419dd4790c03bca64b31b3d4e8"
+  },
+  "ios/Intrada/Views/Screens/PracticeScreen.swift": {
+    "mtime": 1783501819.714753,
+    "ast_hash": "7dbb0761dc49d76a2199f4e7ddbc0ff8",
+    "semantic_hash": "7dbb0761dc49d76a2199f4e7ddbc0ff8"
+  },
+  "ios/Intrada/Views/Screens/ReflectionSheet.swift": {
+    "mtime": 1783953660.936303,
+    "ast_hash": "181f03b9d31534857db3a7f365a97da6",
+    "semantic_hash": "181f03b9d31534857db3a7f365a97da6"
+  },
+  "ios/Intrada/Views/Screens/RoutinesScreen.swift": {
+    "mtime": 1783501819.7151027,
+    "ast_hash": "8b3733961616c657f516c950d7e7ad65",
+    "semantic_hash": "8b3733961616c657f516c950d7e7ad65"
+  },
+  "ios/Intrada/Views/Screens/SessionBuilderScreen.swift": {
+    "mtime": 1783953660.9367044,
+    "ast_hash": "9841cbd03dbda3ec1bc723d70ae90092",
+    "semantic_hash": "9841cbd03dbda3ec1bc723d70ae90092"
+  },
+  "ios/Intrada/Views/Screens/SessionSummaryScreen.swift": {
+    "mtime": 1783953660.9369829,
+    "ast_hash": "2a3bcb14cb2d5305db54fffaa436d097",
+    "semantic_hash": "2a3bcb14cb2d5305db54fffaa436d097"
+  },
+  "ios/IntradaTests/KeyHelperTests.swift": {
+    "mtime": 1783501819.7157967,
+    "ast_hash": "9755d5aec6d7d156a6e93835c4568d68",
+    "semantic_hash": "9755d5aec6d7d156a6e93835c4568d68"
+  },
+  "ios/IntradaTests/LibrarySortMenuTests.swift": {
+    "mtime": 1783501819.715848,
+    "ast_hash": "a18b0da3de805a77717017c00dcb5828",
+    "semantic_hash": "a18b0da3de805a77717017c00dcb5828"
+  },
+  "ios/IntradaTests/LibraryStoreMigrationTests.swift": {
+    "mtime": 1783953660.9372842,
+    "ast_hash": "ab5ff94510afb14236dee2afa094d2ed",
+    "semantic_hash": "ab5ff94510afb14236dee2afa094d2ed"
+  },
+  "ios/IntradaTests/LibraryStoreTests.swift": {
+    "mtime": 1783501819.7166586,
+    "ast_hash": "f3ef68f208aa47a82e65a79845d67e10",
+    "semantic_hash": "f3ef68f208aa47a82e65a79845d67e10"
+  },
+  "ios/IntradaTests/PracticeWeekTests.swift": {
+    "mtime": 1783501819.7169218,
+    "ast_hash": "530d4d331980c87f1d02d604fa257d68",
+    "semantic_hash": "530d4d331980c87f1d02d604fa257d68"
+  },
+  "ios/IntradaTests/ScreenSnapshotTests.swift": {
+    "mtime": 1783953660.9376335,
+    "ast_hash": "008da02d44887d9ea1d0f2305e2b7202",
+    "semantic_hash": "008da02d44887d9ea1d0f2305e2b7202"
+  },
+  "ios/IntradaTests/SessionClockTests.swift": {
+    "mtime": 1783501819.717204,
+    "ast_hash": "cfaf2a1c300016d1c534470505f1190c",
+    "semantic_hash": "cfaf2a1c300016d1c534470505f1190c"
+  },
+  "ios/IntradaTests/StoreEffectLoopTests.swift": {
+    "mtime": 1783953660.938111,
+    "ast_hash": "5a168c069534e08786758b572f4901b1",
+    "semantic_hash": "5a168c069534e08786758b572f4901b1"
+  },
+  "ios/IntradaUITests/LibrarySearchUITests.swift": {
+    "mtime": 1783501819.7564483,
+    "ast_hash": "f1062276160cc173a49b4204e097a6b6",
+    "semantic_hash": "f1062276160cc173a49b4204e097a6b6"
+  },
+  "ios/IntradaUITests/SessionBuilderUITests.swift": {
+    "mtime": 1783501819.756634,
+    "ast_hash": "d60d5db00b852e56dd9b287bd8deea11",
+    "semantic_hash": "d60d5db00b852e56dd9b287bd8deea11"
+  },
+  "scripts/cache-bust-snippets.sh": {
+    "mtime": 1783501819.7577667,
+    "ast_hash": "c54c22c1534d55a0a642fa9e062068b1",
+    "semantic_hash": "c54c22c1534d55a0a642fa9e062068b1"
+  },
+  "scripts/check-comment-density.sh": {
+    "mtime": 1783501819.7579577,
+    "ast_hash": "bcfdfd25b640db73da4e6902ceb98924",
+    "semantic_hash": "bcfdfd25b640db73da4e6902ceb98924"
+  },
+  "scripts/check-snapshots.sh": {
+    "mtime": 1783501819.7581363,
+    "ast_hash": "f04a8f727f0e1fe77cc45409749b4d71",
+    "semantic_hash": "f04a8f727f0e1fe77cc45409749b4d71"
+  },
+  "scripts/install-git-hooks.sh": {
+    "mtime": 1783501819.7582033,
+    "ast_hash": "ea6adc10656ba9a929558e27b93f3997",
+    "semantic_hash": "ea6adc10656ba9a929558e27b93f3997"
+  },
+  "scripts/ios-run-sim.sh": {
+    "mtime": 1783501819.758275,
+    "ast_hash": "5076d834a8da9feefb7ec96873a7a6f2",
+    "semantic_hash": "5076d834a8da9feefb7ec96873a7a6f2"
+  },
+  "scripts/ios-simulator-smoke.sh": {
+    "mtime": 1783501819.7583513,
+    "ast_hash": "9d5b648d01fe9f854186c9f302f2d7ed",
+    "semantic_hash": "9d5b648d01fe9f854186c9f302f2d7ed"
+  },
+  "scripts/prerender.mjs": {
+    "mtime": 1783501819.7584264,
+    "ast_hash": "e6f2b181e508fdc493b073cedc6e8fee",
+    "semantic_hash": "e6f2b181e508fdc493b073cedc6e8fee"
+  },
+  "scripts/refresh-sri-hashes.py": {
+    "mtime": 1783501819.7584844,
+    "ast_hash": "c5a1bce948d2859c1209b67e915804b0",
+    "semantic_hash": "c5a1bce948d2859c1209b67e915804b0"
+  },
+  "scripts/seed-dev-data.sh": {
+    "mtime": 1783501819.758705,
+    "ast_hash": "6aa9c611d6820be90c7c4f3a0719878a",
+    "semantic_hash": "6aa9c611d6820be90c7c4f3a0719878a"
+  },
+  "scripts/vendor-clerk-sdk.sh": {
+    "mtime": 1783501819.7589114,
+    "ast_hash": "a4a9e451360ab59e9ec5498adcdd9d4b",
+    "semantic_hash": "a4a9e451360ab59e9ec5498adcdd9d4b"
+  },
+  "scripts/vendor-sentry-sdk.sh": {
+    "mtime": 1783501819.7590525,
+    "ast_hash": "d5f3271b1a5db2b50715c4c131d12af0",
+    "semantic_hash": "d5f3271b1a5db2b50715c4c131d12af0"
+  },
+  "scripts/verify-sri-hashes.py": {
+    "mtime": 1783501819.7591152,
+    "ast_hash": "3cae0441a3c13a63b683650ee5e80d5d",
+    "semantic_hash": "3cae0441a3c13a63b683650ee5e80d5d"
+  },
+  "worker.js": {
+    "mtime": 1783501819.7993007,
+    "ast_hash": "6e68c6fbd0a7e021628dca7c2501170b",
+    "semantic_hash": "6e68c6fbd0a7e021628dca7c2501170b"
+  },
+  ".claude/agents/ux-auditor.md": {
+    "mtime": 1783501819.5683217,
+    "ast_hash": "463e088cc0939fde1f9e31839f53b251",
+    "semantic_hash": "463e088cc0939fde1f9e31839f53b251"
+  },
+  ".claude/commands/ship.md": {
+    "mtime": 1783501819.5684452,
+    "ast_hash": "c49e4deb89e8f79b6439dec2daac66bf",
+    "semantic_hash": "c49e4deb89e8f79b6439dec2daac66bf"
+  },
+  ".github/dependabot.yml": {
+    "mtime": 1783501819.598697,
+    "ast_hash": "8f455dd6d12e26ec312cdc45e521a23a",
+    "semantic_hash": "8f455dd6d12e26ec312cdc45e521a23a"
+  },
+  ".github/pull_request_template.md": {
+    "mtime": 1783501819.5990283,
+    "ast_hash": "988a22db9f4bba3b7f4ae0ee8174d465",
+    "semantic_hash": "988a22db9f4bba3b7f4ae0ee8174d465"
+  },
+  ".github/workflows/ci.yml": {
+    "mtime": 1783953660.922588,
+    "ast_hash": "2cd4b0dbeb3b25f04b10a871582b9030",
+    "semantic_hash": "2cd4b0dbeb3b25f04b10a871582b9030"
+  },
+  ".github/workflows/release-testflight.yml": {
+    "mtime": 1783953660.9230244,
+    "ast_hash": "f342504d3ea49c2c4e8b0505083d51a3",
+    "semantic_hash": "f342504d3ea49c2c4e8b0505083d51a3"
+  },
+  ".specify/memory/constitution.md": {
+    "mtime": 1783501819.601324,
+    "ast_hash": "dd946a169f3afb331daaf9eecaa6cc9f",
+    "semantic_hash": "dd946a169f3afb331daaf9eecaa6cc9f"
+  },
+  ".specify/templates/agent-file-template.md": {
+    "mtime": 1783501819.6020489,
+    "ast_hash": "b8247a4214e5a2fb2468ad8dcf5fca50",
+    "semantic_hash": "b8247a4214e5a2fb2468ad8dcf5fca50"
+  },
+  ".specify/templates/checklist-template.md": {
+    "mtime": 1783501819.6021204,
+    "ast_hash": "87c4b390cebe71d15364bcd4690a102f",
+    "semantic_hash": "87c4b390cebe71d15364bcd4690a102f"
+  },
+  ".specify/templates/plan-template.md": {
+    "mtime": 1783501819.6021988,
+    "ast_hash": "da13d515cc460ff32df879f1878d7d60",
+    "semantic_hash": "da13d515cc460ff32df879f1878d7d60"
+  },
+  ".specify/templates/spec-template.md": {
+    "mtime": 1783501819.6029978,
+    "ast_hash": "6eec9247dca15d5e6b29b5a6bba768f3",
+    "semantic_hash": "6eec9247dca15d5e6b29b5a6bba768f3"
+  },
+  ".specify/templates/tasks-template.md": {
+    "mtime": 1783501819.603094,
+    "ast_hash": "9bbe5c1fbdbe93da7c522f085de7c0e1",
+    "semantic_hash": "9bbe5c1fbdbe93da7c522f085de7c0e1"
+  },
+  "CLAUDE.md": {
+    "mtime": 1783953660.9239352,
+    "ast_hash": "59038dfa1a9669fb08e0501cb0e996dc",
+    "semantic_hash": "59038dfa1a9669fb08e0501cb0e996dc"
+  },
+  "README.md": {
+    "mtime": 1783501819.6056483,
+    "ast_hash": "2c87d030b06291bc7f535b16144346d1",
+    "semantic_hash": "2c87d030b06291bc7f535b16144346d1"
+  },
+  "SETUP.md": {
+    "mtime": 1783953660.9254906,
+    "ast_hash": "5a86e772d9e9e3185c32be59cd5bb6ce",
+    "semantic_hash": "5a86e772d9e9e3185c32be59cd5bb6ce"
+  },
+  "VISION.md": {
+    "mtime": 1783501819.6066768,
+    "ast_hash": "02f32e59d16932ec7312f50b371547bb",
+    "semantic_hash": "02f32e59d16932ec7312f50b371547bb"
+  },
+  "codecov.yml": {
+    "mtime": 1783501819.6068401,
+    "ast_hash": "732c3da4b6d510a4fae1dc44c5c24ccd",
+    "semantic_hash": "732c3da4b6d510a4fae1dc44c5c24ccd"
+  },
+  "crates/intrada-mobile/plugins/auth-session/permissions/autogenerated/reference.md": {
+    "mtime": 1783501819.6216273,
+    "ast_hash": "3b228f70f58f96940c32f80dd9340936",
+    "semantic_hash": "3b228f70f58f96940c32f80dd9340936"
+  },
+  "crates/intrada-mobile/plugins/background-audio/permissions/autogenerated/reference.md": {
+    "mtime": 1783501819.6230776,
+    "ast_hash": "2e2bd4007992b095e51c146fdad31fb0",
+    "semantic_hash": "2e2bd4007992b095e51c146fdad31fb0"
+  },
+  "crates/intrada-mobile/plugins/live-activity/permissions/autogenerated/reference.md": {
+    "mtime": 1783501819.6244767,
+    "ast_hash": "d07eaf1c5da76c77e7070f27fdddbe9f",
+    "semantic_hash": "d07eaf1c5da76c77e7070f27fdddbe9f"
+  },
+  "crates/intrada-web/index.html": {
+    "mtime": 1783501819.6286478,
+    "ast_hash": "a41e688af5a24ce85d77d01f84eba011",
+    "semantic_hash": "a41e688af5a24ce85d77d01f84eba011"
+  },
+  "crates/intrada-web/static/ios-auth.html": {
+    "mtime": 1783501819.641465,
+    "ast_hash": "2218ad55c341cd873960a20609ac7a7d",
+    "semantic_hash": "2218ad55c341cd873960a20609ac7a7d"
+  },
+  "crates/intrada-web/static/robots.txt": {
+    "mtime": 1783501819.6415808,
+    "ast_hash": "6744e4b21061150efbf28a46218c3457",
+    "semantic_hash": "6744e4b21061150efbf28a46218c3457"
+  },
+  "design/CLAUDE.md": {
+    "mtime": 1783501819.645587,
+    "ast_hash": "77da7cc2324f48b8802a41b7e3cdd97c",
+    "semantic_hash": "77da7cc2324f48b8802a41b7e3cdd97c"
+  },
+  "design/Focus Player.dc.html": {
+    "mtime": 1783501819.6459355,
+    "ast_hash": "7f13a40f4ac995e44426c0dc4967987e",
+    "semantic_hash": "7f13a40f4ac995e44426c0dc4967987e"
+  },
+  "design/HANDOVER.md": {
+    "mtime": 1783501819.6462438,
+    "ast_hash": "7175ea8369bfbe21ad86cf9dad2a075b",
+    "semantic_hash": "7175ea8369bfbe21ad86cf9dad2a075b"
+  },
+  "design/Intrada Concepts.dc.html": {
+    "mtime": 1783501819.6467178,
+    "ast_hash": "d6ffea95f3366427932bcd367d039c16",
+    "semantic_hash": "d6ffea95f3366427932bcd367d039c16"
+  },
+  "design/Linked Exercises.dc.html": {
+    "mtime": 1783501819.6472654,
+    "ast_hash": "62fb952f56565c1dbb7b3d7e545d0e70",
+    "semantic_hash": "62fb952f56565c1dbb7b3d7e545d0e70"
+  },
+  "design/Session Summary.dc.html": {
+    "mtime": 1783501819.6475358,
+    "ast_hash": "2f8eecc29d64f03dce3aa4a6a291d43d",
+    "semantic_hash": "2f8eecc29d64f03dce3aa4a6a291d43d"
+  },
+  "design/design-process.md": {
+    "mtime": 1783501819.6501646,
+    "ast_hash": "f9e201e7b9bc38d8b59ee42fbeedf399",
+    "semantic_hash": "f9e201e7b9bc38d8b59ee42fbeedf399"
+  },
+  "design/intrada-design-system.dc.html": {
+    "mtime": 1783501819.6510062,
+    "ast_hash": "63a5ca3ba3d630d8210b96dbf7a220fb",
+    "semantic_hash": "63a5ca3ba3d630d8210b96dbf7a220fb"
+  },
+  "design/intrada-design-system.html": {
+    "mtime": 1783501819.66436,
+    "ast_hash": "e8e762f2c9dda0320ad1a516477a350b",
+    "semantic_hash": "e8e762f2c9dda0320ad1a516477a350b"
+  },
+  "design/light-mode-exploration.md": {
+    "mtime": 1783501819.6647387,
+    "ast_hash": "ed6545b97b42f31e6ad3a44f16b111db",
+    "semantic_hash": "ed6545b97b42f31e6ad3a44f16b111db"
+  },
+  "docs/design-principles.md": {
+    "mtime": 1783501819.667339,
+    "ast_hash": "1755f260e6de6b8395c80654ef581a0c",
+    "semantic_hash": "1755f260e6de6b8395c80654ef581a0c"
+  },
+  "docs/design-workflow.md": {
+    "mtime": 1783501819.6675985,
+    "ast_hash": "b08bcf613ea4d6913f39e8e1ccae092a",
+    "semantic_hash": "b08bcf613ea4d6913f39e8e1ccae092a"
+  },
+  "docs/development-workflow.md": {
+    "mtime": 1783501819.6679251,
+    "ast_hash": "b8f0a7bc9ab002b3ffed230a9c838f5d",
+    "semantic_hash": "b8f0a7bc9ab002b3ffed230a9c838f5d"
+  },
+  "docs/ios-testing.md": {
+    "mtime": 1783501819.6679966,
+    "ast_hash": "91d3d003711dbe7c8cabd5cf38f23d2c",
+    "semantic_hash": "91d3d003711dbe7c8cabd5cf38f23d2c"
+  },
+  "docs/mcp-setup.md": {
+    "mtime": 1783501819.6680624,
+    "ast_hash": "b9b0c25f440927de33ca601610f231ab",
+    "semantic_hash": "b9b0c25f440927de33ca601610f231ab"
+  },
+  "docs/research-foundation.md": {
+    "mtime": 1783501819.6686132,
+    "ast_hash": "e2ffb7e2ed43f00fec6455e41f92d83a",
+    "semantic_hash": "e2ffb7e2ed43f00fec6455e41f92d83a"
+  },
+  "docs/roadmap.md": {
+    "mtime": 1783953660.927938,
+    "ast_hash": "e8e45bb1008cd82f2b5e35eac33175d2",
+    "semantic_hash": "e8e45bb1008cd82f2b5e35eac33175d2"
+  },
+  "docs/superpowers/plans/2026-05-08-onboarding-welcome-v2.md": {
+    "mtime": 1783501819.6688595,
+    "ast_hash": "2f5ed0e933e8942af729ed94bfc7c26d",
+    "semantic_hash": "2f5ed0e933e8942af729ed94bfc7c26d"
+  },
+  "docs/superpowers/plans/2026-05-08-onboarding-welcome.md": {
+    "mtime": 1783501819.6689444,
+    "ast_hash": "1ed2f6c9e74220c7287d8f32758c6841",
+    "semantic_hash": "1ed2f6c9e74220c7287d8f32758c6841"
+  },
+  "docs/superpowers/plans/2026-05-31-priority-items-phase-a.md": {
+    "mtime": 1783501819.6690328,
+    "ast_hash": "ccff32cea21ca1c3f6a579441ab29261",
+    "semantic_hash": "ccff32cea21ca1c3f6a579441ab29261"
+  },
+  "docs/superpowers/plans/2026-06-01-library-sort.md": {
+    "mtime": 1783501819.6691253,
+    "ast_hash": "603cd458adf8064ecb99e8e0bb3bfa13",
+    "semantic_hash": "603cd458adf8064ecb99e8e0bb3bfa13"
+  },
+  "docs/working-with-claude-code.md": {
+    "mtime": 1783501819.6701884,
+    "ast_hash": "e7ea3abbb3260fc41b0b0697fcf2b5cc",
+    "semantic_hash": "e7ea3abbb3260fc41b0b0697fcf2b5cc"
+  },
+  "ios/Intrada/Resources/Fonts/OFL.txt": {
+    "mtime": 1783501819.697889,
+    "ast_hash": "fe677493332c90df8fec606b95942bee",
+    "semantic_hash": "fe677493332c90df8fec606b95942bee"
+  },
+  "ios/project.yml": {
+    "mtime": 1783501819.756941,
+    "ast_hash": "1eea5e4049cd4d61625d40a434db4f30",
+    "semantic_hash": "1eea5e4049cd4d61625d40a434db4f30"
+  },
+  "specs/_archive/001-music-library/checklists/requirements.md": {
+    "mtime": 1783501819.7593286,
+    "ast_hash": "41ffd35b8ee9a933229f4490e672349c",
+    "semantic_hash": "41ffd35b8ee9a933229f4490e672349c"
+  },
+  "specs/_archive/001-music-library/contracts/library-api.md": {
+    "mtime": 1783501819.7594657,
+    "ast_hash": "07f62d91bbec475a281396c9edb904f3",
+    "semantic_hash": "07f62d91bbec475a281396c9edb904f3"
+  },
+  "specs/_archive/001-music-library/data-model.md": {
+    "mtime": 1783501819.759538,
+    "ast_hash": "346638dfeca30e2a62749ccd3371d5d3",
+    "semantic_hash": "346638dfeca30e2a62749ccd3371d5d3"
+  },
+  "specs/_archive/001-music-library/plan.md": {
+    "mtime": 1783501819.7596254,
+    "ast_hash": "08317d90a19045c578e8949e780a3845",
+    "semantic_hash": "08317d90a19045c578e8949e780a3845"
+  },
+  "specs/_archive/001-music-library/quickstart.md": {
+    "mtime": 1783501819.7596881,
+    "ast_hash": "f71bc1587cf56cab4911fb317cecd194",
+    "semantic_hash": "f71bc1587cf56cab4911fb317cecd194"
+  },
+  "specs/_archive/001-music-library/research.md": {
+    "mtime": 1783501819.7597606,
+    "ast_hash": "9dd2cd165b77f8aa89dacfd0ae65e590",
+    "semantic_hash": "9dd2cd165b77f8aa89dacfd0ae65e590"
+  },
+  "specs/_archive/001-music-library/spec.md": {
+    "mtime": 1783501819.7598608,
+    "ast_hash": "b2d0d0ccd5649fb6f328b4536a8507a7",
+    "semantic_hash": "b2d0d0ccd5649fb6f328b4536a8507a7"
+  },
+  "specs/_archive/001-music-library/tasks.md": {
+    "mtime": 1783501819.7599485,
+    "ast_hash": "a4248a6ff9f4340df96f62a9cf73ed58",
+    "semantic_hash": "a4248a6ff9f4340df96f62a9cf73ed58"
+  },
+  "specs/_archive/002-ci-cd/checklists/requirements.md": {
+    "mtime": 1783501819.7600634,
+    "ast_hash": "292d89312d73fcadfacc52c3b5066af4",
+    "semantic_hash": "292d89312d73fcadfacc52c3b5066af4"
+  },
+  "specs/_archive/002-ci-cd/plan.md": {
+    "mtime": 1783501819.7601297,
+    "ast_hash": "ddcdd0bdf0e33cf40512bc61ccc03a3f",
+    "semantic_hash": "ddcdd0bdf0e33cf40512bc61ccc03a3f"
+  },
+  "specs/_archive/002-ci-cd/quickstart.md": {
+    "mtime": 1783501819.7601848,
+    "ast_hash": "745fe354b637e6c920460ecaa745222f",
+    "semantic_hash": "745fe354b637e6c920460ecaa745222f"
+  },
+  "specs/_archive/002-ci-cd/research.md": {
+    "mtime": 1783501819.7602422,
+    "ast_hash": "09b7ec765440f541b20f49deba43e32c",
+    "semantic_hash": "09b7ec765440f541b20f49deba43e32c"
+  },
+  "specs/_archive/002-ci-cd/spec.md": {
+    "mtime": 1783501819.760305,
+    "ast_hash": "99bc8fbf8868b2e6106b7e55514ac9ab",
+    "semantic_hash": "99bc8fbf8868b2e6106b7e55514ac9ab"
+  },
+  "specs/_archive/002-ci-cd/tasks.md": {
+    "mtime": 1783501819.7603667,
+    "ast_hash": "77e8fa74852f0760685543c7d6871542",
+    "semantic_hash": "77e8fa74852f0760685543c7d6871542"
+  },
+  "specs/_archive/003-leptos-app-mvp/checklists/requirements.md": {
+    "mtime": 1783501819.7604747,
+    "ast_hash": "7d52d39fc7c97f0889c6422dd83bd658",
+    "semantic_hash": "7d52d39fc7c97f0889c6422dd83bd658"
+  },
+  "specs/_archive/003-leptos-app-mvp/data-model.md": {
+    "mtime": 1783501819.760538,
+    "ast_hash": "fda3d62167381d1fcb670cc6e96352cd",
+    "semantic_hash": "fda3d62167381d1fcb670cc6e96352cd"
+  },
+  "specs/_archive/003-leptos-app-mvp/plan.md": {
+    "mtime": 1783501819.760604,
+    "ast_hash": "46e9c1f0a05f3eafc9abbd905d96936e",
+    "semantic_hash": "46e9c1f0a05f3eafc9abbd905d96936e"
+  },
+  "specs/_archive/003-leptos-app-mvp/quickstart.md": {
+    "mtime": 1783501819.760665,
+    "ast_hash": "c413e1514b3707598ef586766753f948",
+    "semantic_hash": "c413e1514b3707598ef586766753f948"
+  },
+  "specs/_archive/003-leptos-app-mvp/research.md": {
+    "mtime": 1783501819.7607362,
+    "ast_hash": "fd6bf77689259f136f3cf5ef2fd12608",
+    "semantic_hash": "fd6bf77689259f136f3cf5ef2fd12608"
+  },
+  "specs/_archive/003-leptos-app-mvp/spec.md": {
+    "mtime": 1783501819.7608075,
+    "ast_hash": "a9eb7c567aba329989c88eb19996e357",
+    "semantic_hash": "a9eb7c567aba329989c88eb19996e357"
+  },
+  "specs/_archive/003-leptos-app-mvp/tasks.md": {
+    "mtime": 1783501819.7608895,
+    "ast_hash": "5ef4c28198a29f22b8be3f31dc435d06",
+    "semantic_hash": "5ef4c28198a29f22b8be3f31dc435d06"
+  },
+  "specs/_archive/004-library-detail-editing/checklists/requirements.md": {
+    "mtime": 1783501819.761006,
+    "ast_hash": "1566e59208e25e9124aebf8524e23506",
+    "semantic_hash": "1566e59208e25e9124aebf8524e23506"
+  },
+  "specs/_archive/004-library-detail-editing/contracts/events.md": {
+    "mtime": 1783501819.7610974,
+    "ast_hash": "7f7a3af5e56ba479f60c8852471cdc2a",
+    "semantic_hash": "7f7a3af5e56ba479f60c8852471cdc2a"
+  },
+  "specs/_archive/004-library-detail-editing/data-model.md": {
+    "mtime": 1783501819.761159,
+    "ast_hash": "e32547f5dcdc84af16bb134c7718ab2c",
+    "semantic_hash": "e32547f5dcdc84af16bb134c7718ab2c"
+  },
+  "specs/_archive/004-library-detail-editing/plan.md": {
+    "mtime": 1783501819.7612243,
+    "ast_hash": "0702d6194d690dba47988c2f65410efb",
+    "semantic_hash": "0702d6194d690dba47988c2f65410efb"
+  },
+  "specs/_archive/004-library-detail-editing/quickstart.md": {
+    "mtime": 1783501819.7612746,
+    "ast_hash": "9a4b49f4f4a621e2d6694bdd0a03bd49",
+    "semantic_hash": "9a4b49f4f4a621e2d6694bdd0a03bd49"
+  },
+  "specs/_archive/004-library-detail-editing/research.md": {
+    "mtime": 1783501819.7613482,
+    "ast_hash": "171bf0fb0d6e2ff0dfd4bfd902c629cd",
+    "semantic_hash": "171bf0fb0d6e2ff0dfd4bfd902c629cd"
+  },
+  "specs/_archive/004-library-detail-editing/spec.md": {
+    "mtime": 1783501819.7614229,
+    "ast_hash": "700f5ffe3c5d7e417848e303b4a5da00",
+    "semantic_hash": "700f5ffe3c5d7e417848e303b4a5da00"
+  },
+  "specs/_archive/004-library-detail-editing/tasks.md": {
+    "mtime": 1783501819.7614894,
+    "ast_hash": "21a474c006287259c3628d3d8c20e4eb",
+    "semantic_hash": "21a474c006287259c3628d3d8c20e4eb"
+  },
+  "specs/_archive/005-component-architecture/checklists/requirements.md": {
+    "mtime": 1783501819.7616255,
+    "ast_hash": "d10e9c0db6d3b263e88d3f67f79f39c7",
+    "semantic_hash": "d10e9c0db6d3b263e88d3f67f79f39c7"
+  },
+  "specs/_archive/005-component-architecture/plan.md": {
+    "mtime": 1783501819.7616966,
+    "ast_hash": "22ce1d0b396cd651a309e27479699563",
+    "semantic_hash": "22ce1d0b396cd651a309e27479699563"
+  },
+  "specs/_archive/005-component-architecture/quickstart.md": {
+    "mtime": 1783501819.7617528,
+    "ast_hash": "e86628abc07095ee20b98355c23e7b8f",
+    "semantic_hash": "e86628abc07095ee20b98355c23e7b8f"
+  },
+  "specs/_archive/005-component-architecture/research.md": {
+    "mtime": 1783501819.761818,
+    "ast_hash": "9c03ff20d3760f8644ea6b84c159a001",
+    "semantic_hash": "9c03ff20d3760f8644ea6b84c159a001"
+  },
+  "specs/_archive/005-component-architecture/spec.md": {
+    "mtime": 1783501819.7618933,
+    "ast_hash": "02f87c1dcd7893cc78672a680b7b6227",
+    "semantic_hash": "02f87c1dcd7893cc78672a680b7b6227"
+  },
+  "specs/_archive/005-component-architecture/tasks.md": {
+    "mtime": 1783501819.7619574,
+    "ast_hash": "09bc88900ed8fd7054e054cb067fc367",
+    "semantic_hash": "09bc88900ed8fd7054e054cb067fc367"
+  },
+  "specs/_archive/006-ui-primitives/checklists/requirements.md": {
+    "mtime": 1783501819.762091,
+    "ast_hash": "fdd34ad20fd4a5b64599b260770c38c7",
+    "semantic_hash": "fdd34ad20fd4a5b64599b260770c38c7"
+  },
+  "specs/_archive/006-ui-primitives/plan.md": {
+    "mtime": 1783501819.7621627,
+    "ast_hash": "8288a47719077314ee55cf888e8c571e",
+    "semantic_hash": "8288a47719077314ee55cf888e8c571e"
+  },
+  "specs/_archive/006-ui-primitives/quickstart.md": {
+    "mtime": 1783501819.7622192,
+    "ast_hash": "d9afe277f8b3141d3ec396b70c53fb9d",
+    "semantic_hash": "d9afe277f8b3141d3ec396b70c53fb9d"
+  },
+  "specs/_archive/006-ui-primitives/research.md": {
+    "mtime": 1783501819.7622757,
+    "ast_hash": "2405eb8b915a9397a51663d303f7a7b7",
+    "semantic_hash": "2405eb8b915a9397a51663d303f7a7b7"
+  },
+  "specs/_archive/006-ui-primitives/spec.md": {
+    "mtime": 1783501819.762355,
+    "ast_hash": "ea07e776990a333ad1dd74dacdfc8691",
+    "semantic_hash": "ea07e776990a333ad1dd74dacdfc8691"
+  },
+  "specs/_archive/006-ui-primitives/tasks.md": {
+    "mtime": 1783501819.7624266,
+    "ast_hash": "fa861ba1dd37859aacc3c976f19f33be",
+    "semantic_hash": "fa861ba1dd37859aacc3c976f19f33be"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/checklists/requirements.md": {
+    "mtime": 1783501819.762545,
+    "ast_hash": "c1859168a652abda76d45cb17b1c1afd",
+    "semantic_hash": "c1859168a652abda76d45cb17b1c1afd"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/plan.md": {
+    "mtime": 1783501819.7626216,
+    "ast_hash": "115d63a7329c97eb8214f49cc0ae4d00",
+    "semantic_hash": "115d63a7329c97eb8214f49cc0ae4d00"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/quickstart.md": {
+    "mtime": 1783501819.762676,
+    "ast_hash": "01e1847e5aae5f7c35d68bdae2bb4f7f",
+    "semantic_hash": "01e1847e5aae5f7c35d68bdae2bb4f7f"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/research.md": {
+    "mtime": 1783501819.762746,
+    "ast_hash": "274bc7d3e5e9b96cc65bd3a426958b07",
+    "semantic_hash": "274bc7d3e5e9b96cc65bd3a426958b07"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/spec.md": {
+    "mtime": 1783501819.7628171,
+    "ast_hash": "18a59c998a5ae4dd584e8819ae7ce216",
+    "semantic_hash": "18a59c998a5ae4dd584e8819ae7ce216"
+  },
+  "specs/_archive/007-crux-leptos-upgrade/tasks.md": {
+    "mtime": 1783501819.7628872,
+    "ast_hash": "b2495fd4a58adcbc2dd83316786536b4",
+    "semantic_hash": "b2495fd4a58adcbc2dd83316786536b4"
+  },
+  "specs/_archive/008-url-routing/checklists/requirements.md": {
+    "mtime": 1783501819.7630005,
+    "ast_hash": "bb31302d0a93fe7de73473eea4869337",
+    "semantic_hash": "bb31302d0a93fe7de73473eea4869337"
+  },
+  "specs/_archive/008-url-routing/plan.md": {
+    "mtime": 1783501819.7630765,
+    "ast_hash": "6f9b906ca4f7d8454ed08309fbe95aac",
+    "semantic_hash": "6f9b906ca4f7d8454ed08309fbe95aac"
+  },
+  "specs/_archive/008-url-routing/quickstart.md": {
+    "mtime": 1783501819.763133,
+    "ast_hash": "fcee023cac82aaeb6e80731a1ca4cc83",
+    "semantic_hash": "fcee023cac82aaeb6e80731a1ca4cc83"
+  },
+  "specs/_archive/008-url-routing/research.md": {
+    "mtime": 1783501819.763198,
+    "ast_hash": "e1f4c670c92914ef573e171ec8afa042",
+    "semantic_hash": "e1f4c670c92914ef573e171ec8afa042"
+  },
+  "specs/_archive/008-url-routing/spec.md": {
+    "mtime": 1783501819.7632673,
+    "ast_hash": "15fc20f22fdbe92532e0b831acd7cf57",
+    "semantic_hash": "15fc20f22fdbe92532e0b831acd7cf57"
+  },
+  "specs/_archive/008-url-routing/tasks.md": {
+    "mtime": 1783501819.7633393,
+    "ast_hash": "e136c2b623730c9c6542b8be97e65d80",
+    "semantic_hash": "e136c2b623730c9c6542b8be97e65d80"
+  },
+  "specs/_archive/009-unified-library-form/checklists/requirements.md": {
+    "mtime": 1783501819.7634676,
+    "ast_hash": "de95acc6cf7f874ab4ffe835984784d6",
+    "semantic_hash": "de95acc6cf7f874ab4ffe835984784d6"
+  },
+  "specs/_archive/009-unified-library-form/data-model.md": {
+    "mtime": 1783501819.7635183,
+    "ast_hash": "6984255d3ab6c8884604104eec1a71b3",
+    "semantic_hash": "6984255d3ab6c8884604104eec1a71b3"
+  },
+  "specs/_archive/009-unified-library-form/plan.md": {
+    "mtime": 1783501819.763596,
+    "ast_hash": "aaa8649d955d81f668f61fd010a6de6a",
+    "semantic_hash": "aaa8649d955d81f668f61fd010a6de6a"
+  },
+  "specs/_archive/009-unified-library-form/quickstart.md": {
+    "mtime": 1783501819.7636623,
+    "ast_hash": "f616d22401bb2f226310ae17e9cbf236",
+    "semantic_hash": "f616d22401bb2f226310ae17e9cbf236"
+  },
+  "specs/_archive/009-unified-library-form/research.md": {
+    "mtime": 1783501819.763729,
+    "ast_hash": "49af62c4b2dcebbae532ad6a17adfb23",
+    "semantic_hash": "49af62c4b2dcebbae532ad6a17adfb23"
+  },
+  "specs/_archive/009-unified-library-form/spec.md": {
+    "mtime": 1783501819.7638068,
+    "ast_hash": "2aaf272fade239fe8b61009a78af27e8",
+    "semantic_hash": "2aaf272fade239fe8b61009a78af27e8"
+  },
+  "specs/_archive/009-unified-library-form/tasks.md": {
+    "mtime": 1783501819.763883,
+    "ast_hash": "3e31f4263d97c158458a9a04b6bf5521",
+    "semantic_hash": "3e31f4263d97c158458a9a04b6bf5521"
+  },
+  "specs/_archive/011-json-persistence/data-model.md": {
+    "mtime": 1783501819.7639718,
+    "ast_hash": "cc9a5ef03ee4c51deec60d8c87043b28",
+    "semantic_hash": "cc9a5ef03ee4c51deec60d8c87043b28"
+  },
+  "specs/_archive/011-json-persistence/plan.md": {
+    "mtime": 1783501819.7640345,
+    "ast_hash": "e055410015ce7dd5aa6a0c5954a04552",
+    "semantic_hash": "e055410015ce7dd5aa6a0c5954a04552"
+  },
+  "specs/_archive/011-json-persistence/quickstart.md": {
+    "mtime": 1783501819.764091,
+    "ast_hash": "de17e5ba09ae834f458ec4befc71df4e",
+    "semantic_hash": "de17e5ba09ae834f458ec4befc71df4e"
+  },
+  "specs/_archive/011-json-persistence/research.md": {
+    "mtime": 1783501819.7641425,
+    "ast_hash": "da1e625305215eb3ad7f65db86b31ae7",
+    "semantic_hash": "da1e625305215eb3ad7f65db86b31ae7"
+  },
+  "specs/_archive/011-json-persistence/spec.md": {
+    "mtime": 1783501819.7642162,
+    "ast_hash": "3c8a402654be3728e983be8b83bcac66",
+    "semantic_hash": "3c8a402654be3728e983be8b83bcac66"
+  },
+  "specs/_archive/011-json-persistence/tasks.md": {
+    "mtime": 1783501819.7642925,
+    "ast_hash": "17b9c1e6155a46cac825b28220eb75d6",
+    "semantic_hash": "17b9c1e6155a46cac825b28220eb75d6"
+  },
+  "specs/_archive/012-practice-sessions/checklists/requirements.md": {
+    "mtime": 1783501819.7644253,
+    "ast_hash": "821c240c77a524781c6fd65e43db7cfd",
+    "semantic_hash": "821c240c77a524781c6fd65e43db7cfd"
+  },
+  "specs/_archive/012-practice-sessions/data-model.md": {
+    "mtime": 1783501819.7645004,
+    "ast_hash": "421ff0482f2b1969288a0f3d86e0d035",
+    "semantic_hash": "421ff0482f2b1969288a0f3d86e0d035"
+  },
+  "specs/_archive/012-practice-sessions/plan.md": {
+    "mtime": 1783501819.764586,
+    "ast_hash": "96b653e79889af958bb9ebf2c23e6b79",
+    "semantic_hash": "96b653e79889af958bb9ebf2c23e6b79"
+  },
+  "specs/_archive/012-practice-sessions/quickstart.md": {
+    "mtime": 1783501819.764666,
+    "ast_hash": "a61136c9018fe99b961d2c8102376473",
+    "semantic_hash": "a61136c9018fe99b961d2c8102376473"
+  },
+  "specs/_archive/012-practice-sessions/research.md": {
+    "mtime": 1783501819.7647479,
+    "ast_hash": "2bc9ed9c9216da3a69a979dea481b4e7",
+    "semantic_hash": "2bc9ed9c9216da3a69a979dea481b4e7"
+  },
+  "specs/_archive/012-practice-sessions/spec.md": {
+    "mtime": 1783501819.7648282,
+    "ast_hash": "f7c5263fcec61dced7d768b1b8da753a",
+    "semantic_hash": "f7c5263fcec61dced7d768b1b8da753a"
+  },
+  "specs/_archive/012-practice-sessions/tasks.md": {
+    "mtime": 1783501819.764897,
+    "ast_hash": "a64cea6bd716a321b1649df12a8b6649",
+    "semantic_hash": "a64cea6bd716a321b1649df12a8b6649"
+  },
+  "specs/_archive/013-web-testing/checklists/requirements.md": {
+    "mtime": 1783501819.7651203,
+    "ast_hash": "37026c4afa21ba39ad1015b8547e9bfa",
+    "semantic_hash": "37026c4afa21ba39ad1015b8547e9bfa"
+  },
+  "specs/_archive/013-web-testing/data-model.md": {
+    "mtime": 1783501819.7651772,
+    "ast_hash": "27c2b6cdcb854476edd08bbba6907368",
+    "semantic_hash": "27c2b6cdcb854476edd08bbba6907368"
+  },
+  "specs/_archive/013-web-testing/plan.md": {
+    "mtime": 1783501819.7652473,
+    "ast_hash": "e7567e0bc3f93fda1a512860a3dc50d2",
+    "semantic_hash": "e7567e0bc3f93fda1a512860a3dc50d2"
+  },
+  "specs/_archive/013-web-testing/quickstart.md": {
+    "mtime": 1783501819.765303,
+    "ast_hash": "49a8ee19ec14b43f89d549c781735cc8",
+    "semantic_hash": "49a8ee19ec14b43f89d549c781735cc8"
+  },
+  "specs/_archive/013-web-testing/research.md": {
+    "mtime": 1783501819.765375,
+    "ast_hash": "106c776561958f675e109d231c5458f6",
+    "semantic_hash": "106c776561958f675e109d231c5458f6"
+  },
+  "specs/_archive/013-web-testing/spec.md": {
+    "mtime": 1783501819.7654533,
+    "ast_hash": "dc2bc7d73db473e62e9072efcab9c398",
+    "semantic_hash": "dc2bc7d73db473e62e9072efcab9c398"
+  },
+  "specs/_archive/013-web-testing/tasks.md": {
+    "mtime": 1783501819.7655349,
+    "ast_hash": "caba4f316fbc8e8bad07448ecf65e5af",
+    "semantic_hash": "caba4f316fbc8e8bad07448ecf65e5af"
+  },
+  "specs/_archive/014-remove-cli/checklists/requirements.md": {
+    "mtime": 1783501819.7656672,
+    "ast_hash": "d6139e5f4882c7b7af912d427f49b48e",
+    "semantic_hash": "d6139e5f4882c7b7af912d427f49b48e"
+  },
+  "specs/_archive/014-remove-cli/plan.md": {
+    "mtime": 1783501819.7657342,
+    "ast_hash": "e774cf972342d6b3309f28aae746b865",
+    "semantic_hash": "e774cf972342d6b3309f28aae746b865"
+  },
+  "specs/_archive/014-remove-cli/quickstart.md": {
+    "mtime": 1783501819.7657878,
+    "ast_hash": "f3c399cdf46402bff55a78a664f2b8de",
+    "semantic_hash": "f3c399cdf46402bff55a78a664f2b8de"
+  },
+  "specs/_archive/014-remove-cli/research.md": {
+    "mtime": 1783501819.7671876,
+    "ast_hash": "3e74b732f4f76a35edcc4afb50bde0d7",
+    "semantic_hash": "3e74b732f4f76a35edcc4afb50bde0d7"
+  },
+  "specs/_archive/014-remove-cli/spec.md": {
+    "mtime": 1783501819.767317,
+    "ast_hash": "5ac37098f816dcb4efe1580a5d82751a",
+    "semantic_hash": "5ac37098f816dcb4efe1580a5d82751a"
+  },
+  "specs/_archive/014-remove-cli/tasks.md": {
+    "mtime": 1783501819.7673962,
+    "ast_hash": "44c06a0adeb216c2b28a48d5488f6b29",
+    "semantic_hash": "44c06a0adeb216c2b28a48d5488f6b29"
+  },
+  "specs/_archive/015-rework-sessions/checklists/requirements.md": {
+    "mtime": 1783501819.7675169,
+    "ast_hash": "84b55957eed5b827b811c1c6f49a69d8",
+    "semantic_hash": "84b55957eed5b827b811c1c6f49a69d8"
+  },
+  "specs/_archive/015-rework-sessions/contracts/session-events.md": {
+    "mtime": 1783501819.76762,
+    "ast_hash": "8ad7a743b2895f7e0e121be862d1120f",
+    "semantic_hash": "8ad7a743b2895f7e0e121be862d1120f"
+  },
+  "specs/_archive/015-rework-sessions/data-model.md": {
+    "mtime": 1783501819.7676885,
+    "ast_hash": "63e1c82d727b5f862bcfa5d85f06853e",
+    "semantic_hash": "63e1c82d727b5f862bcfa5d85f06853e"
+  },
+  "specs/_archive/015-rework-sessions/plan.md": {
+    "mtime": 1783501819.7677531,
+    "ast_hash": "5147f7af2df069778e53c478bef7274a",
+    "semantic_hash": "5147f7af2df069778e53c478bef7274a"
+  },
+  "specs/_archive/015-rework-sessions/quickstart.md": {
+    "mtime": 1783501819.7678168,
+    "ast_hash": "cdd27124369eb355e76086e12110b080",
+    "semantic_hash": "cdd27124369eb355e76086e12110b080"
+  },
+  "specs/_archive/015-rework-sessions/research.md": {
+    "mtime": 1783501819.7678843,
+    "ast_hash": "5e7bc05b18b0c95aad7cb991a92dfb22",
+    "semantic_hash": "5e7bc05b18b0c95aad7cb991a92dfb22"
+  },
+  "specs/_archive/015-rework-sessions/spec.md": {
+    "mtime": 1783501819.767947,
+    "ast_hash": "fbba3f7deeb370be701294529b47c3b7",
+    "semantic_hash": "fbba3f7deeb370be701294529b47c3b7"
+  },
+  "specs/_archive/015-rework-sessions/tasks.md": {
+    "mtime": 1783501819.7680259,
+    "ast_hash": "7d0bb01c7b1d23c812eb20bd28b510e6",
+    "semantic_hash": "7d0bb01c7b1d23c812eb20bd28b510e6"
+  },
+  "specs/_archive/016-glassmorphism-responsive/checklists/requirements.md": {
+    "mtime": 1783501819.7681446,
+    "ast_hash": "146a02cf31c94585ef99a60aa1336f0b",
+    "semantic_hash": "146a02cf31c94585ef99a60aa1336f0b"
+  },
+  "specs/_archive/016-glassmorphism-responsive/plan.md": {
+    "mtime": 1783501819.768215,
+    "ast_hash": "2e13722c1080ab07b922e331d09833d6",
+    "semantic_hash": "2e13722c1080ab07b922e331d09833d6"
+  },
+  "specs/_archive/016-glassmorphism-responsive/quickstart.md": {
+    "mtime": 1783501819.7682655,
+    "ast_hash": "397910a7959e0c8d6ed1e3e29437c155",
+    "semantic_hash": "397910a7959e0c8d6ed1e3e29437c155"
+  },
+  "specs/_archive/016-glassmorphism-responsive/research.md": {
+    "mtime": 1783501819.768334,
+    "ast_hash": "52e1b4b101022a35c547fb83a54cff29",
+    "semantic_hash": "52e1b4b101022a35c547fb83a54cff29"
+  },
+  "specs/_archive/016-glassmorphism-responsive/spec.md": {
+    "mtime": 1783501819.7684057,
+    "ast_hash": "d6b6e04dc7815ec1d37cf311d193491b",
+    "semantic_hash": "d6b6e04dc7815ec1d37cf311d193491b"
+  },
+  "specs/_archive/016-glassmorphism-responsive/tasks.md": {
+    "mtime": 1783501819.7684696,
+    "ast_hash": "a3e8a38eb1f2406d56737d926766e431",
+    "semantic_hash": "a3e8a38eb1f2406d56737d926766e431"
+  },
+  "specs/_archive/019-improve-cicd/checklists/requirements.md": {
+    "mtime": 1783501819.7685988,
+    "ast_hash": "cfd84e206a2414e76f094bc67d644672",
+    "semantic_hash": "cfd84e206a2414e76f094bc67d644672"
+  },
+  "specs/_archive/019-improve-cicd/plan.md": {
+    "mtime": 1783501819.7686589,
+    "ast_hash": "284493e9d0548b2497ad95ccbb6a02af",
+    "semantic_hash": "284493e9d0548b2497ad95ccbb6a02af"
+  },
+  "specs/_archive/019-improve-cicd/quickstart.md": {
+    "mtime": 1783501819.7687063,
+    "ast_hash": "c821f9899330ea8c08e1f873e23ddb78",
+    "semantic_hash": "c821f9899330ea8c08e1f873e23ddb78"
+  },
+  "specs/_archive/019-improve-cicd/research.md": {
+    "mtime": 1783501819.768758,
+    "ast_hash": "9a2effbfa931621935cc71fd3c500d8b",
+    "semantic_hash": "9a2effbfa931621935cc71fd3c500d8b"
+  },
+  "specs/_archive/019-improve-cicd/spec.md": {
+    "mtime": 1783501819.7688177,
+    "ast_hash": "d6298f6d5ff64167ef98f1d74554d5be",
+    "semantic_hash": "d6298f6d5ff64167ef98f1d74554d5be"
+  },
+  "specs/_archive/019-improve-cicd/tasks.md": {
+    "mtime": 1783501819.7688775,
+    "ast_hash": "86fe25784717132a25c1fc25ac595fa7",
+    "semantic_hash": "86fe25784717132a25c1fc25ac595fa7"
+  },
+  "specs/_archive/020-api-server/checklists/requirements.md": {
+    "mtime": 1783501819.769014,
+    "ast_hash": "306a94438df4b4b2dba3340750d52673",
+    "semantic_hash": "306a94438df4b4b2dba3340750d52673"
+  },
+  "specs/_archive/020-api-server/contracts/exercises.md": {
+    "mtime": 1783501819.7691028,
+    "ast_hash": "0e4dddc60268e9c4a1b4bc4ae03c5f32",
+    "semantic_hash": "0e4dddc60268e9c4a1b4bc4ae03c5f32"
+  },
+  "specs/_archive/020-api-server/contracts/health.md": {
+    "mtime": 1783501819.7691555,
+    "ast_hash": "f9ddf66efd18ec1dc5d64f382ac2f64e",
+    "semantic_hash": "f9ddf66efd18ec1dc5d64f382ac2f64e"
+  },
+  "specs/_archive/020-api-server/contracts/pieces.md": {
+    "mtime": 1783501819.7692153,
+    "ast_hash": "282244892378313b5dd7f1e9fe6e7d85",
+    "semantic_hash": "282244892378313b5dd7f1e9fe6e7d85"
+  },
+  "specs/_archive/020-api-server/contracts/sessions.md": {
+    "mtime": 1783501819.7692692,
+    "ast_hash": "b612bb8d2380f54fd8664a74e582fab8",
+    "semantic_hash": "b612bb8d2380f54fd8664a74e582fab8"
+  },
+  "specs/_archive/020-api-server/data-model.md": {
+    "mtime": 1783501819.7693326,
+    "ast_hash": "09cd701fee07f296246108d5f720aee0",
+    "semantic_hash": "09cd701fee07f296246108d5f720aee0"
+  },
+  "specs/_archive/020-api-server/plan.md": {
+    "mtime": 1783501819.7693977,
+    "ast_hash": "cb05adaef8400ee09ccd3c790b984a65",
+    "semantic_hash": "cb05adaef8400ee09ccd3c790b984a65"
+  },
+  "specs/_archive/020-api-server/quickstart.md": {
+    "mtime": 1783501819.7694583,
+    "ast_hash": "7795e6015c03c1e6b5a6eea3fd2b8037",
+    "semantic_hash": "7795e6015c03c1e6b5a6eea3fd2b8037"
+  },
+  "specs/_archive/020-api-server/research.md": {
+    "mtime": 1783501819.769523,
+    "ast_hash": "e1d0da0ce8d92c48ff1193ce89071928",
+    "semantic_hash": "e1d0da0ce8d92c48ff1193ce89071928"
+  },
+  "specs/_archive/020-api-server/spec.md": {
+    "mtime": 1783501819.7695942,
+    "ast_hash": "2209deb3e5c1b242ac99070b65cc2eed",
+    "semantic_hash": "2209deb3e5c1b242ac99070b65cc2eed"
+  },
+  "specs/_archive/020-api-server/tasks.md": {
+    "mtime": 1783501819.769675,
+    "ast_hash": "7814acfc53d7930f58594d84bd0c616e",
+    "semantic_hash": "7814acfc53d7930f58594d84bd0c616e"
+  },
+  "specs/_archive/021-api-sync/checklists/requirements.md": {
+    "mtime": 1783501819.7697845,
+    "ast_hash": "984ef7f50b8b29371b1c097e00f3a77d",
+    "semantic_hash": "984ef7f50b8b29371b1c097e00f3a77d"
+  },
+  "specs/_archive/021-api-sync/contracts/api-client.md": {
+    "mtime": 1783501819.7698622,
+    "ast_hash": "0e7faf5c99ff77da74fa8b6f53066cfc",
+    "semantic_hash": "0e7faf5c99ff77da74fa8b6f53066cfc"
+  },
+  "specs/_archive/021-api-sync/data-model.md": {
+    "mtime": 1783501819.7699327,
+    "ast_hash": "fad7d86e8d97f06a184123a0625e8e9b",
+    "semantic_hash": "fad7d86e8d97f06a184123a0625e8e9b"
+  },
+  "specs/_archive/021-api-sync/plan.md": {
+    "mtime": 1783501819.7699995,
+    "ast_hash": "dac158e5c5f21543dd48f07bacbfc749",
+    "semantic_hash": "dac158e5c5f21543dd48f07bacbfc749"
+  },
+  "specs/_archive/021-api-sync/quickstart.md": {
+    "mtime": 1783501819.7700613,
+    "ast_hash": "d1b67fca53d1908e0e321acdb25f53d9",
+    "semantic_hash": "d1b67fca53d1908e0e321acdb25f53d9"
+  },
+  "specs/_archive/021-api-sync/research.md": {
+    "mtime": 1783501819.7701333,
+    "ast_hash": "fa5a8afa34e90a592a53c27379c04d7b",
+    "semantic_hash": "fa5a8afa34e90a592a53c27379c04d7b"
+  },
+  "specs/_archive/021-api-sync/spec.md": {
+    "mtime": 1783501819.7701998,
+    "ast_hash": "3d66f155c6e0af3884a0551a2a997ffc",
+    "semantic_hash": "3d66f155c6e0af3884a0551a2a997ffc"
+  },
+  "specs/_archive/021-api-sync/tasks.md": {
+    "mtime": 1783501819.7702897,
+    "ast_hash": "e7b2eae1f00e365937b19353ae6f053d",
+    "semantic_hash": "e7b2eae1f00e365937b19353ae6f053d"
+  },
+  "specs/_archive/022-session-scoring/checklists/requirements.md": {
+    "mtime": 1783501819.770712,
+    "ast_hash": "ad8ee37b00a987ac382d1d95cc56aeda",
+    "semantic_hash": "ad8ee37b00a987ac382d1d95cc56aeda"
+  },
+  "specs/_archive/022-session-scoring/contracts/api-changes.md": {
+    "mtime": 1783501819.7710738,
+    "ast_hash": "3b5f5a4fc42b034764a694a1baddb8f0",
+    "semantic_hash": "3b5f5a4fc42b034764a694a1baddb8f0"
+  },
+  "specs/_archive/022-session-scoring/data-model.md": {
+    "mtime": 1783501819.771321,
+    "ast_hash": "5a1822767a448e22a45bd8647e82238b",
+    "semantic_hash": "5a1822767a448e22a45bd8647e82238b"
+  },
+  "specs/_archive/022-session-scoring/plan.md": {
+    "mtime": 1783501819.7715561,
+    "ast_hash": "f938101cb48add6e2d42093e7b3006bc",
+    "semantic_hash": "f938101cb48add6e2d42093e7b3006bc"
+  },
+  "specs/_archive/022-session-scoring/quickstart.md": {
+    "mtime": 1783501819.771774,
+    "ast_hash": "8c2b64e9b96cb15c7175d9952f13bb24",
+    "semantic_hash": "8c2b64e9b96cb15c7175d9952f13bb24"
+  },
+  "specs/_archive/022-session-scoring/research.md": {
+    "mtime": 1783501819.7719872,
+    "ast_hash": "ec6094f792d084c8a4d1fda5df513044",
+    "semantic_hash": "ec6094f792d084c8a4d1fda5df513044"
+  },
+  "specs/_archive/022-session-scoring/spec.md": {
+    "mtime": 1783501819.7722082,
+    "ast_hash": "a931e2b99794686d28d654e19dc39e70",
+    "semantic_hash": "a931e2b99794686d28d654e19dc39e70"
+  },
+  "specs/_archive/022-session-scoring/tasks.md": {
+    "mtime": 1783501819.7724795,
+    "ast_hash": "38015e08ea8ffd8e721943c8afac1727",
+    "semantic_hash": "38015e08ea8ffd8e721943c8afac1727"
+  },
+  "specs/_archive/023-analytics-dashboard/checklists/requirements.md": {
+    "mtime": 1783501819.7728636,
+    "ast_hash": "6a5ed235ed171c978d78ccfaa45348e6",
+    "semantic_hash": "6a5ed235ed171c978d78ccfaa45348e6"
+  },
+  "specs/_archive/023-analytics-dashboard/contracts/api-changes.md": {
+    "mtime": 1783501819.773235,
+    "ast_hash": "5e04af6f2306c6b3e2e3456c4b39a97b",
+    "semantic_hash": "5e04af6f2306c6b3e2e3456c4b39a97b"
+  },
+  "specs/_archive/023-analytics-dashboard/data-model.md": {
+    "mtime": 1783501819.7736588,
+    "ast_hash": "3f9427849ff9f878cd7c01e400c53de1",
+    "semantic_hash": "3f9427849ff9f878cd7c01e400c53de1"
+  },
+  "specs/_archive/023-analytics-dashboard/plan.md": {
+    "mtime": 1783501819.773848,
+    "ast_hash": "093bbbadbfdb5644d7463435c3e878d2",
+    "semantic_hash": "093bbbadbfdb5644d7463435c3e878d2"
+  },
+  "specs/_archive/023-analytics-dashboard/quickstart.md": {
+    "mtime": 1783501819.7740219,
+    "ast_hash": "2f81f3eded644051ca1acd2cc3db5c77",
+    "semantic_hash": "2f81f3eded644051ca1acd2cc3db5c77"
+  },
+  "specs/_archive/023-analytics-dashboard/research.md": {
+    "mtime": 1783501819.7743301,
+    "ast_hash": "ddf99111d2788e63adb9a6c9d47c26f5",
+    "semantic_hash": "ddf99111d2788e63adb9a6c9d47c26f5"
+  },
+  "specs/_archive/023-analytics-dashboard/spec.md": {
+    "mtime": 1783501819.7746344,
+    "ast_hash": "edd84d065d98bf10a689a7b1881135d5",
+    "semantic_hash": "edd84d065d98bf10a689a7b1881135d5"
+  },
+  "specs/_archive/023-analytics-dashboard/tasks.md": {
+    "mtime": 1783501819.7749038,
+    "ast_hash": "b8164b5d034814f1a18a9d820e254f54",
+    "semantic_hash": "b8164b5d034814f1a18a9d820e254f54"
+  },
+  "specs/_archive/024-form-autocomplete/checklists/requirements.md": {
+    "mtime": 1783501819.7752318,
+    "ast_hash": "51eea7d3d5fb3a64cd02870a64f781fa",
+    "semantic_hash": "51eea7d3d5fb3a64cd02870a64f781fa"
+  },
+  "specs/_archive/024-form-autocomplete/contracts/components.md": {
+    "mtime": 1783501819.7755747,
+    "ast_hash": "df6f99d866f022d3eba4c31ee7d6c193",
+    "semantic_hash": "df6f99d866f022d3eba4c31ee7d6c193"
+  },
+  "specs/_archive/024-form-autocomplete/data-model.md": {
+    "mtime": 1783501819.7759001,
+    "ast_hash": "0ee81edf92a3285687503d9269415382",
+    "semantic_hash": "0ee81edf92a3285687503d9269415382"
+  },
+  "specs/_archive/024-form-autocomplete/plan.md": {
+    "mtime": 1783501819.7761297,
+    "ast_hash": "c4883f8fbb470dbd531f80837b4bebb1",
+    "semantic_hash": "c4883f8fbb470dbd531f80837b4bebb1"
+  },
+  "specs/_archive/024-form-autocomplete/quickstart.md": {
+    "mtime": 1783501819.7764008,
+    "ast_hash": "a4266f467c8e59f93dada018fa8fd1f6",
+    "semantic_hash": "a4266f467c8e59f93dada018fa8fd1f6"
+  },
+  "specs/_archive/024-form-autocomplete/research.md": {
+    "mtime": 1783501819.7767172,
+    "ast_hash": "d50c112330cad261025897c88d0152e7",
+    "semantic_hash": "d50c112330cad261025897c88d0152e7"
+  },
+  "specs/_archive/024-form-autocomplete/spec.md": {
+    "mtime": 1783501819.7770448,
+    "ast_hash": "949dfe11206a409b154f01675d03df49",
+    "semantic_hash": "949dfe11206a409b154f01675d03df49"
+  },
+  "specs/_archive/024-form-autocomplete/tasks.md": {
+    "mtime": 1783501819.7774618,
+    "ast_hash": "60a206e485e1ba143272977e40f00aea",
+    "semantic_hash": "60a206e485e1ba143272977e40f00aea"
+  },
+  "specs/_archive/025-reusable-routines/checklists/requirements.md": {
+    "mtime": 1783501819.777898,
+    "ast_hash": "b480c4e8e9dabddc50cc3c5394c2e307",
+    "semantic_hash": "b480c4e8e9dabddc50cc3c5394c2e307"
+  },
+  "specs/_archive/025-reusable-routines/contracts/api-changes.md": {
+    "mtime": 1783501819.7782085,
+    "ast_hash": "0e45045cc169c96e1d7d87090129ef91",
+    "semantic_hash": "0e45045cc169c96e1d7d87090129ef91"
+  },
+  "specs/_archive/025-reusable-routines/data-model.md": {
+    "mtime": 1783501819.7785087,
+    "ast_hash": "5c78e2fe99824d7e5618dfcdd75731d3",
+    "semantic_hash": "5c78e2fe99824d7e5618dfcdd75731d3"
+  },
+  "specs/_archive/025-reusable-routines/plan.md": {
+    "mtime": 1783501819.7788532,
+    "ast_hash": "1a5acde46739dd0d820b735be4841e2d",
+    "semantic_hash": "1a5acde46739dd0d820b735be4841e2d"
+  },
+  "specs/_archive/025-reusable-routines/quickstart.md": {
+    "mtime": 1783501819.7790625,
+    "ast_hash": "984a1d0b354258195ecd78fcdf54f4e9",
+    "semantic_hash": "984a1d0b354258195ecd78fcdf54f4e9"
+  },
+  "specs/_archive/025-reusable-routines/research.md": {
+    "mtime": 1783501819.7793727,
+    "ast_hash": "93d541f88453807dbff29839b515ea36",
+    "semantic_hash": "93d541f88453807dbff29839b515ea36"
+  },
+  "specs/_archive/025-reusable-routines/spec.md": {
+    "mtime": 1783501819.779704,
+    "ast_hash": "a39696bf248c21d33b1a03788e252a65",
+    "semantic_hash": "a39696bf248c21d33b1a03788e252a65"
+  },
+  "specs/_archive/025-reusable-routines/tasks.md": {
+    "mtime": 1783501819.7799573,
+    "ast_hash": "fd63545e40805bfa74ec678563191c48",
+    "semantic_hash": "fd63545e40805bfa74ec678563191c48"
+  },
+  "specs/_archive/026-drag-drop-builder/checklists/requirements.md": {
+    "mtime": 1783501819.7803106,
+    "ast_hash": "62c8e310e348100ccbaef6c34708bc71",
+    "semantic_hash": "62c8e310e348100ccbaef6c34708bc71"
+  },
+  "specs/_archive/026-drag-drop-builder/contracts/README.md": {
+    "mtime": 1783501819.780637,
+    "ast_hash": "edd8dec9c96de2de1c61c1bd3ffc1a80",
+    "semantic_hash": "edd8dec9c96de2de1c61c1bd3ffc1a80"
+  },
+  "specs/_archive/026-drag-drop-builder/data-model.md": {
+    "mtime": 1783501819.7809079,
+    "ast_hash": "5024c2dd6b613f9c464b1901225172f3",
+    "semantic_hash": "5024c2dd6b613f9c464b1901225172f3"
+  },
+  "specs/_archive/026-drag-drop-builder/plan.md": {
+    "mtime": 1783501819.7812085,
+    "ast_hash": "74ff3c7f492aee21b5046bffe5a6b664",
+    "semantic_hash": "74ff3c7f492aee21b5046bffe5a6b664"
+  },
+  "specs/_archive/026-drag-drop-builder/quickstart.md": {
+    "mtime": 1783501819.78149,
+    "ast_hash": "1d9a1882f515c06b926297b049694b0e",
+    "semantic_hash": "1d9a1882f515c06b926297b049694b0e"
+  },
+  "specs/_archive/026-drag-drop-builder/research.md": {
+    "mtime": 1783501819.7818,
+    "ast_hash": "650f4fb23e56b96f9712e423ac6acbd3",
+    "semantic_hash": "650f4fb23e56b96f9712e423ac6acbd3"
+  },
+  "specs/_archive/026-drag-drop-builder/spec.md": {
+    "mtime": 1783501819.7821097,
+    "ast_hash": "89c67ca0deab7c02f2d339aa47238dd0",
+    "semantic_hash": "89c67ca0deab7c02f2d339aa47238dd0"
+  },
+  "specs/_archive/026-drag-drop-builder/tasks.md": {
+    "mtime": 1783501819.7824376,
+    "ast_hash": "15df105b2cba30f14bc52984c8838bc4",
+    "semantic_hash": "15df105b2cba30f14bc52984c8838bc4"
+  },
+  "specs/_archive/048-focus-mode/checklists/requirements.md": {
+    "mtime": 1783501819.7828903,
+    "ast_hash": "ad5bea208f9b73af006c6d11971912d8",
+    "semantic_hash": "ad5bea208f9b73af006c6d11971912d8"
+  },
+  "specs/_archive/048-focus-mode/contracts/api-changes.md": {
+    "mtime": 1783501819.7829764,
+    "ast_hash": "a9745f9d463ec1288b3847e6fa4dd544",
+    "semantic_hash": "a9745f9d463ec1288b3847e6fa4dd544"
+  },
+  "specs/_archive/048-focus-mode/data-model.md": {
+    "mtime": 1783501819.783025,
+    "ast_hash": "ad6ebbdde9db3351ee29aafe0ce90128",
+    "semantic_hash": "ad6ebbdde9db3351ee29aafe0ce90128"
+  },
+  "specs/_archive/048-focus-mode/plan.md": {
+    "mtime": 1783501819.783086,
+    "ast_hash": "a9e52ab3316d0904e15fa3ae0d2342ae",
+    "semantic_hash": "a9e52ab3316d0904e15fa3ae0d2342ae"
+  },
+  "specs/_archive/048-focus-mode/quickstart.md": {
+    "mtime": 1783501819.7831419,
+    "ast_hash": "3a08d51d607f87a3e058061f3dbf60d7",
+    "semantic_hash": "3a08d51d607f87a3e058061f3dbf60d7"
+  },
+  "specs/_archive/048-focus-mode/research.md": {
+    "mtime": 1783501819.7832084,
+    "ast_hash": "04b0122ed22e9cdf2122c24dc01d9ef5",
+    "semantic_hash": "04b0122ed22e9cdf2122c24dc01d9ef5"
+  },
+  "specs/_archive/048-focus-mode/spec.md": {
+    "mtime": 1783501819.7832947,
+    "ast_hash": "a31fe5bed05131c8ab5b0723e17edc3f",
+    "semantic_hash": "a31fe5bed05131c8ab5b0723e17edc3f"
+  },
+  "specs/_archive/048-focus-mode/tasks.md": {
+    "mtime": 1783501819.7833772,
+    "ast_hash": "83138946440dffcd88f025f0fa92adea",
+    "semantic_hash": "83138946440dffcd88f025f0fa92adea"
+  },
+  "specs/_archive/095-user-auth/checklists/requirements.md": {
+    "mtime": 1783501819.7837138,
+    "ast_hash": "aa79c56e3f28fb94e01c5f5f08d3dd5d",
+    "semantic_hash": "aa79c56e3f28fb94e01c5f5f08d3dd5d"
+  },
+  "specs/_archive/095-user-auth/contracts/auth-changes.md": {
+    "mtime": 1783501819.78404,
+    "ast_hash": "bf0ffc785f8fd7daec83528165ce466c",
+    "semantic_hash": "bf0ffc785f8fd7daec83528165ce466c"
+  },
+  "specs/_archive/095-user-auth/data-model.md": {
+    "mtime": 1783501819.7843254,
+    "ast_hash": "8a802f9f43414e108ac28138078231df",
+    "semantic_hash": "8a802f9f43414e108ac28138078231df"
+  },
+  "specs/_archive/095-user-auth/plan.md": {
+    "mtime": 1783501819.7846353,
+    "ast_hash": "6176238fec8c5f9e2dca84370dd984ad",
+    "semantic_hash": "6176238fec8c5f9e2dca84370dd984ad"
+  },
+  "specs/_archive/095-user-auth/quickstart.md": {
+    "mtime": 1783501819.784805,
+    "ast_hash": "d1431daca8db35ec2062511a9fb8c70e",
+    "semantic_hash": "d1431daca8db35ec2062511a9fb8c70e"
+  },
+  "specs/_archive/095-user-auth/research.md": {
+    "mtime": 1783501819.7849922,
+    "ast_hash": "e743ff0dad69bbbbcf3d182065a33c22",
+    "semantic_hash": "e743ff0dad69bbbbcf3d182065a33c22"
+  },
+  "specs/_archive/095-user-auth/spec.md": {
+    "mtime": 1783501819.785186,
+    "ast_hash": "c0f0c703f1222a1fb0718901004e531a",
+    "semantic_hash": "c0f0c703f1222a1fb0718901004e531a"
+  },
+  "specs/_archive/095-user-auth/tasks.md": {
+    "mtime": 1783501819.7854855,
+    "ast_hash": "83a0df631556dd9e2b0c17540e4d2070",
+    "semantic_hash": "83a0df631556dd9e2b0c17540e4d2070"
+  },
+  "specs/_archive/103-repetition-counter/checklists/requirements.md": {
+    "mtime": 1783501819.7859516,
+    "ast_hash": "64d29599d00def4a6f194cc40baafb0a",
+    "semantic_hash": "64d29599d00def4a6f194cc40baafb0a"
+  },
+  "specs/_archive/103-repetition-counter/contracts/api-changes.md": {
+    "mtime": 1783501819.7862468,
+    "ast_hash": "558ded20d2bef117bd85adfbf038911f",
+    "semantic_hash": "558ded20d2bef117bd85adfbf038911f"
+  },
+  "specs/_archive/103-repetition-counter/data-model.md": {
+    "mtime": 1783501819.7865455,
+    "ast_hash": "c1ee3cc7d46ebe5d4cb51e09793a7b16",
+    "semantic_hash": "c1ee3cc7d46ebe5d4cb51e09793a7b16"
+  },
+  "specs/_archive/103-repetition-counter/plan.md": {
+    "mtime": 1783501819.786833,
+    "ast_hash": "946c1515e7abf8f1433d3ecfc361aa02",
+    "semantic_hash": "946c1515e7abf8f1433d3ecfc361aa02"
+  },
+  "specs/_archive/103-repetition-counter/quickstart.md": {
+    "mtime": 1783501819.787114,
+    "ast_hash": "902fcf9ea0ff9caba7a5358c7e25e5ff",
+    "semantic_hash": "902fcf9ea0ff9caba7a5358c7e25e5ff"
+  },
+  "specs/_archive/103-repetition-counter/research.md": {
+    "mtime": 1783501819.7873144,
+    "ast_hash": "aebb86761c69d8f78a66b42838148bf7",
+    "semantic_hash": "aebb86761c69d8f78a66b42838148bf7"
+  },
+  "specs/_archive/103-repetition-counter/spec.md": {
+    "mtime": 1783501819.7876372,
+    "ast_hash": "92340b71e0050f50144102e8bc9b3fed",
+    "semantic_hash": "92340b71e0050f50144102e8bc9b3fed"
+  },
+  "specs/_archive/103-repetition-counter/tasks.md": {
+    "mtime": 1783501819.788024,
+    "ast_hash": "c577822f88810c1c9d2e6c70c4218eb7",
+    "semantic_hash": "c577822f88810c1c9d2e6c70c4218eb7"
+  },
+  "specs/_archive/104-rep-history/checklists/requirements.md": {
+    "mtime": 1783501819.7885506,
+    "ast_hash": "409c9389e5fc92d8c8af041bf355a93d",
+    "semantic_hash": "409c9389e5fc92d8c8af041bf355a93d"
+  },
+  "specs/_archive/104-rep-history/contracts/api-changes.md": {
+    "mtime": 1783501819.78888,
+    "ast_hash": "700f3b409fd54500405e86e2d194fcac",
+    "semantic_hash": "700f3b409fd54500405e86e2d194fcac"
+  },
+  "specs/_archive/104-rep-history/data-model.md": {
+    "mtime": 1783501819.7894406,
+    "ast_hash": "33583399271b35ccd58fb937635b1f1e",
+    "semantic_hash": "33583399271b35ccd58fb937635b1f1e"
+  },
+  "specs/_archive/104-rep-history/plan.md": {
+    "mtime": 1783501819.7896903,
+    "ast_hash": "cac1a383f969cfd04a3c34879072545d",
+    "semantic_hash": "cac1a383f969cfd04a3c34879072545d"
+  },
+  "specs/_archive/104-rep-history/quickstart.md": {
+    "mtime": 1783501819.7900045,
+    "ast_hash": "5e0a92f6ecb0531e40a393ee07256c7a",
+    "semantic_hash": "5e0a92f6ecb0531e40a393ee07256c7a"
+  },
+  "specs/_archive/104-rep-history/research.md": {
+    "mtime": 1783501819.7902277,
+    "ast_hash": "19330c7f3051c27fd33b1a02f29cdb5a",
+    "semantic_hash": "19330c7f3051c27fd33b1a02f29cdb5a"
+  },
+  "specs/_archive/104-rep-history/spec.md": {
+    "mtime": 1783501819.79045,
+    "ast_hash": "fa5b46eaad10e514bcd743350e38a0e1",
+    "semantic_hash": "fa5b46eaad10e514bcd743350e38a0e1"
+  },
+  "specs/_archive/104-rep-history/tasks.md": {
+    "mtime": 1783501819.7908778,
+    "ast_hash": "a5b3aded16f3ea4bb2aaffdc6b0fd9f7",
+    "semantic_hash": "a5b3aded16f3ea4bb2aaffdc6b0fd9f7"
+  },
+  "specs/_archive/105-tempo-tracking/checklists/requirements.md": {
+    "mtime": 1783501819.7910128,
+    "ast_hash": "a735bf0ab31542a4ff6add0246ce03f9",
+    "semantic_hash": "a735bf0ab31542a4ff6add0246ce03f9"
+  },
+  "specs/_archive/105-tempo-tracking/contracts/api.md": {
+    "mtime": 1783501819.7911088,
+    "ast_hash": "da72808064d4b99f974781ba09b26807",
+    "semantic_hash": "da72808064d4b99f974781ba09b26807"
+  },
+  "specs/_archive/105-tempo-tracking/data-model.md": {
+    "mtime": 1783501819.7911868,
+    "ast_hash": "212d0fdbcee37207f2f59e67e7a90a1a",
+    "semantic_hash": "212d0fdbcee37207f2f59e67e7a90a1a"
+  },
+  "specs/_archive/105-tempo-tracking/plan.md": {
+    "mtime": 1783501819.7912655,
+    "ast_hash": "e28151dbd09146a9022ad418764c36b2",
+    "semantic_hash": "e28151dbd09146a9022ad418764c36b2"
+  },
+  "specs/_archive/105-tempo-tracking/quickstart.md": {
+    "mtime": 1783501819.7913272,
+    "ast_hash": "f268fde37388160cd17d7a80d981184d",
+    "semantic_hash": "f268fde37388160cd17d7a80d981184d"
+  },
+  "specs/_archive/105-tempo-tracking/research.md": {
+    "mtime": 1783501819.7914064,
+    "ast_hash": "96bc76bf4edbfe5a09852b2eadd89763",
+    "semantic_hash": "96bc76bf4edbfe5a09852b2eadd89763"
+  },
+  "specs/_archive/105-tempo-tracking/spec.md": {
+    "mtime": 1783501819.79149,
+    "ast_hash": "2d9cb32ac045886ad6fd57c4d045edaf",
+    "semantic_hash": "2d9cb32ac045886ad6fd57c4d045edaf"
+  },
+  "specs/_archive/105-tempo-tracking/tasks.md": {
+    "mtime": 1783501819.7915695,
+    "ast_hash": "f47c7698e6995e4ff13ef27c5a9030a7",
+    "semantic_hash": "f47c7698e6995e4ff13ef27c5a9030a7"
+  },
+  "specs/_archive/151-tempo-progress-charts/checklists/requirements.md": {
+    "mtime": 1783501819.7916918,
+    "ast_hash": "86399fbe6fc513d4ebc36150c3e538a4",
+    "semantic_hash": "86399fbe6fc513d4ebc36150c3e538a4"
+  },
+  "specs/_archive/151-tempo-progress-charts/contracts/README.md": {
+    "mtime": 1783501819.7917812,
+    "ast_hash": "67f16191826dc97028141db33a824e40",
+    "semantic_hash": "67f16191826dc97028141db33a824e40"
+  },
+  "specs/_archive/151-tempo-progress-charts/data-model.md": {
+    "mtime": 1783501819.791835,
+    "ast_hash": "9c35c35ec49d30b10e8c475b90b6847c",
+    "semantic_hash": "9c35c35ec49d30b10e8c475b90b6847c"
+  },
+  "specs/_archive/151-tempo-progress-charts/plan.md": {
+    "mtime": 1783501819.7918942,
+    "ast_hash": "539a359f6720b29e3da3aec32f63c13b",
+    "semantic_hash": "539a359f6720b29e3da3aec32f63c13b"
+  },
+  "specs/_archive/151-tempo-progress-charts/quickstart.md": {
+    "mtime": 1783501819.7919545,
+    "ast_hash": "9a08a36cc50d181e1c654d3a32d4b3fd",
+    "semantic_hash": "9a08a36cc50d181e1c654d3a32d4b3fd"
+  },
+  "specs/_archive/151-tempo-progress-charts/research.md": {
+    "mtime": 1783501819.792018,
+    "ast_hash": "1e2e81353e0c67e950b9335455a144e1",
+    "semantic_hash": "1e2e81353e0c67e950b9335455a144e1"
+  },
+  "specs/_archive/151-tempo-progress-charts/spec.md": {
+    "mtime": 1783501819.7921026,
+    "ast_hash": "f5f4c78c8612bdf539e09b8031eab517",
+    "semantic_hash": "f5f4c78c8612bdf539e09b8031eab517"
+  },
+  "specs/_archive/151-tempo-progress-charts/tasks.md": {
+    "mtime": 1783501819.7921813,
+    "ast_hash": "247fdd1d7d32e8228e5aa706eb80d1ac",
+    "semantic_hash": "247fdd1d7d32e8228e5aa706eb80d1ac"
+  },
+  "specs/_archive/153-weekly-practice-summary/checklists/requirements.md": {
+    "mtime": 1783501819.7923121,
+    "ast_hash": "3a5d40c1594a53798272076bd81b2911",
+    "semantic_hash": "3a5d40c1594a53798272076bd81b2911"
+  },
+  "specs/_archive/153-weekly-practice-summary/contracts/README.md": {
+    "mtime": 1783501819.7923956,
+    "ast_hash": "662081425b1da71bf399690a909093ed",
+    "semantic_hash": "662081425b1da71bf399690a909093ed"
+  },
+  "specs/_archive/153-weekly-practice-summary/data-model.md": {
+    "mtime": 1783501819.7924662,
+    "ast_hash": "1c2e2f0007a729558ae0357b3e4c4a63",
+    "semantic_hash": "1c2e2f0007a729558ae0357b3e4c4a63"
+  },
+  "specs/_archive/153-weekly-practice-summary/plan.md": {
+    "mtime": 1783501819.7925434,
+    "ast_hash": "6be769fa5d82a30b23a8f61d4d379d49",
+    "semantic_hash": "6be769fa5d82a30b23a8f61d4d379d49"
+  },
+  "specs/_archive/153-weekly-practice-summary/quickstart.md": {
+    "mtime": 1783501819.792602,
+    "ast_hash": "ad7996e05a1be4875687030f6d13b58f",
+    "semantic_hash": "ad7996e05a1be4875687030f6d13b58f"
+  },
+  "specs/_archive/153-weekly-practice-summary/research.md": {
+    "mtime": 1783501819.792784,
+    "ast_hash": "110a9f260715cce68eab387986d40a4b",
+    "semantic_hash": "110a9f260715cce68eab387986d40a4b"
+  },
+  "specs/_archive/153-weekly-practice-summary/spec.md": {
+    "mtime": 1783501819.7928712,
+    "ast_hash": "730dd82a1af3da322004b176146c893f",
+    "semantic_hash": "730dd82a1af3da322004b176146c893f"
+  },
+  "specs/_archive/153-weekly-practice-summary/tasks.md": {
+    "mtime": 1783501819.7929432,
+    "ast_hash": "4e232e07175935d2cb8b49c8fc7bf1be",
+    "semantic_hash": "4e232e07175935d2cb8b49c8fc7bf1be"
+  },
+  "specs/_archive/154-session-week-strip/checklists/requirements.md": {
+    "mtime": 1783501819.7931912,
+    "ast_hash": "be8c5dbc7577f6543dbb25e417cf2b83",
+    "semantic_hash": "be8c5dbc7577f6543dbb25e417cf2b83"
+  },
+  "specs/_archive/154-session-week-strip/contracts/README.md": {
+    "mtime": 1783501819.7932734,
+    "ast_hash": "05145a68c485bdb2ef0fafd9ec8dcd55",
+    "semantic_hash": "05145a68c485bdb2ef0fafd9ec8dcd55"
+  },
+  "specs/_archive/154-session-week-strip/data-model.md": {
+    "mtime": 1783501819.7933407,
+    "ast_hash": "a1e0b802c1129952b944c49f26579e8f",
+    "semantic_hash": "a1e0b802c1129952b944c49f26579e8f"
+  },
+  "specs/_archive/154-session-week-strip/plan.md": {
+    "mtime": 1783501819.7934074,
+    "ast_hash": "d60850c744c92a3d93760a138f567d58",
+    "semantic_hash": "d60850c744c92a3d93760a138f567d58"
+  },
+  "specs/_archive/154-session-week-strip/quickstart.md": {
+    "mtime": 1783501819.79347,
+    "ast_hash": "23b1a0861a1bb4510624d6217295cc14",
+    "semantic_hash": "23b1a0861a1bb4510624d6217295cc14"
+  },
+  "specs/_archive/154-session-week-strip/research.md": {
+    "mtime": 1783501819.7935362,
+    "ast_hash": "b9511d60e83e7ef3c3a0013f45a11b0e",
+    "semantic_hash": "b9511d60e83e7ef3c3a0013f45a11b0e"
+  },
+  "specs/_archive/154-session-week-strip/spec.md": {
+    "mtime": 1783501819.7936141,
+    "ast_hash": "ad8ab142e7463b709fdd5264034d9563",
+    "semantic_hash": "ad8ab142e7463b709fdd5264034d9563"
+  },
+  "specs/_archive/154-session-week-strip/tasks.md": {
+    "mtime": 1783501819.79368,
+    "ast_hash": "acaef17f94b8119212e115935a6a2964",
+    "semantic_hash": "acaef17f94b8119212e115935a6a2964"
+  },
+  "specs/_archive/269-teacher-capture/checklists/requirements.md": {
+    "mtime": 1783501819.794216,
+    "ast_hash": "74d6650dfe05d4d44fdbbe26c43a72ad",
+    "semantic_hash": "74d6650dfe05d4d44fdbbe26c43a72ad"
+  },
+  "specs/_archive/269-teacher-capture/contracts/api.md": {
+    "mtime": 1783501819.794506,
+    "ast_hash": "ef44b5f48432bba87bbe72a2ed356803",
+    "semantic_hash": "ef44b5f48432bba87bbe72a2ed356803"
+  },
+  "specs/_archive/269-teacher-capture/data-model.md": {
+    "mtime": 1783501819.7947843,
+    "ast_hash": "2867817f4ea9576048dc040a8bf79a2e",
+    "semantic_hash": "2867817f4ea9576048dc040a8bf79a2e"
+  },
+  "specs/_archive/269-teacher-capture/plan.md": {
+    "mtime": 1783501819.7950683,
+    "ast_hash": "742125d30e0ad44c030653c8b0cf5fcd",
+    "semantic_hash": "742125d30e0ad44c030653c8b0cf5fcd"
+  },
+  "specs/_archive/269-teacher-capture/quickstart.md": {
+    "mtime": 1783501819.7955213,
+    "ast_hash": "d422418dedaaf3e891472bde009f3094",
+    "semantic_hash": "d422418dedaaf3e891472bde009f3094"
+  },
+  "specs/_archive/269-teacher-capture/research.md": {
+    "mtime": 1783501819.795812,
+    "ast_hash": "102ace32ad2f68da7469db30143d89d9",
+    "semantic_hash": "102ace32ad2f68da7469db30143d89d9"
+  },
+  "specs/_archive/269-teacher-capture/spec.md": {
+    "mtime": 1783501819.7961125,
+    "ast_hash": "51e5b81a3de86fe69240328cc651900a",
+    "semantic_hash": "51e5b81a3de86fe69240328cc651900a"
+  },
+  "specs/_archive/269-teacher-capture/tasks.md": {
+    "mtime": 1783501819.7964299,
+    "ast_hash": "09e45251b9f1d3e01df64ec5d2318a38",
+    "semantic_hash": "09e45251b9f1d3e01df64ec5d2318a38"
+  },
+  "specs/_archive/README.md": {
+    "mtime": 1783501819.7964885,
+    "ast_hash": "3facbf675c0e18d6c2471901e9081471",
+    "semantic_hash": "3facbf675c0e18d6c2471901e9081471"
+  },
+  "specs/account-settings-and-deletion.md": {
+    "mtime": 1783501819.796581,
+    "ast_hash": "f1f4611a366a7f1f4f9c264867b64283",
+    "semantic_hash": "f1f4611a366a7f1f4f9c264867b64283"
+  },
+  "specs/background-audio-plugin.md": {
+    "mtime": 1783501819.7966702,
+    "ast_hash": "f7fb6011b29a4b4ced12a472db3ffacf",
+    "semantic_hash": "f7fb6011b29a4b4ced12a472db3ffacf"
+  },
+  "specs/design-refresh-2026.md": {
+    "mtime": 1783501819.7967591,
+    "ast_hash": "f4ee22bc391b6ddb1b18d77903ec170a",
+    "semantic_hash": "f4ee22bc391b6ddb1b18d77903ec170a"
+  },
+  "specs/design-system.md": {
+    "mtime": 1783501819.7970943,
+    "ast_hash": "64c20acab1fe1fd35d6078eb906252f6",
+    "semantic_hash": "64c20acab1fe1fd35d6078eb906252f6"
+  },
+  "specs/ios-testflight-cicd.md": {
+    "mtime": 1783501819.7973897,
+    "ast_hash": "3b1c07dcb391edecd567e276cb16bf76",
+    "semantic_hash": "3b1c07dcb391edecd567e276cb16bf76"
+  },
+  "specs/key-modality.md": {
+    "mtime": 1783501819.7976785,
+    "ast_hash": "bbcb1fba94a5dbb7e874309a1c094b6a",
+    "semantic_hash": "bbcb1fba94a5dbb7e874309a1c094b6a"
+  },
+  "specs/library-sort.md": {
+    "mtime": 1783501819.7977643,
+    "ast_hash": "2e36d2eacc34fb29d4082074aa635e02",
+    "semantic_hash": "2e36d2eacc34fb29d4082074aa635e02"
+  },
+  "specs/live-activity-plugin.md": {
+    "mtime": 1783501819.7978399,
+    "ast_hash": "9f5be4b92c9cf7275145992ba627c1b1",
+    "semantic_hash": "9f5be4b92c9cf7275145992ba627c1b1"
+  },
+  "specs/mcp-server.md": {
+    "mtime": 1783501819.7979422,
+    "ast_hash": "a9b874c60732683f48af2d3241ad4b68",
+    "semantic_hash": "a9b874c60732683f48af2d3241ad4b68"
+  },
+  "specs/native-ios-player.md": {
+    "mtime": 1783501819.7980165,
+    "ast_hash": "c89990bd0fb0261de41d73b2f5925d2c",
+    "semantic_hash": "c89990bd0fb0261de41d73b2f5925d2c"
+  },
+  "specs/native-ios.md": {
+    "mtime": 1783501819.7984583,
+    "ast_hash": "8fdb787c32336fd5755726f027d6b2ae",
+    "semantic_hash": "8fdb787c32336fd5755726f027d6b2ae"
+  },
+  "specs/native-player.md": {
+    "mtime": 1783501819.7985332,
+    "ast_hash": "06640974e62249da1bcfea8ca1072598",
+    "semantic_hash": "06640974e62249da1bcfea8ca1072598"
+  },
+  "specs/onboarding-welcome.md": {
+    "mtime": 1783501819.798622,
+    "ast_hash": "6f69b513689b47f892fa5c144de3f315",
+    "semantic_hash": "6f69b513689b47f892fa5c144de3f315"
+  },
+  "specs/priority-items.md": {
+    "mtime": 1783501819.7986877,
+    "ast_hash": "741be6935832f51496114cac15a7334a",
+    "semantic_hash": "741be6935832f51496114cac15a7334a"
+  },
+  "specs/related-exercises-redesign.md": {
+    "mtime": 1783501819.79889,
+    "ast_hash": "c12d212c8b8d4dbcc6e21504462ab019",
+    "semantic_hash": "c12d212c8b8d4dbcc6e21504462ab019"
+  },
+  "specs/seo-prerender.md": {
+    "mtime": 1783501819.79896,
+    "ast_hash": "9c49eaa48c06b9cbe5dc9c149bce1a44",
+    "semantic_hash": "9c49eaa48c06b9cbe5dc9c149bce1a44"
+  },
+  "specs/session-block-grouping.md": {
+    "mtime": 1783501819.799229,
+    "ast_hash": "299628c604a7149177400ac46d69d3bf",
+    "semantic_hash": "299628c604a7149177400ac46d69d3bf"
+  },
+  "crates/intrada-api/static/icon.svg": {
+    "mtime": 1783501819.612574,
+    "ast_hash": "925066cf6a3db0f1680fa5d276eb01ef",
+    "semantic_hash": "925066cf6a3db0f1680fa5d276eb01ef"
+  },
+  "crates/intrada-mobile/src-tauri/app-icon.svg": {
+    "mtime": 1783501819.6256135,
+    "ast_hash": "91d41a42a31acd83c7da792d43046c77",
+    "semantic_hash": "91d41a42a31acd83c7da792d43046c77"
+  },
+  "crates/intrada-mobile/src-tauri/icons/128x128.png": {
+    "mtime": 1783501819.6259685,
+    "ast_hash": "906fa98008be7f8f832eaa63d80be94a",
+    "semantic_hash": "906fa98008be7f8f832eaa63d80be94a"
+  },
+  "crates/intrada-mobile/src-tauri/icons/128x128@2x.png": {
+    "mtime": 1783501819.6260543,
+    "ast_hash": "afafa70372718f1731dd0b444679d740",
+    "semantic_hash": "afafa70372718f1731dd0b444679d740"
+  },
+  "crates/intrada-mobile/src-tauri/icons/32x32.png": {
+    "mtime": 1783501819.6261115,
+    "ast_hash": "ae47d6e95ad198350b1b1ffa6af0fe68",
+    "semantic_hash": "ae47d6e95ad198350b1b1ffa6af0fe68"
+  },
+  "crates/intrada-mobile/src-tauri/icons/icon.png": {
+    "mtime": 1783501819.6261785,
+    "ast_hash": "b607d71bd02ba978970d141d8845be59",
+    "semantic_hash": "b607d71bd02ba978970d141d8845be59"
+  },
+  "crates/intrada-web/favicon.svg": {
+    "mtime": 1783501819.6274,
+    "ast_hash": "925066cf6a3db0f1680fa5d276eb01ef",
+    "semantic_hash": "925066cf6a3db0f1680fa5d276eb01ef"
+  },
+  "crates/intrada-web/static/og-image.svg": {
+    "mtime": 1783501819.6415207,
+    "ast_hash": "ee1388b2cd230e9082a71014f426f756",
+    "semantic_hash": "ee1388b2cd230e9082a71014f426f756"
+  },
+  "design/assets/app-icon-dark.png": {
+    "mtime": 1783501819.6483731,
+    "ast_hash": "0e780c30896d1f817d8d686266bc7e95",
+    "semantic_hash": "0e780c30896d1f817d8d686266bc7e95"
+  },
+  "design/assets/app-icon-default.png": {
+    "mtime": 1783501819.6490383,
+    "ast_hash": "a2894364df8f050803baf0be32495cd0",
+    "semantic_hash": "a2894364df8f050803baf0be32495cd0"
+  },
+  "design/assets/app-icon-tinted.png": {
+    "mtime": 1783501819.6497884,
+    "ast_hash": "6ed2181b6007c5cca821dfd444830dc9",
+    "semantic_hash": "6ed2181b6007c5cca821dfd444830dc9"
+  },
+  "ios/AppIcon-exports/Icon-iOS-ClearDark-1024x1024@1x.png": {
+    "mtime": 1783501819.6757576,
+    "ast_hash": "735b6aa89266d1d829cdf8cbc72a107e",
+    "semantic_hash": "735b6aa89266d1d829cdf8cbc72a107e"
+  },
+  "ios/AppIcon-exports/Icon-iOS-ClearLight-1024x1024@1x.png": {
+    "mtime": 1783501819.6779737,
+    "ast_hash": "e7707792cb1a0a4ca8f7c5acd8b5bf3c",
+    "semantic_hash": "e7707792cb1a0a4ca8f7c5acd8b5bf3c"
+  },
+  "ios/AppIcon-exports/Icon-iOS-Dark-1024x1024@1x.png": {
+    "mtime": 1783501819.6802979,
+    "ast_hash": "d1812e7bec1a2485ec00115ee8fa410d",
+    "semantic_hash": "d1812e7bec1a2485ec00115ee8fa410d"
+  },
+  "ios/AppIcon-exports/Icon-iOS-Default-1024x1024@1x.png": {
+    "mtime": 1783501819.6840847,
+    "ast_hash": "83f7b695d8ea6eae5b2f3415c1cda43e",
+    "semantic_hash": "83f7b695d8ea6eae5b2f3415c1cda43e"
+  },
+  "ios/AppIcon-exports/Icon-iOS-TintedDark-1024x1024@1x.png": {
+    "mtime": 1783501819.6877117,
+    "ast_hash": "bf261eca821e1a683ab701207fc5082b",
+    "semantic_hash": "bf261eca821e1a683ab701207fc5082b"
+  },
+  "ios/AppIcon-exports/Icon-iOS-TintedLight-1024x1024@1x.png": {
+    "mtime": 1783501819.6896734,
+    "ast_hash": "c00dfa9f18bbb9d7cb7a203a927011f5",
+    "semantic_hash": "c00dfa9f18bbb9d7cb7a203a927011f5"
+  },
+  "ios/Intrada/AppIcon.icon/Assets/quarter-note-rest-music-svgrepo-com.svg": {
+    "mtime": 1783501819.6901202,
+    "ast_hash": "d0f50eb02536a15f01410977f18ea7f5",
+    "semantic_hash": "d0f50eb02536a15f01410977f18ea7f5"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testAddRowButtonVariants.1.png": {
+    "mtime": 1783501819.7178135,
+    "ast_hash": "0240c771bf175db2a90dbdabcb16bb56",
+    "semantic_hash": "0240c771bf175db2a90dbdabcb16bb56"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testAddToSessionSheet.1.png": {
+    "mtime": 1783953660.9395216,
+    "ast_hash": "f25ffd3c7fb1c401375bb295de1752f3",
+    "semantic_hash": "f25ffd3c7fb1c401375bb295de1752f3"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testAnalyticsScreen.1.png": {
+    "mtime": 1783501819.7186723,
+    "ast_hash": "f51da5e154894639fc5af5b1938773c6",
+    "semantic_hash": "f51da5e154894639fc5af5b1938773c6"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testAutocompleteField.1.png": {
+    "mtime": 1783501819.719827,
+    "ast_hash": "4cfd11a89e0b8d32c0d3a263acf78f00",
+    "semantic_hash": "4cfd11a89e0b8d32c0d3a263acf78f00"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testConsistencyBars.1.png": {
+    "mtime": 1783501819.7209997,
+    "ast_hash": "18e4a96b24d64932eca83d42dc385bdd",
+    "semantic_hash": "18e4a96b24d64932eca83d42dc385bdd"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testExerciseDetailLinkedFrom.1.png": {
+    "mtime": 1783953660.9406319,
+    "ast_hash": "06145c25e1cdd89b1569c0802c939cf7",
+    "semantic_hash": "06145c25e1cdd89b1569c0802c939cf7"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testFocusPlayerWithReps.1.png": {
+    "mtime": 1783501819.722438,
+    "ast_hash": "f8e167f5b7548cf7d12cc308faf2e2dc",
+    "semantic_hash": "f8e167f5b7548cf7d12cc308faf2e2dc"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testFocusPlayerWithTarget.1.png": {
+    "mtime": 1783501819.7237594,
+    "ast_hash": "726fce4f84f36f966d52dd6e53030bb3",
+    "semantic_hash": "726fce4f84f36f966d52dd6e53030bb3"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testGlobalBanner.1.png": {
+    "mtime": 1783501819.724185,
+    "ast_hash": "995f8ec977110d7bc032ae52d7839f4d",
+    "semantic_hash": "995f8ec977110d7bc032ae52d7839f4d"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testKeyPickerCollapsed.1.png": {
+    "mtime": 1783501819.725042,
+    "ast_hash": "f3cab28810bb521876622bfdfa91a527",
+    "semantic_hash": "f3cab28810bb521876622bfdfa91a527"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testKeyPickerExpandedEmpty.1.png": {
+    "mtime": 1783501819.7260396,
+    "ast_hash": "ceebc9ccdaf5ce6503b4ad901fcf577e",
+    "semantic_hash": "ceebc9ccdaf5ce6503b4ad901fcf577e"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testKeyPickerExpandedEnharmonic.1.png": {
+    "mtime": 1783501819.7265098,
+    "ast_hash": "aefdf03f47b94d5e2cd6accd47206182",
+    "semantic_hash": "aefdf03f47b94d5e2cd6accd47206182"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryAddScreen.1.png": {
+    "mtime": 1783501819.727293,
+    "ast_hash": "08efdcc10dfe9a34bebfc5174d1822d0",
+    "semantic_hash": "08efdcc10dfe9a34bebfc5174d1822d0"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryAddScreenExercise.1.png": {
+    "mtime": 1783501819.7277887,
+    "ast_hash": "f855369b99cf08b658a865600bb07832",
+    "semantic_hash": "f855369b99cf08b658a865600bb07832"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryAddScreenWithError.1.png": {
+    "mtime": 1783501819.7286944,
+    "ast_hash": "6f6bc596cd2b46b556e07a696aad1bd2",
+    "semantic_hash": "6f6bc596cd2b46b556e07a696aad1bd2"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryDetailScreen.1.png": {
+    "mtime": 1783501819.7298703,
+    "ast_hash": "e2243dc2099cedfc1bb6588eba14783d",
+    "semantic_hash": "e2243dc2099cedfc1bb6588eba14783d"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryEditScreen.1.png": {
+    "mtime": 1783501819.7303696,
+    "ast_hash": "18f8ff0ca8c5b84f3cb935ccd202ee96",
+    "semantic_hash": "18f8ff0ca8c5b84f3cb935ccd202ee96"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryEditScreenExercise.1.png": {
+    "mtime": 1783501819.7313423,
+    "ast_hash": "f44cfebd574651572520020f78eae076",
+    "semantic_hash": "f44cfebd574651572520020f78eae076"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryEditScreenWithError.1.png": {
+    "mtime": 1783501819.7318957,
+    "ast_hash": "a0c50388715d3ea5d3e3df8b71e65cc1",
+    "semantic_hash": "a0c50388715d3ea5d3e3df8b71e65cc1"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryItemCards.1.png": {
+    "mtime": 1783501819.7323368,
+    "ast_hash": "4852da2ea325521fff3e95cb38dbe6cc",
+    "semantic_hash": "4852da2ea325521fff3e95cb38dbe6cc"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreen.1.png": {
+    "mtime": 1783501819.7329974,
+    "ast_hash": "dfa132303912f9cf01a702dc24d53a87",
+    "semantic_hash": "dfa132303912f9cf01a702dc24d53a87"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreenFiltered.1.png": {
+    "mtime": 1783501819.7333288,
+    "ast_hash": "0f0394cfc6aa9d8fb4da169177b95375",
+    "semantic_hash": "0f0394cfc6aa9d8fb4da169177b95375"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreenMastery.1.png": {
+    "mtime": 1783501819.7339787,
+    "ast_hash": "eb179eae597ff04242f5d27cd03d369b",
+    "semantic_hash": "eb179eae597ff04242f5d27cd03d369b"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreenPopulated.1.png": {
+    "mtime": 1783501819.7343478,
+    "ast_hash": "4bcab6994d2da46acdcab6b7b9f6a5bc",
+    "semantic_hash": "4bcab6994d2da46acdcab6b7b9f6a5bc"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreenPriorities.1.png": {
+    "mtime": 1783501819.7347064,
+    "ast_hash": "933520b4bd115fbc7dd54b63ad12ecd1",
+    "semantic_hash": "933520b4bd115fbc7dd54b63ad12ecd1"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLibraryScreenSearching.1.png": {
+    "mtime": 1783501819.7350166,
+    "ast_hash": "9d675d412fc444b15353bca46e116ce1",
+    "semantic_hash": "9d675d412fc444b15353bca46e116ce1"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLinkedExercisePicker.1.png": {
+    "mtime": 1783953660.941927,
+    "ast_hash": "aaba92350ae4bb0ce41b4d17aa66977b",
+    "semantic_hash": "aaba92350ae4bb0ce41b4d17aa66977b"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testLinkedExercisePickerSelectedTray.1.png": {
+    "mtime": 1783953660.9429214,
+    "ast_hash": "0fe490b6e20fecc1cb3a2d67abda6f2e",
+    "semantic_hash": "0fe490b6e20fecc1cb3a2d67abda6f2e"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testMasteryDeltaRows.1.png": {
+    "mtime": 1783501819.7360945,
+    "ast_hash": "7071e8926b95ee66911cfa8ff8b02c5e",
+    "semantic_hash": "7071e8926b95ee66911cfa8ff8b02c5e"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testMasteryDial.1.png": {
+    "mtime": 1783501819.7369514,
+    "ast_hash": "94f085d82fc2b204fc9329521802b28c",
+    "semantic_hash": "94f085d82fc2b204fc9329521802b28c"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPieceDetailLinkedEditing.1.png": {
+    "mtime": 1783953660.944175,
+    "ast_hash": "46ba79503679507695081f1a5e96f146",
+    "semantic_hash": "46ba79503679507695081f1a5e96f146"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPieceDetailLinkedEmpty.1.png": {
+    "mtime": 1783501819.7384484,
+    "ast_hash": "82a1f0f89d2fea0898ec036adc6517e9",
+    "semantic_hash": "82a1f0f89d2fea0898ec036adc6517e9"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPieceDetailLinkedPopulated.1.png": {
+    "mtime": 1783501819.7389045,
+    "ast_hash": "fa309de7d0eaebff4fefd5c3b1f31d8b",
+    "semantic_hash": "fa309de7d0eaebff4fefd5c3b1f31d8b"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPracticeScreen.1.png": {
+    "mtime": 1783501819.7398427,
+    "ast_hash": "9839f3818284bfb440223b3fc3fb1570",
+    "semantic_hash": "9839f3818284bfb440223b3fc3fb1570"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPracticeScreenPopulated.1.png": {
+    "mtime": 1783501819.7410467,
+    "ast_hash": "eb765b47f2d41c6c46de7d81ed2ddcd9",
+    "semantic_hash": "eb765b47f2d41c6c46de7d81ed2ddcd9"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testPracticeScreenQuietDay.1.png": {
+    "mtime": 1783501819.7450733,
+    "ast_hash": "29e2df9ef7657e46a4af631d835a6fff",
+    "semantic_hash": "29e2df9ef7657e46a4af631d835a6fff"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testProgressScreenPopulated.1.png": {
+    "mtime": 1783501819.7461321,
+    "ast_hash": "e1cc428eee4ed31babc8ef731b8eaa0e",
+    "semantic_hash": "e1cc428eee4ed31babc8ef731b8eaa0e"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testRecentSessions.1.png": {
+    "mtime": 1783501819.7464383,
+    "ast_hash": "f04e7ec0b22fa70a9d86d55ac4220c0a",
+    "semantic_hash": "f04e7ec0b22fa70a9d86d55ac4220c0a"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testRecentSessionsDeclining.1.png": {
+    "mtime": 1783501819.7467315,
+    "ast_hash": "b3db630783c57b7919263b80fdf4e04a",
+    "semantic_hash": "b3db630783c57b7919263b80fdf4e04a"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testReflectionSheet.1.png": {
+    "mtime": 1783501819.7473772,
+    "ast_hash": "cffed093ce582a07c5251d0c2f644d10",
+    "semantic_hash": "cffed093ce582a07c5251d0c2f644d10"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testRepCounter.1.png": {
+    "mtime": 1783501819.7483597,
+    "ast_hash": "d886757429ae86db227b522711e729b9",
+    "semantic_hash": "d886757429ae86db227b522711e729b9"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testRootShell.1.png": {
+    "mtime": 1783501819.7494571,
+    "ast_hash": "1d425254433395349ee896780fd749d8",
+    "semantic_hash": "1d425254433395349ee896780fd749d8"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testRoutinesScreen.1.png": {
+    "mtime": 1783501819.74992,
+    "ast_hash": "94b89d24334fcf78d47e25e80948bc64",
+    "semantic_hash": "94b89d24334fcf78d47e25e80948bc64"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testScoreRing.1.png": {
+    "mtime": 1783501819.7503567,
+    "ast_hash": "f26e7917697ca56f300d1abe9c5df129",
+    "semantic_hash": "f26e7917697ca56f300d1abe9c5df129"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testScoreRingHero.1.png": {
+    "mtime": 1783501819.750631,
+    "ast_hash": "fee1a699a75e17f9fe0332ff9a727df0",
+    "semantic_hash": "fee1a699a75e17f9fe0332ff9a727df0"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testScoreSelectorPills.1.png": {
+    "mtime": 1783501819.7511334,
+    "ast_hash": "4bd956c33248dffb429236dd3d5dfb8c",
+    "semantic_hash": "4bd956c33248dffb429236dd3d5dfb8c"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionBuilderEmpty.1.png": {
+    "mtime": 1783501819.7514524,
+    "ast_hash": "1103306409c9cb7847ea853528ccf66f",
+    "semantic_hash": "1103306409c9cb7847ea853528ccf66f"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionBuilderGrouped.1.png": {
+    "mtime": 1783953660.9454174,
+    "ast_hash": "9ae79748f9865ac8ddfa0ff3c6b41508",
+    "semantic_hash": "9ae79748f9865ac8ddfa0ff3c6b41508"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionBuilderPopulated.1.png": {
+    "mtime": 1783501819.7521808,
+    "ast_hash": "8a88d8f13b0acb9292a54b10adfaa554",
+    "semantic_hash": "8a88d8f13b0acb9292a54b10adfaa554"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionSummaryCompleted.1.png": {
+    "mtime": 1783501819.7527723,
+    "ast_hash": "0dcd3cd62a058baa00df48f59748f92d",
+    "semantic_hash": "0dcd3cd62a058baa00df48f59748f92d"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionSummaryEndedEarly.1.png": {
+    "mtime": 1783501819.75326,
+    "ast_hash": "6c0b9b568be2dbe2cd2af8db9f7552ad",
+    "semantic_hash": "6c0b9b568be2dbe2cd2af8db9f7552ad"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testTagChipInput.1.png": {
+    "mtime": 1783501819.7540703,
+    "ast_hash": "09f25529e5d0dd297e3d7546a2b372bf",
+    "semantic_hash": "09f25529e5d0dd297e3d7546a2b372bf"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testTagFilterSheet.1.png": {
+    "mtime": 1783505754.509368,
+    "ast_hash": "494be562ad107d5cca5ee09e7d8af152",
+    "semantic_hash": "494be562ad107d5cca5ee09e7d8af152"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testTagFilterSheetEmpty.1.png": {
+    "mtime": 1783505754.5103436,
+    "ast_hash": "bb373dcd27c075ab295d99403c648c6b",
+    "semantic_hash": "bb373dcd27c075ab295d99403c648c6b"
+  },
+  "ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testTypeBadges.1.png": {
+    "mtime": 1783501819.755995,
+    "ast_hash": "a431a4c72c41d4b31527435bb8dbfb44",
+    "semantic_hash": "a431a4c72c41d4b31527435bb8dbfb44"
+  }
+}


### PR DESCRIPTION
## Summary
- Full-repo graphify run (code + docs, no clustering — chose comprehensiveness over navigability per request)
- AST-extracted all Rust/Swift/TS code (5426 nodes) + semantically extracted 302 docs/specs via 14 parallel subagents (850 nodes)
- Excluded 73 image files (app icons + swift-snapshot-test PNGs) from semantic extraction — pixel diffs, not diagrams, would have cost ~73 extra subagent calls for near-zero graph value
- Result: 6040 nodes, 12714 edges in `graphify-out/graph.json`, human-readable audit in `graphify-out/GRAPH_REPORT.md`

## Notable findings surfaced by the graph
- `docs/development-workflow.md` documents a SpecKit pipeline, but root `CLAUDE.md` says "Do not run `/speckit-*` slash commands" — worth checking if that doc is stale
- Graph health check flagged 902 dangling-endpoint edges (references to stdlib/external types like `Option`/`String`, expected) and ~1100 collapsed duplicate edges (repeated field-access references in code, expected for an unclustered code-heavy graph) — not corruption, just noted for transparency
- Import cycles detected in `intrada-api` (`auth.rs` ↔ `state.rs` ↔ `rate_limit.rs`) and `intrada-core` (`app.rs` ↔ `http.rs`, `domain/session.rs` ↔ `model.rs`) — pre-existing, not introduced by this PR, flagged for awareness

## What's committed vs. gitignored
- Committed: `graph.json`, `GRAPH_REPORT.md`, `manifest.json`, `cost.json` (enables future `graphify --update` incremental runs)
- Gitignored: `.graphify_python`/`.graphify_root` (machine-local paths) and `cache/` (embeds absolute paths, not portable across clones)

## Test plan
- [x] Graph builds without error (6040 nodes, non-empty)
- [x] JSON validated well-formed at each merge stage
- N/A — no code changes, tooling artifact only

Coverage: N/A (Tier 1, no code changes — data/tooling artifact only)

Deferred items tracked: none — this is a one-off tooling run, no follow-up work implied beyond the two findings noted above (which are pre-existing conditions, not new issues to file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)