### PR TITLE
feat(core+store): structured end-of-session reflection (phase 1 core model)

### DIFF
--- a/crates/intrada-api/src/db/sessions.rs
+++ b/crates/intrada-api/src/db/sessions.rs
@@ -223,6 +223,9 @@ fn row_to_session_without_entries(row: &libsql::Row) -> Result<PracticeSession, 
         completion_status: completion_status_from_str(&completion_status_str)?,
         session_intention,
         session_score: None,
+        reflection_improved: None,
+        reflection_still_rough: None,
+        reflection_next_target: None,
     })
 }
 
@@ -423,6 +426,9 @@ pub async fn insert_session(
             completion_status: input.completion_status.clone(),
             session_intention: input.session_intention.clone(),
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         })
     }
     .await;

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -492,6 +492,9 @@ mod tests {
             session_intention: None,
             entries,
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }
     }
 
@@ -757,6 +760,9 @@ mod tests {
                 session_intention: None,
                 entries: vec![make_entry("p1", "Sonata", ItemKind::Piece, 600, None)],
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             }
         };
 
@@ -1530,6 +1536,9 @@ mod tests {
             session_intention: None,
             entries: vec![make_entry("p1", "Sonata", ItemKind::Piece, 600, Some(3))],
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }];
 
         let analytics = compute_analytics(&sessions, &[], today);

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -982,6 +982,9 @@ fn sample_sessions() -> Vec<PracticeSession> {
             total_duration_secs,
             completion_status,
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }
     };
 
@@ -1224,6 +1227,9 @@ mod tests {
                 total_duration_secs: 60,
                 completion_status: CompletionStatus::Completed,
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             }],
             session_status: SessionStatus::Active(ActiveSession {
                 id: "active1".to_string(),
@@ -2014,6 +2020,9 @@ mod tests {
                 session_intention: None,
                 entries,
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             });
         }
         model.practice_summaries = build_practice_summaries(&model.sessions);
@@ -2173,6 +2182,9 @@ mod tests {
                     group_id: None,
                 },
             ],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
         model.practice_summaries = build_practice_summaries(&model.sessions);
 
@@ -2254,6 +2266,9 @@ mod tests {
                 achieved_tempo: None,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
 
         // Session 2: newer, score 5
@@ -2285,6 +2300,9 @@ mod tests {
                 achieved_tempo: None,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
 
         model.practice_summaries = build_practice_summaries(&model.sessions);
@@ -2358,6 +2376,9 @@ mod tests {
                 achieved_tempo: None,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
 
         model.practice_summaries = build_practice_summaries(&model.sessions);
@@ -2445,6 +2466,9 @@ mod tests {
                     group_id: None,
                 },
             ],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
 
         model.practice_summaries = build_practice_summaries(&model.sessions);
@@ -2516,6 +2540,9 @@ mod tests {
                 achieved_tempo: None,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         });
 
         model.practice_summaries = build_practice_summaries(&model.sessions);
@@ -2583,6 +2610,9 @@ mod tests {
                 achieved_tempo: tempo,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }
     }
 
@@ -2637,6 +2667,9 @@ mod tests {
                 achieved_tempo: None,
                 group_id: None,
             }],
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
 
         let summaries = build_practice_summaries(&[mk("s1", earlier), mk("s2", later)]);
@@ -3384,6 +3417,9 @@ mod tests {
                 session_notes: None,
                 session_intention: None,
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             },
             PracticeSession {
                 id: "s2".to_string(),
@@ -3395,6 +3431,9 @@ mod tests {
                 session_notes: None,
                 session_intention: None,
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             },
         ];
         let vm = app.view(&model);

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -100,6 +100,23 @@ pub struct PracticeSession {
     pub completion_status: CompletionStatus,
     #[serde(default)]
     pub session_score: Option<u8>,
+    #[serde(default)]
+    pub reflection_improved: Option<String>,
+    #[serde(default)]
+    pub reflection_still_rough: Option<String>,
+    #[serde(default)]
+    pub reflection_next_target: Option<String>,
+}
+
+/// Which of the three structured end-of-session reflection prompts an
+/// `UpdateSessionReflection` targets (design-principles T7).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum ReflectionField {
+    Improved,
+    StillRough,
+    NextTarget,
 }
 
 // ── Transient State Types ──────────────────────────────────────────────
@@ -143,6 +160,9 @@ pub struct SummarySession {
     pub session_intention: Option<String>,
     pub completion_status: CompletionStatus,
     pub session_score: Option<u8>,
+    pub reflection_improved: Option<String>,
+    pub reflection_still_rough: Option<String>,
+    pub reflection_next_target: Option<String>,
 }
 
 /// The lifecycle state of a session in the core Model.
