### PR TITLE
feat(core+ios): AddPieceWithScaffold — one-pass lesson capture, transactional batch save (#1080 A1)

### DIFF
--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -346,6 +346,20 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             save_or_put(model, piece)
         }
         ItemEvent::AddPieceWithScaffold { piece, scaffold } => {
+            if !model.local_first {
+                // Online items use the temp-id dance (server-assigned ids), which
+                // can't remap a piece's linked_exercise_ids minted client-side —
+                // the composite is local-first-only for now (#1080).
+                model.last_error = Some(
+                    LibraryError::Validation {
+                        field: "scaffold".to_string(),
+                        message: "Adding a lesson is not available online yet".to_string(),
+                    }
+                    .to_string(),
+                );
+                return crux_core::render::render();
+            }
+
             // Validate everything before mutating anything — the event is
             // atomic in the model: on any invalid part, nothing is applied.
             let piece_input = validation::normalize_create_item(piece);
@@ -393,20 +407,6 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
                         entries.push(ScaffoldEntry::Existing { id });
                     }
                 }
-            }
-
-            if !model.local_first {
-                // Online items use the temp-id dance (server-assigned ids), which
-                // can't remap a piece's linked_exercise_ids minted client-side —
-                // the composite is local-first-only for now (#1080).
-                model.last_error = Some(
-                    LibraryError::Validation {
-                        field: "scaffold".to_string(),
-                        message: "Adding a lesson is not available online yet".to_string(),
-                    }
-                    .to_string(),
-                );
-                return crux_core::render::render();
             }
 
             let now = chrono::Utc::now();
@@ -462,13 +462,15 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
             model.last_error = None;
             model.record_success();
 
-            let mut cmds: Vec<Command<Effect, Event>> = new_items
-                .into_iter()
-                .map(crate::persistence::save_item)
-                .collect();
-            cmds.push(crate::persistence::save_item(piece_item));
-            cmds.push(crux_core::render::render());
-            Command::all(cmds)
+            // One SaveItems batch (shell executes it in a single transaction),
+            // exercises before the piece — the composite can't half-land on
+            // disk and the piece never exists without its scaffold (#1080).
+            let mut to_save = new_items;
+            to_save.push(piece_item);
+            Command::all([
+                crate::persistence::save_items(to_save),
+                crux_core::render::render(),
+            ])
         }
     }
 }
@@ -1006,7 +1008,7 @@ mod tests {
     }
 
     #[test]
