### PR TITLE
feat(core): per-piece exercise context derivation (#1081 B1)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -387,6 +387,10 @@ impl Intrada {
             }
         }
 
+        // Derived per-exercise practice contexts (piece + "on its own"), keyed
+        // by exercise id. Built once over sessions, attached to exercises below.
+        let contexts_by_exercise = build_exercise_contexts(&model.sessions, &item_index);
+
         let mut items: Vec<LibraryItemView> = Vec::new();
 
         for item in &model.items {
@@ -428,6 +432,15 @@ impl Intrada {
                 vec![]
             };
 
+            let exercise_contexts = if item.kind == ItemKind::Exercise {
+                contexts_by_exercise
+                    .get(item.id.as_str())
+                    .cloned()
+                    .unwrap_or_default()
+            } else {
+                vec![]
+            };
+
             items.push(LibraryItemView {
                 id: item.id.clone(),
                 item_type: item.kind.clone(),
@@ -451,6 +464,7 @@ impl Intrada {
                 priority: item.priority,
                 linked_exercises,
                 linked_from_pieces,
+                exercise_contexts,
             });
         }
 
@@ -748,6 +762,111 @@ pub(crate) fn build_practice_summaries(
             },
         )
         .collect()
+}
+
+/// Derive, per exercise, the piece/standalone contexts it has been practised
+/// in across `sessions` (#1087 B1). For each session entry that is an exercise,
+/// the context is the piece sharing its block `group_id` in that same session,
+/// or the "On its own" bucket (`piece: None`) when the entry is ungrouped or its
+/// block carries no piece. Rollup v1 keeps the latest recorded score, distinct
+/// session count, and most-recent date per context.
+fn build_exercise_contexts(
+    sessions: &[PracticeSession],
+    item_index: &std::collections::HashMap<&str, &crate::domain::item::Item>,
+) -> std::collections::HashMap<String, Vec<crate::model::ExerciseContextView>> {
+    use crate::model::{ExerciseContextView, PieceRefView};
+    use std::collections::{HashMap, HashSet};
+
+    // (exercise_id, piece_id | None) → accumulated rollup for that context.
+    struct Acc {
+        piece_title: Option<String>,
+        session_ids: HashSet<String>,
+        last_practiced_at: Option<String>,
+        // (date, score) of the most recent scored entry in this context.
+        latest_scored: Option<(String, u8)>,
+    }
+
+    let mut acc: HashMap<(String, Option<String>), Acc> = HashMap::new();
+
+    for session in sessions {
+        let date = session.started_at.to_rfc3339();
+        for entry in &session.entries {
+            if entry.item_type != ItemKind::Exercise {
+                continue;
+            }
+            // Context = the piece sharing this entry's block in the same
+            // session; ungrouped or piece-less blocks fall to the None bucket.
+            let piece = entry.group_id.as_deref().and_then(|g| {
+                session
+                    .entries
+                    .iter()
+                    .find(|e| e.item_type == ItemKind::Piece && e.group_id.as_deref() == Some(g))
+            });
+            let piece_id = piece.map(|p| p.item_id.clone());
+
+            let record = acc
+                .entry((entry.item_id.clone(), piece_id))
+                .or_insert_with(|| Acc {
+                    piece_title: None,
+                    session_ids: HashSet::new(),
+                    last_practiced_at: None,
+                    latest_scored: None,
+                });
+            if let Some(p) = piece {
+                record.piece_title = Some(p.item_title.clone());
+            }
+            record.session_ids.insert(session.id.clone());
+            if record
+                .last_practiced_at
+                .as_ref()
+                .map_or(true, |cur| date > *cur)
+            {
+                record.last_practiced_at = Some(date.clone());
+            }
+            if let Some(score) = entry.score {
+                if record
+                    .latest_scored
+                    .as_ref()
+                    .map_or(true, |(d, _)| date > *d)
+                {
+                    record.latest_scored = Some((date.clone(), score));
+                }
+            }
+        }
+    }
+
+    let mut by_exercise: HashMap<String, Vec<ExerciseContextView>> = HashMap::new();
+    for ((exercise_id, piece_id), record) in acc {
+        let piece = piece_id.map(|id| PieceRefView {
+            title: record.piece_title.unwrap_or_default(),
+            subtitle: item_index.get(id.as_str()).and_then(|p| p.composer.clone()),
+            id,
+        });
+        by_exercise
+            .entry(exercise_id)
+            .or_default()
+            .push(ExerciseContextView {
+                piece,
+                latest_score: record.latest_scored.map(|(_, s)| s),
+                session_count: record.session_ids.len(),
+                last_practiced_at: record.last_practiced_at,
+            });
+    }
+
+    // Deterministic order: piece contexts first (most-recent practice first,
+    // tie-broken by piece id), then the "On its own" bucket last.
+    for contexts in by_exercise.values_mut() {
+        contexts.sort_by(|a, b| match (&a.piece, &b.piece) {
+            (Some(x), Some(y)) => b
+                .last_practiced_at
+                .cmp(&a.last_practiced_at)
+                .then_with(|| x.id.cmp(&y.id)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+    }
+    by_exercise
 }
 
 fn sort_library_items(items: &mut [LibraryItemView], sort: &LibrarySort) {
@@ -4122,6 +4241,253 @@ mod tests {
         let ex3_view = vm.items.iter().find(|i| i.id == "ex-3").unwrap();
         assert!(ex3_view.linked_exercises.is_empty());
         assert!(ex3_view.linked_from_pieces.is_empty());
+    }
+
+    // ── Exercise context derivation (#1087 B1) ───────────────────────────
+
+    fn ctx_entry(
+        item_id: &str,
+        title: &str,
+        kind: ItemKind,
+        score: Option<u8>,
+        group: Option<&str>,
+    ) -> SetlistEntry {
+        SetlistEntry {
+            id: format!("{item_id}-{}", group.unwrap_or("solo")),
+            item_id: item_id.to_string(),
+            item_title: title.to_string(),
+            item_type: kind,
+            position: 0,
+            duration_secs: 300,
+            status: EntryStatus::Completed,
+            notes: None,
+            score,
+            intention: None,
+            rep_target: None,
+            rep_count: None,
+            rep_target_reached: None,
+            rep_history: None,
+            planned_duration_secs: None,
+            achieved_tempo: None,
+            group_id: group.map(String::from),
+        }
+    }
+
+    fn ctx_session(
+        id: &str,
+        started: chrono::DateTime<chrono::Utc>,
+        entries: Vec<SetlistEntry>,
+    ) -> PracticeSession {
+        PracticeSession {
+            id: id.to_string(),
+            started_at: started,
+            completed_at: started,
+            total_duration_secs: 300,
+            completion_status: CompletionStatus::Completed,
+            session_notes: None,
+            session_intention: None,
+            session_score: None,
+            entries,
+            reflection_improved: None,
+            reflection_still_rough: None,
+            reflection_next_target: None,
+        }
+    }
+
+    fn ctx_item(id: &str, title: &str, kind: ItemKind, composer: Option<&str>) -> Item {
+        let now = chrono::Utc::now();
+        Item {
+            id: id.to_string(),
+            title: title.to_string(),
+            kind,
+            composer: composer.map(String::from),
+            key: None,
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+            created_at: now,
+            updated_at: now,
+            linked_exercise_ids: vec![],
+            priority: false,
+        }
+    }
+
+    /// The core B1 derivation: an exercise practised in a piece's block twice
+    /// and standalone once yields two contexts — the piece (latest score, count,
+    /// date rolled up) then the "On its own" bucket last.
+    #[test]
+    fn test_exercise_contexts_derive_piece_and_on_its_own() {
+        let app = Intrada;
+        let d1 = chrono::Utc::now() - chrono::Duration::days(5);
+        let d2 = chrono::Utc::now() - chrono::Duration::days(3);
+        let d3 = chrono::Utc::now() - chrono::Duration::days(1);
+
+        let model = Model {
+            items: vec![
+                ctx_item("P", "Sonata", ItemKind::Piece, Some("Beethoven")),
+                ctx_item("ex-1", "Scales", ItemKind::Exercise, None),
+            ],
+            sessions: vec![
+                // s1 (earliest): ex-1 scored 4 in block g1 with piece P.
+                ctx_session(
+                    "s1",
+                    d1,
+                    vec![
+                        ctx_entry("ex-1", "Scales", ItemKind::Exercise, Some(4), Some("g1")),
+                        ctx_entry("P", "Sonata", ItemKind::Piece, None, Some("g1")),
+                    ],
+                ),
+                // s2 (middle): ex-1 scored 6 again in a P block.
+                ctx_session(
+                    "s2",
+                    d2,
+                    vec![
+                        ctx_entry("ex-1", "Scales", ItemKind::Exercise, Some(6), Some("g2")),
+                        ctx_entry("P", "Sonata", ItemKind::Piece, None, Some("g2")),
+                    ],
+                ),
+                // s3 (latest): ex-1 scored 8 standalone.
+                ctx_session(
+                    "s3",
+                    d3,
+                    vec![ctx_entry(
+                        "ex-1",
+                        "Scales",
+                        ItemKind::Exercise,
+                        Some(8),
+                        None,
+                    )],
+                ),
+            ],
+            ..Default::default()
+        };
+
+        let vm = app.view(&model);
+        let ex1 = vm.items.iter().find(|i| i.id == "ex-1").unwrap();
+        assert_eq!(ex1.exercise_contexts.len(), 2, "piece + on-its-own");
+
+        let piece_ctx = &ex1.exercise_contexts[0];
+        let piece = piece_ctx.piece.as_ref().expect("piece context first");
+        assert_eq!(piece.id, "P");
+        assert_eq!(piece.title, "Sonata");
+        assert_eq!(
+            piece.subtitle.as_deref(),
+            Some("Beethoven"),
+            "composer live"
+        );
+        assert_eq!(
+            piece_ctx.latest_score,
+            Some(6),
+            "latest scored in P is d2's 6"
+        );
+        assert_eq!(piece_ctx.session_count, 2);
+        assert_eq!(piece_ctx.last_practiced_at, Some(d2.to_rfc3339()));
+
+        let solo = &ex1.exercise_contexts[1];
+        assert!(solo.piece.is_none(), "'On its own' bucket has no piece");
+        assert_eq!(solo.latest_score, Some(8));
+        assert_eq!(solo.session_count, 1);
+        assert_eq!(solo.last_practiced_at, Some(d3.to_rfc3339()));
+
+        // Pieces themselves carry no contexts.
+        let piece_view = vm.items.iter().find(|i| i.id == "P").unwrap();
+        assert!(piece_view.exercise_contexts.is_empty());
+    }
+
+    /// A grouped run with no piece entry (a dissolved block) falls into the
+    /// "On its own" bucket, not a phantom piece context.
+    #[test]
+    fn test_exercise_contexts_grouped_without_piece_is_on_its_own() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let model = Model {
+            items: vec![ctx_item("ex-1", "Scales", ItemKind::Exercise, None)],
+            sessions: vec![ctx_session(
+                "s1",
+                now,
+                vec![ctx_entry(
+                    "ex-1",
+                    "Scales",
+                    ItemKind::Exercise,
+                    Some(5),
+                    Some("orphan-group"),
+                )],
+            )],
+            ..Default::default()
+        };
+
+        let ex1 = app
+            .view(&model)
+            .items
+            .into_iter()
+            .find(|i| i.id == "ex-1")
+            .unwrap();
+        assert_eq!(ex1.exercise_contexts.len(), 1);
+        assert!(ex1.exercise_contexts[0].piece.is_none());
+        assert_eq!(ex1.exercise_contexts[0].latest_score, Some(5));
+    }
+
+    /// Invariant 6: the derivation is identical whether sessions arrive via the
+    /// online `SessionsLoaded` path or the local-first `SessionsStoreLoaded`
+    /// persistence path — it's a pure projection over `model.sessions`.
+    #[test]
+    fn test_exercise_contexts_identical_in_both_modes() {
+        let app = Intrada;
+        let now = chrono::Utc::now();
+        let items = vec![
+            ctx_item("P", "Sonata", ItemKind::Piece, None),
+            ctx_item("ex-1", "Scales", ItemKind::Exercise, None),
+        ];
+        let sessions = vec![ctx_session(
+            "s1",
+            now,
+            vec![
+                ctx_entry("ex-1", "Scales", ItemKind::Exercise, Some(7), Some("g1")),
+                ctx_entry("P", "Sonata", ItemKind::Piece, None, Some("g1")),
+            ],
+        )];
+
+        // Online: local_first stays false, sessions arrive via SessionsLoaded.
+        let mut online = Model::test_default();
+        online.items = items.clone();
+        let _ = app.update(
+            Event::SessionsLoaded {
+                sessions: sessions.clone(),
+            },
+            &mut online,
+        );
+        let online_ctx = app
+            .view(&online)
+            .items
+            .into_iter()
+            .find(|i| i.id == "ex-1")
+            .unwrap()
+            .exercise_contexts;
+
+        // Local-first: sessions arrive via the persistence store.
+        let mut local = Model::test_default();
+        local.local_first = true;
+        local.items = items;
+        let _ = app.update(
+            Event::SessionsStoreLoaded(PersistenceOutput::Sessions(sessions)),
+            &mut local,
+        );
+        let local_ctx = app
+            .view(&local)
+            .items
+            .into_iter()
+            .find(|i| i.id == "ex-1")
+            .unwrap()
+            .exercise_contexts;
+
+        assert_eq!(online_ctx.len(), 1);
+        assert_eq!(online_ctx[0].piece.as_ref().unwrap().id, "P");
+        assert_eq!(online_ctx[0].latest_score, Some(7));
+        assert_eq!(
+            online_ctx, local_ctx,
+            "context derivation must not depend on load path (invariant 6)"
+        );
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -5034,4 +5034,32 @@ mod tests {
             panic!("Expected Summary state");
         }
     }
+
+    /// `group_id` rides `SetlistEntry` across the bincode FFI wire (in the
+    /// persisted `PracticeSession` and the ViewModel). It is the sole input to
+    /// the B1 context derivation, so a silent drop on the wire would erase every
+    /// piece context. Guard the whole entry, with `group_id` set, against the
+    /// #846 class.
+    #[test]
+    fn setlist_entry_with_group_id_round_trips_on_ffi_bincode_wire() {
+        crate::domain::types::assert_round_trips(SetlistEntry {
+            id: "e1".to_string(),
+            item_id: "ex-1".to_string(),
+            item_title: "Scales".to_string(),
+            item_type: ItemKind::Exercise,
+            position: 0,
+            duration_secs: 300,
+            status: EntryStatus::Completed,
+            notes: Some("warm up".to_string()),
+            score: Some(6),
+            intention: Some("even tone".to_string()),
+            rep_target: Some(5),
+            rep_count: Some(5),
+            rep_target_reached: Some(true),
+            rep_history: Some(vec![RepAction::Success, RepAction::Missed]),
+            planned_duration_secs: Some(300),
+            achieved_tempo: Some(96),
+            group_id: Some("g1".to_string()),
+        });
+    }
 }

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -228,6 +228,23 @@ pub struct LibrarySort {
     pub direction: SortDirection,
 }
 
+/// Round-trip through crux's actual FFI format (`BincodeFfiFormat`) — the
+/// exact wire the iOS bridge uses, so tests can't drift from the real
+/// serializer and we don't take a direct bincode dependency. Shared by every
+/// bridge-crossing type's round-trip guard (#846 class).
+#[cfg(test)]
+pub(crate) fn assert_round_trips<T>(value: T)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
+{
+    use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
+    let mut bytes = Vec::new();
+    BincodeFfiFormat::serialize(&mut bytes, &value).expect("serialize");
+    let back: T =
+        BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
+    assert_eq!(value, back, "round-trip changed the value");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,22 +301,8 @@ mod tests {
     // The native iOS shell ships these write payloads as positional bincode
     // (crux's BincodeFfiFormat). A serde attr that assumes a self-describing
     // format (see `double_option` above) misaligns that wire and the event
-    // silently fails to decode. These guard against that whole class.
-
-    /// Round-trip through crux's actual FFI format (`BincodeFfiFormat`) — the
-    /// exact wire the iOS bridge uses, so the test can't drift from the real
-    /// serializer and we don't take a direct bincode dependency.
-    fn assert_round_trips<T>(value: T)
-    where
-        T: serde::Serialize + serde::de::DeserializeOwned + std::fmt::Debug + PartialEq,
-    {
-        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
-        let mut bytes = Vec::new();
-        BincodeFfiFormat::serialize(&mut bytes, &value).expect("serialize");
-        let back: T =
-            BincodeFfiFormat::deserialize(&bytes).expect("must decode on the FFI wire (#846)");
-        assert_eq!(value, back, "round-trip changed the value");
-    }
+    // silently fails to decode. These guard against that whole class, via the
+    // module-level `assert_round_trips` shared with the other domain modules.
 
     #[test]
     fn update_item_round_trips_on_ffi_bincode_wire() {

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -243,6 +243,25 @@ pub struct PieceRefView {
     pub subtitle: Option<String>,
 }
 
+/// One derived context an exercise has been practised in: either alongside a
+/// piece (the block's anchor, resolved per past session from `group_id`), or on
+/// its own. Derived from session history, not from the static links — it
+/// answers "where has this drill actually done its work, and how's it scoring
+/// there?" (#1087 B1). Rollup v1 = `latest_score` per context.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct ExerciseContextView {
+    /// The piece this exercise was practised alongside; `None` is the "On its
+    /// own" bucket — standalone practice with no piece in the session block.
+    pub piece: Option<PieceRefView>,
+    /// The exercise's most recent recorded score in this context.
+    pub latest_score: Option<u8>,
+    /// Distinct sessions the exercise was practised in, in this context.
+    pub session_count: usize,
+    /// Most recent session date for this context (RFC3339, sorts as a string).
+    pub last_practiced_at: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct LibraryItemView {
@@ -264,6 +283,11 @@ pub struct LibraryItemView {
     pub priority: bool,
     pub linked_exercises: Vec<LinkedExerciseView>,
     pub linked_from_pieces: Vec<PieceRefView>,
+    /// For exercises: the piece (and standalone) contexts this exercise has
+    /// been practised in, derived from session history (#1087 B1). Empty for
+    /// pieces.
+    #[serde(default)]
+    pub exercise_contexts: Vec<ExerciseContextView>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -601,6 +625,22 @@ pub fn session_to_view(session: &PracticeSession) -> PracticeSessionView {
 mod tests {
     use super::*;
     use chrono::Utc;
+
+    /// `ExerciseContextView` crosses the bincode FFI bridge inside the
+    /// ViewModel; guard it against the #846 silent-drop class.
+    #[test]
+    fn exercise_context_view_round_trips_on_ffi_bincode_wire() {
+        crate::domain::types::assert_round_trips(ExerciseContextView {
+            piece: Some(PieceRefView {
+                id: "P".to_string(),
+                title: "Sonata".to_string(),
+                subtitle: Some("Beethoven".to_string()),
+            }),
+            latest_score: Some(6),
+            session_count: 2,
+            last_practiced_at: Some("2026-07-01T00:00:00+00:00".to_string()),
+        });
+    }
 
     fn make_entry(id: &str, item_id: &str, title: &str, position: usize) -> SetlistEntry {
         SetlistEntry {

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -343,7 +343,7 @@
           LinkedExerciseView(
             id: "exercise-2", title: "Db Major Scale", key: "Db major", tempo: nil, practice: nil),
         ],
-        linkedFromPieces: [])
+        linkedFromPieces: [], exerciseContexts: [])
     }
 
     static var previewExercise: LibraryItemView {
@@ -352,7 +352,8 @@
         subtitle: "Charles-Louis Hanon",
         key: "C", modality: .major, tempo: "108 BPM", tempoMarking: nil, tempoBpm: 108,
         notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-        latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [])
+        latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+        exerciseContexts: [])
     }
 
     static var previewDetail: LibraryItemView {
@@ -363,7 +364,7 @@
         notes: "Focus on the rubato in the opening phrase; keep the left hand soft.",
         tags: ["recital", "impressionist", "memorised"], createdAt: "", updatedAt: "",
         practice: nil, latestAchievedTempo: nil, priority: false, linkedExercises: [],
-        linkedFromPieces: [])
+        linkedFromPieces: [], exerciseContexts: [])
     }
 
     static var previewMinimal: LibraryItemView {
@@ -371,7 +372,8 @@
         id: "piece-2", itemType: .piece, title: "Prelude in C", subtitle: "",
         key: nil, modality: nil, tempo: nil, tempoMarking: nil, tempoBpm: nil,
         notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-        latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [])
+        latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+        exerciseContexts: [])
     }
 
     /// A piece with a populated linked-exercises list (3 items, varied scores including
@@ -407,7 +409,7 @@
             id: "exercise-3", title: "Arpeggios in Db", key: nil, tempo: nil,
             practice: nil),
         ],