@@ -291,6 +311,10 @@ pub enum SessionEvent {
     },
     UpdateSessionNotes {
         notes: Option<String>,
+    },
+    UpdateSessionReflection {
+        field: ReflectionField,
+        text: Option<String>,
     },
     SaveSession {
         now: DateTime<Utc>,
@@ -527,6 +551,9 @@ fn transition_to_summary(
         session_intention: active.session_intention.clone(),
         completion_status,
         session_score: None,
+        reflection_improved: None,
+        reflection_still_rough: None,
+        reflection_next_target: None,
     }
 }
 
@@ -1108,6 +1135,9 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                     session_intention: active.session_intention.clone(),
                     completion_status: CompletionStatus::Completed,
                     session_score: None,
+                    reflection_improved: None,
+                    reflection_still_rough: None,
+                    reflection_next_target: None,
                 };
                 model.session_status = SessionStatus::Summary(summary);
                 model.last_error = None;
@@ -1371,6 +1401,27 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             crux_core::render::render()
         }
 
+        SessionEvent::UpdateSessionReflection { field, text } => {
+            let SessionStatus::Summary(ref mut summary) = model.session_status else {
+                model.last_error = Some("Not in summary state".to_string());
+                return crux_core::render::render();
+            };
+
+            if let Err(e) = validation::validate_reflection(&text) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+
+            let text = text.filter(|t| !t.trim().is_empty());
+            match field {
+                ReflectionField::Improved => summary.reflection_improved = text,
+                ReflectionField::StillRough => summary.reflection_still_rough = text,
+                ReflectionField::NextTarget => summary.reflection_next_target = text,
+            }
+            model.last_error = None;
+            crux_core::render::render()
+        }
+
         SessionEvent::UpdateSessionNotes { notes } => {
             let SessionStatus::Summary(ref mut summary) = model.session_status else {
                 model.last_error = Some("Not in summary state".to_string());
@@ -1420,6 +1471,9 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 total_duration_secs,
                 completion_status: summary.completion_status.clone(),
                 session_score: summary.session_score,
+                reflection_improved: summary.reflection_improved.clone(),
+                reflection_still_rough: summary.reflection_still_rough.clone(),
+                reflection_next_target: summary.reflection_next_target.clone(),
             };
 
             model.sessions.push(practice_session.clone());
@@ -2700,6 +2754,133 @@ mod tests {
         );
 
         assert!(model.last_error.is_some());
+    }
+
+    #[test]
+    fn test_update_session_reflection_sets_each_field_in_summary() {
+        let mut model = model_with_summary();
+
+        for (field, text) in [
+            (ReflectionField::Improved, "Thumb-unders even at 92"),
+            (ReflectionField::StillRough, "Bars 12-14 rush past 88"),
+            (
+                ReflectionField::NextTarget,
+                "Bars 12-14 at 80, hands together",
+            ),
+        ] {
+            update(
+                &mut model,
+                Event::Session(SessionEvent::UpdateSessionReflection {
+                    field,
+                    text: Some(text.to_string()),
+                }),
+            );
+            assert!(model.last_error.is_none());
+        }
+
+        let SessionStatus::Summary(ref s) = model.session_status else {
+            panic!("Expected Summary state");
+        };
+        assert_eq!(
+            s.reflection_improved,
+            Some("Thumb-unders even at 92".to_string())
+        );
+        assert_eq!(
+            s.reflection_still_rough,
+            Some("Bars 12-14 rush past 88".to_string())
+        );
+        assert_eq!(
+            s.reflection_next_target,
+            Some("Bars 12-14 at 80, hands together".to_string())
+        );
+    }
+
+    #[test]
+    fn test_update_session_reflection_rejected_outside_summary() {
+        let (mut model, _start) = model_with_active_session(2);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::Improved,
+                text: Some("mid-session thought".to_string()),
+            }),
+        );
+
+        assert_eq!(model.last_error, Some("Not in summary state".to_string()));
+        let SessionStatus::Active(_) = model.session_status else {
+            panic!("Active session must be untouched");
+        };
+    }
+
+    #[test]
+    fn test_update_session_reflection_blank_normalises_to_none() {
+        let mut model = model_with_summary();
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::Improved,
+                text: Some("real note".to_string()),
+            }),
+        );
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::Improved,
+                text: Some("   ".to_string()),
+            }),
+        );
+
+        assert!(model.last_error.is_none());
+        let SessionStatus::Summary(ref s) = model.session_status else {
+            panic!("Expected Summary state");
+        };
+        assert_eq!(s.reflection_improved, None);
+    }
+
+    #[test]
+    fn test_update_session_reflection_over_cap_rejected() {
+        let mut model = model_with_summary();
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::NextTarget,
+                text: Some("x".repeat(validation::MAX_REFLECTION + 1)),
+            }),
+        );
+
+        assert!(model.last_error.is_some());
+        let SessionStatus::Summary(ref s) = model.session_status else {
+            panic!("Expected Summary state");
+        };
+        assert_eq!(s.reflection_next_target, None);
+    }
+
+    #[test]
+    fn test_save_session_carries_reflections() {
+        let mut model = model_with_summary();
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::StillRough,
+                text: Some("left hand collapses in the bridge".to_string()),
+            }),
+        );
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SaveSession { now: Utc::now() }),
+        );
+
+        assert_eq!(model.sessions.len(), 1);
+        assert_eq!(model.sessions[0].reflection_improved, None);
+        assert_eq!(
+            model.sessions[0].reflection_still_rough,
+            Some("left hand collapses in the bridge".to_string())
+        );
+        assert_eq!(model.sessions[0].reflection_next_target, None);
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -1412,7 +1412,7 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
                 return crux_core::render::render();
             }
 
