### PR TITLE
docs(vision): vision v2 — reflection loop, narrative progress, piece scaffolding, goals ruling

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -118,7 +118,7 @@ A piece is not practised alone; it is built. A jazz standard accumulates the
 exercises that construct it: the melody, shells in each inversion, scales to
 each chord tone on every change, constrained improvisation. Intrada makes that
 relationship first-class: a piece anchors an ordered set of related exercises,
-each tracked separately, practisable together as a block, and navigable in
+each tracked separately, practised together as a block, and navigable in
 both directions. Exercises can serve several pieces; mastery earned in one
 context is visible in every context that shares it.
 

--- a/VISION.md
+++ b/VISION.md
@@ -2,7 +2,10 @@
 
 **Your Intentional Practice Companion**
 
-*Product Vision — April 2026*
+*Product Vision — April 2026, revised July 2026*
+
+*The companion walkthrough of the ideal user journey lives in
+[`docs/journeys.md`](docs/journeys.md); features are judged against it.*
 
 ---
 
@@ -32,7 +35,7 @@ These build on each other. You can't schedule what you haven't captured, you can
 
 **3. Space it for retention.** Intrada schedules returns to material at intervals optimised for long-term retention, not just coverage. Items you're learning surface frequently; items you've consolidated appear less often but before you've forgotten them. The app manages the spacing so you don't have to — and so exercises from six weeks ago don't silently decay while you focus on this week's assignment. This is grounded in decades of research on spaced repetition and interleaved practice.
 
-**4. Show that it's working.** Progress in music is real but gradual. Intrada makes it visible. Mastery ratings per item, per key, and per tempo accumulate over weeks and months into evidence you can see: "Your Db mastery went from 2 to 4 over the last three weeks." This isn't gamification — it's the external confirmation that the process is working, delivered before you can feel it yourself. It turns weeks of invisible improvement into daily visible signals.
+**4. Show that it's working.** Progress in music is real but gradual. Intrada makes it visible. Mastery ratings per item, per key, and per tempo accumulate over weeks and months into evidence you can see: "Your Db mastery went from 2 to 4 over the last three weeks." And the evidence isn't only numbers: Intrada keeps what you *said*, the reflections captured during and after practice, and plays it back against the data. "Two weeks ago you wrote 'bridge still rushing'; this week: 'bridge steady at 96'." Progress reported in your own words is proof no chart can match. This isn't gamification: it's the external confirmation that the process is working, delivered before you can feel it yourself. It turns weeks of invisible improvement into daily visible signals.
 
 **5. Identify gaps and guide what's next.** Over time, Intrada gets smarter. It surfaces patterns you can't see yourself — "You consistently struggle with keys that have four or more flats" or "You spend most of your time on pieces and almost none on the keys you rated lowest." Initially this comes from your practice data alone. Later, it extends to suggesting specific exercises to address weaknesses and generating practice pathways toward goals — the kind of curriculum guidance that a teacher provides instinctively.
 
@@ -70,6 +73,17 @@ Every interaction should feel lightweight. If logging a practice session takes m
 
 Every decision point between "I want to practise" and "I am practising" is a potential session-ending barrier — particularly for musicians with executive function challenges. The default path requires one decision: tap start. Everything else is optional.
 
