### PR TITLE
docs: recover the shipped linked-exercises spec, brief, mock, and plans

### DIFF
--- a/design/linked-exercises-mock.dc.html
+++ b/design/linked-exercises-mock.dc.html
@@ -1,0 +1,545 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @keyframes pop { 0% { opacity: 0; transform: scale(.55); } 62% { transform: scale(1.09); } 100% { opacity: 1; transform: scale(1); } }
+  @keyframes toastIn { 0% { opacity: 0; transform: translateY(-10px) scale(.96); } 100% { opacity: 1; transform: none; } }
+  @keyframes ringDraw { from { stroke-dashoffset: 188.5; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; } }
+</style>
+</helmet>
+
+<div style="min-height:100vh;background:linear-gradient(180deg,#F4F1E8 0%,#EBE7D9 100%);font-family:'Inter',system-ui,sans-serif;color:#2B2A26;padding:44px 32px 90px;">
+  <template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#FBFAF3"/><circle cx="50" cy="50" r="26" fill="none" stroke="#E6DECB" stroke-width="7"/><path d="M50 24 A26 26 0 0 1 73 63" fill="none" stroke="#4C3FA6" stroke-width="7" stroke-linecap="round"/><text x="50" y="50" text-anchor="middle" dominant-baseline="central" font-family="Inter,sans-serif" font-weight="700" font-size="26" fill="#2B2A26">7</text></svg></template>
+
+  <!-- ============ HEADER / DESIGNER NOTE ============ -->
+  <div style="max-width:1000px;margin:0 auto;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Intrada · Paper &amp; Score · Feature mock</div>
+    <h1 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:44px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Linked exercises</h1>
+    <p style="font-size:15px;line-height:1.65;color:#6E6557;max-width:660px;margin:14px 0 0;">A new <strong style="font-weight:600;color:#2B2A26;">Linked exercises</strong> section on the piece detail, the multi-select picker that fills it, and the genuinely new piece — the <strong style="font-weight:600;color:#2B2A26;">0–10 score ring</strong> (#1009) that retires the 5-step bars everywhere a mastery signal appears.</p>
+
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:26px;">
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:18px 20px;">
+        <div style="display:flex;align-items:center;gap:8px;"><i data-lucide="circle-check" width="16" height="16" style="color:#1F8A5B;"></i><div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Decided with you</div></div>
+        <ul style="margin:12px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+          <li><strong style="color:#2B2A26;font-weight:600;">Ring:</strong> monochrome arc gauge, numeral centred — 4 treatments below to confirm.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Row density:</strong> title + key/tempo + ring only. No last-practised / best-tempo clutter.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Score 0:</strong> empty ring, faint en-dash, never a numeral.</li>
+          <li><strong style="color:#2B2A26;font-weight:600;">Picker:</strong> both multi-select patterns drawn (<a href="#f-pickA" style="color:#4C3FA6;text-decoration:none;font-weight:600;">A</a> / <a href="#f-pickB" style="color:#4C3FA6;text-decoration:none;font-weight:600;">B</a>).</li>
+        </ul>
+      </div>
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:14px;padding:18px 20px;">
+        <div style="display:flex;align-items:center;gap:8px;"><i data-lucide="layers" width="16" height="16" style="color:#4C3FA6;"></i><div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Reused, not reinvented</div></div>
+        <p style="font-size:13.5px;line-height:1.7;color:#6E6557;margin:12px 0 0;">ScreenScaffold, <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">.cardSurface()</span>, HairlineDivider, the type-coded bar (gold = exercise), TypeBadge and the TagFilterSheet chrome all carry over unchanged. The ring reuses the existing score-indigo — <strong style="color:#2B2A26;font-weight:600;">no new tokens</strong>. The MasteryMeter bars are replaced by the ring on library rows and on the exercise detail.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ SCORE RING LAB ============ -->
+  <div style="max-width:1000px;margin:64px auto 0;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">The one new component · #1009</div>
+    <h2 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;letter-spacing:-0.01em;margin:8px 0 0;color:#2B2A26;">Score ring · 0–10</h2>
+    <p style="font-size:14.5px;line-height:1.65;color:#6E6557;max-width:640px;margin:12px 0 0;">Monochrome on cream, numeral centred. Value is encoded <strong style="font-weight:600;color:#2B2A26;">twice</strong> — by the fill and by the numeral — so it reads with no colour at all. Four treatments at the same score (7) for a fair look; pick one and I'll standardise it.</p>
+
+    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:28px;">
+      <!-- A · ARC GAUGE -->
+      <div style="position:relative;background:#FCFAF3;border:1.5px solid #4C3FA6;border-radius:16px;padding:24px 18px 20px;display:flex;flex-direction:column;align-items:center;">
+        <span style="position:absolute;top:-10px;left:50%;transform:translateX(-50%);background:#4C3FA6;color:#F2EFE8;font-size:9.5px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;padding:3px 9px;border-radius:999px;">My pick · A</span>
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="30" fill="none" stroke="#E6DECB" stroke-width="6"/><circle cx="40" cy="40" r="30" fill="none" stroke="#4C3FA6" stroke-width="6" stroke-linecap="round" stroke-dasharray="188.5" stroke-dashoffset="56.55" transform="rotate(-90 40 40)" style="animation:ringDraw 1s .1s ease both;"/><text x="40" y="40" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="30" fill="#2B2A26">7</text></svg>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;margin-top:14px;color:#2B2A26;">Arc gauge</div>
+        <div style="font-size:12px;line-height:1.5;color:#6E6557;text-align:center;margin-top:5px;">Proportional sweep, round cap. Calm, glanceable, scales tiny.</div>
+      </div>
+      <!-- B · SEGMENTED -->
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:24px 18px 20px;display:flex;flex-direction:column;align-items:center;">
+        <svg width="80" height="80" viewBox="0 0 80 80">
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(0 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(36 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(72 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(108 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(144 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(180 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" transform="rotate(216 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#E6DECB" stroke-width="4" stroke-linecap="round" transform="rotate(252 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#E6DECB" stroke-width="4" stroke-linecap="round" transform="rotate(288 40 40)"/>
+          <line x1="40" y1="6" x2="40" y2="15" stroke="#E6DECB" stroke-width="4" stroke-linecap="round" transform="rotate(324 40 40)"/>
+          <text x="40" y="40" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="28" fill="#2B2A26">7</text>
+        </svg>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;margin-top:14px;color:#2B2A26;">Segmented</div>
+        <div style="font-size:12px;line-height:1.5;color:#6E6557;text-align:center;margin-top:5px;">Ten ticks = literal 0–10. Countable, very accessible.</div>
+      </div>
+      <!-- C · WEDGE -->
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:24px 18px 20px;display:flex;flex-direction:column;align-items:center;">
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="30" fill="#ECE7F4"/><path d="M40 40 L40 10 A30 30 0 1 1 11.46 49.27 Z" fill="#4C3FA6" opacity="0.9"/><circle cx="40" cy="40" r="16" fill="#FCFAF3"/><text x="40" y="40" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="24" fill="#2B2A26">7</text></svg>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;margin-top:14px;color:#2B2A26;">Wedge</div>
+        <div style="font-size:12px;line-height:1.5;color:#6E6557;text-align:center;margin-top:5px;">Pie fill, boldest read. Heavier; less calm at small sizes.</div>
+      </div>
+      <!-- D · DIAL MARKER -->
+      <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:24px 18px 20px;display:flex;flex-direction:column;align-items:center;">
+        <svg width="80" height="80" viewBox="0 0 80 80"><circle cx="40" cy="40" r="30" fill="none" stroke="#E0D9C8" stroke-width="2.5"/><circle cx="11.46" cy="49.27" r="5" fill="#4C3FA6"/><text x="40" y="40" text-anchor="middle" dominant-baseline="central" font-family="Source Serif 4,serif" font-weight="600" font-size="30" fill="#2B2A26">7</text></svg>
+        <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;margin-top:14px;color:#2B2A26;">Dial marker</div>
+        <div style="font-size:12px;line-height:1.5;color:#6E6557;text-align:center;margin-top:5px;">Static ring, serif numeral leads. Calmest, most typographic.</div>
+      </div>
+    </div>
+
+    <!-- the scale, in treatment A -->
+    <div style="margin-top:22px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:20px 24px;">
+      <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">The arc across the whole scale</div>
+      <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:8px;margin-top:16px;flex-wrap:wrap;">
+        <div style="display:flex;flex-direction:column;align-items:center;gap:7px;"><svg width="48" height="48" viewBox="0 0 48 48"><circle cx="24" cy="24" r="18" fill="none" stroke="#E6DECB" stroke-width="3.5"/><text x="24" y="24" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="15" fill="#9A927F">–</text></svg><span style="font-size:11px;color:#6E6557;font-weight:500;">0 · unrated</span></div>
+        <div style="display:flex;flex-direction:column;align-items:center;gap:7px;"><svg width="48" height="48" viewBox="0 0 48 48"><circle cx="24" cy="24" r="18" fill="none" stroke="#E6DECB" stroke-width="3.5"/><circle cx="24" cy="24" r="18" fill="none" stroke="#4C3FA6" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="79.17" transform="rotate(-90 24 24)"/><text x="24" y="24" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">3</text></svg><span style="font-size:11px;color:#6E6557;font-weight:500;">3 · learning</span></div>
+        <div style="display:flex;flex-direction:column;align-items:center;gap:7px;"><svg width="48" height="48" viewBox="0 0 48 48"><circle cx="24" cy="24" r="18" fill="none" stroke="#E6DECB" stroke-width="3.5"/><circle cx="24" cy="24" r="18" fill="none" stroke="#4C3FA6" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="45.24" transform="rotate(-90 24 24)"/><text x="24" y="24" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">6</text></svg><span style="font-size:11px;color:#6E6557;font-weight:500;">6 · solid</span></div>
+        <div style="display:flex;flex-direction:column;align-items:center;gap:7px;"><svg width="48" height="48" viewBox="0 0 48 48"><circle cx="24" cy="24" r="18" fill="none" stroke="#E6DECB" stroke-width="3.5"/><circle cx="24" cy="24" r="18" fill="none" stroke="#4C3FA6" stroke-width="3.5" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="22.62" transform="rotate(-90 24 24)"/><text x="24" y="24" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">8</text></svg><span style="font-size:11px;color:#6E6557;font-weight:500;">8 · fluent</span></div>
+        <div style="display:flex;flex-direction:column;align-items:center;gap:7px;"><svg width="48" height="48" viewBox="0 0 48 48"><circle cx="24" cy="24" r="18" fill="none" stroke="#4C3FA6" stroke-width="3.5"/><text x="24" y="24" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">10</text></svg><span style="font-size:11px;color:#6E6557;font-weight:500;">10 · mastered</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============ PHONE FRAMES ============ -->
+  <div style="max-width:1240px;margin:72px auto 0;display:flex;flex-wrap:wrap;gap:44px 40px;justify-content:center;">
+
+    <!-- ===== FRAME 1 · PIECE DETAIL · EMPTY ===== -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Piece detail · empty</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;">
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="chevron-left" width="20" height="20" style="color:#4C3FA6;"></i></div>
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="ellipsis" width="19" height="19" style="color:#6E6557;"></i></div>
+          </div>
+          <div style="flex:1;overflow:hidden;padding:14px 16px 24px;display:flex;flex-direction:column;gap:16px;">
+            <div style="animation:fadeUp .5s ease both;">
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:8px;background:#E7E3F4;color:#4C3FA6;font-weight:600;font-size:11.5px;">Piece</span>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1.05;margin-top:10px;">Clair de Lune</div>
+              <div style="font-size:13px;color:#6E6557;margin-top:5px;">Debussy · D♭ major · ♩=66</div>
+            </div>
+            <!-- notes card (context) -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:16px 18px;animation:fadeUp .5s .04s ease both;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Notes</div>
+              <div style="font-size:13.5px;line-height:1.55;color:#6E6557;margin-top:8px;">Voice the melody over the arpeggios. Keep the pedal clean through bar 27.</div>
+            </div>
+            <!-- LINKED EXERCISES · EMPTY -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:18px;animation:fadeUp .5s .08s ease both;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Linked exercises</div>
+              <div style="display:flex;flex-direction:column;align-items:center;text-align:center;padding:18px 8px 6px;">
+                <div style="width:52px;height:52px;border-radius:50%;background:#F0E7D6;display:flex;align-items:center;justify-content:center;"><i data-lucide="link" width="22" height="22" style="color:#9A927F;"></i></div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;margin-top:14px;">No exercises linked yet</div>
+                <div style="font-size:13px;line-height:1.55;color:#6E6557;margin-top:6px;max-width:230px;">Link the scales, arpeggios or studies you practise alongside this piece.</div>
+              </div>
+              <button style="width:100%;border:1px solid #4C3FA6;background:transparent;color:#4C3FA6;font-family:Inter;font-weight:600;font-size:14px;padding:12px;border-radius:12px;margin-top:8px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px;" style-active="transform:scale(0.985)"><i data-lucide="plus" width="17" height="17"></i>Link an exercise</button>
+            </div>
+            <!-- delete -->
+            <button style="width:100%;border:1px solid #E5DECD;background:#FCFAF3;color:#B3261E;font-family:Inter;font-weight:600;font-size:14px;padding:13px;border-radius:12px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px;animation:fadeUp .5s .12s ease both;"><i data-lucide="trash-2" width="16" height="16"></i>Delete piece</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 2 · PIECE DETAIL · POPULATED ===== -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Piece detail · populated</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;">
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="chevron-left" width="20" height="20" style="color:#4C3FA6;"></i></div>
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="ellipsis" width="19" height="19" style="color:#6E6557;"></i></div>
+          </div>
+          <div style="flex:1;overflow:hidden;padding:14px 16px 24px;display:flex;flex-direction:column;gap:16px;">
+            <div style="animation:fadeUp .5s ease both;">
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:8px;background:#E7E3F4;color:#4C3FA6;font-weight:600;font-size:11.5px;">Piece</span>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1.05;margin-top:10px;">Clair de Lune</div>
+              <div style="font-size:13px;color:#6E6557;margin-top:5px;">Debussy · D♭ major · ♩=66</div>
+            </div>
+            <!-- tags card (context) -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:16px 18px;animation:fadeUp .5s .04s ease both;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Tags</div>
+              <div style="display:flex;flex-wrap:wrap;gap:7px;margin-top:10px;"><span style="padding:5px 11px;border-radius:999px;background:#F0E7D6;font-size:12px;color:#6E6557;font-weight:500;">Impressionist</span><span style="padding:5px 11px;border-radius:999px;background:#F0E7D6;font-size:12px;color:#6E6557;font-weight:500;">Recital</span><span style="padding:5px 11px;border-radius:999px;background:#F0E7D6;font-size:12px;color:#6E6557;font-weight:500;">Pedal study</span></div>
+            </div>
+            <!-- LINKED EXERCISES · POPULATED -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:6px 4px 4px;animation:fadeUp .5s .08s ease both;">
+              <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px 10px;">
+                <div style="display:flex;align-items:center;gap:8px;"><span style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Linked exercises</span><span style="font-size:11px;font-weight:600;color:#9A927F;background:#F0E7D6;border-radius:999px;padding:1px 7px;">3</span></div>
+                <span style="font-size:13px;font-weight:600;color:#4C3FA6;cursor:pointer;">Edit</span>
+              </div>
+              <!-- row -->
+              <div style="display:flex;align-items:center;gap:13px;padding:11px 14px;">
+                <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Scales · D♭ major</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Two octaves · ♩=96</div></div>
+                <svg width="44" height="44" viewBox="0 0 44 44" style="flex:none;"><circle cx="22" cy="22" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="22" cy="22" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="33.93" transform="rotate(-90 22 22)"/><text x="22" y="22" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">7</text></svg>
+              </div>
+              <div style="height:1px;background:#E5DECD;margin:0 14px;"></div>
+              <div style="display:flex;align-items:center;gap:13px;padding:11px 14px;">
+                <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Broken arpeggios</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">D♭ · ♩=84</div></div>
+                <svg width="44" height="44" viewBox="0 0 44 44" style="flex:none;"><circle cx="22" cy="22" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="22" cy="22" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="67.86" transform="rotate(-90 22 22)"/><text x="22" y="22" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">4</text></svg>
+              </div>
+              <div style="height:1px;background:#E5DECD;margin:0 14px;"></div>
+              <div style="display:flex;align-items:center;gap:13px;padding:11px 14px;">
+                <span style="width:4px;height:34px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Pedalling study</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Bars 12–27 · ♩=72</div></div>
+                <svg width="44" height="44" viewBox="0 0 44 44" style="flex:none;"><circle cx="22" cy="22" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="22" cy="22" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="11.31" transform="rotate(-90 22 22)"/><text x="22" y="22" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">9</text></svg>
+              </div>
+              <div style="height:1px;background:#E5DECD;margin:0 14px;"></div>
+              <button style="width:100%;background:none;border:none;color:#4C3FA6;font-family:Inter;font-weight:600;font-size:14px;padding:14px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:7px;"><i data-lucide="plus" width="16" height="16"></i>Link an exercise</button>
+            </div>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 3 · PIECE DETAIL · EDIT/REORDER ===== -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Linked card · edit &amp; reorder</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;">
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="chevron-left" width="20" height="20" style="color:#4C3FA6;"></i></div>
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="ellipsis" width="19" height="19" style="color:#6E6557;"></i></div>
+          </div>
+          <div style="flex:1;overflow:hidden;padding:14px 16px 24px;display:flex;flex-direction:column;gap:16px;">
+            <div style="animation:fadeUp .5s ease both;">
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 10px;border-radius:8px;background:#E7E3F4;color:#4C3FA6;font-weight:600;font-size:11.5px;">Piece</span>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1.05;margin-top:10px;">Clair de Lune</div>
+              <div style="font-size:13px;color:#6E6557;margin-top:5px;">Debussy · D♭ major · ♩=66</div>
+            </div>
+            <!-- LINKED EXERCISES · EDIT MODE -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:6px 4px 8px;animation:fadeUp .5s .06s ease both;">
+              <div style="display:flex;align-items:center;justify-content:space-between;padding:12px 16px 10px;">
+                <div style="display:flex;align-items:center;gap:8px;"><span style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Linked exercises</span></div>
+                <span style="font-size:13px;font-weight:700;color:#4C3FA6;cursor:pointer;">Done</span>
+              </div>
+              <!-- lifted/dragging row -->
+              <div style="display:flex;align-items:center;gap:11px;padding:12px 14px;margin:0 6px;border-radius:12px;background:#FFFEFB;box-shadow:0 12px 22px -8px rgba(43,42,38,0.28);border:1px solid #E5DECD;transform:scale(1.015);position:relative;z-index:2;">
+                <i data-lucide="minus-circle" width="22" height="22" style="color:#B3261E;flex:none;"></i>
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Scales · D♭ major</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Two octaves · ♩=96</div></div>
+                <i data-lucide="grip-vertical" width="22" height="22" style="color:#9A927F;flex:none;"></i>
+              </div>
+              <div style="display:flex;align-items:center;gap:11px;padding:12px 14px;margin:4px 6px 0;opacity:0.92;">
+                <i data-lucide="minus-circle" width="22" height="22" style="color:#B3261E;flex:none;"></i>
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Broken arpeggios</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">D♭ · ♩=84</div></div>
+                <i data-lucide="grip-vertical" width="22" height="22" style="color:#9A927F;flex:none;"></i>
+              </div>
+              <div style="display:flex;align-items:center;gap:11px;padding:12px 14px;margin:4px 6px 0;opacity:0.92;">
+                <i data-lucide="minus-circle" width="22" height="22" style="color:#B3261E;flex:none;"></i>
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Pedalling study</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Bars 12–27 · ♩=72</div></div>
+                <i data-lucide="grip-vertical" width="22" height="22" style="color:#9A927F;flex:none;"></i>
+              </div>
+            </div>
+            <div style="display:flex;align-items:center;gap:8px;padding:0 4px;font-size:12px;color:#9A927F;animation:fadeUp .5s .1s ease both;"><i data-lucide="info" width="14" height="14"></i>Drag to reorder · the score ring is hidden while editing.</div>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 4 · PICKER A ===== -->
+    <div id="f-pickA" style="display:flex;flex-direction:column;align-items:center;gap:16px;scroll-margin-top:20px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Picker A · checkmark + sticky add</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:#2B2A26;display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <!-- dimmed detail behind -->
+          <div style="position:absolute;inset:0;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);opacity:0.34;"></div>
+          <!-- sheet -->
+          <div style="position:absolute;left:0;right:0;bottom:0;height:712px;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);display:flex;flex-direction:column;overflow:hidden;animation:fadeUp .4s ease both;">
+            <div style="display:flex;justify-content:center;padding:10px 0 4px;flex:none;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 18px 12px;flex:none;">
+              <span style="font-size:14px;color:#6E6557;font-weight:500;cursor:pointer;">Cancel</span>
+              <span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:18px;color:#2B2A26;">Add exercises</span>
+              <span style="width:48px;"></span>
+            </div>
+            <div style="padding:0 18px 10px;flex:none;">
+              <div style="display:flex;align-items:center;gap:9px;background:#F0E7D6;border-radius:11px;padding:11px 13px;"><i data-lucide="search" width="17" height="17" style="color:#9A927F;"></i><span style="font-size:15px;color:#9A927F;">Search exercises</span></div>
+            </div>
+            <div style="flex:1;overflow:hidden;padding:4px 12px 0;display:flex;flex-direction:column;">
+              <!-- create new -->
+              <div style="display:flex;align-items:center;gap:13px;padding:13px 12px;border-radius:12px;cursor:pointer;" style-hover="background:#FCFAF3;">
+                <span style="width:34px;height:34px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="plus" width="18" height="18" style="color:#4C3FA6;"></i></span>
+                <div style="font-size:15px;font-weight:600;color:#4C3FA6;">Create new exercise</div>
+              </div>
+              <div style="height:1px;background:#E5DECD;margin:2px 12px 4px;"></div>
+              <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;padding:6px 12px 2px;">Your exercises · already-linked hidden</div>
+              <!-- selectable rows -->
+              <div class="paRow" data-name="Hanon No.1" data-meta="C major · ♩=108" data-on="1" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Hanon No.1</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">C major · ♩=108</div></div>
+                <span class="paChk" style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #D8D0BD;"></span>
+              </div>
+              <div class="paRow" data-name="Chromatic run" data-meta="Bars 12–16 · ♩=72" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Chromatic run</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Bars 12–16 · ♩=72</div></div>
+                <span class="paChk" style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #D8D0BD;"></span>
+              </div>
+              <div class="paRow" data-name="Octave leaps" data-meta="Two octaves · ♩=88" data-on="1" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Octave leaps</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Two octaves · ♩=88</div></div>
+                <span class="paChk" style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #D8D0BD;"></span>
+              </div>
+              <div class="paRow" data-name="Trill drill" data-meta="Both hands · ♩=60" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Trill drill</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Both hands · ♩=60</div></div>
+                <span class="paChk" style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #D8D0BD;"></span>
+              </div>
+              <div class="paRow" data-name="Thirds, legato" data-meta="A minor · ♩=76" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Thirds, legato</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">A minor · ♩=76</div></div>
+                <span class="paChk" style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #D8D0BD;"></span>
+              </div>
+            </div>
+            <!-- sticky add -->
+            <div style="flex:none;padding:12px 18px 26px;background:rgba(244,241,232,0.92);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);border-top:1px solid #E5DECD;">
+              <button id="paBtn" style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;cursor:pointer;transition:transform .15s;" style-active="transform:scale(0.985)">Add 2 exercises</button>
+            </div>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.55;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 5 · PICKER B ===== -->
+    <div id="f-pickB" style="display:flex;flex-direction:column;align-items:center;gap:16px;scroll-margin-top:20px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Picker B · running selected tray</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:#2B2A26;display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="position:absolute;inset:0;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);opacity:0.34;"></div>
+          <div style="position:absolute;left:0;right:0;bottom:0;height:712px;background:#F4F1E8;border-radius:28px 28px 0 0;box-shadow:0 -16px 40px -12px rgba(0,0,0,0.3);display:flex;flex-direction:column;overflow:hidden;animation:fadeUp .4s ease both;">
+            <div style="display:flex;justify-content:center;padding:10px 0 4px;flex:none;"><span style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;"></span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 18px 12px;flex:none;">
+              <span style="font-size:14px;color:#6E6557;font-weight:500;cursor:pointer;">Cancel</span>
+              <span style="font-family:'Source Serif 4',serif;font-weight:600;font-size:18px;color:#2B2A26;">Add exercises</span>
+              <span style="width:48px;"></span>
+            </div>
+            <div style="padding:0 18px 10px;flex:none;">
+              <div style="display:flex;align-items:center;gap:9px;background:#F0E7D6;border-radius:11px;padding:11px 13px;"><i data-lucide="search" width="17" height="17" style="color:#9A927F;"></i><span style="font-size:15px;color:#9A927F;">Search exercises</span></div>
+            </div>
+            <!-- selected tray -->
+            <div id="pbTray" style="flex:none;padding:0 18px 10px;"></div>
+            <div style="flex:1;overflow:hidden;padding:4px 12px 0;display:flex;flex-direction:column;">
+              <div style="display:flex;align-items:center;gap:13px;padding:13px 12px;border-radius:12px;cursor:pointer;" style-hover="background:#FCFAF3;">
+                <span style="width:34px;height:34px;border-radius:50%;background:#E7E3F4;display:flex;align-items:center;justify-content:center;flex:none;"><i data-lucide="plus" width="18" height="18" style="color:#4C3FA6;"></i></span>
+                <div style="font-size:15px;font-weight:600;color:#4C3FA6;">Create new exercise</div>
+              </div>
+              <div style="height:1px;background:#E5DECD;margin:2px 12px 4px;"></div>
+              <div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;padding:6px 12px 2px;">Your exercises · already-linked hidden</div>
+              <div class="pbRow" data-name="Hanon No.1" data-meta="C major · ♩=108" data-on="1" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Hanon No.1</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">C major · ♩=108</div></div>
+                <span class="pbChk" style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #C9B98E;color:#9E7B33;"><i data-lucide="plus" width="16" height="16"></i></span>
+              </div>
+              <div class="pbRow" data-name="Chromatic run" data-meta="Bars 12–16 · ♩=72" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Chromatic run</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Bars 12–16 · ♩=72</div></div>
+                <span class="pbChk" style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #C9B98E;color:#9E7B33;"><i data-lucide="plus" width="16" height="16"></i></span>
+              </div>
+              <div class="pbRow" data-name="Octave leaps" data-meta="Two octaves · ♩=88" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Octave leaps</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Two octaves · ♩=88</div></div>
+                <span class="pbChk" style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #C9B98E;color:#9E7B33;"><i data-lucide="plus" width="16" height="16"></i></span>
+              </div>
+              <div class="pbRow" data-name="Trill drill" data-meta="Both hands · ♩=60" data-on="0" style="display:flex;align-items:center;gap:13px;padding:12px;border-radius:12px;cursor:pointer;transition:background .15s;">
+                <span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);flex:none;"></span>
+                <div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Trill drill</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Both hands · ♩=60</div></div>
+                <span class="pbChk" style="width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex:none;border:2px solid #C9B98E;color:#9E7B33;"><i data-lucide="plus" width="16" height="16"></i></span>
+              </div>
+            </div>
+            <div style="flex:none;padding:12px 18px 26px;background:rgba(244,241,232,0.92);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);border-top:1px solid #E5DECD;">
+              <button id="pbBtn" style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;cursor:pointer;transition:transform .15s;" style-active="transform:scale(0.985)">Add 1 exercise</button>
+            </div>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.55;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 6 · RING IN CONTEXT · LIBRARY ===== -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">In context · ring replaces the bars</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="flex:1;display:flex;flex-direction:column;min-height:0;">
+            <div style="padding:6px 16px 0;display:flex;align-items:flex-start;justify-content:space-between;">
+              <div><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;color:#2B2A26;line-height:1;">Library</div><div style="font-size:12px;color:#6E6557;margin-top:5px;">8 pieces · 5 exercises</div></div>
+              <div style="width:44px;height:44px;display:flex;align-items:center;justify-content:center;"><div style="width:30px;height:30px;border-radius:50%;background:#4C3FA6;display:flex;align-items:center;justify-content:center;"><i data-lucide="plus" width="16" height="16" style="color:#F2EFE8;"></i></div></div>
+            </div>
+            <div style="height:1px;background:#E0D9C8;margin:12px 16px 0;"></div>
+            <div style="display:flex;align-items:center;gap:8px;padding:12px 16px 6px;">
+              <div style="display:flex;gap:8px;flex:1;align-items:center;"><span style="padding:6px 13px;border-radius:999px;background:#4C3FA6;color:#F2EFE8;font-weight:500;font-size:13px;">All</span><span style="padding:6px 13px;border-radius:999px;color:#9A927F;font-weight:500;font-size:13px;">Pieces</span><span style="padding:6px 13px;border-radius:999px;color:#9A927F;font-weight:500;font-size:13px;">Exercises</span></div>
+              <i data-lucide="search" width="17" height="17" style="color:#9A927F;"></i>
+            </div>
+            <div style="flex:1;overflow:hidden;padding:10px 16px 104px;display:flex;flex-direction:column;gap:12px;">
+              <!-- piece row, indigo bar, ring -->
+              <div style="position:relative;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:14px 16px 14px 20px;overflow:hidden;display:flex;align-items:center;gap:14px;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;">Clair de Lune</div><div style="font-size:13px;color:#6E6557;margin-top:1px;">Debussy · D♭ · ♩=66</div></div><svg width="46" height="46" viewBox="0 0 46 46" style="flex:none;"><circle cx="23" cy="23" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="23" cy="23" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="22.62" transform="rotate(-90 23 23)"/><text x="23" y="23" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">8</text></svg></div>
+              <!-- exercise row, gold bar, ring -->
+              <div style="position:relative;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:14px 16px 14px 20px;overflow:hidden;display:flex;align-items:center;gap:14px;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;">Scales · C major</div><div style="font-size:13px;color:#6E6557;margin-top:1px;">Two octaves · ♩=120</div></div><svg width="46" height="46" viewBox="0 0 46 46" style="flex:none;"><circle cx="23" cy="23" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="23" cy="23" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="56.55" transform="rotate(-90 23 23)"/><text x="23" y="23" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">5</text></svg></div>
+              <div style="position:relative;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:14px 16px 14px 20px;overflow:hidden;display:flex;align-items:center;gap:14px;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;">Nocturne Op.9 No.2</div><div style="font-size:13px;color:#6E6557;margin-top:1px;">Chopin · E♭ · ♩=132</div></div><svg width="46" height="46" viewBox="0 0 46 46" style="flex:none;"><circle cx="23" cy="23" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><circle cx="23" cy="23" r="18" fill="none" stroke="#4C3FA6" stroke-width="4" stroke-linecap="round" stroke-dasharray="113.1" stroke-dashoffset="79.17" transform="rotate(-90 23 23)"/><text x="23" y="23" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="16" fill="#2B2A26">3</text></svg></div>
+              <div style="position:relative;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:14px 16px 14px 20px;overflow:hidden;display:flex;align-items:center;gap:14px;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;min-width:0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;">Trill drill</div><div style="font-size:13px;color:#6E6557;margin-top:1px;">Both hands · ♩=60</div></div><svg width="46" height="46" viewBox="0 0 46 46" style="flex:none;"><circle cx="23" cy="23" r="18" fill="none" stroke="#E6DECB" stroke-width="4"/><text x="23" y="23" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="15" fill="#9A927F">–</text></svg></div>
+            </div>
+          </div>
+          <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;display:flex;align-items:flex-start;justify-content:space-around;padding:10px 4px 22px;background:rgba(247,243,233,0.8);backdrop-filter:blur(20px) saturate(180%);-webkit-backdrop-filter:blur(20px) saturate(180%);border-top:1px solid rgba(176,168,146,0.3);">
+            <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="library" width="25" height="25" style="color:#4C3FA6;"></i><span style="font-size:10px;font-weight:600;color:#4C3FA6;">Library</span></div>
+            <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="timer" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Practice</span></div>
+            <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="list-music" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Routines</span></div>
+            <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="trending-up" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Progress</span></div>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== FRAME 7 · EXERCISE DETAIL · HERO RING ===== -->
+    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+      <div style="font-size:12px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Exercise detail · ring at hero size</div>
+      <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+        <div style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+          <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+          <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+          <div style="display:flex;align-items:center;justify-content:space-between;padding:4px 16px 0;flex:none;">
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="chevron-left" width="20" height="20" style="color:#4C3FA6;"></i></div>
+            <div style="width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:999px;background:#FCFAF3;border:1px solid #E5DECD;"><i data-lucide="ellipsis" width="19" height="19" style="color:#6E6557;"></i></div>
+          </div>
+          <div style="flex:1;overflow:hidden;padding:14px 16px 24px;display:flex;flex-direction:column;gap:16px;">
+            <div style="text-align:center;animation:fadeUp .5s ease both;">
+              <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11.5px;">Exercise</span>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:26px;color:#2B2A26;line-height:1.1;margin-top:12px;">Scales · D♭ major</div>
+              <div style="font-size:13px;color:#6E6557;margin-top:5px;">Two octaves · ♩=96</div>
+            </div>
+            <!-- hero ring -->
+            <div style="display:flex;flex-direction:column;align-items:center;padding:6px 0 2px;animation:fadeUp .5s .08s ease both;">
+              <svg width="156" height="156" viewBox="0 0 156 156"><circle cx="78" cy="78" r="62" fill="none" stroke="#E6DECB" stroke-width="9"/><circle cx="78" cy="78" r="62" fill="none" stroke="#4C3FA6" stroke-width="9" stroke-linecap="round" stroke-dasharray="389.56" stroke-dashoffset="116.87" transform="rotate(-90 78 78)"/><text x="78" y="74" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="700" font-size="52" fill="#2B2A26">7</text><text x="78" y="106" text-anchor="middle" dominant-baseline="central" font-family="Inter" font-weight="600" font-size="13" letter-spacing="0.5" fill="#9A927F">OF 10</text></svg>
+              <div style="font-size:13px;color:#6E6557;margin-top:12px;">Tap the ring to rate this session</div>
+            </div>
+            <!-- linked-back card -->
+            <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:14px 16px;animation:fadeUp .5s .12s ease both;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Linked from</div>
+              <div style="display:flex;align-items:center;gap:12px;margin-top:10px;"><span style="width:4px;height:30px;border-radius:999px;background:linear-gradient(180deg,#6346E5,#4C3FA6);flex:none;"></span><div style="flex:1;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16px;color:#2B2A26;">Clair de Lune</div><div style="font-size:12px;color:#6E6557;margin-top:1px;">Debussy · D♭ major</div></div><i data-lucide="chevron-right" width="18" height="18" style="color:#9A927F;"></i></div>
+            </div>
+            <button style="width:100%;border:none;background:linear-gradient(180deg,#6346E5,#4C3FA6);color:#F2EFE8;font-family:Inter;font-weight:600;font-size:15px;padding:15px;border-radius:13px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:8px;animation:fadeUp .5s .16s ease both;" style-active="transform:scale(0.985)"><i data-lucide="timer" width="18" height="18"></i>Practise this</button>
+          </div>
+          <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  componentDidMount() {
+    if (window.lucide) window.lucide.createIcons();
+    this.bindA();
+    this.bindB();
+  }
+  bindA() {
+    const rows = [...document.querySelectorAll('.paRow')];
+    rows.forEach(r => r.addEventListener('click', () => {
+      r.dataset.on = r.dataset.on === '1' ? '0' : '1';
+      this.refreshA();
+    }));
+    this.refreshA();
+  }
+  refreshA() {
+    const rows = [...document.querySelectorAll('.paRow')];
+    let n = 0;
+    rows.forEach(r => {
+      const on = r.dataset.on === '1';
+      if (on) n++;
+      r.style.background = on ? '#EFEBF8' : 'transparent';
+      const chk = r.querySelector('.paChk');
+      if (chk) {
+        chk.style.background = on ? '#4C3FA6' : 'transparent';
+        chk.style.borderColor = on ? '#4C3FA6' : '#D8D0BD';
+        chk.innerHTML = on ? '<i data-lucide="check" width="15" height="15" style="color:#F2EFE8;"></i>' : '';
+      }
+    });
+    const btn = document.querySelector('#paBtn');
+    if (btn) {
+      btn.textContent = n ? ('Add ' + n + (n > 1 ? ' exercises' : ' exercise')) : 'Select exercises to add';
+      btn.style.opacity = n ? '1' : '0.5';
+    }
+    if (window.lucide) window.lucide.createIcons();
+  }
+  bindB() {
+    const rows = [...document.querySelectorAll('.pbRow')];
+    rows.forEach(r => r.addEventListener('click', () => {
+      r.dataset.on = r.dataset.on === '1' ? '0' : '1';
+      this.refreshB();
+    }));
+    this.refreshB();
+  }
+  refreshB() {
+    const rows = [...document.querySelectorAll('.pbRow')];
+    const sel = [];
+    rows.forEach(r => {
+      const on = r.dataset.on === '1';
+      if (on) sel.push(r.dataset.name);
+      r.style.background = on ? '#FCFAF3' : 'transparent';
+      const chk = r.querySelector('.pbChk');
+      if (chk) {
+        chk.style.background = on ? '#9E7B33' : 'transparent';
+        chk.style.borderColor = on ? '#9E7B33' : '#C9B98E';
+        chk.style.color = on ? '#F6EFD8' : '#9E7B33';
+        chk.innerHTML = on
+          ? '<i data-lucide="check" width="16" height="16"></i>'
+          : '<i data-lucide="plus" width="16" height="16"></i>';
+      }
+    });
+    const tray = document.querySelector('#pbTray');
+    if (tray) {
+      if (sel.length === 0) {
+        tray.innerHTML = '<div style="font-size:12.5px;color:#9A927F;padding:2px 2px 4px;">No exercises selected yet — tap to add.</div>';
+      } else {
+        const chips = sel.map(name =>
+          '<span class="pbChip" data-name="' + name + '" style="display:inline-flex;align-items:center;gap:6px;padding:6px 8px 6px 11px;border-radius:999px;background:#F0E5CC;color:#8A6A2E;font-size:12.5px;font-weight:600;cursor:pointer;">' + name +
+          '<i data-lucide="x" width="13" height="13" style="color:#9E7B33;"></i></span>'
+        ).join('');
+        tray.innerHTML =
+          '<div style="font-size:10.5px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-bottom:8px;">' + sel.length + ' selected</div>' +
+          '<div style="display:flex;flex-wrap:wrap;gap:7px;">' + chips + '</div>';
+      }
+      tray.querySelectorAll('.pbChip').forEach(chip => chip.addEventListener('click', () => {
+        const name = chip.dataset.name;
+        const row = rows.find(r => r.dataset.name === name);
+        if (row) { row.dataset.on = '0'; this.refreshB(); }
+      }));
+    }
+    const btn = document.querySelector('#pbBtn');
+    if (btn) {
+      const n = sel.length;
+      btn.textContent = n ? ('Add ' + n + (n > 1 ? ' exercises' : ' exercise')) : 'Select exercises to add';
+      btn.style.opacity = n ? '1' : '0.5';
+    }
+    if (window.lucide) window.lucide.createIcons();
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-06-29-scoring-0-10-and-session-score.md
+++ b/docs/superpowers/plans/2026-06-29-scoring-0-10-and-session-score.md
@@ -1,0 +1,584 @@
+# Scoring 0–10 + overall session score — Implementation Plan (Phase 1 / #1008)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move practice scoring from a 1–5 scale to 1–10 (with `None` = unrated), rescale existing recorded scores ×2, and add an optional overall session score — all in `intrada-core` + the native iOS app.
+
+**Architecture:** The score scale is governed by two core constants (`MIN_SCORE`/`MAX_SCORE`); the per-entry handler and validation already read them, so the data-layer change is small. The overall session score is a new `Option<u8>` carried through `SummarySession` → `PracticeSession` → `PracticeSessionView`/`SummaryView`, set by a new `UpdateSessionScore` event. On device, GRDB gains a `session_score` column and a one-time migration that doubles each stored entry score. The Swift bindings are regenerated, and the summary UI gains a 1–10 entry scorer plus an overall scorer.
+
+**Tech Stack:** Rust (crux_core, serde, bincode FFI), SwiftUI, GRDB (SQLite), swift-snapshot-testing.
+
+## Global Constraints
+
+- **Scope: `intrada-core` + native iOS only.** Do **not** touch `intrada-api` (Turso) or the Leptos web shell — web/API parity is deferred (tracked on #1008).
+- **A rated score is `1..=10`; unrated is `None`, never `0`.** `MIN_SCORE = 1`, `MAX_SCORE = 10`. The ring (#1009) renders `None`/unrated as an en-dash; `0` is never a settable score.
+- **Historical scores rescale ×2** (a stored `3` → `6`), clamped to `10`. One-time, forward-only GRDB migration. **Never edit a shipped migration** — append new ones.
+- **Bincode FFI bridge:** new fields use `#[serde(default)]`; append the new `SessionEvent` variant (don't reorder). Bridge-crossing types get an `assert_round_trips` test (#846).
+- **Generated Swift bindings are a build artifact** — regenerate via `just ios-gen`; never hand-edit `ios/generated/`.
+- **TDD:** write the failing test, watch it fail, implement minimally, watch it pass, commit. `cargo fmt --check` + `cargo clippy -- -D warnings` must pass before any push.
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+## File Structure
+
+**Core (`crates/intrada-core/src/`):**
+- `validation.rs` — `MIN_SCORE`/`MAX_SCORE` constants + `validate_score` (range only).
+- `domain/session.rs` — `SetlistEntry`/`SummarySession`/`PracticeSession`, `SessionEvent` (+ new `UpdateSessionScore`), `transition_to_summary`, `SaveSession` handler, tests.
+- `model.rs` — `SummaryView`, `PracticeSessionView` (+ `session_score`), and the view builder.
+- `domain/types.rs` — `assert_round_trips` session test.
+
+**iOS (`ios/`):**
+- `Intrada/Core/LibraryStore.swift` — `session` schema, migrations (v4 add column, v5 rescale), `saveSession`, session load mapping.
+- `Intrada/Views/Screens/SessionSummaryScreen.swift` — per-entry scorer (1→10) + new overall scorer.
+- `Intrada/Views/Components/MasteryMeter.swift` — interim /10 correctness (Phase 2 replaces it).
+- `IntradaTests/ScreenSnapshotTests.swift` + `__Snapshots__/` — re-record summary snapshots.
+- `IntradaTests/` — new GRDB migration upgrade-path test.
+
+---
+
+### Task 1: Score scale → 1–10 (core constants + validation)
+
+**Files:**
+- Modify: `crates/intrada-core/src/validation.rs:14-15` (constants) and the `validate_score` tests
+- Modify (tests): `crates/intrada-core/src/domain/session.rs:2631` (`test_update_entry_score_boundary_values`)
+
+**Interfaces:**
+- Produces: `validation::MIN_SCORE = 1`, `validation::MAX_SCORE = 10` (consumed by the existing `UpdateEntryScore` handler at `session.rs:974` and `validate_score`).
+
+- [ ] **Step 1: Write the failing test** — add to `validation.rs` tests module:
+
+```rust
+#[test]
+fn validate_score_accepts_full_0_to_10_band() {
+    assert!(validate_score(&Some(1)).is_ok());
+    assert!(validate_score(&Some(10)).is_ok());
+    assert!(validate_score(&None).is_ok());
+    // 0 is "unrated" (None), never a settable score; 11 is out of range.
+    assert!(validate_score(&Some(0)).is_err());
+    assert!(validate_score(&Some(11)).is_err());
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cargo test -p intrada-core validate_score_accepts_full_0_to_10_band`
+Expected: FAIL — `Some(10)` currently rejected (MAX_SCORE is 5).
+
+- [ ] **Step 3: Update the constants** at `validation.rs:14-15`:
+
+```rust
+pub const MIN_SCORE: u8 = 1;
+pub const MAX_SCORE: u8 = 10;
+```
+
+- [ ] **Step 4: Fix the existing boundary test** at `session.rs:2631` — change the "maximum valid" arm from `Some(5)` to `Some(10)`:
+
+```rust
+    // Score 10 — maximum valid
+    update(
+        &mut model,
+        Event::Session(SessionEvent::UpdateEntryScore {
+            entry_id: entry_id.clone(),
+            score: Some(10),
+        }),
+    );
+
+    if let SessionStatus::Summary(ref s) = model.session_status {
+        assert_eq!(s.entries[0].score, Some(10));
+    }
+```
+
+- [ ] **Step 5: Run the suite, verify green**
+
+Run: `cargo test -p intrada-core score`
+Expected: PASS (new band test + boundary test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/intrada-core/src/validation.rs crates/intrada-core/src/domain/session.rs
+git commit -m "feat(core): widen practice score scale to 1–10"
+```
+
+---
+
+### Task 2: Overall session score — model field + event (core)
+
+**Files:**
+- Modify: `crates/intrada-core/src/domain/session.rs` — `SummarySession` struct, `PracticeSession` struct (`:86-96`), `transition_to_summary` (`:376-404`), `SessionEvent` enum (`:152-269`), the event handler block, `SaveSession` handler (`:1044-1084`)
+- Test: same file's `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Produces: `SessionEvent::UpdateSessionScore { score: Option<u8> }`; `PracticeSession.session_score: Option<u8>`; `SummarySession.session_score: Option<u8>`.
+
+- [ ] **Step 1: Write the failing test** (in `session.rs` tests):
+
+```rust
+#[test]
+fn test_update_session_score_sets_and_validates() {
+    let mut model = model_with_summary();
+
+    update(
+        &mut model,
+        Event::Session(SessionEvent::UpdateSessionScore { score: Some(8) }),
+    );
+    assert!(model.last_error.is_none());
+    if let SessionStatus::Summary(ref s) = model.session_status {
+        assert_eq!(s.session_score, Some(8));
+    } else {
+        panic!("Expected Summary state");
+    }
+
+    // Out of range is rejected, leaving the prior value intact.
+    update(
+        &mut model,
+        Event::Session(SessionEvent::UpdateSessionScore { score: Some(11) }),
+    );
+    if let SessionStatus::Summary(ref s) = model.session_status {
+        assert_eq!(s.session_score, Some(8));
+    }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cargo test -p intrada-core test_update_session_score_sets_and_validates`
+Expected: FAIL — `UpdateSessionScore` variant and `session_score` field don't exist (compile error).
+
+- [ ] **Step 3: Add the field to `SummarySession`** (find the struct in `session.rs`; it currently ends with `completion_status`). Add:
+
+```rust
+    #[serde(default)]
+    pub session_score: Option<u8>,
+```
+
+- [ ] **Step 4: Add the field to `PracticeSession`** (`:86-96`), after `completion_status`:
+
+```rust
+    #[serde(default)]
+    pub session_score: Option<u8>,
+```
+
+- [ ] **Step 5: Initialise it in `transition_to_summary`** (`:376-404`) — in the returned `SummarySession { ... }`, add `session_score: None,`.
+
+- [ ] **Step 6: Append the event variant** to `SessionEvent` (next to `UpdateSessionNotes`, `:152-269`):
+
+```rust
+    UpdateSessionScore { score: Option<u8> },
+```
+
+- [ ] **Step 7: Handle it** — add a match arm beside `UpdateEntryScore`/`UpdateSessionNotes` in the session update fn:
+
+```rust
+SessionEvent::UpdateSessionScore { score } => {
+    if let Some(s) = score {
+        if !(validation::MIN_SCORE..=validation::MAX_SCORE).contains(&s) {
+            return crux_core::render::render();
+        }
+    }
+    let SessionStatus::Summary(ref mut summary) = model.session_status else {
+        model.last_error = Some("Not in summary state".to_string());
+        return crux_core::render::render();
+    };
+    summary.session_score = score;
+    model.last_error = None;
+    crux_core::render::render()
+}
+```
+
+- [ ] **Step 8: Carry it into the saved session** — in the `SaveSession` handler (`:1044-1084`), add to the `PracticeSession { ... }` literal:
+
+```rust
+        session_score: summary.session_score,
+```
+
+- [ ] **Step 9: Run the test, verify green**
+
+Run: `cargo test -p intrada-core test_update_session_score_sets_and_validates`
+Expected: PASS.
+
+- [ ] **Step 10: Compile the whole workspace** (shared core type touched):
+
+Run: `cargo test -p intrada-core && cargo clippy -p intrada-core -- -D warnings`
+Expected: PASS (any other constructors of `PracticeSession`/`SummarySession` now need the field — fix them to `session_score: None` if the compiler flags them).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/intrada-core/src/domain/session.rs
+git commit -m "feat(core): add overall session score + UpdateSessionScore event"
+```
+
+---
+
+### Task 3: Expose `session_score` in the ViewModel (core)
+
+**Files:**
+- Modify: `crates/intrada-core/src/model.rs` — `SummaryView` (`:362-368`), `PracticeSessionView` (`:275-285`)
+- Modify: the view builder in `app.rs`/`model.rs` that constructs `SummaryView` from `SummarySession` and `PracticeSessionView` from `PracticeSession`
+- Test: `model.rs` (or `app.rs`) tests
+
+**Interfaces:**
+- Consumes: `SummarySession.session_score`, `PracticeSession.session_score` (Task 2).
+- Produces: `SummaryView.session_score: Option<u8>`, `PracticeSessionView.session_score: Option<u8>` (consumed by Swift in Task 7).
+
+- [ ] **Step 1: Write the failing test** — drive a session to summary, set the score, assert the view exposes it:
+
+```rust
+#[test]
+fn summary_view_exposes_session_score() {
+    let mut model = model_with_summary();
+    update(
+        &mut model,
+        Event::Session(SessionEvent::UpdateSessionScore { score: Some(7) }),
+    );
+    let view = view(&model); // the crate's ViewModel builder
+    assert_eq!(view.summary.unwrap().session_score, Some(7));
+}
+```
+
+(Use the crate's existing pattern for building the `ViewModel` in tests — match how other `view(&model)` / `app.view()` tests are written in this module.)
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cargo test -p intrada-core summary_view_exposes_session_score`
+Expected: FAIL — `SummaryView` has no `session_score` field.
+
+- [ ] **Step 3: Add the field to `SummaryView`** (`:362-368`):
+
+```rust
+    pub session_score: Option<u8>,
+```
+
+- [ ] **Step 4: Add the field to `PracticeSessionView`** (`:275-285`):
+
+```rust
+    pub session_score: Option<u8>,
+```
+
+- [ ] **Step 5: Populate both** in their builders — set `session_score: summary.session_score` (and `session.session_score` for the persisted-session view).
+
+- [ ] **Step 6: Run the test, verify green**
+
+Run: `cargo test -p intrada-core summary_view_exposes_session_score`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/intrada-core/src/model.rs crates/intrada-core/src/app.rs
+git commit -m "feat(core): expose session_score on summary + session views"
+```
+
+---
+
+### Task 4: Round-trip coverage for the new field (core)
+
+**Files:**
+- Modify: `crates/intrada-core/src/domain/types.rs:432-468` (the existing session round-trip test)
+
+**Interfaces:**
+- Consumes: `PracticeSession.session_score` (Task 2).
+
+- [ ] **Step 1: Extend the round-trip test** — in `save_session_persistence_op_round_trips_on_ffi_bincode_wire`, add `session_score: Some(8),` to the `PracticeSession { ... }` literal so a populated value crosses the bincode wire.
+
+- [ ] **Step 2: Run it, verify green**
+
+Run: `cargo test -p intrada-core save_session_persistence_op_round_trips_on_ffi_bincode_wire`
+Expected: PASS (proves `session_score` survives the FFI bincode round-trip, #846).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/intrada-core/src/domain/types.rs
+git commit -m "test(core): round-trip session_score on the FFI bincode wire"
+```
+
+---
+
+### Task 5: Regenerate Swift bindings
+
+**Files:**
+- Generated (do not hand-edit): `ios/generated/SharedTypes/Sources/SharedTypes/SharedTypes.swift`
+
+- [ ] **Step 1: Regenerate**
+
+Run: `just ios-gen`
+Expected: success; `SharedTypes.swift` now contains `case updateSessionScore(score: UInt8?)` in `SessionEvent` and a `sessionScore: UInt8?` field on `SummaryView`/`PracticeSessionView`.
+
+- [ ] **Step 2: Sanity-check the diff**
+
+Run: `git diff --stat ios/generated`
+Expected: only generated changes for the new field/variant.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ios/generated
+git commit -m "build(ios): regenerate bindings for session_score + UpdateSessionScore"
+```
+
+---
+
+### Task 6: GRDB — add `session_score` column + rescale existing scores (iOS)
+
+**Files:**
+- Modify: `ios/Intrada/Core/LibraryStore.swift` — migrations (after `v3_session`, `:159-175`), `saveSession` (`:102-124`), the session load/row-mapping
+- Test: `ios/IntradaTests/LibraryStoreMigrationTests.swift` (create)
+
+**Interfaces:**
+- Produces: `session.session_score` column; existing entry scores doubled (≤10).
+
+- [ ] **Step 1: Write the failing upgrade-path test** — `ios/IntradaTests/LibraryStoreMigrationTests.swift`:
+
+```swift
+import GRDB
+import XCTest
+@testable import Intrada
+
+final class LibraryStoreMigrationTests: XCTestCase {
+  func testV5RescalesEntryScoresAndAddsSessionScore() throws {
+    let queue = try DatabaseQueue()  // in-memory
+
+    // Migrate only up to v3 (the pre-rescale schema), then seed a session
+    // whose single entry scored 3 on the old 1–5 scale.
+    try LibraryStore.migrator.migrate(queue, upTo: "v3_session")
+    try queue.write { db in
+      let entriesJSON = #"[{"id":"e1","itemId":"i1","itemTitle":"Scales","itemType":"exercise","position":0,"durationSecs":60,"status":"completed","score":3}]"#
+      try db.execute(sql: """
+        INSERT INTO session (id, started_at, completed_at, total_duration_secs,
+          completion_status, session_notes, session_intention, entries, updated_at, deleted_at)
+        VALUES ('s1','2026-01-01T00:00:00Z','2026-01-01T00:01:00Z',60,'completed',NULL,NULL,?, '2026-01-01T00:00:00Z',NULL)
+        """, arguments: [entriesJSON])
+    }
+
+    // Run the remaining migrations (v4 add column, v5 rescale).
+    try LibraryStore.migrator.migrate(queue)
+
+    try queue.read { db in
+      let row = try Row.fetchOne(db, sql: "SELECT entries, session_score FROM session WHERE id='s1'")!
+      let entries: String = row["entries"]
+      XCTAssertTrue(entries.contains("\"score\":6"), "old score 3 should rescale ×2 to 6")
+      XCTAssertNil(row["session_score"] as String?, "session_score column exists, null for old rows")
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run (quit Xcode first — see `docs/ios-testing.md`): `just ios-test` (or the equivalent `xcodebuild test` for `LibraryStoreMigrationTests`).
+Expected: FAIL — `LibraryStore.migrator` isn't accessible and migrations `v4`/`v5` don't exist.
+
+- [ ] **Step 3: Make the migrator testable** — if `migrator` is a private local in `LibraryStore`, hoist it to a `static let migrator: DatabaseMigrator` (internal) built by a `static func makeMigrator()`, and have the init use `Self.migrator`. (Mirror the existing registration order; do not change v1–v3 bodies.)
+
+- [ ] **Step 4: Append migration v4 (add column)** after `v3_session`:
+
+```swift
+migrator.registerMigration("v4_session_score") { db in
+  try db.execute(sql: "ALTER TABLE session ADD COLUMN session_score INTEGER")
+}
+```
+
+- [ ] **Step 5: Append migration v5 (rescale entry scores ×2)**:
+
+```swift
+migrator.registerMigration("v5_rescale_entry_scores") { db in
+  let rows = try Row.fetchAll(db, sql: "SELECT id, entries FROM session")
+  for row in rows {
+    let id: String = row["id"]
+    let json: String = row["entries"]
+    guard var dtos = try? JSONDecoder().decode([StoredEntry].self, from: Data(json.utf8))
+    else { continue }
+    for i in dtos.indices {
+      if let s = dtos[i].score { dtos[i].score = min(10, s &* 2) }
+    }
+    guard let data = try? JSONEncoder().encode(dtos),
+          let rescaled = String(data: data, encoding: .utf8) else { continue }
+    try db.execute(sql: "UPDATE session SET entries = ? WHERE id = ?", arguments: [rescaled, id])
+  }
+}
+```
+
+(`StoredEntry` is the existing private DTO at `LibraryStore.swift:263-280`; it must be visible to the migration closure — it already lives in the same file.)
+
+- [ ] **Step 6: Persist & load `session_score`** — in `saveSession` (`:102-124`) add `session_score` to the column list, the `VALUES` placeholders, the `ON CONFLICT` set, and the `arguments` (`session.sessionScore.map(Int.init) as Any`). Then update the session **load** query (the `SELECT ... FROM session` that hydrates `PracticeSession`) to select `session_score` and map it into `PracticeSession(... sessionScore: row["session_score"])`.
+
+- [ ] **Step 7: Run the migration test, verify green**
+
+Run: `just ios-test` (filtered to `LibraryStoreMigrationTests`).
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ios/Intrada/Core/LibraryStore.swift ios/IntradaTests/LibraryStoreMigrationTests.swift
+git commit -m "feat(ios): rescale stored scores ×2 + persist session_score (GRDB v4/v5)"
+```
+
+---
+
+### Task 7: Summary UI — 1–10 entry scorer + overall session scorer (iOS)
+
+**Files:**
+- Modify: `ios/Intrada/Views/Screens/SessionSummaryScreen.swift` — `scoreRow` (`:120-143`), insert an overall scorer between `noteField` and `controls`
+
+**Interfaces:**
+- Consumes: `SummaryView.session_score` (Task 3), `SessionEvent.updateSessionScore` (Task 5).
+
+- [ ] **Step 1: Widen the per-entry scorer** — in `scoreRow` (`:124`) change the range and the a11y label; wrap so 10 dots fit the row width:
+
+```swift
+  return HStack(spacing: 5) {
+    ForEach(1...10, id: \.self) { value in
+```
+and (`:142`):
+```swift
+    .accessibilityValue(score == 0 ? "not scored" : "\(score) of 10")
+```
+
+(If 10 dots are too wide at the current 18pt size, drop the dot to ~15pt and `spacing: 4`; verify on the simulator. This row is replaced by the ring tap-target in Phase 2/#1009, so keep changes minimal.)
+
+- [ ] **Step 2: Add an overall-session scorer** — a new private view, inserted in `body` between `noteField` and `controls`:
+
+```swift
+  private func sessionScoreRow(_ summary: SummaryView) -> some View {
+    let score = summary.sessionScore.map(Int.init) ?? 0
+    return VStack(alignment: .leading, spacing: IntradaSpacing.controlGap) {
+      Text("Overall")
+        .font(IntradaFont.fieldLabel)
+        .foregroundStyle(IntradaColor.inkSecondary)
+      HStack(spacing: 5) {
+        ForEach(1...10, id: \.self) { value in
+          Button {
+            let next: UInt8? = summary.sessionScore == UInt8(value) ? nil : UInt8(value)
+            store.send(.session(.updateSessionScore(score: next)))
+          } label: {
+            Circle()
+              .fill(score >= value ? AnyShapeStyle(IntradaColor.accent) : AnyShapeStyle(.clear))
+              .frame(width: 18, height: 18)
+              .overlay(Circle().stroke(IntradaColor.divider, lineWidth: 1.5)
+                .opacity(score >= value ? 0 : 1))
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel("Overall session score")
+      .accessibilityValue(score == 0 ? "not scored" : "\(score) of 10")
+    }
+  }
+```
+
+(Use the real `IntradaFont`/`IntradaColor`/`IntradaSpacing` tokens that the file already imports; match the surrounding card styling — wrap in `.cardSurface()` like `noteField` if that's the existing pattern.)
+
+- [ ] **Step 3: Wire it into `body`** — add `sessionScoreRow(summary)` to the `VStack` between `noteField` and `controls`.
+
+- [ ] **Step 4: Build & exercise on the simulator** (per `docs/ios-testing.md`): launch `just ios-run`, drive a session to the summary, confirm the 1–10 per-entry dots and the overall scorer both set/clear and that a failed core write would surface (re-read `viewModel` after `send`). Capture a screenshot.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/Intrada/Views/Screens/SessionSummaryScreen.swift
+git commit -m "feat(ios): 1–10 entry scorer + overall session score on the summary"
+```
+
+---
+
+### Task 8: MasteryMeter interim correctness on the 0–10 scale (iOS)
+
+> Throwaway-but-correct: #1009 replaces `MasteryMeter` with the ring next phase. This keeps Phase 1 self-consistent so library cards don't read "7 / 5" in the interim.
+
+**Files:**
+- Modify: `ios/Intrada/Views/Components/MasteryMeter.swift`
+
+- [ ] **Step 1: Update the doc + caption + a11y for /10, keep the 5 bars proportional.** Change `steps` semantics so the meter maps a 0–10 `level` across its 5 bars, and the caption/label read out of 10:
+
+```swift
+  private func filled(_ index: Int) -> Bool {
+    guard let level else { return false }
+    // 5 bars across a 0–10 scale: each bar ≈ 2 points.
+    return index < Int((Double(level) / 2.0).rounded())
+  }
+
+  private var caption: String {
+    guard let level else { return "—" }
+    return "\(level) / 10"
+  }
+```
+and the accessibility label:
+```swift
+      level == nil ? "Not yet practised" : "Mastery \(level ?? 0) of 10")
+```
+
+- [ ] **Step 2: Update the preview** (`#Preview`) to iterate `1...10` (or a representative 1,3,6,8,10) so the preview reflects the new scale.
+
+- [ ] **Step 3: Build to confirm it compiles** (`just ios` or a build of the Intrada scheme).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ios/Intrada/Views/Components/MasteryMeter.swift
+git commit -m "fix(ios): MasteryMeter reads on the 0–10 scale (interim, pre-ring)"
+```
+
+---
+
+### Task 9: Re-record + optimize snapshots (iOS)
+
+**Files:**
+- Modify: `ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testSessionSummaryCompleted.1.png`, `testSessionSummaryEndedEarly.1.png`, and any `LibraryItemCard`/library snapshot whose `MasteryMeter` changed
+- Possibly modify: `ios/IntradaTests/ScreenSnapshotTests.swift` (preview fixtures `previewSummary` to carry a `sessionScore`)
+
+- [ ] **Step 1: Give the summary preview a session score** — update the `Store.previewSummary` fixture so the recorded snapshot shows the overall scorer populated (e.g. `sessionScore: 8`). Match the existing fixture-construction pattern.
+
+- [ ] **Step 2: Re-record** the affected snapshots (set `isRecording = true` per the project's snapshot convention, run, then revert), per `docs/ios-testing.md` and the Snapshot test hygiene rules in `CLAUDE.md`.
+
+- [ ] **Step 3: Optimize + check**
+
+Run: `just ios-snapshots-optimize && just ios-snapshots-check`
+Expected: references shrink (alpha dropped), hygiene job passes (no orphans, under size ceiling).
+
+- [ ] **Step 4: Run the snapshot suite green**
+
+Run: `just ios-test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/IntradaTests
+git commit -m "test(ios): re-record summary snapshots for the 1–10 scale + overall score"
+```
+
+---
+
+### Task 10: Final gates + PR
+
+- [ ] **Step 1: Core gates**
+
+Run: `cargo fmt --check && cargo clippy -- -D warnings && cargo test`
+Expected: all PASS.
+
+- [ ] **Step 2: iOS build + tests** (quit Xcode first)
+
+Run: `just ios-test`
+Expected: PASS.
+
+- [ ] **Step 3: Open the PR via the `ship` skill** (not raw `gh pr create`). PR body: scope = core + iOS (web/API deferred), closes #1008; Coverage line; note the ×2 rescale + the 1→10 scorer + the new overall score; flag MasteryMeter as interim (replaced by #1009). Post the `ship` self-review as a `gh pr comment`; end it with `Deferred items tracked: web/API parity on #1008`.
+
+---
+
+## Self-Review
+
+**Spec coverage (#1008):**
+- Per-item 1–5 → 0–10 (rated 1–10, None=unrated) → Task 1. ✓
+- Overall session score (new field) → Tasks 2, 3, 7. ✓
+- ×2 rescale of historical scores → Task 6 (v5). ✓
+- Score input UI + labels → Task 7; interim display → Task 8. ✓
+- Bridge round-trip + bindings → Tasks 4, 5. ✓
+- Migration upgrade-path test → Task 6. ✓
+- Core + iOS only, web/API deferred → Global Constraints + Task 10. ✓
+
+**Open follow-ups (not this plan):** #1009 (ring replaces MasteryMeter — deletes the Task 8 interim) and the linked-exercises feature build on top.
+
+**Type consistency:** `session_score: Option<u8>` (Rust) ↔ `sessionScore: UInt8?` (Swift) across `SummarySession`/`PracticeSession`/`SummaryView`/`PracticeSessionView`; event `UpdateSessionScore { score: Option<u8> }` ↔ `.updateSessionScore(score: UInt8?)`. Consistent throughout.

--- a/docs/superpowers/plans/2026-06-30-linked-exercises.md
+++ b/docs/superpowers/plans/2026-06-30-linked-exercises.md
@@ -1,0 +1,134 @@
+# Linked exercises (Phase 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Let a piece carry an ordered group of linked exercises (each shown with its 0–10 `ScoreRing`), with a multi-select picker to add them and a "Linked from" reverse card on the exercise. Full design: `specs/piece-linked-exercises.md`; mock: `design/linked-exercises-mock.dc.html`.
+
+**Architecture:** `linked_exercise_ids: Vec<String>` on `Item` (structurally identical to the existing `tags: Vec<String>` — mirror its lifecycle end-to-end). Dedicated `LinkExercise`/`UnlinkExercise`/`ReorderLinkedExercises` events (NOT via `CreateItem`/`UpdateItem`). The core resolves ids → live exercise views (reusing the `practice` rollup) and computes the reverse `linked_from_pieces`. GRDB stores a JSON column. Builds on merged Phase 1 (0–10 scoring) + Phase 2 (`ScoreRing`).
+
+**Tech Stack:** Rust (crux_core, serde/bincode FFI), SwiftUI, GRDB.
+
+## Global Constraints
+
+- **Offline-first:** writes go through `save_or_put` (the `local_first` GRDB branch — invariant 1); the piece is the synced entity, its `updated_at` bumped on each link change (invariant 2); client-owned ids (3); reconciliation in core (4); a failed local write surfaces, never a silent success (5).
+- **Bincode FFI:** new `Item` field uses `#[serde(default)]`; **append** new `ItemEvent` variants (never reorder); bridge-crossing types (the new events) get an `assert_round_trips` test (#846).
+- **`linked_exercise_ids` is managed ONLY by the link/unlink/reorder events** — it is NOT added to `CreateItem`/`UpdateItem`.
+- **Generated bindings** regenerate via `just ios-gen` (gitignored — never committed/hand-edited).
+- iOS: tokens only (`IntradaColor`/`IntradaFont`/`IntradaSpacing`/`IntradaRadius`), no literals; VoiceOver + Dynamic Type; reuse `ScoreRing`, `.cardSurface()`, `HairlineDivider`, `NavigationLink(value:)` (the existing `navigationDestination(for: String.self)` already routes any id → `LibraryDetailScreen`).
+- **api compile-compat:** the new `Item` field breaks `intrada-api`'s `Item {…}` constructors — add `linked_exercise_ids: vec![]` there (api parity is deferred; CI builds api). `intrada-web` is CI-excluded/paused — leave it.
+- Per-task green gate: core → `cargo test -p intrada-core` + clippy + fmt; iOS → `just ios-test` on the worktree-scoped sim (shared-sim rule). Commit messages end `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`; scoped `git add` only.
+
+## File Structure
+- Core: `crates/intrada-core/src/domain/item.rs` (field + events + handlers), `src/validation.rs` (validate fn), `src/model.rs` (`LinkedExerciseView`, `PieceRefView`, `LibraryItemView` fields), `src/app.rs` (view resolution), `src/domain/types.rs` (round-trip test).
+- api compat: `crates/intrada-api/src/db/items.rs`.
+- Persistence: `ios/Intrada/Core/LibraryStore.swift` (v6 migration + codec).
+- iOS UI: `ios/Intrada/Views/Screens/LibraryDetailScreen.swift` (+ section + linked-from card), new `ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift`, `ios/IntradaTests/ScreenSnapshotTests.swift`.
+
+---
+
+### Task 1: Core — `linked_exercise_ids` field + link events + handlers + validation
+
+**Files:** `crates/intrada-core/src/domain/item.rs`, `src/validation.rs`; compile-compat any forced `Item {…}` constructor across the workspace (core + `intrada-api`).
+
+**Interfaces produced:** `Item.linked_exercise_ids: Vec<String>`; `ItemEvent::LinkExercise { piece_id, exercise_id }`, `ItemEvent::UnlinkExercise { piece_id, exercise_id }`, `ItemEvent::ReorderLinkedExercises { piece_id, ordered_ids }`.
+
+- [ ] **Step 1: Failing tests** (in `item.rs` tests) — drive each event and assert the model + validation. Cover: link adds the id to the piece; link rejects a non-existent exercise / a non-Exercise target / a non-Piece host / a duplicate / a self-link (leaving the list unchanged + `last_error` set); unlink removes it; reorder sets the order; and that each bumps `updated_at`. Use the test fixtures already in `item.rs`.
+
+- [ ] **Step 2: Add the field** to `Item` (after `tags`): `#[serde(default)] pub linked_exercise_ids: Vec<String>,`. Fix every `Item {…}` literal the compiler flags (core fixtures + `intrada-api/src/db/items.rs`) with `linked_exercise_ids: vec![]`. Do NOT add it to `CreateItem`/`UpdateItem`.
+
+- [ ] **Step 3: Append the three event variants** to `ItemEvent` (after `RemoveTags`).
+
+- [ ] **Step 4: Add `validate_link_exercise(piece_id, exercise_id, model)`** in `validation.rs`: piece exists + is `Piece`; exercise exists + is `Exercise`; not already linked; `piece_id != exercise_id`. Return `LibraryError::Validation`/`NotFound`.
+
+- [ ] **Step 5: Handlers** in the `ItemEvent` match — mirror `AddTags`: validate (set `last_error` + `render()` on failure, leaving the list unchanged), else mutate (`LinkExercise` push if absent; `UnlinkExercise` retain≠id; `ReorderLinkedExercises` set to `ordered_ids` filtered to the currently-linked set so a stale id can't inject), bump `updated_at`, `model.last_error = None`, return `save_or_put(model, piece.clone())`.
+
+- [ ] **Step 6: Green** — `cargo test -p intrada-core` (new tests pass), `cargo clippy -p intrada-core -- -D warnings`, and `cargo test -p intrada-api` (compat compiles). Commit: `feat(core): link exercises to a piece (field + events + validation)`.
+
+---
+
+### Task 2: Core — resolved views (`linked_exercises` + `linked_from_pieces`)
+
+**Files:** `crates/intrada-core/src/model.rs` (new view structs + `LibraryItemView` fields), `src/app.rs` (the `view()` builder ~345–373).
+
+**Interfaces produced:** `LinkedExerciseView { id, title, key, tempo, practice: Option<ItemPracticeSummary> }`; `PieceRefView { id, title }`; `LibraryItemView.linked_exercises: Vec<LinkedExerciseView>`; `LibraryItemView.linked_from_pieces: Vec<PieceRefView>` (consumed by Swift in Tasks 6/8).
+
+- [ ] **Step 1: Failing test** — build a model with a piece linking two exercises (one tombstoned/missing) and assert the piece's `LibraryItemView.linked_exercises` resolves the live one in order, drops the missing one; and the exercise's `linked_from_pieces` lists the piece. Use the crate's `view(&model)` / `app.view()` pattern.
+
+- [ ] **Step 2: Add the view structs** to `model.rs` (mirror the field/derive style of neighbouring views) and the two `Vec` fields on `LibraryItemView`.
+
+- [ ] **Step 3: Resolve in `app.rs view()`** — for a `Piece`, map `item.linked_exercise_ids` → find live `Exercise` (skip missing/non-exercise), attaching `model.practice_summaries.get(&ex.id)`; preserve order. For an `Exercise`, scan `model.items` for pieces whose `linked_exercise_ids.contains(&item.id)` → `PieceRefView`. Non-matching kinds get `vec![]`.
+
+- [ ] **Step 4: Green** — `cargo test -p intrada-core` + clippy. Commit: `feat(core): resolve linked_exercises + linked_from_pieces on the view`.
+
+---
+
+### Task 3: Core — FFI round-trip coverage
+
+**Files:** `crates/intrada-core/src/domain/types.rs`.
+
+- [ ] **Step 1: Add `item_link_events_round_trip_on_ffi_bincode_wire`** (mirror `item_tag_events_round_trip…`) asserting `assert_round_trips` for all three new `ItemEvent` variants (with populated ids/ordered_ids). If an existing `Item` round-trip test exists, ensure it covers a populated `linked_exercise_ids`.
+- [ ] **Step 2: Green** — `cargo test -p intrada-core`. Commit: `test(core): round-trip link events on the FFI bincode wire`.
+
+---
+
+### Task 4: Regenerate Swift bindings
+
+- [ ] **Step 1:** `just ios-gen`; confirm `SharedTypes.swift` has `case linkExercise(pieceId:exerciseId:)` etc., `linkedExerciseIds` on `Item`, and `linkedExercises`/`linkedFromPieces` on `LibraryItemView` + the `LinkedExerciseView`/`PieceRefView` types. `ios/generated` is gitignored — nothing to commit. (No commit; this is a build artifact.)
+
+---
+
+### Task 5: iOS GRDB — persist `linked_exercise_ids`
+
+**Files:** `ios/Intrada/Core/LibraryStore.swift`; test `ios/IntradaTests/LibraryStoreMigrationTests.swift`.
+
+- [ ] **Step 1: Failing upgrade-path test** — populate an `item`-table DB migrated to `v5_rescale_entry_scores`, insert an item row (no `linked_exercise_ids` column yet), run the full migrator, assert the column exists defaulting to `'[]'` and a save/load round-trips a populated `linkedExerciseIds` (e.g. `["e1","e2"]`).
+- [ ] **Step 2: Append migration** `v6_item_linked_exercises`: `ALTER TABLE item ADD COLUMN linked_exercise_ids TEXT NOT NULL DEFAULT '[]'`.
+- [ ] **Step 3: Codec** — add `encodeLinkedExerciseIds`/`decodeLinkedExerciseIds` (mirror `encodeTags`/`decodeTags`); decode in `item(from:)`; add the column + arg to `save()`'s INSERT + `ON CONFLICT` set (mirror `tags`).
+- [ ] **Step 4: Green** — `just ios-test`. Commit: `feat(ios): persist linked_exercise_ids (GRDB v6)`.
+
+---
+
+### Task 6: iOS — "Linked exercises" section on the piece detail
+
+**Files:** `ios/Intrada/Views/Screens/LibraryDetailScreen.swift`; `ios/IntradaTests/ScreenSnapshotTests.swift`.
+
+- [ ] **Step 1: Add the section** (Pieces only, after tags, before delete): a `.cardSurface()` block with a header ("Linked exercises" + a count + an **Edit/Done** toggle), the linked-exercise rows divided by `HairlineDivider`, and a "Link an exercise" footer button (opens the picker — Task 7 wires it; for this task a `@State showingPicker` + a placeholder `.sheet` stub is fine, finalized in Task 7).
+- [ ] **Step 2: Tracked-exercise row** — `NavigationLink(value: exercise.id)` wrapping: title (`cardTitle`) + key/tempo meta + trailing `ScoreRing(score: exercise.practice?.latestScore.map(Int.init), size: 44)`. (Routing is already handled by the parent `navigationDestination(for: String.self)`.)
+- [ ] **Step 3: Edit mode** — when editing, rows show a leading remove (red minus) that dispatches `.item(.unlinkExercise(pieceId: item.id, exerciseId: ex.id))` and a drag affordance dispatching `.item(.reorderLinkedExercises(pieceId:orderedIds:))` on `onMove`; the `ScoreRing` is hidden while editing (per the mock). Re-read `viewModel.error` after each `send` — surface failures, never a silent success.
+- [ ] **Step 4: Empty state** — an in-card prompt + the "Link an exercise" button when the piece has no links.
+- [ ] **Step 5: Snapshots** — add `testPieceDetailLinkedEmpty`, `testPieceDetailLinkedPopulated`, `testPieceDetailLinkedEditing` using preview fixtures (a piece with 0 / N linked exercises). Record + `just ios-snapshots-optimize`/`-check`.
+- [ ] **Step 6: Green** — `just ios-test`. Commit: `feat(ios): Linked exercises section on the piece detail`.
+
+---
+
+### Task 7: iOS — multi-select "Add exercises" picker (Picker A)
+
+**Files:** create `ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift`; wire it in `LibraryDetailScreen.swift`.
+
+- [ ] **Step 1: Build `LinkedExercisePickerSheet`** (model on `TagFilterSheet`): a searchable list of exercises (`viewModel.items` filtered to `kind == .exercise` AND not already linked to this piece), checkmark multi-select, a "Create new exercise" row → `NavigationLink` → `LibraryAddScreen(defaultKind: .exercise)`, and a sticky "Add N" confirm (disabled when none) that returns the selected ids.
+- [ ] **Step 2: Wire it** — the section's "Link an exercise" button presents the sheet; on confirm, dispatch one `.item(.linkExercise(pieceId: item.id, exerciseId: id))` per selected id; re-read `viewModel.error`.
+- [ ] **Step 3: Snapshot** — `testLinkedExercisePicker` (a few selectable rows, some selected). Record + optimize/check.
+- [ ] **Step 4: Green** — `just ios-test`. Commit: `feat(ios): multi-select Add-exercises picker (links to the piece)`.
+
+---
+
+### Task 8: iOS — "Linked from" card on the exercise detail
+
+**Files:** `ios/Intrada/Views/Screens/LibraryDetailScreen.swift`; `ScreenSnapshotTests.swift`.
+
+- [ ] **Step 1: Add a "Linked from" `.cardSurface()` card** (Exercises only, when `linked_from_pieces` non-empty): header "Linked from" + a `NavigationLink(value: piece.id)` row per piece (title + chevron) routing to the piece's detail.
+- [ ] **Step 2: Snapshot** — `testExerciseDetailLinkedFrom`. Record + optimize/check.
+- [ ] **Step 3: Green** — `just ios-test`. Commit: `feat(ios): Linked-from card on the exercise detail`.
+
+---
+
+### Task 9: Final — gates, review, PR
+
+- [ ] **Step 1: Full gates** — `cargo fmt --check`, `cargo clippy -- -D warnings` (or `-p intrada-core -p intrada-api`), `cargo test -p intrada-core` + `cargo test -p intrada-api` (FULL output, no `head` truncation — confirm 0 failed everywhere), and `just ios-test` green.
+- [ ] **Step 2: Whole-branch review** (capable model) over the full diff — focus on offline-first invariants, the reverse-view computation, silent-success in the edit-mode dispatches, and end-to-end coherence. Fix Critical/Important.
+- [ ] **Step 3: PR** — push the branch, open the PR (per CLAUDE.md, via the gates funnel). Body: scope (core + iOS; api compat; web paused), the offline-first checklist, Coverage line, and that it implements `specs/piece-linked-exercises.md`. Post the review as a PR comment ending with `Deferred items tracked: …`.
+
+## Self-Review (controller)
+- Each `Vec<String>` link op mirrors `tags` end-to-end; the piece is the synced entity; no silent-success in the edit dispatches.
+- Reverse `linked_from_pieces` is a live scan (no schema); tombstoned/missing exercises drop from `linked_exercises`.
+- api compiles (compat `vec![]`); web left (CI-excluded).

--- a/docs/superpowers/plans/2026-06-30-score-ring-1009.md
+++ b/docs/superpowers/plans/2026-06-30-score-ring-1009.md
@@ -1,0 +1,76 @@
+# Score ring (#1009) — Implementation Plan (Phase 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** Replace the stepped `MasteryMeter` bar meter with a monochrome **0–10 arc-gauge ring** (`ScoreRing`) on library cards, per the approved design mock.
+
+**Architecture:** A new `ScoreRing` SwiftUI component (arc gauge: track + trimmed arc + centred numeral, monochrome, en-dash when unrated). Swap it into `LibraryItemCard`, retire `MasteryMeter`. `MasteryDial` (Analytics hero, already a ring) is unchanged this phase.
+
+**Tech Stack:** SwiftUI, swift-snapshot-testing. Builds on Phase 1 (#1008) which is merged (scores are 0–10).
+
+## Global Constraints
+
+- **iOS-only.** No core/api/web changes.
+- **Design (from the mock `design/linked-exercises-mock.dc.html`, treatment A "arc gauge"):** monochrome — arc = `IntradaColor.masteryFill`, track = `IntradaColor.masteryTrack`; **no new tokens**. Value encoded twice (arc fill + numeral). **Unrated (`nil` or `0`) → empty track ring + a faint en-dash (`inkFaint`), never a "0" numeral.** Arc starts at 12 o'clock, sweeps clockwise proportional to `score/10`, round line-cap. Numeral centred (the app's existing numeric style). Arc animates from empty on appear, honouring Reduce Motion / `intradaMotionDisabled` / `UITestFlags.animationsDisabled`.
+- **Reuse, don't reinvent:** `MasteryDial.swift` already draws a trimmed-circle ring with the right tokens + reduce-motion handling — **mirror its approach** for `ScoreRing` (ScoreRing is a smaller, simpler dial: no "OF 10.0" caption, no counting-number, sizable). Use the real tokens it uses; if a font/motion token named in this plan doesn't exist, substitute the closest real token (as Phase 1 did) and note it.
+- **Tokens only**, no raw colour/font literals. VoiceOver: "Score N of 10" / "Not yet rated".
+- **Snapshot hygiene:** re-record only what changed; run `just ios-snapshots-optimize` + `just ios-snapshots-check`. **No orphans** — deleting a test deletes its PNG; renaming `testMasteryMeter` means removing the old PNG.
+- TDD where it fits (snapshot-driven for visual). Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Scoped `git add` only — never `git add -A` (untracked design/plan docs + gitignored `ios/generated` must stay out).
+- Green gate per task: `just ios-test` builds + all tests pass on the worktree-scoped sim (shared-sim rule: never touch other sims / no global `simctl` reset).
+
+## File Structure
+- Create: `ios/Intrada/Views/Components/ScoreRing.swift`
+- Modify: `ios/Intrada/Views/Components/LibraryItemCard.swift` (swap the meter)
+- Delete: `ios/Intrada/Views/Components/MasteryMeter.swift`
+- Modify: `ios/IntradaTests/ScreenSnapshotTests.swift` (`testMasteryMeter` → `testScoreRing`; `testLibraryScreenMastery` re-records)
+- Snapshots: add `testScoreRing.1.png`; delete `testMasteryMeter.1.png`; re-record `testLibraryScreenMastery.1.png`
+
+---
+
+### Task 1: ScoreRing component + snapshot
+
+**Files:** Create `ios/Intrada/Views/Components/ScoreRing.swift`; modify `ios/IntradaTests/ScreenSnapshotTests.swift` (replace `testMasteryMeter` with `testScoreRing`).
+
+**Interfaces produced:** `ScoreRing(score: Int?, size: CGFloat = 46)` — Task 2 consumes it.
+
+- [ ] **Step 1: Build `ScoreRing`.** A `View` with `let score: Int?` and `var size: CGFloat = 46`. Treat `score == nil || score == 0` as **unrated**; otherwise clamp to `1...10`. Render (mirror `MasteryDial`'s ring): a track `Circle().stroke(IntradaColor.masteryTrack, lineWidth: lw)`; when rated, a `Circle().trim(from: 0, to: fraction).stroke(IntradaColor.masteryFill, style: StrokeStyle(lineWidth: lw, lineCap: .round)).rotationEffect(.degrees(-90))` where `fraction = score/10` and `lw ≈ size * 0.09` (≥3); the arc animates from `0` on appear, guarded by the same reduce-motion/`intradaMotionDisabled`/`UITestFlags.animationsDisabled` check `MasteryDial` uses. Centre a numeral (rated → "\(score)" in the app's numeric/title font scaled to ~`size*0.36`, `IntradaColor.ink`; unrated → "–" in `IntradaColor.inkFaint`). `.frame(width: size, height: size)`. A11y: `.accessibilityElement(children: .ignore)` + label "Score \(n) of 10" / "Not yet rated". Keep it **monochrome** — never recolour by level.
+
+- [ ] **Step 2: Add a `#Preview`** iterating representative scores `[0, 1, 4, 7, 10]` + `nil` so the unrated and full states are visible.
+
+- [ ] **Step 3: Replace the `testMasteryMeter` snapshot test** in `ScreenSnapshotTests.swift` with `testScoreRing` — snapshot a row of `ScoreRing(score:)` across `[nil, 1, 4, 7, 10]` (use the existing host/`sizeThatFits` pattern the meter test used). This exercises the full 0–10 range + unrated.
+
+- [ ] **Step 4: Record the new snapshot** (project's recording convention) + `just ios-snapshots-optimize`.
+
+- [ ] **Step 5: Green gate** — `just ios-test` builds + all tests pass (the new `testScoreRing` records/passes; `testMasteryMeter` is gone so no stale ref). `just ios-snapshots-check` clean.
+
+- [ ] **Step 6: Spot-check** the recorded `testScoreRing.1.png` renders correct (arcs proportional 1→10, en-dash for nil/0, numeral centred) — the controller will view it.
+
+- [ ] **Step 7: Commit** (`ScoreRing.swift`, `ScreenSnapshotTests.swift`, the new + removed PNG references): `feat(ios): ScoreRing 0–10 arc gauge (replaces MasteryMeter bars, #1009)`.
+
+---
+
+### Task 2: Swap LibraryItemCard to ScoreRing; retire MasteryMeter
+
+**Files:** Modify `ios/Intrada/Views/Components/LibraryItemCard.swift:48`; **delete** `ios/Intrada/Views/Components/MasteryMeter.swift`; delete `ios/IntradaTests/__Snapshots__/ScreenSnapshotTests/testMasteryMeter.1.png` (if not already removed in Task 1); re-record `testLibraryScreenMastery.1.png`.
+
+**Interfaces consumed:** `ScoreRing(score:size:)` (Task 1).
+
+- [ ] **Step 1: Swap the card.** At `LibraryItemCard.swift:48`, replace `MasteryMeter(level: item.practice?.latestScore.map(Int.init))` with `ScoreRing(score: item.practice?.latestScore.map(Int.init))` (default size 46, or pass a size that fits the row trailing slot — match the meter's footprint so the row height is stable).
+
+- [ ] **Step 2: Delete `MasteryMeter.swift`** (now unused — confirm no remaining references: `grep -rn MasteryMeter ios/Intrada ios/IntradaTests` returns nothing but the now-removed file). Remove the `testMasteryMeter` PNG if still present (the rename in Task 1 should have handled it; verify no orphan).
+
+- [ ] **Step 3: Re-record `testLibraryScreenMastery`** — the library cards now show the ring; record + `just ios-snapshots-optimize`.
+
+- [ ] **Step 4: Green gate** — `just ios-test` builds + all tests pass; `just ios-snapshots-check` clean (no orphan PNG, no dangling test).
+
+- [ ] **Step 5: Spot-check** the re-recorded `testLibraryScreenMastery.1.png` — cards show the ring legibly (controller views it).
+
+- [ ] **Step 6: Commit** (`LibraryItemCard.swift`, deleted `MasteryMeter.swift`, re-recorded PNG): `refactor(ios): library cards use ScoreRing; retire MasteryMeter (#1009)`.
+
+---
+
+## Self-Review (controller, after both tasks)
+- ScoreRing matches the mock (arc gauge, monochrome, en-dash unrated, numeral) — confirmed by viewing the snapshot.
+- No `MasteryMeter` references remain; no orphan PNG; snapshot hygiene clean.
+- Tokens only; a11y present; reduce-motion honoured.
+- Then: whole-branch review (it's small), push, open PR — **Relates to #1009** (the ring); note `MasteryDial`/exercise-detail-hero/linked-rows are out of scope (exercise-detail hero ring lands with Phase 3).

--- a/specs/piece-linked-exercises-design-brief.md
+++ b/specs/piece-linked-exercises-design-brief.md
@@ -1,0 +1,76 @@
+# Design brief — Linked exercises
+
+> Companion to [`piece-linked-exercises.md`](piece-linked-exercises.md). For the
+> Claude Design pass: only the *new* surfaces, with the real SwiftUI primitives
+> to reuse (the Paper & Score system / `Theme.swift` tokens are already loaded).
+> Scope: native iOS only.
+
+## What to mock
+
+1. **Piece detail → "Linked exercises" section.** A new `.cardSurface()` card in
+   `LibraryDetailScreen`'s detail `VStack`, slotted **after notes/tags, before
+   the Delete button**. Pieces only. Three states:
+   - **Empty** — section header + a quiet in-card prompt + an "Add exercise"
+     button.
+   - **Populated** — header + ordered tracked-exercise rows (divided by
+     `HairlineDivider`) + an "Add exercise" footer affordance.
+   - **Edit / reorder** — rows with drag grips (system edit-mode look).
+
+2. **Tracked-exercise row** — the row inside the section. Contents:
+   - Exercise **title** (+ optional key/tempo meta line, like
+     `LibraryItemCard`'s `metaLine`).
+   - **Score indicator** — the latest practice score (see the ring, below).
+   - *Optional* micro-stats (last practised / best tempo) **only if they fit
+     cleanly** — title + score is the floor.
+   - Tap row → exercise detail. Swipe → unlink. No status pill (dropped).
+
+3. **Multi-select add-exercise picker** (sheet). Searchable list of exercises
+   (`kind == Exercise`), already-linked ones excluded/greyed, **checkmark
+   multi-select** to add several at once, plus a "Create new" path. Model the
+   chrome on the existing `TagFilterSheet`; create-new routes into
+   `LibraryAddScreen`.
+
+4. **The 0–10 score ring** (this is issue
+   [#1009](https://github.com/jonyardley/intrada/issues/1009)). The one genuinely
+   new visual — design it here. A radial ring (fraction = score ÷ 10) with the
+   **numeral centred**, **monochrome** (don't recolour by level; the numeral
+   carries the meaning — colour-blind-safe, preserving the current `MasteryMeter`
+   intent), and an empty "—" state when never practised. It replaces the stepped
+   bars on `LibraryItemCard` (library rows) and also appears on the exercise
+   detail.
+
+## Reuse these (don't redraw)
+
+| Need | Primitive |
+|------|-----------|
+| Screen chrome | `ScreenScaffold(title:subtitle:)` |
+| Card container | `.cardSurface()` / `CardSurface` |
+| Row dividers | `HairlineDivider()` |
+| Type signal | `TypeBadge(kind:)`, `ItemKind.bar` |
+| Tags | `TagChip(_:style:)`, `TagPills(tags:)` |
+| Compact row reference | `SetlistQueueRow` |
+| Segmented control (if needed) | `SegmentedPills` |
+| Score indicator (→ ring) | `MasteryMeter(level:steps:)` |
+| Sheet pattern | `TagFilterSheet` |
+| Create-new flow | `LibraryAddScreen` |
+
+## The real decisions to make in the mock
+
+- **The score ring** — its proportions, weight, and how the numeral reads at row
+  scale and on library cards. This is the headline new component.
+- **Row density** — title + score is the minimum; add last-practised / best-tempo
+  only if the row stays clean.
+- **Multi-select interaction** in the picker — selection affordance, "add N"
+  confirmation.
+
+## Tokens
+
+Likely **no new tokens** — the ring reuses the existing score colours
+(`masteryFill` / `masteryTrack`) and standard ink/paper tokens. If anything new
+is needed, add it to `Theme.swift` **and** the design reference together.
+
+## Out of scope for this mock (tracked separately)
+
+- 0–10 scoring rescale + overall session score —
+  [#1008](https://github.com/jonyardley/intrada/issues/1008).
+- Reverse "linked from N pieces" view on an exercise — deferred fast-follow.

--- a/specs/piece-linked-exercises.md
+++ b/specs/piece-linked-exercises.md
@@ -1,0 +1,157 @@
+# Piece-linked exercises
+
+> Tier 3 lightweight spec. Status: **shipped** (#1015, merged 2026-07; design
+> handoff 2026-06-29). **Scope: `intrada-core` + native iOS only.**
+> Web/API (Turso) is out of scope for now (see Deferred).
+> Design mock: [`design/linked-exercises-mock.dc.html`](../design/linked-exercises-mock.dc.html).
+
+## Problem
+
+Users create pieces and exercises as standalone library items, but nothing
+relates them, and there's no way to see per-exercise progress in the context of a
+piece. A classical piece has associated scales/arpeggios; a jazz standard has a
+progression of practice activities (learn the tune, learn the shells, runs to the
+3rd of each chord, improvise). The practitioner wants to see "the things I
+practise for this piece" in one place **and see how each one is scoring**.
+
+## Goal
+
+A piece carries an ordered group of linked exercises, each showing its latest
+0–10 practice score (as a ring), so the user sees at a glance how each drill for
+the piece is progressing and can jump to any of them. From an exercise, they can
+see which pieces it's linked from.
+
+## Build sequence (layered — decided 2026-06-29)
+
+Three dependent phases, each its own PR, in order:
+
+1. **#1008 — scoring → 0–10 + overall session score.** The data foundation the
+   ring renders.
+2. **#1009 — score ring** replaces the `MasteryMeter` stepped bars everywhere a
+   score appears (library rows, exercise detail).
+3. **Linked exercises** (this spec) — builds on the ring and the 0–10 score.
+
+This spec covers Phase 3; #1008/#1009 carry their own scope (finalised design
+recorded as comments on those issues).
+
+## Non-goals
+
+- **No group practice run.** Tapping a linked exercise opens that exercise (and
+  its normal scored practice). No "practise the whole group" flow; the session /
+  Set / timer machinery is untouched.
+- **No gated stages.** Ordered, but nothing is locked behind a prior exercise.
+- **No separate manual status.** Tracking *is* the per-item 0–10 score — no
+  Learning/Solid/Performance-ready axis (considered and dropped).
+- **Exercises are not owned by a piece.** First-class, reusable; the same
+  exercise can be linked to many pieces; its score is global to the exercise.
+- **Online/web is out of scope** (see Deferred).
+
+## Key decisions
+
+1. **Shared & reusable links, not ownership.** Many-to-many; an exercise's edits
+   and score are live everywhere it's linked.
+2. **Ordered id list stored on the piece** — `Item.linked_exercise_ids:
+   Vec<String>`, resolved to live exercises in the core view function. Chosen
+   over a dedicated link entity (more machinery) and over reusing Sets/routines
+   (not local-first yet; conflates "routine" with "a piece's exercises").
+   Trade-off: whole-list LWW if the same piece's list is edited on two devices at
+   once — fine at current single-user scale.
+3. **Tracking reuses the per-item 0–10 score rollup** (`practice.latestScore`) —
+   no new per-item state. Row shows **title + key/tempo + ring** only (no
+   last-practised / best-tempo clutter — design decision).
+4. **Reverse "Linked from" view is in scope** (was deferred; the design includes
+   it). The exercise detail lists pieces that link the exercise — a core
+   computation scanning pieces, no schema change.
+
+## Data model (intrada-core)
+
+- `Item` gains one additive field (`#[serde(default)]`):
+  - `linked_exercise_ids: Vec<String>` (only populated for pieces).
+- Events:
+  - `LinkExercise { piece_id, exercise_id }`
+  - `UnlinkExercise { piece_id, exercise_id }`
+  - `ReorderLinkedExercises { piece_id, ordered_ids }`
+  Each mutates the piece, bumps `updated_at`, persists via the persistence
+  `Effect` (local-first path). See Offline-first re: the online branch.
+- Validation (`validation.rs`): link target must be an existing `Exercise`; host
+  must be a `Piece`; no duplicate ids; no self-link; missing id rejected.
+- ViewModel:
+  - For pieces, `linked_exercises: Vec<LinkedExerciseView>` — resolved from the
+    ids → live title / key / tempo / kind **+ the `practice` rollup** (latest
+    score), filtering out tombstoned/missing. A soft-deleted exercise drops out.
+  - For exercises, `linked_from_pieces: Vec<PieceRefView>` — pieces whose
+    `linked_exercise_ids` contains this exercise (computed; live).
+
+## Offline-first / invariants
+
+- Reads/writes go through the persistence `Effect`, not HTTP (invariant 1).
+- The piece is the synced entity; the link list rides its `updated_at` +
+  `deleted_at` — no separate entity (invariant 2).
+- Client-owned ids; links reference existing ids (invariant 3).
+- Reconciliation stays in the core (LWW on the piece) (invariant 4).
+- **Invariant 6 (both modes) consciously deferred for the new handlers**:
+  implement and test `local_first` now; the online branch + API column land with
+  the Deferred web/API work. New events must still compile cleanly with existing
+  online plumbing.
+
+## Persistence (iOS only)
+
+- **iOS GRDB:** append-only migration `vN_item_linked_exercise_ids` adds
+  `linked_exercise_ids TEXT NOT NULL DEFAULT '[]'` (JSON array) to `item`. The
+  row↔`Item` codec updated. Upgrade-path test: populate a DB at the prior
+  version, migrate, assert data intact + column defaulted.
+- Core type + GRDB schema + codec evolve together.
+
+## iOS UI (SwiftUI) — per the handoff mock
+
+- **"Linked exercises" section** on the piece's `LibraryDetailScreen` (Pieces
+  only) — a `.cardSurface()` block after notes/tags, before Delete. Header:
+  "Linked exercises" + a **count badge** + an **Edit / Done** toggle. Rows
+  divided by `HairlineDivider`. A "Link an exercise" footer button.
+  - **Row:** gold type bar + title (serif) + key/tempo meta + trailing **44pt
+    score ring** (from #1009; unrated → empty ring + en-dash). Tap row → exercise
+    detail. Swipe to unlink (removes the link, never the exercise).
+  - **Edit mode:** ring **hidden**; row shows a leading red remove (minus-circle)
+    + trailing drag grip; `onMove` reorder.
+  - **Empty state:** link icon + serif "No exercises linked yet" + body + an
+    outlined "Link an exercise" button.
+- **Add exercises sheet — Picker A** (model presentation on `TagFilterSheet`):
+  search field, a "Create new exercise" row (→ `LibraryAddScreen`), then "Your
+  exercises · already-linked hidden" with **checkmark multi-select** rows, and a
+  **sticky "Add N exercises"** button (disabled with "Select exercises to add"
+  when none).
+- **Library rows** (`LibraryItemCard`) show the ring for pieces *and* exercises
+  (the #1009 swap).
+- **Exercise detail:** a **"Linked from"** `.cardSurface()` card listing the
+  piece(s) that link this exercise, each tappable → the piece. (Hero ring +
+  "Practise this" are #1009 / existing.)
+- Tokens only; no literals. Ships with snapshot tests (empty, populated, edit,
+  picker), VoiceOver labels, Dynamic Type, iPad `SplitView`.
+
+## Testing
+
+- Core: link / unlink / reorder handlers (`local_first`); validation edges
+  (non-exercise target, non-piece host, duplicate, self-link, missing id); view
+  resolution filters tombstoned/missing and attaches the score rollup;
+  `linked_from_pieces` computation; real bincode-bridge round-trip
+  (`assert_round_trips`) for the extended `Item`.
+- iOS: GRDB migration upgrade-path test; snapshot tests for the section + picker.
+
+## Resolved questions
+
+- Add picker = **Picker A** (checkmark + sticky Add N).
+- Row density = **title + meta + ring** (no micro-stats).
+- Reverse **"Linked from"** view = **in scope**.
+- Library row shows the ring for pieces too.
+
+## Deferred / out of scope (tracked)
+
+- **Web/API (Turso) parity** — API migration for `linked_exercise_ids`, routes,
+  the online write branch + "test both modes" (invariant 6). When web un-pauses.
+
+## Phasing
+
+Phase 3 of the layered sequence. Single PR: core field (`linked_exercise_ids`)
++ events + validation + view (link list + `linked_from_pieces`), the GRDB
+migration + codec, the iOS section + Picker A + edit mode + exercise "Linked
+from" card, tests. Depends on #1008 (Phase 1) and #1009 (Phase 2) having landed.


### PR DESCRIPTION
## Summary

Commits six files recovered from the retired linked-exercises worktree before it was removed: the Tier 3 spec, its design brief, the approved design mock, and the three phase implementation plans (0-10 scoring #1008, ScoreRing #1009, linked exercises). The feature shipped in #1015 but per the Tier 3 rule the spec should have ridden with the implementation PR and never did. Spec status line updated from "pre-implementation" to shipped.

## Roadmap alignment

- [x] Documents already-shipped roadmap work (linked exercises, #1015): no new scope
- [x] Pillar: Plan
- [x] Horizon: Now (documentation of shipped work)

## Coverage

Coverage: n/a — Tier 1, docs only, no code paths.

## Checklist

- [x] Docs pass the typos gate config from #1086 (future-proofed)
- [x] No code, CI, or CLAUDE.md changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)