-        linkedFromPieces: [])
+        linkedFromPieces: [], exerciseContexts: [])
     }
 
     /// An exercise related to 2 pieces — for the "Related pieces" card snapshot.
@@ -429,7 +431,7 @@
         linkedFromPieces: [
           PieceRefView(id: "piece-1", title: "Clair de Lune", subtitle: "Claude Debussy"),
           PieceRefView(id: "piece-2", title: "Gymnopédie No. 1", subtitle: "Erik Satie"),
-        ])
+        ], exerciseContexts: [])
     }
 
     /// A piece with no linked exercises — for the empty-state snapshot.
@@ -440,7 +442,7 @@
         tempoMarking: "Lent et douloureux",
         tempoBpm: 60, notes: nil, tags: [], createdAt: "", updatedAt: "",
         practice: nil, latestAchievedTempo: nil, priority: false,
-        linkedExercises: [], linkedFromPieces: [])
+        linkedExercises: [], linkedFromPieces: [], exerciseContexts: [])
     }
   }
 

--- a/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
+++ b/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
@@ -371,12 +371,14 @@ struct LinkedExercisePickerSheet: View {
           id: "exercise-2", itemType: .exercise, title: "Db Major Scale", subtitle: "",
           key: "Db", modality: .major, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
         LibraryItemView(
           id: "exercise-3", itemType: .exercise, title: "Arpeggios in Db", subtitle: "",
           key: "Db", modality: .major, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
       ],
       linkedIds: ["exercise-1"],
       onApply: { _ in })