-    fn add_piece_with_scaffold_local_first_saves_all_items_piece_last_no_http() {
+    fn add_piece_with_scaffold_local_first_saves_one_transactional_batch_no_http() {
         let mut model = model_with_piece_and_exercise();
 
         let mut cmd = send_cmd(
@@ -1022,17 +1024,21 @@ mod tests {
             },
         );
 
-        let mut saved_ids: Vec<String> = vec![];
+        let mut batches: Vec<Vec<String>> = vec![];
         let mut saw_http = false;
+        let mut saw_single_save = false;
         for effect in cmd.effects() {
             match effect {
                 crate::app::Effect::Http(_) => saw_http = true,
-                crate::app::Effect::Persistence(req) => {
-                    if let crate::persistence::PersistenceOperation::SaveItem(item) = &req.operation
-                    {
-                        saved_ids.push(item.id.clone());
+                crate::app::Effect::Persistence(req) => match &req.operation {
+                    crate::persistence::PersistenceOperation::SaveItems(items) => {
+                        batches.push(items.iter().map(|i| i.id.clone()).collect());
                     }
-                }
+                    crate::persistence::PersistenceOperation::SaveItem(_) => {
+                        saw_single_save = true;
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }
@@ -1041,6 +1047,13 @@ mod tests {
             !saw_http,
             "local-first path must be HTTP-free (invariant 1)"
         );
+        assert!(
+            !saw_single_save,
+            "composite must not use independent SaveItem ops — a partial \
+             failure would land a piece with dangling links"
+        );
+        assert_eq!(batches.len(), 1, "exactly one all-or-nothing batch");
+
         let piece_id = model
             .items
             .iter()
@@ -1048,21 +1061,80 @@ mod tests {
             .unwrap()
             .id
             .clone();
-        assert_eq!(saved_ids.len(), 2, "one new exercise + the piece");
+        let melody_id = model
+            .items
+            .iter()
+            .find(|i| i.title == "Learn the melody")
+            .unwrap()
+            .id
+            .clone();
         assert_eq!(
-            saved_ids.last(),
-            Some(&piece_id),
-            "piece saved after its exercises"
+            batches[0],
+            vec![melody_id, piece_id],
+            "new exercises first, piece last; already-persisted Existing \
+             entries are not re-saved"
         );
     }
 
-    // FFI bincode round-trip (#846): mirrors `assert_round_trips` in types.rs —
-    // ScaffoldEntry is a new bridge-crossing type.
+    #[test]
+    fn add_piece_with_scaffold_empty_scaffold_creates_bare_piece_locally() {
+        let mut model = model_with_piece_and_exercise();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![],
+            },
+        );
+
+        assert!(model.last_error.is_none());
+        let piece = model
+            .items
+            .iter()
+            .find(|i| i.title == "Strasbourg / St. Denis")
+            .expect("bare piece created");
+        assert!(piece.linked_exercise_ids.is_empty());
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_allows_duplicate_new_titles() {
+        // Same policy as ItemEvent::Add: titles are not unique. Two identical
+        // New entries are two distinct exercises (A3's typeahead is the UX
+        // guard against accidental duplicates, not the domain layer).
+        let mut model = model_with_piece_and_exercise();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![
+                    ScaffoldEntry::New(create_exercise_input("Enclosures")),
+                    ScaffoldEntry::New(create_exercise_input("Enclosures")),
+                ],
+            },
+        );
+
+        assert!(model.last_error.is_none());
+        let dupes: Vec<&Item> = model
+            .items
+            .iter()
+            .filter(|i| i.title == "Enclosures")
+            .collect();
+        assert_eq!(dupes.len(), 2);
+        assert_ne!(dupes[0].id, dupes[1].id);
+        let piece = model
+            .items
+            .iter()
+            .find(|i| i.title == "Strasbourg / St. Denis")
+            .unwrap();
+        assert_eq!(piece.linked_exercise_ids.len(), 2);
+    }
+
+    // FFI bincode round-trip (#846) — ScaffoldEntry is a new bridge-crossing type.
     #[test]
     fn add_piece_with_scaffold_event_round_trips_on_ffi_bincode_wire() {
-        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
-
-        let event = ItemEvent::AddPieceWithScaffold {
+        crate::domain::types::assert_round_trips(ItemEvent::AddPieceWithScaffold {
             piece: create_piece_input("Strasbourg / St. Denis"),
             scaffold: vec![
                 ScaffoldEntry::New(create_exercise_input("Learn the melody")),
@@ -1070,12 +1142,6 @@ mod tests {
                     id: "ex-1".to_string(),
                 },
             ],
-        };
-
-        let mut bytes = Vec::new();
-        BincodeFfiFormat::serialize(&mut bytes, &event).expect("serialize");
-        let back: ItemEvent =
-            BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
-        assert_eq!(event, back, "round-trip changed the value");
+        });
     }
 }

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -93,6 +93,20 @@ pub enum ItemEvent {
         piece_id: String,
         ordered_ids: Vec<String>,
     },
+    AddPieceWithScaffold {
+        piece: CreateItem,
+        scaffold: Vec<ScaffoldEntry>,
+    },
+}
+
+/// One entry in a new piece's ordered exercise scaffold: create alongside the
+/// piece, or link an exercise already in the library.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum ScaffoldEntry {
+    New(CreateItem),
+    Existing { id: String },
 }
 
 /// Shared by Update / AddTags / RemoveTags.
@@ -330,6 +344,131 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
 
             let piece = piece.clone();
             save_or_put(model, piece)
