### PR TITLE
ci(ios): derive TestFlight marketing version from the release tag

### DIFF
--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -81,6 +81,9 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           BUILD_NUMBER: ${{ github.run_number }}
+          # Tag drives the version (v0.3.0 → 0.3.0); empty on workflow_dispatch,
+          # where the Fastfile falls back to project.yml's MARKETING_VERSION.
+          MARKETING_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         run: bundle exec fastlane ios beta
       - name: Upload IPA artifact
         if: always()

--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -5,7 +5,9 @@ name: Release — TestFlight
 on:
   workflow_dispatch:
   push:
-    tags: ["v*"]
+    # X.Y.Z only: the beta lane hard-rejects other shapes, and failing at the
+    # trigger beats failing after ~15 min of 10x-billed macOS build.
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 # Don't cancel an in-flight upload if another tag/dispatch lands.
 concurrency:
@@ -81,8 +83,7 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           BUILD_NUMBER: ${{ github.run_number }}
-          # Tag drives the version (v0.3.0 → 0.3.0); empty on workflow_dispatch,
-          # where the Fastfile falls back to project.yml's MARKETING_VERSION.
+          # Empty on branch dispatch; the Fastfile then falls back to project.yml.
           MARKETING_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
         run: bundle exec fastlane ios beta
       - name: Upload IPA artifact

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,14 +51,18 @@ platform :ios do
     # GENERATE_INFOPLIST_FILE=YES (PlistBuddy on the partial plist won't work).
     build_number = ENV.fetch("BUILD_NUMBER", "1")
 
-    # Marketing version comes from the release tag (v0.3.0 → 0.3.0) so
-    # TestFlight shows each tagged release as a new version, not another build
-    # of 0.1.0. Unset (local runs, workflow_dispatch) → project.yml's value.
+    # Tag-derived (v0.3.0 → 0.3.0) so each tagged release is a new TestFlight
+    # version. Unset (local runs, branch dispatch): project.yml's value.
     marketing_version = ENV.fetch("MARKETING_VERSION", "").delete_prefix("v")
     unless marketing_version.empty? || marketing_version.match?(/\A\d+\.\d+\.\d+\z/)
       UI.user_error!("MARKETING_VERSION #{marketing_version.inspect} is not X.Y.Z")
     end
-    version_arg = marketing_version.empty? ? "" : " MARKETING_VERSION=#{marketing_version}"
+
+    xcargs = [
+      "CURRENT_PROJECT_VERSION=#{build_number}",
+      ("MARKETING_VERSION=#{marketing_version}" unless marketing_version.empty?),
+      "-clonedSourcePackagesDirPath build/spm"
+    ].compact.join(" ")
 
     build_app(
       project: "ios/Intrada.xcodeproj",
@@ -72,7 +76,7 @@ platform :ios do
       export_options: {
         provisioningProfiles: { APP_IDENTIFIER => PROFILE_NAME }
       },
-      xcargs: "CURRENT_PROJECT_VERSION=#{build_number}#{version_arg} -clonedSourcePackagesDirPath build/spm"
+      xcargs: xcargs
     )
 
     upload_to_testflight(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,6 +51,15 @@ platform :ios do
     # GENERATE_INFOPLIST_FILE=YES (PlistBuddy on the partial plist won't work).
     build_number = ENV.fetch("BUILD_NUMBER", "1")
 
+    # Marketing version comes from the release tag (v0.3.0 → 0.3.0) so
+    # TestFlight shows each tagged release as a new version, not another build
+    # of 0.1.0. Unset (local runs, workflow_dispatch) → project.yml's value.
+    marketing_version = ENV.fetch("MARKETING_VERSION", "").delete_prefix("v")
+    unless marketing_version.empty? || marketing_version.match?(/\A\d+\.\d+\.\d+\z/)
+      UI.user_error!("MARKETING_VERSION #{marketing_version.inspect} is not X.Y.Z")
+    end
+    version_arg = marketing_version.empty? ? "" : " MARKETING_VERSION=#{marketing_version}"
+
     build_app(
       project: "ios/Intrada.xcodeproj",
       scheme: "Intrada",
@@ -63,7 +72,7 @@ platform :ios do
       export_options: {
         provisioningProfiles: { APP_IDENTIFIER => PROFILE_NAME }
       },
-      xcargs: "CURRENT_PROJECT_VERSION=#{build_number} -clonedSourcePackagesDirPath build/spm"
+      xcargs: "CURRENT_PROJECT_VERSION=#{build_number}#{version_arg} -clonedSourcePackagesDirPath build/spm"
     )
 
     upload_to_testflight(

--- a/specs/ios-testflight-cicd.md
+++ b/specs/ios-testflight-cicd.md
@@ -69,7 +69,11 @@ workflow_dispatch / tag v*
    xcodebuild build setting (not PlistBuddy — under `GENERATE_INFOPLIST_FILE=YES`
    `CFBundleVersion` is generated from `CURRENT_PROJECT_VERSION`). `run_number`
    is monotonic across the repo, satisfying TestFlight's "unique build per
-   version" rule. `MARKETING_VERSION` stays `0.1.0`.
+   version" rule. `MARKETING_VERSION` is derived from the release tag
+   (`v0.3.0` → `0.3.0`), validated as `X.Y.Z` in the lane and injected the
+   same way, so each tagged release appears in TestFlight as a new version.
+   When unset (local runs, branch dispatch) the lane falls back to
+   `project.yml`'s value.
 
 5. **Release core, device slice.** The lane runs `cargo swift package … --release`
    (debug cores are 10–100× slower in hot paths). Verified at source level


### PR DESCRIPTION
## Problem

Every `v*` tag uploaded to TestFlight as **0.1.0** — the pipeline injects only `CURRENT_PROJECT_VERSION` (build number), while `MARKETING_VERSION` stays pinned at 0.1.0 in `ios/project.yml`. So v0.1.1, v0.2.0 and v0.3.0 all appeared as new builds of 0.1.0 rather than new versions.

## Change

- Workflow passes the tag name through as `MARKETING_VERSION` (empty on `workflow_dispatch`).
- The `beta` lane strips the `v` prefix, validates the value is `X.Y.Z` (fails the lane otherwise — the value is shell-interpolated into `xcargs`), and injects `MARKETING_VERSION` alongside the build number.
- Unset (local `just testflight`, `workflow_dispatch`) falls back to `project.yml`'s value, as before.

## Coverage

CI-config only — not reachable from unit tests. Verified with `ruby -c`, a derivation check for tagged/unset cases, and YAML validation. Real verification is the next `v*` tag release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)