-            let text = text.filter(|t| !t.trim().is_empty());
+            let text = text.map(|t| t.trim().to_string()).filter(|t| !t.is_empty());
             match field {
                 ReflectionField::Improved => summary.reflection_improved = text,
                 ReflectionField::StillRough => summary.reflection_still_rough = text,
@@ -2837,6 +2837,24 @@ mod tests {
             panic!("Expected Summary state");
         };
         assert_eq!(s.reflection_improved, None);
+    }
+
+    #[test]
+    fn test_update_session_reflection_trims_retained_text() {
+        let mut model = model_with_summary();
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateSessionReflection {
+                field: ReflectionField::NextTarget,
+                text: Some("  bridge at 80  ".to_string()),
+            }),
+        );
+
+        let SessionStatus::Summary(ref s) = model.session_status else {
+            panic!("Expected Summary state");
+        };
+        assert_eq!(s.reflection_next_target, Some("bridge at 80".to_string()));
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/set.rs
+++ b/crates/intrada-core/src/domain/set.rs
@@ -565,6 +565,9 @@ mod tests {
                 session_intention: None,
                 completion_status: CompletionStatus::Completed,
                 session_score: None,
+                reflection_improved: None,
+                reflection_still_rough: None,
+                reflection_next_target: None,
             }),
             ..Default::default()
         };

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -483,6 +483,9 @@ mod tests {
             total_duration_secs: 300,
             completion_status: CompletionStatus::Completed,
             session_score: Some(8),
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }));
     }
 
@@ -562,6 +565,42 @@ mod tests {
             planned_duration_secs: None,
             achieved_tempo: None,
             group_id: Some("block-1".to_string()),
+        });
+    }
+
+    #[test]
+    fn session_reflection_event_round_trips_on_ffi_bincode_wire() {
+        use crate::domain::session::{ReflectionField, SessionEvent};
+        for field in [
+            ReflectionField::Improved,
+            ReflectionField::StillRough,
+            ReflectionField::NextTarget,
+        ] {
+            assert_round_trips(SessionEvent::UpdateSessionReflection {
+                field,
+                text: Some("bars 12-14 at 80 first".to_string()),
+            });
+            assert_round_trips(SessionEvent::UpdateSessionReflection { field, text: None });
+        }
+    }
+
+    #[test]
+    fn practice_session_with_reflections_round_trips_on_ffi_bincode_wire() {
+        use crate::domain::session::{CompletionStatus, PracticeSession};
+        use chrono::TimeZone;
+        assert_round_trips(PracticeSession {
+            id: "s1".to_string(),
+            entries: vec![],
+            session_notes: Some("note".to_string()),
+            session_intention: Some("even RH at 96".to_string()),
+            started_at: chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            completed_at: chrono::Utc.timestamp_opt(1_700_003_600, 0).unwrap(),
+            total_duration_secs: 3600,
+            completion_status: CompletionStatus::Completed,
+            session_score: Some(7),
+            reflection_improved: Some("thumb-unders even".to_string()),
+            reflection_still_rough: None,
+            reflection_next_target: Some("bridge at 80".to_string()),
         });
     }
 }

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -625,6 +625,9 @@ mod tests {
             total_duration_secs: 600,
             completion_status: crate::domain::session::CompletionStatus::Completed,
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
         let req = take_http(&mut create_session(BASE, &session));
         assert_eq!(req.method, "POST");

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -310,6 +310,9 @@ pub struct PracticeSessionView {
     pub entries: Vec<SetlistEntryView>,
     pub session_intention: Option<String>,
     pub session_score: Option<u8>,
+    pub reflection_improved: Option<String>,
+    pub reflection_still_rough: Option<String>,
+    pub reflection_next_target: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -427,6 +430,9 @@ pub struct SummaryView {
     pub entries: Vec<SetlistEntryView>,
     pub session_intention: Option<String>,
     pub session_score: Option<u8>,
+    pub reflection_improved: Option<String>,
+    pub reflection_still_rough: Option<String>,
+    pub reflection_next_target: Option<String>,
 }
 
 // ── View helpers ──────────────────────────────────────────────────────
@@ -563,6 +569,9 @@ pub fn build_summary_view(summary: &SummarySession) -> SummaryView {
         entries: summary.entries.iter().map(entry_to_view).collect(),
         session_intention: summary.session_intention.clone(),
         session_score: summary.session_score,
+        reflection_improved: summary.reflection_improved.clone(),
+        reflection_still_rough: summary.reflection_still_rough.clone(),
+        reflection_next_target: summary.reflection_next_target.clone(),
     }
 }
 
@@ -582,6 +591,9 @@ pub fn session_to_view(session: &PracticeSession) -> PracticeSessionView {
         entries: session.entries.iter().map(entry_to_view).collect(),
         session_intention: session.session_intention.clone(),
         session_score: session.session_score,
+        reflection_improved: session.reflection_improved.clone(),
+        reflection_still_rough: session.reflection_still_rough.clone(),
+        reflection_next_target: session.reflection_next_target.clone(),
     }
 }
 