+### Reflection Closes Every Loop
+
+Practice without reflection is repetition. Intrada treats reflection as a
+first-class act at two moments: a one-tap capture *during* practice that never
+breaks flow, and a short structured beat *after* the session (what improved,
+what's still broken, what to target next time) that is skippable but never
+skipped by design. What you write feeds forward: the next target becomes the
+next session's suggested aim, and your words become the spine of your progress
+report. This is the "good friction" the design principles protect; everything
+else stays frictionless so this can stay deliberate.
+
 ### Celebrate Comeback, Not Streak
 
 Intrada never shows a broken streak counter or a zero. It celebrates returns: "Welcome back — your scheduling has adapted and we've got a session ready." Consistency matters, but the framing determines whether it motivates or shames.
@@ -98,6 +112,16 @@ The app also recognises when a musician always practises keys as a sequential lo
 
 Pieces (repertoire with sections), exercises (scales, arpeggios, technical studies), licks and vocabulary (jazz patterns, typically across keys), and techniques (specific technical goals like left-hand independence or pedalling).
 
+### Piece Scaffolding
+
+A piece is not practised alone; it is built. A jazz standard accumulates the
+exercises that construct it: the melody, shells in each inversion, scales to
+each chord tone on every change, constrained improvisation. Intrada makes that
+relationship first-class: a piece anchors an ordered set of related exercises,
+each tracked separately, practisable together as a block, and navigable in
+both directions. Exercises can serve several pieces; mastery earned in one
+context is visible in every context that shares it.
+
 ### Routines
 
 Reusable sequences of items — a warm-up routine, a technical block, a cool-down set — that can be inserted into any session. This reduces daily decision-making, supports consistency, and is particularly valuable for musicians who struggle with session initiation.
@@ -107,6 +131,8 @@ Reusable sequences of items — a warm-up routine, a technical block, a cool-dow
 ## The Scheduling Intelligence
 
 The scheduler combines spaced repetition urgency (what's overdue for review), interleaved ordering (mixing material types for better retention), goal alignment (what serves the musician's current objectives), and time fitting (what fits in the available session length).
+
+Goals here are deliberately small: an outcome statement ("learn Body and Soul", "improvise fluently over rhythm changes") linked to library items, with an optional target date. Nothing more. An earlier, heavier goals feature (confidence tracking, progress percentages, photos) was built and removed twice; the lesson was that goals earn their place only as an *input to planning*, never as an admin surface of their own. The per-item priority star remains the zero-ceremony shortcut; a goal is the named ambition sitting above it.
 
 This isn't AI — it's an algorithm grounded in well-established learning science. The research basis is documented in the [Research Foundation](docs/research-foundation.md).
 

--- a/design/Reflection Narrative.dc.html
+++ b/design/Reflection Narrative.dc.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  a { color: #4C3FA6; } a:hover { color: #6346E5; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @keyframes toastIn { 0% { opacity: 0; transform: translateY(-10px) scale(.96); } 100% { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; } }
+</style>
+</helmet>
+
+<div style="min-height:100vh;background:linear-gradient(180deg,#F4F1E8 0%,#EBE7D9 100%);font-family:'Inter',system-ui,sans-serif;color:#2B2A26;padding:44px 32px 90px;">
+  <template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#FBFAF3"/><path d="M32 36 h36 a6 6 0 0 1 6 6 v18 a6 6 0 0 1 -6 6 h-20 l-10 9 v-9 h-6 a6 6 0 0 1 -6 -6 v-18 a6 6 0 0 1 6 -6 z" fill="none" stroke="#4C3FA6" stroke-width="6" stroke-linejoin="round"/><line x1="40" y1="48" x2="60" y2="48" stroke="#9E7B33" stroke-width="6" stroke-linecap="round"/><line x1="40" y1="58" x2="52" y2="58" stroke="#9E7B33" stroke-width="6" stroke-linecap="round"/></svg></template>
+
+  <!-- ============ HEADER / DESIGNER NOTE ============ -->
+  <div style="max-width:1000px;margin:0 auto;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Intrada · Paper &amp; Score · Feature mock · Brief 2026-07 reflection-and-narrative</div>
+    <h1 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:44px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Reflection &amp; narrative</h1>
+    <p style="font-size:15px;line-height:1.65;color:#6E6557;max-width:680px;margin:14px 0 0;">Phase 1: four surfaces that turn a session into a story — <strong style="font-weight:600;color:#2B2A26;">capture mid-item</strong> without leaving the timer, <strong style="font-weight:600;color:#2B2A26;">tempo reached</strong> at hand-off, <strong style="font-weight:600;color:#2B2A26;">structured reflection</strong> on the summary, and a <strong style="font-weight:600;color:#2B2A26;">session intention</strong> set in the builder that echoes at the end. One capture grammar throughout: the sheet, one gesture down.</p>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:26px;">
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:18px 20px;">
+        <div style="display:flex;align-items:center;gap:8px;"><i data-lucide="circle-check" width="16" height="16" style="color:#1F8A5B;"></i><div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Calls made</div></div>
+        <ul style="margin:12px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+          <li><strong style="color:#2B2A26;font-weight:600;">Capture = a sheet, never chrome.</strong> The player stays bare; the note sheet rises on a swipe and drops back to the running timer. No advance, ever.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Tempo = stepper, prefilled at target.</strong> A few taps, no keyboard mid-sheet.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Reflection lives on the summary,</strong> inline and skippable — Save is never gated.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Intention is one optional line in the builder,</strong> echoed verbatim on the summary.</li>
+        </ul>
+      </div>
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:18px 20px;">
+        <div style="display:flex;align-items:center;gap:8px;"><i data-lucide="flag" width="16" height="16" style="color:#8A6A2E;"></i><div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Flagged, not invented</div></div>
+        <p style="font-size:13.5px;line-height:1.7;color:#6E6557;margin:12px 0 0;"><strong style="color:#2B2A26;font-weight:600;">TempoStepper</strong> is the one new primitive candidate — built entirely from existing tokens (hairline border, card surface, 44px targets). If it survives review it goes into <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">Theme.swift</span> + the DS together. The quick-note sheet is the existing BottomSheet at a <strong style="color:#2B2A26;font-weight:600;">compact detent</strong> — a variant, not a new component. The reflection prompt rows and intention field are composed from shipped inputs and labels. <strong style="color:#2B2A26;font-weight:600;">No new colours, no new spacing.</strong></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ SURFACE 1 · MID-ITEM QUICK CAPTURE ============ -->
+  <div style="max-width:1000px;margin:72px auto 0;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Surface 1 · Focus player</div>
+    <h2 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Mid-item quick capture</h2>
+    <p style="font-size:14.5px;line-height:1.65;color:#6E6557;max-width:680px;margin:12px 0 0;">Three directions weighed: a resident note button in the transport row (<strong style="font-weight:600;color:#2B2A26;">rejected</strong> — resident chrome on the bare player), a long-press on the item title (<strong style="font-weight:600;color:#2B2A26;">rejected</strong> — invisible affordance), and the winner: <strong style="font-weight:600;color:#2B2A26;">a compact sheet, one swipe up</strong>. It reuses the hand-off sheet's grammar, the timer ring stays visible and ticking behind it, and Save or a swipe down returns straight to play. It never advances the item.</p>
+  </div>
+
+  <div style="max-width:1240px;margin:32px auto 0;display:flex;flex-wrap:wrap;gap:44px 40px;justify-content:center;align-items:flex-start;">
+
+    <!-- Bare player, unchanged (canonical import) -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Unchanged · the bare player (canonical)</div>
+      <dc-import name="Focus Player" hint-size="392px,860px"></dc-import>
+      <div style="max-width:340px;font-size:12.5px;line-height:1.6;color:#6E6557;text-align:center;">Nothing new lives here. The capture affordance is the gesture itself — swipe up anywhere below the ring (also reachable via <strong style="color:#2B2A26;font-weight:600;">···</strong>).</div>
+    </div>
+
+    <!-- FRAME 1 · CAPTURE SHEET OPEN -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">One swipe up · quick note, timer still running</div>
+      <div data-screen-label="S1 · Quick capture" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+            <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">FOCUS · 3 OF 5</span><i data-lucide="ellipsis" width="22" height="22" style="color:#6E6557;"></i></div>
+            <div style="display:flex;gap:5px;margin-top:14px;"><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#6346E5,#4C3FA6);"></span><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#6346E5,#4C3FA6);"></span><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#9E7B33,#8A6A2E);"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span></div>
+            <div style="text-align:center;margin-top:20px;">
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;"><i data-lucide="dumbbell" width="12" height="12"></i>Exercise</span>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:27px;color:#2B2A26;line-height:1.1;margin-top:12px;">Scales · D♭ major</div>
+            </div>
+            <div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding-top:22px;min-height:0;">
+              <div style="position:relative;width:206px;height:206px;">
+                <svg width="206" height="206" viewBox="0 0 206 206" style="display:block;"><circle cx="103" cy="103" r="86" fill="none" stroke="#E5DDCB" stroke-width="10"/><circle id="qc-ring" cx="103" cy="103" r="86" fill="none" stroke="url(#qcgrad)" stroke-width="10" stroke-linecap="round" stroke-dasharray="540.354" stroke-dashoffset="293.33" transform="rotate(-90 103 103)"/><defs><linearGradient id="qcgrad" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6346E5"/><stop offset="1" stop-color="#4C3FA6"/></linearGradient></defs></svg>
+                <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;"><div id="qc-time" style="font-family:Inter;font-weight:600;font-size:46px;color:#2B2A26;font-variant-numeric:tabular-nums;line-height:1;">3:12</div><div style="font-size:12px;color:#6E6557;margin-top:6px;">of 7:00</div></div>
+              </div>
+            </div>
+          </div>
+          <!-- scrim over the player, sheet stops below the ring -->
+          <div style="position:absolute;inset:0;background:rgba(43,42,38,0.22);z-index:40;"></div>
+          <!-- compact capture sheet -->
+          <div style="position:absolute;left:0;right:0;bottom:0;z-index:50;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);padding:0 22px 30px;animation:fadeUp .4s ease both;">
+            <div style="display:flex;justify-content:center;padding:12px 0 6px;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-top:6px;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#9A927F;">Quick note</div>
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;font-variant-numeric:tabular-nums;"><i data-lucide="timer" width="12" height="12"></i>at 3:12</span>
+            </div>
+            <textarea rows="3" placeholder="What just happened? One line is plenty." style="width:100%;border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:13px 14px;font-family:Inter;font-size:14px;line-height:1.55;color:#2B2A26;resize:none;outline:none;margin-top:12px;transition:border-color .15s;" style-focus="border-color:#4C3FA6;">Bars 12–14 rushing again — metronome back to 80.</textarea>
+            <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:14px;cursor:pointer;" style-active="transform:scale(0.985)">Save note</button>
+            <button style="display:block;margin:0 auto;background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Close</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+      <div style="max-width:340px;font-size:12.5px;line-height:1.6;color:#6E6557;text-align:center;">The ring keeps ticking behind the sheet — capture is stamped at the moment of the swipe. Save and Close both land back on the running timer. <strong style="color:#2B2A26;font-weight:600;">No advance, no pause.</strong></div>
+    </div>
+  </div>
+
+  <!-- ============ SURFACE 2 · HAND-OFF + TEMPO ============ -->
+  <div style="max-width:1000px;margin:80px auto 0;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Surface 2 · Reflection hand-off sheet</div>
+    <h2 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Tempo reached, three taps</h2>
+    <p style="font-size:14.5px;line-height:1.65;color:#6E6557;max-width:680px;margin:12px 0 0;">A free numeric field summons a keyboard over the sheet; a slider is hopeless across ♩=40–208. The <strong style="font-weight:600;color:#2B2A26;">stepper prefilled at the item's target</strong> wins: most results land a few taps from target, both buttons are 44px, and an untouched stepper still reads as a true "played at target". Score, tempo, note — then one primary action, exactly as shipped. <strong style="font-weight:600;color:#2B2A26;">Skip rating</strong> still skips everything.</p>
+  </div>
+
+  <div style="max-width:1240px;margin:32px auto 0;display:flex;flex-wrap:wrap;gap:44px 40px;justify-content:center;align-items:flex-start;">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Hand-off · score + tempo + note</div>
+      <div data-screen-label="S2 · Hand-off with tempo" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:#2B2A26;display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="position:absolute;inset:0;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC,#E7E2D2);opacity:0.3;"></div>
+          <div style="position:absolute;left:0;right:0;bottom:0;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);display:flex;flex-direction:column;padding:0 22px 30px;animation:fadeUp .4s ease both;">
+            <div style="display:flex;justify-content:center;padding:12px 0 6px;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+            <div style="text-align:center;margin-top:10px;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#8A6A2E;">Item complete · 7:00</div>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:24px;color:#2B2A26;line-height:1.1;margin-top:8px;">How did <span style="white-space:nowrap;">Scales · D♭</span> go?</div>
+            </div>
+            <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;">Score</div>
+            <div id="ho-score" style="display:flex;justify-content:space-between;gap:4px;margin-top:10px;">
+              <span class="rateDot" data-v="1" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">1</span>
+              <span class="rateDot" data-v="2" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">2</span>
+              <span class="rateDot" data-v="3" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">3</span>
+              <span class="rateDot" data-v="4" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">4</span>
+              <span class="rateDot" data-v="5" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">5</span>
+              <span class="rateDot" data-v="6" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">6</span>
+              <span class="rateDot" data-v="7" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">7</span>
+              <span class="rateDot" data-v="8" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">8</span>
+              <span class="rateDot" data-v="9" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">9</span>
+              <span class="rateDot" data-v="10" style="flex:1.4;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:13px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">10</span>
+            </div>
+            <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;">Tempo reached <span style="color:#B0A892;font-weight:500;text-transform:none;letter-spacing:0;">· target ♩ = 96</span></div>
+            <div style="display:flex;align-items:center;gap:12px;margin-top:10px;">
+              <button id="tempo-minus" style="width:44px;height:44px;border-radius:12px;border:1.5px solid #D8D0BD;background:#FCFAF3;display:flex;align-items:center;justify-content:center;color:#6E6557;cursor:pointer;flex:none;" style-active="transform:scale(0.93)"><i data-lucide="minus" width="18" height="18"></i></button>
+              <div style="flex:1;text-align:center;font-family:Inter;font-weight:600;font-size:24px;color:#2B2A26;font-variant-numeric:tabular-nums;">♩ = <span id="tempo-val">92</span></div>
+              <button id="tempo-plus" style="width:44px;height:44px;border-radius:12px;border:1.5px solid #D8D0BD;background:#FCFAF3;display:flex;align-items:center;justify-content:center;color:#6E6557;cursor:pointer;flex:none;" style-active="transform:scale(0.93)"><i data-lucide="plus" width="18" height="18"></i></button>
+            </div>
+            <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;margin-bottom:9px;">Reflection · optional</div>
+            <textarea rows="2" placeholder="What went well? What to fix next time?" style="width:100%;border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:13px 14px;font-family:Inter;font-size:14px;line-height:1.55;color:#2B2A26;resize:none;outline:none;transition:border-color .15s;" style-focus="border-color:#4C3FA6;">RH evenness much better at 92.</textarea>
+            <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:16px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;" style-active="transform:scale(0.985)">Save &amp; continue<i data-lucide="arrow-right" width="16" height="16"></i></button>
+            <button style="background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Skip rating</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#F2EFE8;opacity:0.5;z-index:60;"></div>
+        </div>
+      </div>
+      <div style="max-width:340px;font-size:12.5px;line-height:1.6;color:#6E6557;text-align:center;"><strong style="color:#2B2A26;font-weight:600;">TempoStepper</strong> — the flagged new primitive. Everything else on this sheet is the shipped Frame 9, untouched.</div>
+    </div>
+  </div>
+
+  <!-- ============ SURFACE 3 · SUMMARY REFLECTION ============ -->
+  <div style="max-width:1000px;margin:80px auto 0;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Surface 3 · Session summary</div>
+    <h2 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Structured reflection, where the evidence is</h2>
+    <p style="font-size:14.5px;line-height:1.65;color:#6E6557;max-width:680px;margin:12px 0 0;">A post-save interstitial gates the primary action — rejected. Instead the summary itself gains a reflection block: the session <strong style="font-weight:600;color:#2B2A26;">intention echoed verbatim</strong>, then three prompts — <strong style="font-weight:600;color:#2B2A26;">Improved · Still rough · Next target</strong>. All optional; blank rows save as nothing. To make the room, the played-ledger collapses to one line (tap expands the shipped rows). <strong style="font-weight:600;color:#2B2A26;">Save session</strong> stays the only primary action.</p>
+  </div>
+
+  <div style="max-width:1240px;margin:32px auto 0;display:flex;flex-wrap:wrap;gap:44px 40px;justify-content:center;align-items:flex-start;">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Summary · intention echo + three prompts</div>
+      <div data-screen-label="S3 · Summary reflection" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="flex:1;display:flex;flex-direction:column;padding:14px 18px 26px;min-height:0;">
+            <div style="animation:fadeUp .5s ease both;"><div style="font-size:11px;font-weight:600;letter-spacing:1.8px;color:#9E7B33;">SESSION COMPLETE</div><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1.05;margin-top:6px;">Nice work.</div><div style="font-size:13px;color:#6E6557;margin-top:5px;">42 min · 3 of 4 items</div></div>
+            <div style="display:flex;align-items:flex-start;gap:12px;padding:13px 16px;border-radius:14px;background:linear-gradient(120deg,#F1E9D6,#ECE0C6);border:1px solid #E6D6B0;margin-top:16px;animation:toastIn .55s .3s ease both;">
+              <i data-lucide="quote" width="16" height="16" style="color:#9E7B33;flex:none;margin-top:2px;"></i>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#7A6A3F;">Your intention</div><div style="font-family:'Source Serif 4',serif;font-style:italic;font-size:15.5px;color:#2B2A26;line-height:1.4;margin-top:4px;">“{{ intention }}”</div></div>
+            </div>
+            <div style="margin-top:18px;font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Reflect · optional</div>
+            <div style="flex:none;margin-top:4px;">
+              <sc-if value="{{ reflectionFilled }}" hint-placeholder-val="{{ true }}">
+                <div>
+                  <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#E7F1EB;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="trending-up" width="15" height="15" style="color:#1F8A5B;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Improved</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Thumb-unders even at 92 — bars 1–8 clean twice in a row.</div></div>
+                  </div>
+                  <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#F0E5CC;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="wrench" width="15" height="15" style="color:#8A6A2E;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Still rough</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Bars 12–14 rush every run past 88.</div></div>
+                  </div>
+                  <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="target" width="15" height="15" style="color:#4C3FA6;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Next target</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Bars 12–14 at 80, hands together, before pushing tempo.</div></div>
+                  </div>
+                </div>
+              </sc-if>
+              <sc-if value="{{ reflectionEmpty }}" hint-placeholder-val="{{ false }}">
+                <div>
+                  <div style="display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#E7F1EB;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="trending-up" width="15" height="15" style="color:#1F8A5B;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Improved</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">What moved forward?</div></div>
+                  </div>
+                  <div style="display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#F0E5CC;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="wrench" width="15" height="15" style="color:#8A6A2E;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Still rough</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">What's still fighting you?</div></div>
+                  </div>
+                  <div style="display:flex;align-items:center;gap:12px;padding:12px 0;">
+                    <span style="width:28px;height:28px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="target" width="15" height="15" style="color:#4C3FA6;"></i></span>
+                    <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Next target</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">Where does the next session start?</div></div>
+                  </div>
+                </div>
+              </sc-if>
+            </div>
+            <div style="flex:1;"></div>
+            <div style="display:flex;align-items:center;gap:12px;padding:13px 14px;border-radius:14px;background:#FCFAF3;border:1px solid #E5DECD;cursor:pointer;">
+              <div style="flex:1;min-width:0;"><div style="font-size:13.5px;font-weight:600;color:#2B2A26;">What you played</div><div style="font-size:11px;color:#9A927F;margin-top:2px;">3 of 4 items · Clair de Lune moved 3 → 4</div></div>
+              <i data-lucide="chevron-down" width="18" height="18" style="color:#9A927F;flex:none;"></i>
+            </div>
+            <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:12px;cursor:pointer;" style-active="transform:scale(0.98)">Save session</button>
+            <button style="background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Discard</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+      <div style="max-width:340px;font-size:12.5px;line-height:1.6;color:#6E6557;text-align:center;">Blank prompts save as nothing — reflection never gates <strong style="color:#2B2A26;font-weight:600;">Save session</strong>. The collapsed ledger row expands to the shipped what-you-played list; the mastery move folds into its subtitle. Toggle the <strong style="color:#2B2A26;font-weight:600;">Filled reflection</strong> tweak for the empty state.</div>
+    </div>
+  </div>
+
+  <!-- ============ SURFACE 4 · INTENTION IN THE BUILDER ============ -->
+  <div style="max-width:1000px;margin:80px auto 0;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Surface 4 · Session builder</div>
+    <h2 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">One line of intention, before you start</h2>
+    <p style="font-size:14.5px;line-height:1.65;color:#6E6557;max-width:680px;margin:12px 0 0;">Putting it in the sticky bar competes with <strong style="font-weight:600;color:#2B2A26;">Start session</strong>, the one primary action; an interstitial after Start is a whole screen for one sentence. The winner: an <strong style="font-weight:600;color:#2B2A26;">optional single line under the header</strong> — intention-before friction spent exactly where the plan is being made. Whatever is written here is what the summary echoes back.</p>
+  </div>
+
+  <div style="max-width:1240px;margin:32px auto 0;display:flex;flex-wrap:wrap;gap:44px 40px;justify-content:center;align-items:flex-start;">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Builder · intention field under the header</div>
+      <div data-screen-label="S4 · Builder intention" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;"><span style="font-size:14px;color:#6E6557;font-weight:500;">Cancel</span><span style="width:48px;"></span></div>
+          <div style="padding:8px 18px 4px;flex:none;">
+            <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Build session</div>
+            <div style="font-size:12.5px;color:#6E6557;margin-top:5px;">32 min · 3 blocks · 5 items</div>
+          </div>
+          <div style="padding:10px 18px 0;flex:none;">
+            <div style="display:flex;align-items:center;gap:7px;"><i data-lucide="feather" width="14" height="14" style="color:#8A6A2E;"></i><span style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's intention · optional</span></div>
+            <div style="border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:12px 14px;font-size:14px;line-height:1.5;color:#2B2A26;margin-top:8px;">{{ intention }}</div>
+          </div>
+          <div style="flex:1;overflow:hidden;padding:12px 16px 100px;display:flex;flex-direction:column;gap:12px;">
+            <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s ease both;">
+              <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+              <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#6346E5,#4C3FA6);flex:none;"></span>
+              <div style="flex:1;min-width:0;"><div style="display:flex;align-items:center;gap:7px;"><span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Clair de Lune</span><span style="font-size:9.5px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:#4C3FA6;background:#E7E3F4;border-radius:6px;padding:1.5px 6px;">Group</span></div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">2 related, then piece · 18 min</div></div>
+              <i data-lucide="chevron-down" width="19" height="19" style="color:#9A927F;flex:none;"></i>
+            </div>
+            <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s .06s ease both;">
+              <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+              <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#6346E5,#4C3FA6);flex:none;"></span>
+              <div style="flex:1;min-width:0;"><div style="display:flex;align-items:center;gap:7px;"><span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Nocturne Op.9</span><span style="font-size:11px;color:#6E6557;">+2 related</span></div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">14 min</div></div>
+              <i data-lucide="chevron-down" width="19" height="19" style="color:#9A927F;flex:none;"></i>
+            </div>
+            <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s .12s ease both;">
+              <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+              <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+              <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Sight-reading</div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">Standalone exercise · 6 min</div></div>
+              <i data-lucide="x" width="18" height="18" style="color:#9A927F;flex:none;"></i>
+            </div>
+            <button style="width:100%;border:1px dashed #C9C0AC;background:transparent;color:#4C3FA6;font-family:Inter;font-weight:600;font-size:14px;padding:14px;border-radius:14px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px;animation:fadeUp .5s .18s ease both;"><i data-lucide="plus" width="17" height="17"></i>Add piece or exercise</button>
+          </div>
+          <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;padding:12px 18px 30px;background:rgba(247,243,233,0.9);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);border-top:1px solid rgba(176,168,146,0.3);">
+            <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;" style-active="transform:scale(0.985)"><i data-lucide="play" width="17" height="17" style="fill:#F2EFE8;"></i>Start session · 32 min</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+      <div style="max-width:340px;font-size:12.5px;line-height:1.6;color:#6E6557;text-align:center;">Empty state shows the placeholder <em>"What's today about? One line."</em> and nothing is required. The <strong style="color:#2B2A26;font-weight:600;">Intention text</strong> tweak drives this field and the summary echo together — the narrative thread, live.</div>
+    </div>
+  </div>
+
+  <div style="max-width:1000px;margin:72px auto 0;border-top:1px solid #E5DECD;padding-top:18px;font-size:12px;color:#9A927F;line-height:1.7;">Journey file per <strong style="color:#6E6557;font-weight:600;">design-process.md</strong> — commit under <span style="font-family:ui-monospace,Menlo,monospace;">specs/&lt;NNN&gt;-reflection-and-narrative/design/</span>. The bare Focus Player is imported, not redrawn. Fold-in list on agreement: TempoStepper (+ Theme.swift), compact BottomSheet detent, ReflectionPromptRow, the intention field pattern.</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1300,&quot;height&quot;:900},&quot;intentionText&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Even RH at 96 through bars 12–14&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Narrative thread&quot;},&quot;achievedTempo&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:92,&quot;min&quot;:40,&quot;max&quot;:208,&quot;unit&quot;:&quot;bpm&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Hand-off sheet&quot;},&quot;reflectionFilled&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Session summary&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() {
+    this.renderIcons();
+    this.startCaptureTimer();
+    this.bindScore();
+    this.bindStepper();
+  }
+  componentDidUpdate() { this.renderIcons(); }
+  componentWillUnmount() { if (this._t) clearInterval(this._t); }
+  renderVals() {
+    const filled = this.props.reflectionFilled ?? true;
+    return {
+      intention: this.props.intentionText ?? 'Even RH at 96 through bars 12–14',
+      reflectionFilled: filled,
+      reflectionEmpty: !filled
+    };
+  }
+  renderIcons() { if (window.lucide) window.lucide.createIcons(); }
+  startCaptureTimer() {
+    const r = 86, circ = 2 * Math.PI * r, total = 420;
+    let sec = 192;
+    const ring = document.querySelector('#qc-ring'), time = document.querySelector('#qc-time');
+    this._t = setInterval(() => {
+      sec++; if (sec > total) sec = 192;
+      if (time) { const m = Math.floor(sec / 60), s = sec % 60; time.textContent = m + ':' + String(s).padStart(2, '0'); }
+      if (ring) ring.setAttribute('stroke-dashoffset', circ * (1 - sec / total));
+    }, 1000);
+  }
+  bindScore() {
+    const dots = Array.from(document.querySelectorAll('#ho-score .rateDot'));
+    const paint = (v) => {
+      dots.forEach((d) => {
+        const on = Number(d.dataset.v) <= v;
+        d.style.background = on ? '#4C3FA6' : 'transparent';
+        d.style.borderColor = on ? '#4C3FA6' : '#D8D0BD';
+        d.style.color = on ? '#F2EFE8' : '#6E6557';
+      });
+    };
+    dots.forEach((d) => d.addEventListener('click', () => paint(Number(d.dataset.v))));
+    paint(8);
+  }
+  bindStepper() {
+    let v = this.props.achievedTempo ?? 92;
+    const val = document.querySelector('#tempo-val');
+    const set = (n) => { v = Math.max(40, Math.min(208, n)); if (val) val.textContent = v; };
+    const minus = document.querySelector('#tempo-minus'), plus = document.querySelector('#tempo-plus');
+    if (minus) minus.addEventListener('click', () => set(v - 2));
+    if (plus) plus.addEventListener('click', () => set(v + 2));
+    set(v);
+  }
+}
+</script>
+</body>
+</html>