--- a/ios/IntradaTests/ScreenSnapshotTests.swift
+++ b/ios/IntradaTests/ScreenSnapshotTests.swift
@@ -569,12 +569,14 @@ final class ScreenSnapshotTests: XCTestCase {
           id: "exercise-2", itemType: .exercise, title: "Db Major Scale", subtitle: "",
           key: "Db", modality: .major, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
         LibraryItemView(
           id: "exercise-3", itemType: .exercise, title: "Arpeggios in Db", subtitle: "",
           key: nil, modality: nil, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
       ],
       linkedIds: ["exercise-1"],
       onApply: { _ in })
@@ -591,12 +593,14 @@ final class ScreenSnapshotTests: XCTestCase {
           id: "exercise-2", itemType: .exercise, title: "Db Major Scale", subtitle: "",
           key: "Db", modality: .major, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
         LibraryItemView(
           id: "exercise-3", itemType: .exercise, title: "Arpeggios in Db", subtitle: "",
           key: nil, modality: nil, tempo: nil, tempoMarking: nil, tempoBpm: nil,
           notes: nil, tags: [], createdAt: "", updatedAt: "", practice: nil,
-          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: []),
+          latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+          exerciseContexts: []),
       ],
       linkedIds: ["exercise-1", "exercise-3"],
       onApply: { _ in })