@@ -890,6 +902,9 @@ mod tests {
             session_notes: None,
             session_intention: Some("focus".to_string()),
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
         let view = build_summary_view(&summary);
         assert_eq!(view.total_duration_display, "2m 30s");
@@ -910,6 +925,9 @@ mod tests {
             total_duration_secs: 2700,
             completion_status: CompletionStatus::Completed,
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
         let view = session_to_view(&session);
         // Precise (live-timer) form keeps seconds; the summary line drops them.
@@ -928,6 +946,9 @@ mod tests {
             session_notes: None,
             session_intention: None,
             session_score: Some(7),
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
         let view = build_summary_view(&summary);
         assert_eq!(view.session_score, Some(7));
@@ -945,9 +966,64 @@ mod tests {
             total_duration_secs: 60,
             completion_status: CompletionStatus::Completed,
             session_score: Some(5),
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         };
         let view = session_to_view(&session);
         assert_eq!(view.session_score, Some(5));
+    }
+
+    #[test]
+    fn session_to_view_exposes_reflections() {
+        let session = crate::domain::session::PracticeSession {
+            id: "s3".to_string(),
+            entries: vec![],
+            session_notes: None,
+            session_intention: None,
+            started_at: Utc::now(),
+            completed_at: Utc::now(),
+            total_duration_secs: 60,
+            completion_status: CompletionStatus::Completed,
+            session_score: None,
+            reflection_improved: Some("bars 1-8 clean".to_string()),
+            reflection_still_rough: Some("bridge rushes".to_string()),
+            reflection_next_target: Some("bridge at 80".to_string()),
+        };
+        let view = session_to_view(&session);
+        assert_eq!(view.reflection_improved, Some("bars 1-8 clean".to_string()));
+        assert_eq!(
+            view.reflection_still_rough,
+            Some("bridge rushes".to_string())
+        );
+        assert_eq!(
+            view.reflection_next_target,
+            Some("bridge at 80".to_string())
+        );
+    }
+
+    #[test]
+    fn summary_view_exposes_reflections() {
+        let summary = crate::domain::session::SummarySession {
+            id: "s4".to_string(),
+            entries: vec![],
+            session_started_at: Utc::now(),
+            session_ended_at: Utc::now(),
+            session_notes: None,
+            session_intention: Some("even RH at 96".to_string()),
+            completion_status: CompletionStatus::Completed,
+            session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: Some("bridge rushes".to_string()),
+            reflection_next_target: None,
+        };
+        let view = build_summary_view(&summary);
+        assert_eq!(view.reflection_improved, None);
+        assert_eq!(
+            view.reflection_still_rough,
+            Some("bridge rushes".to_string())
+        );
+        assert_eq!(view.reflection_next_target, None);
     }
 
     // ── Integration: Event → model → ViewModel ────────────────────────

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -478,6 +478,9 @@ mod tests {
             total_duration_secs: 0,
             completion_status: crate::domain::session::CompletionStatus::Completed,
             session_score: None,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
         }
     }
 

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -7,6 +7,7 @@ use crate::model::Model;
 pub const MAX_TITLE: usize = 500;
 pub const MAX_COMPOSER: usize = 200;
 pub const MAX_NOTES: usize = 5000;
+pub const MAX_REFLECTION: usize = 500;
 pub const MAX_INTENTION: usize = 500;
 pub const MAX_TAG: usize = 100;
 pub const MAX_TEMPO_MARKING: usize = 100;
@@ -167,6 +168,18 @@ pub fn validate_session_notes(notes: &Option<String>) -> Result<(), LibraryError
             return Err(LibraryError::Validation {
                 field: "session_notes".to_string(),
                 message: format!("Practice notes must not exceed {MAX_NOTES} characters"),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_reflection(text: &Option<String>) -> Result<(), LibraryError> {
+    if let Some(ref t) = text {
+        if t.len() > MAX_REFLECTION {
+            return Err(LibraryError::Validation {
+                field: "reflection".to_string(),
+                message: format!("A reflection must not exceed {MAX_REFLECTION} characters"),
             });
         }
     }

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -107,15 +107,19 @@ final class LibraryStore: ItemStore {
         sql: """
           INSERT INTO session
             (id, started_at, completed_at, total_duration_secs, completion_status,
-             session_notes, session_intention, entries, updated_at, deleted_at, session_score)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+             session_notes, session_intention, entries, updated_at, deleted_at, session_score,
+             reflection_improved, reflection_still_rough, reflection_next_target)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             started_at = excluded.started_at, completed_at = excluded.completed_at,
             total_duration_secs = excluded.total_duration_secs,
             completion_status = excluded.completion_status,
             session_notes = excluded.session_notes, session_intention = excluded.session_intention,
             entries = excluded.entries, updated_at = excluded.updated_at, deleted_at = NULL,
-            session_score = excluded.session_score
+            session_score = excluded.session_score,
+            reflection_improved = excluded.reflection_improved,
+            reflection_still_rough = excluded.reflection_still_rough,
+            reflection_next_target = excluded.reflection_next_target
           """,
         arguments: [
           session.id, session.startedAt, session.completedAt,
@@ -123,6 +127,8 @@ final class LibraryStore: ItemStore {
           session.sessionNotes, session.sessionIntention,
           Self.encodeEntries(session.entries), session.completedAt,
           session.sessionScore.map { Int($0) },
+          session.reflectionImproved, session.reflectionStillRough,
+          session.reflectionNextTarget,
         ])
     }
   }
@@ -200,6 +206,11 @@ final class LibraryStore: ItemStore {
     migrator.registerMigration("v6_item_linked_exercises") { db in
       try db.execute(
         sql: "ALTER TABLE item ADD COLUMN linked_exercise_ids TEXT NOT NULL DEFAULT '[]'")
+    }
+    migrator.registerMigration("v7_session_reflections") { db in
+      try db.execute(sql: "ALTER TABLE session ADD COLUMN reflection_improved TEXT")
+      try db.execute(sql: "ALTER TABLE session ADD COLUMN reflection_still_rough TEXT")
+      try db.execute(sql: "ALTER TABLE session ADD COLUMN reflection_next_target TEXT")
     }
     return migrator
   }()
@@ -296,7 +307,10 @@ final class LibraryStore: ItemStore {
       startedAt: row["started_at"], completedAt: row["completed_at"],
       totalDurationSecs: UInt64(row["total_duration_secs"] as Int64),
       completionStatus: completionStatus(from: row["completion_status"]),
-      sessionScore: score.map { UInt8(clamping: $0) })
+      sessionScore: score.map { UInt8(clamping: $0) },
+      reflectionImproved: row["reflection_improved"],
+      reflectionStillRough: row["reflection_still_rough"],
+      reflectionNextTarget: row["reflection_next_target"])
   }
 
   // Entries (a nested, optional-heavy aggregate) go to JSON via a Codable DTO,

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -484,7 +484,8 @@
           previewEntry(1, "Gymnopédie No. 1", .piece),
           previewEntry(2, "Nocturne Op. 9 No. 2", .piece),
         ],