+        }
+        ItemEvent::AddPieceWithScaffold { piece, scaffold } => {
+            // Validate everything before mutating anything — the event is
+            // atomic in the model: on any invalid part, nothing is applied.
+            let piece_input = validation::normalize_create_item(piece);
+            if let Err(e) = validation::validate_create_item(&piece_input) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+            if piece_input.kind != ItemKind::Piece {
+                model.last_error = Some(
+                    LibraryError::Validation {
+                        field: "kind".to_string(),
+                        message: "A lesson starts from a piece, not an exercise".to_string(),
+                    }
+                    .to_string(),
+                );
+                return crux_core::render::render();
+            }
+
+            let mut entries = Vec::with_capacity(scaffold.len());
+            for entry in scaffold {
+                match entry {
+                    ScaffoldEntry::New(input) => {
+                        let input = validation::normalize_create_item(input);
+                        if let Err(e) = validation::validate_create_item(&input) {
+                            model.last_error = Some(e.to_string());
+                            return crux_core::render::render();
+                        }
+                        if input.kind != ItemKind::Exercise {
+                            model.last_error = Some(
+                                LibraryError::Validation {
+                                    field: "scaffold".to_string(),
+                                    message: "Scaffold entries must be exercises".to_string(),
+                                }
+                                .to_string(),
+                            );
+                            return crux_core::render::render();
+                        }
+                        entries.push(ScaffoldEntry::New(input));
+                    }
+                    ScaffoldEntry::Existing { id } => {
+                        if let Err(e) = validation::validate_scaffold_link_target(&id, model) {
+                            model.last_error = Some(e.to_string());
+                            return crux_core::render::render();
+                        }
+                        entries.push(ScaffoldEntry::Existing { id });
+                    }
+                }
+            }
+
+            if !model.local_first {
+                // Online items use the temp-id dance (server-assigned ids), which
+                // can't remap a piece's linked_exercise_ids minted client-side —
+                // the composite is local-first-only for now (#1080).
+                model.last_error = Some(
+                    LibraryError::Validation {
+                        field: "scaffold".to_string(),
+                        message: "Adding a lesson is not available online yet".to_string(),
+                    }
+                    .to_string(),
+                );
+                return crux_core::render::render();
+            }
+
+            let now = chrono::Utc::now();
+            let mut new_items: Vec<Item> = Vec::new();
+            let mut linked_ids: Vec<String> = Vec::new();
+            for entry in entries {
+                match entry {
+                    ScaffoldEntry::New(input) => {
+                        let item = Item {
+                            id: ulid::Ulid::gen().to_string(),
+                            title: input.title,
+                            kind: input.kind,
+                            composer: input.composer,
+                            key: input.key,
+                            modality: input.modality,
+                            tempo: input.tempo,
+                            notes: input.notes,
+                            tags: input.tags,
+                            linked_exercise_ids: vec![],
+                            created_at: now,
+                            updated_at: now,
+                            priority: false,
+                        };
+                        linked_ids.push(item.id.clone());
+                        new_items.push(item);
+                    }
+                    ScaffoldEntry::Existing { id } => {
+                        if !linked_ids.contains(&id) {
+                            linked_ids.push(id);
+                        }
+                    }
+                }
+            }
+
+            let piece_item = Item {
+                id: ulid::Ulid::gen().to_string(),
+                title: piece_input.title,
+                kind: ItemKind::Piece,
+                composer: piece_input.composer,
+                key: piece_input.key,
+                modality: piece_input.modality,
+                tempo: piece_input.tempo,
+                notes: piece_input.notes,
+                tags: piece_input.tags,
+                linked_exercise_ids: linked_ids,
+                created_at: now,
+                updated_at: now,
+                priority: false,
+            };
+
+            model.items.extend(new_items.iter().cloned());
+            model.items.push(piece_item.clone());
+            model.last_error = None;
+            model.record_success();
+
+            let mut cmds: Vec<Command<Effect, Event>> = new_items
+                .into_iter()
+                .map(crate::persistence::save_item)
+                .collect();
+            cmds.push(crate::persistence::save_item(piece_item));
+            cmds.push(crux_core::render::render());
+            Command::all(cmds)
         }
     }
 }