--- a/design/briefs/2026-07-reflection-and-narrative.md
+++ b/design/briefs/2026-07-reflection-and-narrative.md
@@ -1,0 +1,116 @@
+# Design brief — reflection loop & narrative progress
+
+> Handover to Claude Design, 2026-07-14, from the vision/journey audit.
+> Work against `design/intrada-design-system.dc.html` (tokens canonical in
+> `ios/Intrada/DesignSystem/Theme.swift`). Mockups land per
+> `docs/design-workflow.md`: `specs/<feature>/design/<screen>.dc.html`.
+> These are the surfaces for build phases 1 and 2 (`docs/journeys.md`,
+> steps 7, 8, 9), plus two look-ahead surfaces worth rough passes now
+> because they shape the Practice tab.
+
+## Global constraints (non-negotiable)
+
+- **T1**: intention-before and reflection-after are good friction; keep them
+  deliberate, never pad them with admin.
+- **T2**: the app disappears during practice; anything added to the player is
+  one gesture down, never resident chrome.
+- **T7**: mid-item capture never forces an advance; end-of-session reflection
+  is structured, skippable, never a gate on saving; everything captured must
+  be re-readable later.
+- One primary action per screen. Comeback framing, never shame. Every screen
+  ships with VoiceOver labels + Dynamic Type.
+
+## Phase 1 — the reflection loop
+
+### 1. Mid-item quick capture (Focus Player)
+
+A musician notices something in bar 12 and wants it out of their head and
+back to the keys in under five seconds.
+
+- Current: notes exist only in the hand-off sheet, and saving one advances
+  the item. The core already accepts mid-item notes; this is pure surface.
+- Design questions: where does the affordance live (player chrome vs the
+  options menu vs a gesture)? What is the capture surface: a sheet, an inline
+  field over the timer? A second capture on the same item: append visibly, or
+  edit the existing note? Does the timer visibly keep running during capture
+  (it should feel like it never stopped)?
+
+### 2. Reflection hand-off sheet + tempo (Focus Player)
+
+The existing between-items beat (score 1–10 + note) gains achieved tempo.
+
+- Current: `ReflectionSheet` is score + note + "Save & continue".
+- Design questions: how does tempo enter without bloating the beat: stepper,
+  numeric pad, prefill from the item's target? Is it visible by default or
+  only when the item has a tempo target? (Lean: only when relevant;
+  progressive disclosure.)
+
+### 3. Structured end-of-session reflection (Session Summary)
+
+Three prompts: what improved, what's still broken, what to target next time,
+shown against the session's stated intention.
+
+- Current: one unlabelled free-text box.
+- Design questions: three fields or one guided flow? How does the stated
+  intention get echoed (header quote, ghost text)? How does "skippable" look
+  without reading as "skip me"? Where does the next-target answer preview
+  that it will resurface ("we'll suggest this as the aim next time")?
+
+### 4. Session intention (Session Builder)
+
+"What is this session for?" — set once at build time, echoed in the player
+and at reflection.
+
+- Current: the core supports it; iOS never sends it. The per-entry Aim
+  exists; this is the session-level sibling.
+- Design questions: where in the builder does it live without becoming a
+  form? Is it ever prompted, or purely optional? Relationship to a goal
+  (phase 4): does picking a goal prefill the intention?
+
+## Phase 2 — narrative progress
+
+### 5. Session detail (new screen)
+
+Past sessions become tappable: a read-only recap of intention, per-item
+scores and notes, session reflection.
+
+- Current: `SessionCard` rows are dead ends; everything written is invisible
+  after saving.
+- Design questions: how much hierarchy does a recap need (it is a reading
+  surface, the first one in the app)? Does it reuse the Summary's recap rows
+  or want a calmer, journal-like treatment?
+
+### 6. Item note history (Library detail)
+
+An exercise's own timeline of what you said about it, next to its score ring.
+
+- Design questions: interleave notes with the score history or a separate
+  list? How many entries before truncation + "see all"?
+
+### 7. Progress, with your words in it (Progress tab)
+
+Reflections quoted next to the quantitative deltas; aim-attainment as the
+headline stat; cold-score trends when cold scoring lands.
+
+- Design questions: what does a quote look like in the Paper &amp; Score
+  language (this is the surface where the serif voice could earn its keep)?
+  How do words and numbers pair in one card without clutter? What is the
+  empty state before enough reflections exist?
+
+## Look-ahead (rough passes only)
+
+### 8. Goals v1 surfaces (phase 4)
+
+A rough exploration exists (Claude Code artifact "Goals v1 sketch",
+2026-07-14; ask Claude Code to re-share): Practice-tab goal card, creation
+sheet, item-detail chip. Redo properly against the kit when phase 4 nears.
+The shape is locked (statement + linked items + optional freeform target);
+the design question is how quiet the Practice-tab presence can be while
+still framing the recommendation card.
+
+### 9. Today's plan (phase 5)
+
+The recommendation card: named entries with one-line reasons, one-tap start,
+"tweak it instead" as the escape hatch. Worth a rough pass now because it
+competes with the hero for the Practice tab's one primary action; decide
+early which wins when a plan exists.

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -167,3 +167,16 @@ irreversible actions → confirm dialog.** New destructive actions default to th
 undo-toast path unless the data loss is unrecoverable. Existing destructive
 actions (e.g. item delete's confirm sheet) need a per-action audit to reclassify
 — tracked as a follow-on issue.
+
+### T7 — Reflection capture vs "the app disappears during practice"
+**Status:** DECIDED 2026-07-14 (vision/journey audit).
+Reflection is the good friction T1 protects, but capture must never cost flow.
+Rules: **mid-item capture is one tap from the player, saves, and returns
+straight to the running timer; it never forces an advance** (the current
+hand-off sheet conflates "note" with "next"; that coupling is a bug, not a
+design). **End-of-session reflection is structured**: what improved, what's
+still broken, what to target next time, shown against the session's stated
+intention, skippable, and never a gate on saving. What's captured must feed
+forward: the "next target" answer surfaces as the item's suggested aim next
+time, and reflections are re-readable (session detail, item history, progress
+report). A note the user can never see again is admin, not reflection.

--- a/docs/design-workflow.md
+++ b/docs/design-workflow.md
@@ -16,11 +16,14 @@ The `.dc.html` is the working file; the `.html` is its exported snapshot. Both
 trace back to `Theme.swift` — the reference visualises the tokens, it never
 defines new ones.
 
-A synced copy lives in the claude.ai/design project **"Intrada Paper & Score"**
-(design system, screen mockups, process docs, briefs) so Claude Design sessions
-can pull it directly. **The repo stays canonical**: sync direction is repo →
-project, pushed via `DesignSync` after design files change here. Mockups made
-in Claude Design still land back in the repo per the SDLC steps below.
+The Claude Design workspace is the claude.ai/design project **"Intrada"**
+(`claude.ai/design/p/cd74e299-f5c1-4915-a603-347db46158d6`). **The repo stays
+canonical**: Claude Code bridges the two with `DesignSync` — pushing repo
+design files up after they change here, and pulling finished mockups down
+(design sessions save to project paths like `mockups/`; they cannot write to
+GitHub or the repo). Pulled mockups land under `specs/<feature>/design/` per
+the SDLC steps below, with `support.js` copied alongside so they render
+standalone.
 
 ## Committing it
 

--- a/docs/design-workflow.md
+++ b/docs/design-workflow.md
@@ -16,6 +16,12 @@ The `.dc.html` is the working file; the `.html` is its exported snapshot. Both
 trace back to `Theme.swift` — the reference visualises the tokens, it never
 defines new ones.
 
+A synced copy lives in the claude.ai/design project **"Intrada Paper & Score"**
+(design system, screen mockups, process docs, briefs) so Claude Design sessions
+can pull it directly. **The repo stays canonical**: sync direction is repo →
+project, pushed via `DesignSync` after design files change here. Mockups made
+in Claude Design still land back in the repo per the SDLC steps below.
+
 ## Committing it
 
 1. Copy into the repo:

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -1,0 +1,54 @@
+# The Ideal Journey
+
+> Canonical walkthrough of what Intrada is for, written from the musician's
+> side of the screen. Every feature is judged against this document: if a
+> change doesn't move one of these steps forward, ask why it's being built.
+> Status column last audited 2026-07-14 (vision/journey audit). Use this as
+> the walking-skeleton checklist: before starting new feature work, walk the
+> ten steps on a device; the first place the journey breaks is the next
+> priority.
+
+## The journey, told as one story
+
+I'm learning a jazz standard. The tune lives in my **library** alongside
+everything else I'm working on. To build it up (and build the ability to
+improvise over it) I create the **exercises and activities that scaffold it**:
+learn the melody, shells in each inversion, scales down to each chord tone on
+every change, improvising on limited chord tones, improvising in rhythm only.
+Each of those is **tracked separately**: its own score, its own tempo, its own
+keys, its own reps.
+
+Intrada knows my **goals**, so when I sit down to practise it **recommends a
+session**: drawn from what I'm working towards, what's going stale, and where
+I'm weak. **Focus mode guides me through it** one exercise at a time and stays
+out of the way. When something clicks (or breaks) mid-exercise, I can **jot it
+in the moment** without stopping. At the end I **reflect properly**: what
+improved, what's still broken, what to target next time.
+
+Later, my **progress report speaks my language**: not just charts, but what I
+actually said, played back against the numbers. And when an exercise stops
+serving me, Intrada **suggests alternatives** that work the same skill.
+
+## The ten steps
+
+| # | Step | What "done" means | Status (2026-07) |
+|---|------|-------------------|------------------|
+| 1 | Library of pieces | Add a piece in seconds, enrich progressively: composer, key(s), tempo, difficulty, named sections. Find it by any facet. | Partial – multi-key (#46), difficulty (#372), sections (#50) missing |
+| 2 | Exercises scaffold a piece | Build and maintain an ordered set of related exercises per piece; create inline; navigate both directions; practise as a block. | Built |
+| 3 | Track each exercise separately | An exercise's detail answers "how is this going?" across score, tempo, reps, and keys. | Partial – score only; tempo has no iOS input, reps not aggregated, keys absent |
+| 4 | Goals drive planning | Capture an outcome ("learn Body and Soul") linked to items; planning consumes it. | Missing – rebuilt small per the 2026-07 ruling (roadmap Q5) |
+| 5 | Recommended sessions | The Practice tab proposes one concrete session with per-item reasons; one tap starts it. | Missing – signals exist in core, nothing composes them |
+| 6 | Guided focus mode | One item at a time, chrome-free, survives interruption and relaunch. | Built – crash recovery (#962) and pause (#1000) outstanding |
+| 7 | Reflection in the moment | One-tap capture mid-item that saves and returns to the timer; never forces advance. | Partial – capture only at item hand-off, and it advances |
+| 8 | End-of-session reflection | Structured prompts (improved / still broken / next target) against the session's intention; skippable, never a gate. | Partial – single unlabelled note box |
+| 9 | Narrative progress | Past sessions re-readable; item note history visible; Progress quotes your words next to the deltas. | Missing on iOS – notes persist but are write-only |
+| 10 | Suggest alternative exercises | 2–3 quiet, dismissible suggestions that work the same skill; one tap to adopt. | Missing |
+
+## Priority within the journey
+
+The front half (1–3, 6) is the logbook; the back half (4, 5, 7–10) is the
+companion. The companion loop is what differentiates Intrada: reflection feeds
+narrative progress, narrative progress and goals feed recommendation,
+recommendation feeds the next session. Sequence work to close that loop:
+reflection first (cheapest, highest leverage), then narrative surfaces, then
+tracking completeness, then goals, then recommendation, then suggestions.

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -36,9 +36,9 @@ serving me, Intrada **suggests alternatives** that work the same skill.
 | 1 | Library of pieces | Add a piece in seconds, enrich progressively: composer, key(s), tempo, difficulty, named sections. Find it by any facet. | Partial – multi-key (#46), difficulty (#372), sections (#50) missing |
 | 2 | Exercises scaffold a piece | Build and maintain an ordered set of related exercises per piece; create inline; navigate both directions; practise as a block. | Built |
 | 3 | Track each exercise separately | An exercise's detail answers "how is this going?" across score, tempo, reps, and keys. | Partial – score only; tempo has no iOS input, reps not aggregated, keys absent |
-| 4 | Goals drive planning | Capture an outcome ("learn Body and Soul") linked to items; planning consumes it. | Missing – rebuilt small per the 2026-07 ruling (roadmap Q5) |
+| 4 | Goals drive planning | Capture an outcome ("learn Body and Soul") linked to items; planning consumes it. | Missing – to be rebuilt small per the 2026-07 ruling (roadmap Q5) |
 | 5 | Recommended sessions | The Practice tab proposes one concrete session with per-item reasons; one tap starts it. | Missing – signals exist in core, nothing composes them |
-| 6 | Guided focus mode | One item at a time, chrome-free, survives interruption and relaunch. | Built – crash recovery (#962) and pause (#1000) outstanding |
+| 6 | Guided focus mode | One item at a time, chrome-free, survives interruption and relaunch. | Partial – guided loop shipped; crash recovery (#962) and pause (#1000) outstanding |
 | 7 | Reflection in the moment | One-tap capture mid-item that saves and returns to the timer; never forces advance. | Partial – capture only at item hand-off, and it advances |
 | 8 | End-of-session reflection | Structured prompts (improved / still broken / next target) against the session's intention; skippable, never a gate. | Partial – single unlabelled note box |
 | 9 | Narrative progress | Past sessions re-readable; item note history visible; Progress quotes your words next to the deltas. | Missing on iOS – notes persist but are write-only |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,9 +158,20 @@ These are unresolved product questions. Each one likely produces issues
    The teacher-assignment capture (#267) addressed the immediate capture
    problem without teacher-facing features.
 
-5. **Goals → priority flag (resolved).** Goals were judged too complex from a user's perspective and removed. Direction is now a lightweight per-item `priority` flag (see `specs/priority-items.md`); "Plan" is a view over the library. Foundation shipped (#765); the priority UI and a Track "neglected priority" signal are tracked in #763 / #764.
+5. **Goals (re-resolved 2026-07-14).** History: goals were built twice
+   (lessons #273, then Goals #711–#740), judged too complex, and removed
+   twice (last #769), leaving the per-item `priority` flag (#765,
+   `specs/priority-items.md`). The vision/journey audit reopened the
+   question: the ideal journey requires goals that *drive planning*, and
+   the ruling is to rebuild them deliberately small: an outcome statement
+   linked to library items with an optional target date, consumed by
+   session planning, and none of the confidence/photo apparatus that sank
+   the previous versions. The priority star stays as the zero-ceremony
+   layer beneath. See VISION.md "The Scheduling Intelligence" and
+   `docs/journeys.md` step 4.
 
-6. **Lessons / photos / R2 surface.** A lessons + photos surface
-   (#274–#281) has started shipping without a roadmap home. Decide
-   whether it's a Layer-1 Capture feature, a separate teacher-facing
-   surface, or scaffolding to roll back.
+6. **Lessons / photos / R2 surface (resolved 2026-07-14).** Rolled back:
+   the lessons vertical was superseded by Goals and both were removed in
+   #769 (migrations 0081–0083); nothing dormant remains. #570 closed as
+   part of the vision/journey audit. R2 photo storage hardening (#281)
+   survives independently as a security item.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -159,9 +159,11 @@ These are unresolved product questions. Each one likely produces issues
    problem without teacher-facing features.
 
 5. **Goals (re-resolved 2026-07-14).** History: goals were built twice
-   (lessons #273, then Goals #711–#740), judged too complex, and removed
-   twice (last #769), leaving the per-item `priority` flag (#765,
-   `specs/priority-items.md`). The vision/journey audit reopened the
+   (an early goals feature, removed in #213 for a ground-up redesign;
+   then Goals #711–#740, removed in #769), with the lessons vertical
+   (#273) in between, leaving the per-item `priority` flag (#765,
+   `specs/priority-items.md`; priority UI and "neglected priority"
+   signal tracked in #763 / #764). The vision/journey audit reopened the
    question: the ideal journey requires goals that *drive planning*, and
    the ruling is to rebuild them deliberately small: an outcome statement
    linked to library items with an optional target date, consumed by
@@ -171,7 +173,8 @@ These are unresolved product questions. Each one likely produces issues
    `docs/journeys.md` step 4.
 
 6. **Lessons / photos / R2 surface (resolved 2026-07-14).** Rolled back:
-   the lessons vertical was superseded by Goals and both were removed in
-   #769 (migrations 0081–0083); nothing dormant remains. #570 closed as
+   the lessons vertical was superseded by Goals in #711 (migrations
+   0067–0068 dropped the lesson tables); Goals were then removed in #769
+   (migrations 0081–0083). Nothing dormant remains, so #570 closes as
    part of the vision/journey audit. R2 photo storage hardening (#281)
    survives independently as a security item.

--- a/specs/reflection-loop/design/DECISIONS.md
+++ b/specs/reflection-loop/design/DECISIONS.md
@@ -1,0 +1,86 @@
+# Reflection & narrative — Phase 1 · direction explorations & decisions
+
+Brief: `design/briefs/2026-07-reflection-and-narrative.md`.
+Mockups: this folder, one `.dc.html` per surface. The annotated journey view
+(all four frames + designer notes) is `design/Reflection Narrative.dc.html`.
+
+## Hard constraints honoured (from the brief)
+- Mid-item capture never forces an advance; returns straight to the running timer.
+- The player stays bare — anything new is one gesture down, not resident chrome.
+- End-of-session reflection is skippable and never gates saving.
+- One primary action per screen.
+- Tokens only — no new colours or spacing; new primitives flagged, not invented.
+
+---
+
+## Surface 1 — Mid-item quick capture (`focus-player-quick-capture.dc.html`)
+
+Directions explored:
+- **A. Resident note button in the transport row** — rejected: resident chrome
+  on the bare player, the exact thing the brief bans.
+- **B. Compact bottom sheet, one swipe up** — ✅ recommended. Reuses the
+  hand-off sheet's grammar (handle, paper surface, dim scrim); the timer ring
+  stays visible and ticking behind it; Save/Close land back on the running
+  timer; also reachable via •••.
+- **C. Long-press the item title → inline field** — rejected: invisible
+  affordance, collides with future title actions.
+
+Details: note stamped at gesture time ("at 3:12" chip, gold); one primary
+action (Save note); Close is a text button; swipe-down also dismisses.
+This decision sets the app's capture grammar — sheets over a live player —
+which surfaces 2–4 follow.
+
+## Surface 2 — Achieved tempo on the hand-off sheet (`reflection-sheet-tempo.dc.html`)
+
+Directions explored:
+- **A. Stepper prefilled at the item's target** — ✅ recommended. Most results
+  land a few taps from target; 44×44 buttons; ±2 bpm; clamp 40–208; no
+  keyboard mid-sheet. Untouched = a true "played at target".
+- **B. Free numeric field** — rejected: summons a keyboard over the sheet.
+- **C. Slider** — rejected: hopeless precision across ♩ = 40–208.
+
+Placement: between ScoreSelector and the note. "Skip rating" still skips
+everything. **Flag: TempoStepper is the one new primitive candidate** — built
+from existing tokens (hairline `#D8D0BD`, card `#FCFAF3`, radius 12); goes into
+`Theme.swift` + the DS together if accepted.
+
+## Surface 3 — Structured reflection on the summary (`session-summary-reflection.dc.html`)
+
+Directions explored:
+- **A. Inline on the summary** — ✅ recommended. Intention echoed verbatim
+  (gold card, serif italic), then three prompt rows: **Improved** (green ·
+  trending-up) / **Still rough** (gold · wrench) / **Next target** (indigo ·
+  target). Blank rows save as nothing.
+- **B. Post-save interstitial** — rejected: gates the primary action.
+- **C. Single free-text** — what ships today; loses the structure the brief asks for.
+
+To make room, "What you played" collapses to a one-line row (mastery move in
+its subtitle); tap expands the shipped ledger unchanged. **Save session stays
+the only primary action.** Tweak `reflectionFilled` shows the empty state.
+
+## Surface 4 — Session intention in the builder (`session-builder-intention.dc.html`)
+
+Directions explored:
+- **A. Optional single line under the "Build session" header** — ✅ recommended.
+  Intention-before friction spent where the plan is made; feather icon, gold;
+  placeholder "What's today about? One line."
+- **B. Inside the sticky Start bar** — rejected: competes with the one primary action.
+- **C. Interstitial after tapping Start** — rejected: a whole screen for one sentence.
+
+The text threads to the summary echo (surface 3) — `intentionText` tweak
+drives both mockups.
+
+---
+
+## Fold-in list on sign-off (per design-process.md)
+1. **TempoStepper** → `Theme.swift` + DS catalogue (the one new primitive).
+2. **Compact BottomSheet detent** → variant on the shared BottomSheet.
+3. **ReflectionPromptRow** (icon circle + eyebrow + line) → DS when reused.
+4. Intention field pattern; builder/summary pillar updates in the DS gallery.
+
+## Implementation notes for the core
+- Mid-item capture writes notes on a **pending** entry (the hand-off sheet
+  writes on a completed one) — may need a notes-append/timestamped-note event.
+- Achieved tempo rides with the existing entry-update events at hand-off
+  (order per #1042: notes → NextItem → score).
+- Intention + the three reflection prompts are session-level fields.

--- a/specs/reflection-loop/design/HANDOFF.md
+++ b/specs/reflection-loop/design/HANDOFF.md
@@ -1,0 +1,63 @@
+# Handoff — Reflection & narrative, Phase 1 (brief: design/briefs/2026-07-reflection-and-narrative.md)
+
+## Commit
+- Copy `Reflection Narrative.dc.html` into `design/` (siblings `support.js` and
+  `Focus Player.dc.html` already live there — the file imports the Focus Player
+  via `<dc-import>` and loads `./support.js`, so it must sit next to them).
+  If you keep it under `specs/NNN-reflection-and-narrative/design/`, copy those
+  two files alongside it or the frame won't render.
+- Open in a browser (or Claude Design) to review; four annotated phone frames.
+
+## The four surfaces — decisions to implement
+
+### 1. Mid-item quick capture (Focus Player)
+- A **compact bottom sheet**, one swipe up from the bare player (also via •••).
+  No resident chrome added to the player.
+- Contents: "QUICK NOTE" label, timestamp chip (stamped at gesture time, e.g.
+  "at 3:12"), 3-row note field, primary **Save note**, text **Close**.
+- Timer never pauses; sheet never advances the item; Save/Close return to the
+  running timer. Wire to the existing `updateEntryNotes` path (mid-session
+  writes on a not-yet-completed entry — note this is a *pending* entry, unlike
+  the hand-off sheet's completed-entry writes; may need a notes-append or
+  timestamped-note event in core).
+
+### 2. Hand-off sheet + achieved tempo
+- Insert a **TempoStepper** row between the ScoreSelector and the note field:
+  label "TEMPO REACHED · target ♩ = N", 44×44 −/+ buttons (±2 bpm, clamp
+  40–208), value prefilled at the item's target.
+- **New primitive candidate** — flagged, not invented: hairline border
+  `#D8D0BD`, card surface `#FCFAF3`, radius 12, Inter 24 semibold tabular.
+  If accepted: add to `Theme.swift` + the design system in the same PR.
+- "Skip rating" skips everything, unchanged. Save order per #1042 stays
+  (notes → NextItem → score; tempo rides with the entry updates).
+
+### 3. Structured end-of-session reflection (Session Summary)
+- New blocks above the ledger: **intention echo** (gold card, serif italic,
+  quotes the builder intention verbatim) + three prompt rows:
+  **Improved** (green/trending-up) · **Still rough** (gold/wrench) ·
+  **Next target** (indigo/target). Single-line each, all optional.
+- Blank prompts save as nothing; **Save session stays the only primary action**
+  — reflection never gates saving.
+- "What you played" collapses to a one-line row (count + mastery move in the
+  subtitle); tap expands the shipped ledger rows unchanged.
+
+### 4. Session intention (Session Builder)
+- Optional single-line field directly under the "Build session" header:
+  label "TODAY'S INTENTION · OPTIONAL" (feather icon, gold), standard input
+  chrome. Placeholder: "What's today about? One line."
+- Text is stored on the session and echoed verbatim by surface 3.
+- Rejected: in the sticky Start bar (competes with the one primary action)
+  and a post-Start interstitial (a screen for one sentence).
+
+## Hard constraints honoured (from the brief)
+- Capture never forces an advance; returns straight to the running timer.
+- Player stays bare — everything new is one gesture down.
+- End-of-session reflection is skippable and never gates saving.
+- One primary action per screen. Tokens only — zero new colours/spacing.
+
+## Fold-in list (on sign-off, per design-process.md)
+1. **TempoStepper** → Theme.swift + DS catalogue (the one new primitive).
+2. **Compact BottomSheet detent** → variant on the shared BottomSheet.
+3. **ReflectionPromptRow** (icon circle + label + line) → DS if reused.
+4. Intention field pattern; summary/builder pillar updates in the DS gallery.
+5. Strip superseded frames from this journey file after fold-in.

--- a/specs/reflection-loop/design/focus-player-quick-capture.dc.html
+++ b/specs/reflection-loop/design/focus-player-quick-capture.dc.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; }
+  a { color: #4C3FA6; } a:hover { color: #6346E5; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div data-screen-label="Focus · quick capture" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+  <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+    <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+    <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+    <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+      <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">FOCUS · 3 OF 5</span><i data-lucide="ellipsis" width="22" height="22" style="color:#6E6557;"></i></div>
+      <div style="display:flex;gap:5px;margin-top:14px;"><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#6346E5,#4C3FA6);"></span><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#6346E5,#4C3FA6);"></span><span style="flex:1;height:4px;border-radius:999px;background:linear-gradient(90deg,#9E7B33,#8A6A2E);"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span></div>
+      <div style="text-align:center;margin-top:20px;">
+        <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;"><i data-lucide="dumbbell" width="12" height="12"></i>Exercise</span>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:27px;color:#2B2A26;line-height:1.1;margin-top:12px;">Scales · D♭ major</div>
+      </div>
+      <div style="flex:1;display:flex;align-items:flex-start;justify-content:center;padding-top:22px;min-height:0;">
+        <div style="position:relative;width:206px;height:206px;">
+          <svg width="206" height="206" viewBox="0 0 206 206" style="display:block;"><circle cx="103" cy="103" r="86" fill="none" stroke="#E5DDCB" stroke-width="10"/><circle id="qc-ring" cx="103" cy="103" r="86" fill="none" stroke="url(#qcgrad)" stroke-width="10" stroke-linecap="round" stroke-dasharray="540.354" stroke-dashoffset="293.33" transform="rotate(-90 103 103)"/><defs><linearGradient id="qcgrad" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6346E5"/><stop offset="1" stop-color="#4C3FA6"/></linearGradient></defs></svg>
+          <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;"><div id="qc-time" style="font-family:Inter;font-weight:600;font-size:46px;color:#2B2A26;font-variant-numeric:tabular-nums;line-height:1;">3:12</div><div style="font-size:12px;color:#6E6557;margin-top:6px;">of 7:00</div></div>
+        </div>
+      </div>
+    </div>
+    <div style="position:absolute;inset:0;background:rgba(43,42,38,0.22);z-index:40;"></div>
+    <div style="position:absolute;left:0;right:0;bottom:0;z-index:50;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);padding:0 22px 30px;animation:fadeUp .4s ease both;">
+      <div style="display:flex;justify-content:center;padding:12px 0 6px;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+      <div style="display:flex;align-items:center;justify-content:space-between;margin-top:6px;">
+        <div style="font-size:11px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#9A927F;">Quick note</div>
+        <span style="display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;font-variant-numeric:tabular-nums;"><i data-lucide="timer" width="12" height="12"></i>at 3:12</span>
+      </div>
+      <textarea rows="3" placeholder="What just happened? One line is plenty." style="width:100%;border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:13px 14px;font-family:Inter;font-size:14px;line-height:1.55;color:#2B2A26;resize:none;outline:none;margin-top:12px;transition:border-color .15s;" style-focus="border-color:#4C3FA6;">Bars 12–14 rushing again — metronome back to 80.</textarea>
+      <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:14px;cursor:pointer;" style-active="transform:scale(0.985)">Save note</button>
+      <button style="display:block;margin:0 auto;background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Close</button>
+    </div>
+    <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:392,&quot;height&quot;:860}}">
+class Component extends DCLogic {
+  componentDidMount() {
+    if (window.lucide) window.lucide.createIcons();
+    const r = 86, circ = 2 * Math.PI * r, total = 420;
+    let sec = 192;
+    const ring = document.querySelector('#qc-ring'), time = document.querySelector('#qc-time');
+    this._t = setInterval(() => {
+      sec++; if (sec > total) sec = 192;
+      if (time) { const m = Math.floor(sec / 60), s = sec % 60; time.textContent = m + ':' + String(s).padStart(2, '0'); }
+      if (ring) ring.setAttribute('stroke-dashoffset', circ * (1 - sec / total));
+    }, 1000);
+  }
+  componentWillUnmount() { if (this._t) clearInterval(this._t); }
+}
+</script>
+</body>
+</html>

--- a/specs/reflection-loop/design/reflection-sheet-tempo.dc.html
+++ b/specs/reflection-loop/design/reflection-sheet-tempo.dc.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; }
+  a { color: #4C3FA6; } a:hover { color: #6346E5; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div data-screen-label="Hand-off · score + tempo" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+  <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:#2B2A26;display:flex;flex-direction:column;">
+    <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+    <div style="position:absolute;inset:0;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC,#E7E2D2);opacity:0.3;"></div>
+    <div style="position:absolute;left:0;right:0;bottom:0;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);display:flex;flex-direction:column;padding:0 22px 30px;animation:fadeUp .4s ease both;">
+      <div style="display:flex;justify-content:center;padding:12px 0 6px;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+      <div style="text-align:center;margin-top:10px;">
+        <div style="font-size:11px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#8A6A2E;">Item complete · 7:00</div>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:24px;color:#2B2A26;line-height:1.1;margin-top:8px;">How did <span style="white-space:nowrap;">Scales · D♭</span> go?</div>
+      </div>
+      <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;">Score</div>
+      <div id="ho-score" style="display:flex;justify-content:space-between;gap:4px;margin-top:10px;">
+        <span class="rateDot" data-v="1" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">1</span>
+        <span class="rateDot" data-v="2" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">2</span>
+        <span class="rateDot" data-v="3" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">3</span>
+        <span class="rateDot" data-v="4" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">4</span>
+        <span class="rateDot" data-v="5" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">5</span>
+        <span class="rateDot" data-v="6" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">6</span>
+        <span class="rateDot" data-v="7" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">7</span>
+        <span class="rateDot" data-v="8" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">8</span>
+        <span class="rateDot" data-v="9" style="flex:1;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:14px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">9</span>
+        <span class="rateDot" data-v="10" style="flex:1.4;height:34px;border-radius:9px;border:1.5px solid #D8D0BD;display:flex;align-items:center;justify-content:center;font-family:Inter;font-size:13px;font-weight:600;color:#6E6557;cursor:pointer;transition:all .15s;">10</span>
+      </div>
+      <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;">Tempo reached <span style="color:#B0A892;font-weight:500;text-transform:none;letter-spacing:0;">· target ♩ = 96</span></div>
+      <div style="display:flex;align-items:center;gap:12px;margin-top:10px;">
+        <button id="tempo-minus" style="width:44px;height:44px;border-radius:12px;border:1.5px solid #D8D0BD;background:#FCFAF3;display:flex;align-items:center;justify-content:center;color:#6E6557;cursor:pointer;flex:none;" style-active="transform:scale(0.93)"><i data-lucide="minus" width="18" height="18"></i></button>
+        <div style="flex:1;text-align:center;font-family:Inter;font-weight:600;font-size:24px;color:#2B2A26;font-variant-numeric:tabular-nums;">♩ = <span id="tempo-val">92</span></div>
+        <button id="tempo-plus" style="width:44px;height:44px;border-radius:12px;border:1.5px solid #D8D0BD;background:#FCFAF3;display:flex;align-items:center;justify-content:center;color:#6E6557;cursor:pointer;flex:none;" style-active="transform:scale(0.93)"><i data-lucide="plus" width="18" height="18"></i></button>
+      </div>
+      <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:20px;margin-bottom:9px;">Reflection · optional</div>
+      <textarea rows="2" placeholder="What went well? What to fix next time?" style="width:100%;border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:13px 14px;font-family:Inter;font-size:14px;line-height:1.55;color:#2B2A26;resize:none;outline:none;transition:border-color .15s;" style-focus="border-color:#4C3FA6;">RH evenness much better at 92.</textarea>
+      <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:16px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;" style-active="transform:scale(0.985)">Save &amp; continue<i data-lucide="arrow-right" width="16" height="16"></i></button>
+      <button style="background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Skip rating</button>
+    </div>
+    <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#F2EFE8;opacity:0.5;z-index:60;"></div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:392,&quot;height&quot;:860},&quot;achievedTempo&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:92,&quot;min&quot;:40,&quot;max&quot;:208,&quot;unit&quot;:&quot;bpm&quot;,&quot;tsType&quot;:&quot;number&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() {
+    if (window.lucide) window.lucide.createIcons();
+    const dots = Array.from(document.querySelectorAll('#ho-score .rateDot'));
+    const paint = (v) => {
+      dots.forEach((d) => {
+        const on = Number(d.dataset.v) <= v;
+        d.style.background = on ? '#4C3FA6' : 'transparent';
+        d.style.borderColor = on ? '#4C3FA6' : '#D8D0BD';
+        d.style.color = on ? '#F2EFE8' : '#6E6557';
+      });
+    };
+    dots.forEach((d) => d.addEventListener('click', () => paint(Number(d.dataset.v))));
+    paint(8);
+    let v = this.props.achievedTempo ?? 92;
+    const val = document.querySelector('#tempo-val');
+    const set = (n) => { v = Math.max(40, Math.min(208, n)); if (val) val.textContent = v; };
+    const minus = document.querySelector('#tempo-minus'), plus = document.querySelector('#tempo-plus');
+    if (minus) minus.addEventListener('click', () => set(v - 2));
+    if (plus) plus.addEventListener('click', () => set(v + 2));
+    set(v);
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/reflection-loop/design/session-builder-intention.dc.html
+++ b/specs/reflection-loop/design/session-builder-intention.dc.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; }
+  a { color: #4C3FA6; } a:hover { color: #6346E5; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div data-screen-label="Builder · session intention" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+  <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+    <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+    <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;"><span style="font-size:14px;color:#6E6557;font-weight:500;">Cancel</span><span style="width:48px;"></span></div>
+    <div style="padding:8px 18px 4px;flex:none;">
+      <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Build session</div>
+      <div style="font-size:12.5px;color:#6E6557;margin-top:5px;">32 min · 3 blocks · 5 items</div>
+    </div>
+    <div style="padding:10px 18px 0;flex:none;">
+      <div style="display:flex;align-items:center;gap:7px;"><i data-lucide="feather" width="14" height="14" style="color:#8A6A2E;"></i><span style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's intention · optional</span></div>
+      <div style="border:1px solid #E5DECD;background:#FCFAF3;border-radius:13px;padding:12px 14px;font-size:14px;line-height:1.5;color:#2B2A26;margin-top:8px;">{{ intention }}</div>
+    </div>
+    <div style="flex:1;overflow:hidden;padding:12px 16px 100px;display:flex;flex-direction:column;gap:12px;">
+      <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s ease both;">
+        <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+        <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#6346E5,#4C3FA6);flex:none;"></span>
+        <div style="flex:1;min-width:0;"><div style="display:flex;align-items:center;gap:7px;"><span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Clair de Lune</span><span style="font-size:9.5px;font-weight:600;letter-spacing:.4px;text-transform:uppercase;color:#4C3FA6;background:#E7E3F4;border-radius:6px;padding:1.5px 6px;">Group</span></div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">2 related, then piece · 18 min</div></div>
+        <i data-lucide="chevron-down" width="19" height="19" style="color:#9A927F;flex:none;"></i>
+      </div>
+      <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s .06s ease both;">
+        <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+        <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#6346E5,#4C3FA6);flex:none;"></span>
+        <div style="flex:1;min-width:0;"><div style="display:flex;align-items:center;gap:7px;"><span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Nocturne Op.9</span><span style="font-size:11px;color:#6E6557;">+2 related</span></div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">14 min</div></div>
+        <i data-lucide="chevron-down" width="19" height="19" style="color:#9A927F;flex:none;"></i>
+      </div>
+      <div style="display:flex;align-items:center;gap:11px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:14px 14px;animation:fadeUp .5s .12s ease both;">
+        <i data-lucide="grip-vertical" width="20" height="20" style="color:#B0A892;flex:none;"></i>
+        <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+        <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;">Sight-reading</div><div style="font-size:11.5px;color:#6E6557;margin-top:2px;">Standalone exercise · 6 min</div></div>
+        <i data-lucide="x" width="18" height="18" style="color:#9A927F;flex:none;"></i>
+      </div>
+      <button style="width:100%;border:1px dashed #C9C0AC;background:transparent;color:#4C3FA6;font-family:Inter;font-weight:600;font-size:14px;padding:14px;border-radius:14px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px;animation:fadeUp .5s .18s ease both;"><i data-lucide="plus" width="17" height="17"></i>Add piece or exercise</button>
+    </div>
+    <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;padding:12px 18px 30px;background:rgba(247,243,233,0.9);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);border-top:1px solid rgba(176,168,146,0.3);">
+      <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;" style-active="transform:scale(0.985)"><i data-lucide="play" width="17" height="17" style="fill:#F2EFE8;"></i>Start session · 32 min</button>
+    </div>
+    <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:392,&quot;height&quot;:860},&quot;intentionText&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Even RH at 96 through bars 12–14&quot;,&quot;tsType&quot;:&quot;string&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() { if (window.lucide) window.lucide.createIcons(); }
+  componentDidUpdate() { if (window.lucide) window.lucide.createIcons(); }
+  renderVals() {
+    return { intention: this.props.intentionText ?? 'Even RH at 96 through bars 12–14' };
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/reflection-loop/design/session-summary-reflection.dc.html
+++ b/specs/reflection-loop/design/session-summary-reflection.dc.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; }
+  a { color: #4C3FA6; } a:hover { color: #6346E5; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @keyframes toastIn { 0% { opacity: 0; transform: translateY(-10px) scale(.96); } 100% { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div data-screen-label="Summary · structured reflection" style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;font-family:'Inter',system-ui,sans-serif;">
+  <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+    <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+    <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+    <div style="flex:1;display:flex;flex-direction:column;padding:14px 18px 26px;min-height:0;">
+      <div style="animation:fadeUp .5s ease both;"><div style="font-size:11px;font-weight:600;letter-spacing:1.8px;color:#9E7B33;">SESSION COMPLETE</div><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1.05;margin-top:6px;">Nice work.</div><div style="font-size:13px;color:#6E6557;margin-top:5px;">42 min · 3 of 4 items</div></div>
+      <div style="display:flex;align-items:flex-start;gap:12px;padding:13px 16px;border-radius:14px;background:linear-gradient(120deg,#F1E9D6,#ECE0C6);border:1px solid #E6D6B0;margin-top:16px;animation:toastIn .55s .3s ease both;">
+        <i data-lucide="quote" width="16" height="16" style="color:#9E7B33;flex:none;margin-top:2px;"></i>
+        <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#7A6A3F;">Your intention</div><div style="font-family:'Source Serif 4',serif;font-style:italic;font-size:15.5px;color:#2B2A26;line-height:1.4;margin-top:4px;">“{{ intention }}”</div></div>
+      </div>
+      <div style="margin-top:18px;font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Reflect · optional</div>
+      <div style="flex:none;margin-top:4px;">
+        <sc-if value="{{ reflectionFilled }}" hint-placeholder-val="{{ true }}">
+          <div>
+            <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#E7F1EB;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="trending-up" width="15" height="15" style="color:#1F8A5B;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Improved</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Thumb-unders even at 92 — bars 1–8 clean twice in a row.</div></div>
+            </div>
+            <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#F0E5CC;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="wrench" width="15" height="15" style="color:#8A6A2E;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Still rough</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Bars 12–14 rush every run past 88.</div></div>
+            </div>
+            <div style="display:flex;align-items:flex-start;gap:12px;padding:12px 0;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="target" width="15" height="15" style="color:#4C3FA6;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Next target</div><div style="font-size:13.5px;line-height:1.5;color:#2B2A26;margin-top:3px;">Bars 12–14 at 80, hands together, before pushing tempo.</div></div>
+            </div>
+          </div>
+        </sc-if>
+        <sc-if value="{{ reflectionEmpty }}" hint-placeholder-val="{{ false }}">
+          <div>
+            <div style="display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#E7F1EB;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="trending-up" width="15" height="15" style="color:#1F8A5B;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Improved</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">What moved forward?</div></div>
+            </div>
+            <div style="display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid #E5DECD;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#F0E5CC;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="wrench" width="15" height="15" style="color:#8A6A2E;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Still rough</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">What's still fighting you?</div></div>
+            </div>
+            <div style="display:flex;align-items:center;gap:12px;padding:12px 0;">
+              <span style="width:28px;height:28px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="target" width="15" height="15" style="color:#4C3FA6;"></i></span>
+              <div style="flex:1;min-width:0;"><div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Next target</div><div style="font-size:13.5px;color:#9A927F;margin-top:3px;">Where does the next session start?</div></div>
+            </div>
+          </div>
+        </sc-if>
+      </div>
+      <div style="flex:1;"></div>
+      <div style="display:flex;align-items:center;gap:12px;padding:13px 14px;border-radius:14px;background:#FCFAF3;border:1px solid #E5DECD;cursor:pointer;">
+        <div style="flex:1;min-width:0;"><div style="font-size:13.5px;font-weight:600;color:#2B2A26;">What you played</div><div style="font-size:11px;color:#9A927F;margin-top:2px;">3 of 4 items · Clair de Lune moved 3 → 4</div></div>
+        <i data-lucide="chevron-down" width="18" height="18" style="color:#9A927F;flex:none;"></i>
+      </div>
+      <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;margin-top:12px;cursor:pointer;" style-active="transform:scale(0.98)">Save session</button>
+      <button style="background:none;border:none;color:#6E6557;font-family:Inter;font-weight:500;font-size:14px;padding:12px 0 0;cursor:pointer;">Discard</button>
+    </div>
+    <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:392,&quot;height&quot;:860},&quot;intentionText&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;Even RH at 96 through bars 12–14&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;reflectionFilled&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() { if (window.lucide) window.lucide.createIcons(); }
+  componentDidUpdate() { if (window.lucide) window.lucide.createIcons(); }
+  renderVals() {
+    const filled = this.props.reflectionFilled ?? true;
+    return {
+      intention: this.props.intentionText ?? 'Even RH at 96 through bars 12–14',
+      reflectionFilled: filled,
+      reflectionEmpty: !filled
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/reflection-loop/design/support.js
+++ b/specs/reflection-loop/design/support.js
@@ -1,0 +1,1648 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+      const raw = t ? parseDcText(t) : null;
+      if (raw?.template) runtime.updateHtml(rootName, raw.template);
+    }).catch(() => {
+    });
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || el.getAttribute("src") || el.getAttribute("import") || "";
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const kids = hasContent ? walkChildren(el, host) : [];
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...kids.map((b, j) => b(vals, ctx, j)));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.26.4/babel.min.js";
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = BABEL_URL;
+        s.crossOrigin = "anonymous";
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => fetch(url)).then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee9";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = doc.documentElement.dataset.theme === "dark" ? "dark" : "light";
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const sel = pseudo === "before" || pseudo === "after" ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(sel + "{" + css + "}", el.sheet.cssRules.length);
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      fetch(url).then((res) => {
+        if (!res.ok) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/> failed:",
+            url,
+            "returned",
+            res.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res.text();
+      }).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            "[dc-runtime] sibling fetch for <" + name + "/>:",
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          "[dc-runtime] sibling fetch for <" + name + "/> threw:",
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/index.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      s.integrity = integrity;
+      s.crossOrigin = "anonymous";
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    return Promise.all([
+      loadScript(REACT_URL, REACT_SRI),
+      loadScript(REACT_DOM_URL, REACT_DOM_SRI)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const api = {
+      __dcUpdate: (name, kind, content, streaming) => {
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`<sc-comp>`,
+       *  `sc-camel-*` attrs); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
## Summary

Records the outcome of the 2026-07-14 vision/journey audit (23-agent review of the ten-step ideal journey against the core, the native iOS surface, and all 161 open issues).

- **VISION.md**: the Show layer gains narrative progress (progress reported in the user's own words alongside the numbers); new core principle **Reflection Closes Every Loop**; new **Piece Scaffolding** section making the piece->exercise relationship canon (the shipped Related Exercises feature had outrun the doc); the Scheduling Intelligence section records the lightweight-goals ruling.
- **docs/journeys.md** (new): the ten-step ideal journey as the canonical walkthrough and walking-skeleton checklist, with audited build status per step.
- **docs/design-principles.md**: decision **T7** — reflection capture rules: mid-item capture never forces an advance; end-of-session reflection is structured (improved / still broken / next target), skippable, never a gate; captured reflection must be re-readable.
- **docs/roadmap.md**: Open Question 5 re-resolved — goals return, deliberately small (outcome statement + linked items + optional target, consumed by planning; none of the confidence/photo apparatus that sank #213/#769). Open Question 6 resolved — lessons rolled back (#711 dropped the tables, #769 removed Goals); #570 closes with this audit.

## Review

Self-review ran via a reviewer agent verifying every factual claim against the codebase (migration numbers, issue states, per-step status claims). Four Important findings (lessons/goals chronology, #570 tense, step-6 status, dropped issue pointers) fixed in the second commit; no Blockers.

Coverage: docs only — no code paths changed, no tests expected.

Deferred items tracked: none — all flagged items addressed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)