-        sessionIntention: nil, sessionScore: nil)
+        sessionIntention: nil, sessionScore: nil,
+        reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     }
 
     static var previewEndedEarly: PracticeSessionView {
@@ -496,7 +497,8 @@
           previewEntry(0, "Hanon No. 1", .exercise),
           previewEntry(1, "Major Scales", .exercise),
         ],
-        sessionIntention: nil, sessionScore: nil)
+        sessionIntention: nil, sessionScore: nil,
+        reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     }
 
     private static func previewEntry(_ position: UInt64, _ title: String, _ type: ItemKind)
@@ -581,7 +583,8 @@
             intention: "Land each finger evenly"),
           summaryEntry("e3", "Gymnopédie No. 1", .piece, "11m 30s", .completed, score: 5),
           summaryEntry("e4", "Czerny Op. 299", .exercise, "5m 30s", .completed, score: 3),
-        ], sessionIntention: nil, sessionScore: 8)
+        ], sessionIntention: nil, sessionScore: 8,
+        reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     }
 
     static var previewSummaryEndedEarly: SummaryView {
@@ -591,7 +594,8 @@
           summaryEntry("e1", "Clair de Lune", .piece, "12m 40s", .completed, score: 3),
           summaryEntry("e2", "Hanon No. 1", .exercise, "8m 10s", .completed, score: 4),
           summaryEntry("e3", "Étude Op. 10", .piece, "0s", .notAttempted, score: nil),
-        ], sessionIntention: nil, sessionScore: 8)
+        ], sessionIntention: nil, sessionScore: 8,
+        reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     }
 
     private static func summaryEntry(

--- a/ios/IntradaTests/LibraryStoreMigrationTests.swift
+++ b/ios/IntradaTests/LibraryStoreMigrationTests.swift
@@ -46,13 +46,49 @@ final class LibraryStoreMigrationTests: XCTestCase {
       id: "sess-rt", entries: [entry],
       sessionNotes: nil, sessionIntention: nil,
       startedAt: "2026-01-01T10:00:00Z", completedAt: "2026-01-01T10:30:00Z",
-      totalDurationSecs: 1800, completionStatus: .completed, sessionScore: 7)
+      totalDurationSecs: 1800, completionStatus: .completed, sessionScore: 7,
+      reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     try store.saveSession(session)
     let loaded = try store.loadSessions()
     XCTAssertEqual(loaded.count, 1)
     XCTAssertEqual(
       loaded[0].sessionScore, 7,
       "sessionScore UInt8→Int64→UInt8(clamping:) round-trip must preserve 7")
+  }
+
+  func testSessionReflectionsRoundTrip() throws {
+    let store = try LibraryStore.inMemory()
+    let session = PracticeSession(
+      id: "sess-refl", entries: [],
+      sessionNotes: nil, sessionIntention: "even RH at 96",
+      startedAt: "2026-07-14T10:00:00Z", completedAt: "2026-07-14T10:30:00Z",
+      totalDurationSecs: 1800, completionStatus: .completed, sessionScore: nil,
+      reflectionImproved: "thumb-unders even at 92",
+      reflectionStillRough: "bars 12-14 rush past 88",
+      reflectionNextTarget: "bars 12-14 at 80, hands together")
+    try store.saveSession(session)
+    let loaded = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(loaded.reflectionImproved, "thumb-unders even at 92")
+    XCTAssertEqual(loaded.reflectionStillRough, "bars 12-14 rush past 88")
+    XCTAssertEqual(loaded.reflectionNextTarget, "bars 12-14 at 80, hands together")
+  }
+
+  func testV6SessionSurvivesReflectionMigration() throws {
+    let store = try LibraryStore.upgradeTestStore(
+      migratedTo: "v6_item_linked_exercises",
+      seed: """
+        INSERT INTO session
+          (id, started_at, completed_at, total_duration_secs, completion_status,
+           session_notes, session_intention, entries, updated_at, deleted_at, session_score)
+        VALUES ('s-pre', '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 60, 'completed',
+                'old note', NULL, '[]', '2026-01-01T00:00:00Z', NULL, 7)
+        """)
+    let loaded = try XCTUnwrap(try store.loadSessions().first)
+    XCTAssertEqual(loaded.sessionNotes, "old note", "pre-migration row survives intact")
+    XCTAssertEqual(loaded.sessionScore, 7)
+    XCTAssertNil(loaded.reflectionImproved, "old rows read back with nil reflections")
+    XCTAssertNil(loaded.reflectionStillRough)
+    XCTAssertNil(loaded.reflectionNextTarget)
   }
 
   func testGroupIdRoundTripsThroughTheJsonCodec() throws {
@@ -67,7 +103,8 @@ final class LibraryStoreMigrationTests: XCTestCase {
       id: "sess-g", entries: [entry],
       sessionNotes: nil, sessionIntention: nil,
       startedAt: "2026-01-01T10:00:00Z", completedAt: "2026-01-01T10:30:00Z",
-      totalDurationSecs: 60, completionStatus: .completed, sessionScore: nil)
+      totalDurationSecs: 60, completionStatus: .completed, sessionScore: nil,
+      reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
     try store.saveSession(session)
     let loaded = try store.loadSessions()
     XCTAssertEqual(

--- a/ios/IntradaTests/LibraryStoreTests.swift
+++ b/ios/IntradaTests/LibraryStoreTests.swift
@@ -134,7 +134,8 @@ final class LibraryStoreTests: XCTestCase {
     PracticeSession(
       id: id, entries: [entry("a"), entry("b")], sessionNotes: "solid",
       sessionIntention: "warm up", startedAt: "2026-01-01T00:00:00Z", completedAt: completedAt,
-      totalDurationSecs: 600, completionStatus: .completed, sessionScore: nil)
+      totalDurationSecs: 600, completionStatus: .completed, sessionScore: nil,
+      reflectionImproved: nil, reflectionStillRough: nil, reflectionNextTarget: nil)
   }
 
   func testSaveThenLoadSessionRoundTrips() throws {

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -447,6 +447,22 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(try bridge.view().summary?.notes, "Felt good", "notes should round-trip")
     _ = try bridge.update(.session(.updateSessionNotes(notes: nil)))
     XCTAssertNil(try bridge.view().summary?.notes, "clearing notes round-trips")
+    // Structured reflection — a brand-new wire surface (ReflectionField's
+    // variant indices) never sent from Swift before (#846). Set + clear each.
+    _ = try bridge.update(
+      .session(.updateSessionReflection(field: .improved, text: "thumb-unders even")))
+    XCTAssertEqual(
+      try bridge.view().summary?.reflectionImproved, "thumb-unders even",
+      "reflection 'improved' should round-trip the live bridge")
+    _ = try bridge.update(
+      .session(.updateSessionReflection(field: .stillRough, text: "bridge rushes")))
+    XCTAssertEqual(try bridge.view().summary?.reflectionStillRough, "bridge rushes")
+    _ = try bridge.update(
+      .session(.updateSessionReflection(field: .nextTarget, text: "bridge at 80")))
+    XCTAssertEqual(try bridge.view().summary?.reflectionNextTarget, "bridge at 80")
+    _ = try bridge.update(.session(.updateSessionReflection(field: .improved, text: nil)))
+    XCTAssertNil(
+      try bridge.view().summary?.reflectionImproved, "clearing a reflection round-trips")
 
     _ = try bridge.update(.session(.saveSession(now: "2026-06-16T10:20:30Z")))
     let saved = try bridge.view()

--- a/specs/reflection-loop/spec.md
+++ b/specs/reflection-loop/spec.md
@@ -25,10 +25,11 @@ one string is write-only prose downstream.
    with `ReflectionField::{Improved, StillRough, NextTarget}` — one handler,
    one validation path, instead of three clones of `UpdateSessionNotes`
    (consolidate-before-template).
-3. **Semantics.** Blank or whitespace-only text normalises to `None`
-   ("blank prompts save as nothing" — DECISIONS surface 3). Length cap
-   `MAX_REFLECTION = 500` chars per field (single-line prompts;
-   `validation.rs` stays the single source of truth).
+3. **Semantics.** Retained text is trimmed; blank or whitespace-only text
+   normalises to `None` ("blank prompts save as nothing" — DECISIONS
+   surface 3). Length cap `MAX_REFLECTION = 500` bytes per field (matching
+   the byte-length convention of every existing cap in `validation.rs`,
+   which stays the single source of truth).
 4. **Carry-through.** `SaveSession` copies the three fields onto the saved
    `PracticeSession`; `build_summary_view` and `session_to_view` expose them
    so the summary screen and (later) past-session surfaces can render them.

--- a/specs/reflection-loop/spec.md
+++ b/specs/reflection-loop/spec.md
@@ -1,0 +1,60 @@
+# Reflection loop — Phase 1 core model
+
+> Tier 3 spec, riding with the first implementation PR per the workflow.
+> Design inputs: `design/BRIEF` (design/briefs/2026-07-reflection-and-narrative.md),
+> `design/DECISIONS.md`, `design/HANDOFF.md` in this folder, and
+> design-principles decision T7. Journey steps 7–8 (docs/journeys.md).
+
+## Problem
+
+The end-of-session reflection is a single unlabelled note box. The journey
+requires a structured beat — what improved, what's still rough, what to
+target next time — stored as distinct fields so narrative progress (step 9)
+and future session planning (step 5) can consume the answers. Free text in
+one string is write-only prose downstream.
+
+## Approach (this PR: core + local persistence only, no UI)
+
+1. **Fields.** `PracticeSession` and `SummarySession` gain
+   `reflection_improved`, `reflection_still_rough`, `reflection_next_target`
+   — all `Option<String>`, `#[serde(default)]` (same pattern as
+   `session_score`, safe on both JSON and bincode wires: no format-specific
+   attrs).
+2. **Event.** One Summary-gated event,
+   `UpdateSessionReflection { field: ReflectionField, text: Option<String> }`
+   with `ReflectionField::{Improved, StillRough, NextTarget}` — one handler,
+   one validation path, instead of three clones of `UpdateSessionNotes`
+   (consolidate-before-template).
+3. **Semantics.** Blank or whitespace-only text normalises to `None`
+   ("blank prompts save as nothing" — DECISIONS surface 3). Length cap
+   `MAX_REFLECTION = 500` chars per field (single-line prompts;
+   `validation.rs` stays the single source of truth).
+4. **Carry-through.** `SaveSession` copies the three fields onto the saved
+   `PracticeSession`; `build_summary_view` and `session_to_view` expose them
+   so the summary screen and (later) past-session surfaces can render them.
+5. **Local persistence.** GRDB migration (additive, three nullable TEXT
+   columns on `session`), upsert + row codec updated together, plus an
+   upgrade-path test from the previous migration version (offline
+   invariants 2 and the migration checklist).
+6. **FFI.** bincode round-trip tests for the new event and the widened
+   `PracticeSession` (real-wire guarantee, #846 class).
+
+## Key decisions
+
+- **Field enum over three events**: fewer FFI surfaces, one gate + one
+  validator; the shell stays a dumb pipe either way.
+- **500-char cap, not MAX_NOTES (5000)**: these are one-line prompts by
+  design; a lower cap keeps them honest without being restrictive.
+- **Online path deferred**: the API's `SaveSessionRequest` ignores unknown
+  JSON fields, so online mode keeps working but does not persist
+  reflections server-side. Tracked as a sync-parity issue (same family as
+  #842/#1021); acceptable while web is paused and sync is future work.
+- **Session-level, not per-entry**: per-entry reflection already exists
+  (entry notes/score/tempo). These three answer for the session as a whole.
+
+## Out of scope (later tasks in the phase)
+
+- iOS UI for the prompts (task: summary reflection surface).
+- Mid-item quick capture and its append-vs-overwrite core decision.
+- Feeding `reflection_next_target` forward as a suggested Aim (needs the
+  recommendation surface; the field lands now so the data accrues).


### PR DESCRIPTION
## Summary

Phase 1 of the reflection loop ([spec](specs/reflection-loop/spec.md), design-principles T7, journey step 8). Builds on the mockups + handoff merged in #1072.

- **core**: `PracticeSession`/`SummarySession` gain `reflection_improved` / `reflection_still_rough` / `reflection_next_target`. One Summary-gated event `UpdateSessionReflection { field: ReflectionField, text }`; retained text is trimmed, blank normalises to `None` (blank prompts save as nothing), 500-byte cap in `validation.rs`. `SaveSession` carries the fields; both views expose them.
- **ffi**: real-wire bincode round-trips for the new event + widened `PracticeSession`, plus live-bridge set/clear legs in `StoreEffectLoopTests` driving the generated Swift serializer's `ReflectionField` variants against the Rust deserializer (#846 class).
- **ios store**: migration `v7_session_reflections` (additive, three nullable TEXT columns), upsert + codec updated together, round-trip + v6-populated upgrade-path tests.
- **api**: compiles and accepts the fields; online persistence deferred to #1073 (sync parity, web paused).

No UI in this PR — the summary-screen surface builds on this next, against the committed mockups.

## TDD

Every behaviour red-first: 10 core tests + 2 store tests + 4 bridge legs. Suites: cargo 476 core green, workspace green, clippy `-D warnings` clean; iOS 141/141 on the worktree sim (twice: pre- and post-review fixes).

## Self-review

Reviewer agent on the diff: 1 Important (missing live-bridge legs — fixed), 2 nits (trim semantics — fixed; spec byte/char wording — fixed). Verified clean on FFI hazards, offline invariants (append-only migration, upsert/codec column parity), and construction-site completeness.

Coverage: full on the core paths — every new handler branch, validator, view projection, and codec has a direct test; `ios/generated` and `migrations.rs`-style SQL strings are outside coverage scope per codecov.yml.

Deferred items tracked: #1073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)