### PR TITLE
docs(roadmap): point current focus at the lesson-to-mastery epic

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,15 @@ horizon.
 
 Filter `is:open is:issue` on the board to see what's currently in flight.
 
+### Current focus (2026-07): the lesson-to-mastery loop
+
+Making the weekly teacher-lesson loop first-class: capture a lesson in one
+pass (#1080), track exercises per piece (#1081), suggest the next session
+(#1082), and let exercises progress along step/key ladders (#1083, closes
+#46). Sequenced A -> B -> R -> C; decisions and the phase checklist live in
+the [lesson-to-mastery epic (#1087)](https://github.com/jonyardley/intrada/issues/1087),
+which is the live progress view for this slice.
+
 ---
 
 ## Three pillars


### PR DESCRIPTION
Adds a "Current focus (2026-07)" subsection to the roadmap pointing at the lesson-to-mastery epic (#1087) and its four workstreams (#1080, #1081, #1082, #1083), so the plan and its progress are discoverable from the repo across sessions.

Tier 1, docs-only. No code change, no coverage impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)