@@ -637,5 +776,306 @@ mod tests {
         let piece = model.items.iter().find(|i| i.id == "piece-1").unwrap();
         assert_eq!(piece.linked_exercise_ids, vec!["ex-1".to_string()]);
         assert!(model.last_error.is_none());
+    }
+
+    // ── AddPieceWithScaffold ──
+
+    fn create_piece_input(title: &str) -> CreateItem {
+        CreateItem {
+            title: title.to_string(),
+            kind: ItemKind::Piece,
+            composer: Some("Roy Hargrove".to_string()),
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        }
+    }
+
+    fn create_exercise_input(title: &str) -> CreateItem {
+        CreateItem {
+            title: title.to_string(),
+            kind: ItemKind::Exercise,
+            composer: None,
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        }
+    }
+
+    fn send_cmd(
+        model: &mut Model,
+        event: ItemEvent,
+    ) -> crux_core::Command<crate::app::Effect, crate::app::Event> {
+        let app = Intrada;
+        app.update(crate::app::Event::Item(event), model)
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_creates_piece_and_new_exercises_linked_in_order() {
+        let mut model = model_with_piece_and_exercise();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis "),
+                scaffold: vec![
+                    ScaffoldEntry::New(create_exercise_input("Learn the melody")),
+                    ScaffoldEntry::Existing {
+                        id: "ex-1".to_string(),
+                    },
+                    ScaffoldEntry::New(create_exercise_input("Enclosures")),
+                ],
+            },
+        );
+
+        assert!(model.last_error.is_none());
+        // 2 pre-existing + piece + 2 new exercises
+        assert_eq!(model.items.len(), 5);
+
+        let piece = model
+            .items
+            .iter()
+            .find(|i| i.title == "Strasbourg / St. Denis")
+            .expect("piece created with normalized (trimmed) title");
+        assert_eq!(piece.kind, ItemKind::Piece);
+
+        let melody = model
+            .items
+            .iter()
+            .find(|i| i.title == "Learn the melody")
+            .expect("new exercise created");
+        assert_eq!(melody.kind, ItemKind::Exercise);
+        let enclosures = model
+            .items
+            .iter()
+            .find(|i| i.title == "Enclosures")
+            .expect("new exercise created");
+
+        assert_eq!(
+            piece.linked_exercise_ids,
+            vec![melody.id.clone(), "ex-1".to_string(), enclosures.id.clone()],
+            "scaffold order is the teacher's assignment order"
+        );
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_rejects_invalid_new_entry_and_applies_nothing() {
+        let mut model = model_with_piece_and_exercise();
+        let count_before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![
+                    ScaffoldEntry::New(create_exercise_input("Valid one")),
+                    ScaffoldEntry::New(create_exercise_input("   ")),
+                ],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before, "nothing applied");
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_rejects_unknown_existing_id_and_applies_nothing() {
+        let mut model = model_with_piece_and_exercise();
+        let count_before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![ScaffoldEntry::Existing {
+                    id: "no-such-id".to_string(),
+                }],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before);
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_rejects_existing_id_that_is_a_piece() {
+        let mut model = model_with_piece_and_exercise();
+        let count_before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![ScaffoldEntry::Existing {
+                    id: "piece-1".to_string(),
+                }],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before);
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_rejects_non_piece_kind_input() {
+        let mut model = model_with_piece_and_exercise();
+        let count_before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_exercise_input("Not a piece"),
+                scaffold: vec![],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before);
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_rejects_new_entry_with_piece_kind() {
+        let mut model = model_with_piece_and_exercise();
+        let count_before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![ScaffoldEntry::New(create_piece_input("Nested piece"))],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before);
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_dedupes_repeated_existing_ids() {
+        let mut model = model_with_piece_and_exercise();
+
+        send(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![
+                    ScaffoldEntry::Existing {
+                        id: "ex-1".to_string(),
+                    },
+                    ScaffoldEntry::Existing {
+                        id: "ex-1".to_string(),
+                    },
+                ],
+            },
+        );
+
+        assert!(model.last_error.is_none());
+        let piece = model
+            .items
+            .iter()
+            .find(|i| i.title == "Strasbourg / St. Denis")
+            .unwrap();
+        assert_eq!(piece.linked_exercise_ids, vec!["ex-1".to_string()]);
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_errors_in_online_mode_and_applies_nothing() {
+        let mut model = model_with_piece_and_exercise();
+        model.local_first = false;
+        let count_before = model.items.len();
+
+        let mut cmd = send_cmd(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![ScaffoldEntry::New(create_exercise_input("Melody"))],
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), count_before);
+        assert!(
+            !cmd.effects()
+                .any(|e| matches!(e, crate::app::Effect::Http(_))),
+            "online rejection must not fire HTTP"
+        );
+    }
+
+    #[test]
+    fn add_piece_with_scaffold_local_first_saves_all_items_piece_last_no_http() {
+        let mut model = model_with_piece_and_exercise();
+
+        let mut cmd = send_cmd(
+            &mut model,
+            ItemEvent::AddPieceWithScaffold {
+                piece: create_piece_input("Strasbourg / St. Denis"),
+                scaffold: vec![
+                    ScaffoldEntry::New(create_exercise_input("Learn the melody")),
+                    ScaffoldEntry::Existing {
+                        id: "ex-1".to_string(),
+                    },
+                ],
+            },
+        );
+
+        let mut saved_ids: Vec<String> = vec![];
+        let mut saw_http = false;
+        for effect in cmd.effects() {
+            match effect {
+                crate::app::Effect::Http(_) => saw_http = true,
+                crate::app::Effect::Persistence(req) => {
+                    if let crate::persistence::PersistenceOperation::SaveItem(item) = &req.operation
+                    {
+                        saved_ids.push(item.id.clone());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert!(
+            !saw_http,
+            "local-first path must be HTTP-free (invariant 1)"
+        );
+        let piece_id = model
+            .items
+            .iter()
+            .find(|i| i.title == "Strasbourg / St. Denis")
+            .unwrap()
+            .id
+            .clone();
+        assert_eq!(saved_ids.len(), 2, "one new exercise + the piece");
+        assert_eq!(
+            saved_ids.last(),
+            Some(&piece_id),
+            "piece saved after its exercises"
+        );
+    }
+
+    // FFI bincode round-trip (#846): mirrors `assert_round_trips` in types.rs —
+    // ScaffoldEntry is a new bridge-crossing type.
+    #[test]
+    fn add_piece_with_scaffold_event_round_trips_on_ffi_bincode_wire() {
+        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
+
+        let event = ItemEvent::AddPieceWithScaffold {
+            piece: create_piece_input("Strasbourg / St. Denis"),
+            scaffold: vec![
+                ScaffoldEntry::New(create_exercise_input("Learn the melody")),
+                ScaffoldEntry::Existing {
+                    id: "ex-1".to_string(),
+                },
+            ],
+        };
+
+        let mut bytes = Vec::new();
+        BincodeFfiFormat::serialize(&mut bytes, &event).expect("serialize");
+        let back: ItemEvent =
+            BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
+        assert_eq!(event, back, "round-trip changed the value");
     }
 }

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -228,6 +228,23 @@ pub struct LibrarySort {
     pub direction: SortDirection,
 }
 
+/// Round-trip through crux's actual FFI format (`BincodeFfiFormat`) — the
+/// exact wire the iOS bridge uses, so tests can't drift from the real
+/// serializer and we don't take a direct bincode dependency. Shared by every
+/// bridge-crossing type's round-trip guard (#846 class).
+#[cfg(test)]
+pub(crate) fn assert_round_trips<T>(value: T)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
+{
+    use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
+    let mut bytes = Vec::new();
+    BincodeFfiFormat::serialize(&mut bytes, &value).expect("serialize");
+    let back: T =
+        BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
+    assert_eq!(value, back, "round-trip changed the value");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,22 +301,8 @@ mod tests {
     // The native iOS shell ships these write payloads as positional bincode
     // (crux's BincodeFfiFormat). A serde attr that assumes a self-describing
     // format (see `double_option` above) misaligns that wire and the event
-    // silently fails to decode. These guard against that whole class.
-
-    /// Round-trip through crux's actual FFI format (`BincodeFfiFormat`) — the
-    /// exact wire the iOS bridge uses, so the test can't drift from the real
-    /// serializer and we don't take a direct bincode dependency.
-    fn assert_round_trips<T>(value: T)
-    where
-        T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
-    {
-        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
-        let mut bytes = Vec::new();
-        BincodeFfiFormat::serialize(&mut bytes, &value).expect("serialize");
-        let back: T =
-            BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
-        assert_eq!(value, back, "round-trip changed the value");
-    }
+    // silently fails to decode. These guard against that whole class, via the
+    // module-level `assert_round_trips` shared with the other domain modules.
 
     #[test]
     fn update_item_round_trips_on_ffi_bincode_wire() {

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -25,6 +25,9 @@ pub enum PersistenceOperation {
     },
     LoadSessions,
     SaveSession(PracticeSession),
+    /// Multi-item write in one shell transaction — all-or-nothing, so a
+    /// composite (piece + its scaffold) can never half-land on disk (#1080).
+    SaveItems(Vec<Item>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -48,6 +51,11 @@ pub fn load_items() -> Command<Effect, Event> {
 
 pub fn save_item(item: Item) -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::SaveItem(item)).then_send(Event::StoreWritten)
+}
+
+pub fn save_items(items: Vec<Item>) -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::SaveItems(items))
+        .then_send(Event::StoreWritten)
 }
 
 pub fn delete_item(id: String, deleted_at: DateTime<Utc>) -> Command<Effect, Event> {
@@ -195,6 +203,37 @@ mod tests {
     fn save_item_requests_a_save_op() {
         let mut cmd = save_item(sample_item("p1"));
         assert!(has_save(&mut cmd, "p1"));
+    }
+
+    #[test]
+    fn save_items_requests_one_batch_op_preserving_order() {
+        let mut cmd = save_items(vec![sample_item("ex-a"), sample_item("piece-z")]);
+        let ids: Vec<Vec<String>> = cmd
+            .effects()
+            .filter_map(|e| match e {
+                Effect::Persistence(req) => match &req.operation {
+                    PersistenceOperation::SaveItems(items) => {
+                        Some(items.iter().map(|i| i.id.clone()).collect())
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            vec![vec!["ex-a".to_string(), "piece-z".to_string()]],
+            "one SaveItems op, order preserved"
+        );
+    }
+
+    // FFI bincode round-trip (#846) — SaveItems is a new bridge-crossing op.
+    #[test]
+    fn save_items_op_round_trips_on_ffi_bincode_wire() {
+        crate::domain::types::assert_round_trips(PersistenceOperation::SaveItems(vec![
+            sample_item("ex-a"),
+            sample_item("piece-z"),
+        ]));
     }
 
     #[test]

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -411,6 +411,25 @@ pub fn validate_link_exercise(
     Ok(())
 }
 
+pub fn validate_scaffold_link_target(exercise_id: &str, model: &Model) -> Result<(), LibraryError> {
+    let exercise = model
+        .items
+        .iter()
+        .find(|i| i.id == exercise_id)
+        .ok_or_else(|| LibraryError::NotFound {
+            id: exercise_id.to_string(),
+        })?;
+
+    if exercise.kind != ItemKind::Exercise {
+        return Err(LibraryError::Validation {
+            field: "scaffold".to_string(),
+            message: "Linked item must be an exercise, not a piece".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
 pub fn validate_set_entry_fields(item_id: &str, item_title: &str) -> Result<(), LibraryError> {
     if item_id.trim().is_empty() {
         return Err(LibraryError::Validation {

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -386,20 +386,7 @@ pub fn validate_link_exercise(
         });
     }
 
-    let exercise = model
-        .items
-        .iter()
-        .find(|i| i.id == exercise_id)
-        .ok_or_else(|| LibraryError::NotFound {
-            id: exercise_id.to_string(),
-        })?;
-
-    if exercise.kind != ItemKind::Exercise {
-        return Err(LibraryError::Validation {
-            field: "exercise_id".to_string(),
-            message: "Linked item must be an exercise, not a piece".to_string(),
-        });
-    }
+    validate_exercise_target(exercise_id, model, "exercise_id")?;
 
     if piece.linked_exercise_ids.contains(&exercise_id.to_string()) {
         return Err(LibraryError::Validation {
@@ -412,6 +399,14 @@ pub fn validate_link_exercise(
 }
 
 pub fn validate_scaffold_link_target(exercise_id: &str, model: &Model) -> Result<(), LibraryError> {
+    validate_exercise_target(exercise_id, model, "scaffold")
+}
+
+fn validate_exercise_target(
+    exercise_id: &str,
+    model: &Model,
+    field: &str,
+) -> Result<(), LibraryError> {
     let exercise = model
         .items
         .iter()
@@ -422,7 +417,7 @@ pub fn validate_scaffold_link_target(exercise_id: &str, model: &Model) -> Result
 
     if exercise.kind != ItemKind::Exercise {
         return Err(LibraryError::Validation {
-            field: "scaffold".to_string(),
+            field: field.to_string(),
             message: "Linked item must be an exercise, not a piece".to_string(),
         });
     }

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -6,6 +6,7 @@ import SharedTypes
 protocol ItemStore {
   func loadItems() throws -> [Item]
   func save(_ item: Item) throws
+  func save(_ items: [Item]) throws
   func delete(id: String, deletedAt: String) throws
   func loadSessions() throws -> [PracticeSession]
   func saveSession(_ session: PracticeSession) throws
@@ -54,29 +55,43 @@ final class LibraryStore: ItemStore {
   /// Insert or update by id; clears any tombstone (an upsert revives a row).
   func save(_ item: Item) throws {
     try dbQueue.write { db in
-      try db.execute(
-        sql: """
-          INSERT INTO item
-            (id, title, kind, composer, key, modality, tempo_marking, tempo_bpm, notes, tags,
-             linked_exercise_ids, created_at, updated_at, priority, deleted_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
-          ON CONFLICT(id) DO UPDATE SET
-            title = excluded.title, kind = excluded.kind, composer = excluded.composer,
-            key = excluded.key, modality = excluded.modality,
-            tempo_marking = excluded.tempo_marking,
-            tempo_bpm = excluded.tempo_bpm, notes = excluded.notes, tags = excluded.tags,
-            linked_exercise_ids = excluded.linked_exercise_ids,
-            updated_at = excluded.updated_at, priority = excluded.priority, deleted_at = NULL
-          """,
-        arguments: [
-          item.id, item.title, Self.kindString(item.kind), item.composer, item.key,
-          Self.modalityString(item.modality),
-          item.tempo?.marking, item.tempo?.bpm.map { Int($0) }, item.notes,
-          Self.encodeTags(item.tags),
-          Self.encodeLinkedExerciseIds(item.linkedExerciseIds),
-          item.createdAt, item.updatedAt, item.priority,
-        ])
+      try Self.upsert(item, in: db)
     }
+  }
+
+  /// All items in one transaction — all-or-nothing, so a composite write
+  /// (a piece plus its scaffold) can never half-land on disk (#1080).
+  func save(_ items: [Item]) throws {
+    try dbQueue.write { db in
+      for item in items {
+        try Self.upsert(item, in: db)
+      }
+    }
+  }
+
+  private static func upsert(_ item: Item, in db: Database) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO item
+          (id, title, kind, composer, key, modality, tempo_marking, tempo_bpm, notes, tags,
+           linked_exercise_ids, created_at, updated_at, priority, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+        ON CONFLICT(id) DO UPDATE SET
+          title = excluded.title, kind = excluded.kind, composer = excluded.composer,
+          key = excluded.key, modality = excluded.modality,
+          tempo_marking = excluded.tempo_marking,
+          tempo_bpm = excluded.tempo_bpm, notes = excluded.notes, tags = excluded.tags,
+          linked_exercise_ids = excluded.linked_exercise_ids,
+          updated_at = excluded.updated_at, priority = excluded.priority, deleted_at = NULL
+        """,
+      arguments: [
+        item.id, item.title, Self.kindString(item.kind), item.composer, item.key,
+        Self.modalityString(item.modality),
+        item.tempo?.marking, item.tempo?.bpm.map { Int($0) }, item.notes,
+        Self.encodeTags(item.tags),
+        Self.encodeLinkedExerciseIds(item.linkedExerciseIds),
+        item.createdAt, item.updatedAt, item.priority,
+      ])
   }
 
   /// Soft-delete: write the core-stamped `deletedAt` tombstone (RFC3339, same

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -134,6 +134,9 @@ final class Store {
       case .saveItem(let item):
         try store.save(item)
         return .ack
+      case .saveItems(let items):
+        try store.save(items)
+        return .ack
       case .deleteItem(let id, let deletedAt):
         try store.delete(id: id, deletedAt: deletedAt)
         return .ack

--- a/ios/IntradaTests/LibraryStoreBatchSaveTests.swift
+++ b/ios/IntradaTests/LibraryStoreBatchSaveTests.swift
@@ -1,0 +1,55 @@
+import SharedTypes
+import Testing
+
+@testable import Intrada
+
+struct LibraryStoreBatchSaveTests {
+  private func makeStore() throws -> LibraryStore { try LibraryStore.inMemory() }
+
+  private func item(
+    _ id: String, title: String = "Etude", kind: ItemKind = .exercise,
+    linkedExerciseIds: [String] = [], createdAt: String = "2026-01-01T00:00:00Z"
+  ) -> Item {
+    Item(
+      id: id, title: title, kind: kind, composer: nil, key: nil, modality: nil,
+      tempo: nil, notes: nil, tags: [], linkedExerciseIds: linkedExerciseIds,
+      createdAt: createdAt, updatedAt: createdAt, priority: false)
+  }
+
+  @Test func batchSavePersistsEveryItem() throws {
+    let store = try makeStore()
+
+    try store.save([
+      item("ex-melody", title: "Learn the melody"),
+      item("ex-shells", title: "Chord shells"),
+      item(
+        "piece-1", title: "Strasbourg / St. Denis", kind: .piece,
+        linkedExerciseIds: ["ex-melody", "ex-shells"]),
+    ])
+
+    let loaded = try store.loadItems()
+    #expect(loaded.count == 3)
+    let piece = try #require(loaded.first { $0.id == "piece-1" })
+    #expect(piece.linkedExerciseIds == ["ex-melody", "ex-shells"])
+  }
+
+  @Test func batchSaveUpsertsExistingRows() throws {
+    let store = try makeStore()
+    try store.save(item("ex-1", title: "Before"))
+
+    try store.save([
+      item("ex-1", title: "After"),
+      item("ex-2", title: "New"),
+    ])
+
+    let loaded = try store.loadItems()
+    #expect(loaded.count == 2)
+    #expect(try #require(loaded.first { $0.id == "ex-1" }).title == "After")
+  }
+
+  @Test func emptyBatchIsANoOp() throws {
+    let store = try makeStore()
+    try store.save([Item]())
+    #expect(try store.loadItems().isEmpty)
+  }
+}

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -379,6 +379,44 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(afterEdit.items.first?.itemType, .exercise, "edited type should apply")
   }
 
+  /// Real-bridge lesson capture (#1080): AddPieceWithScaffold carries the new
+  /// ScaffoldEntry enum, so drive the actual Swift-to-Rust bincode wire (#846)
+  /// and assert the composite lands: piece + new exercises, linked in order.
+  func testRealBridgeAddPieceWithScaffoldAppliesToViewModel() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    _ = try bridge.update(
+      .item(
+        .add(
+          CreateItem(
+            title: "Enclosures", kind: .exercise, composer: nil, key: nil, modality: nil,
+            tempo: nil, notes: nil, tags: []))))
+    let existingId = try XCTUnwrap(try bridge.view().items.first?.id)
+
+    _ = try bridge.update(
+      .item(
+        .addPieceWithScaffold(
+          piece: CreateItem(
+            title: "Strasbourg / St. Denis", kind: .piece, composer: "Roy Hargrove",
+            key: nil, modality: nil, tempo: nil, notes: nil, tags: []),
+          scaffold: [
+            .new(
+              CreateItem(
+                title: "Learn the melody", kind: .exercise, composer: nil, key: nil,
+                modality: nil, tempo: nil, notes: nil, tags: [])),
+            .existing(id: existingId),
+          ])))
+
+    let after = try bridge.view()
+    XCTAssertNil(after.error, "composite should apply (err=\(after.error ?? "nil"))")
+    XCTAssertEqual(after.items.count, 3, "existing exercise + new exercise + piece")
+    let piece = try XCTUnwrap(after.items.first { $0.title == "Strasbourg / St. Denis" })
+    let melodyId = try XCTUnwrap(after.items.first { $0.title == "Learn the melody" }?.id)
+    XCTAssertEqual(
+      piece.linkedExercises.map(\.id), [melodyId, existingId],
+      "scaffold order preserved across the real bridge")
+  }
+
   /// Real-bridge priority toggle (#763): the star sends an UpdateItem with every
   /// optional field "no change" (outer nil) and only `priority` set — a different
   /// bincode shape than the full edit, so round-trip it through the live bridge to
@@ -687,6 +725,7 @@ private struct TestError: Error {}
 private struct FailingStore: ItemStore {
   func loadItems() throws -> [Item] { throw TestError() }
   func save(_ item: Item) throws { throw TestError() }
+  func save(_ items: [Item]) throws { throw TestError() }
   func delete(id: String, deletedAt: String) throws { throw TestError() }
   func loadSessions() throws -> [PracticeSession] { throw TestError() }
   func saveSession(_ session: PracticeSession) throws { throw TestError() }


### PR DESCRIPTION
## Summary

Phase A1 of #1080 (epic #1087): new `ItemEvent::AddPieceWithScaffold { piece, scaffold }` creates a piece and its ordered exercise scaffold in one event. `ScaffoldEntry::New` mints exercises alongside; `ScaffoldEntry::Existing` links library exercises (deduped). Everything validates before anything applies. The composite persists as one `PersistenceOperation::SaveItems` batch that the shell executes in a single GRDB transaction, so it can never half-land on disk; online mode rejects cleanly (the temp-id dance cannot remap client-minted linked ids; local-first-only per the #1080 decision).

## Roadmap alignment

- [x] Links to a roadmap item: issue #1080 (epic #1087, roadmap "Current focus" section)
- [x] Pillar: Plan
- [x] Horizon: Now

## Coverage

Coverage: full. 13 new core tests (happy path with ordering, atomic-rejection paths x5, dedupe, empty scaffold, duplicate titles, online rejection, one-batch effect shape, FFI bincode round-trips for the event and the new op) + 3 Swift Testing batch-save tests + a LiveBridge real-bridge test driving the new event over the actual bincode wire (#846 class).

## Checklist

- [x] `just check` passes (fmt + clippy + nextest + typos + cargo-shear)
- [x] `ios/` changes: `just ios-fmt-check` passes; full `just ios-test` 159/159 on the worktree sim, plus targeted `StoreEffectLoopTests` rerun 25/25 including the new LiveBridge test. No UI change, no snapshots touched
- [x] No new UI (core + persistence only)
- [x] Persistence checklist: batch op reuses the existing upsert (tombstone revive semantics preserved); client-minted ulids; `local_first` branches both tested (local composite + online rejection)
- [x] CLAUDE.md: no architecture change beyond what #1080/#1087 already record
- [ ] Roadmap: untouched (A1 is one phase; epic checklist tracks it)

## Notes

TDD throughout: red (todo! stub, 9 failing) then green, then the batch rework red-green after self-review. Self-review findings and outcomes posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)