### PR DESCRIPTION
## What

B1 of the "lesson to mastery" epic (#1087, workstream **B** #1081): derive, per exercise, the piece and standalone contexts it has actually been practised in — the data layer B2 renders as "By piece" rows.

For each exercise entry in past sessions, the context is the **piece sharing its block `group_id`** in that same session (related-first, piece-last — resolved order-independently), or the **"On its own"** bucket when the entry was ungrouped or its block carried no piece. Surfaces as:

- `LibraryItemView.exercise_contexts: Vec<ExerciseContextView>` (populated for exercises; empty for pieces)
- `ExerciseContextView { piece: Option<PieceRefView>, latest_score, session_count, last_practiced_at }`
- Rollup v1 = latest recorded score per context; distinct-session count; most-recent date. Deterministic order: piece contexts (most-recent first, tie-broken by id), then "On its own" last.

Core-only, no UI.

## Invariants

- **6 (both modes):** pure ViewModel projection over `model.sessions` — identical whether sessions arrive online (`SessionsLoaded`) or local-first (`SessionsStoreLoaded`). Tested both paths.
- **Codec guard (#846 class):** `group_id` is the sole derivation input; a silent drop on the FFI wire erases every piece context. Added bincode round-trip guards for `SetlistEntry` with `group_id` set, and for `ExerciseContextView`.

## Tests (TDD — red first, then green)

- `test_exercise_contexts_derive_piece_and_on_its_own` — piece rollup (latest score across sessions, count, date) + "On its own" bucket + ordering + live composer subtitle + pieces carry no contexts.
- `test_exercise_contexts_grouped_without_piece_is_on_its_own` — a piece-less block falls to the bucket, not a phantom piece.
- `test_exercise_contexts_identical_in_both_modes` — invariant 6, online vs local-first load paths.
- Two FFI bincode round-trip guards.

## Coverage

Full — new derivation has both-modes + edge-case tests; new bridge types have round-trip guards. `build_view` wiring exercised via `app.view`.

## Deferred (tracked)

- #1093 — piece identity: snapshot title vs live composer, and tombstoned-piece filtering — decide during B2.
- #1094 — cache `exercise_contexts` on session-change instead of per-render (perf; negligible at current scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)