### PR TITLE
docs(roadmap): mark C2 landed

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,9 +46,10 @@ The lesson-to-mastery loop (see the
 [epic, #1087](https://github.com/jonyardley/intrada/issues/1087)) has
 workstream **B: track exercises per piece** (#1081) merged (B1 #1095, B2
 #1097). **C: exercise steps** (#1083) is under way: C1 (the core variant
-mechanism + GRDB child table, spec in `specs/exercise-variants.md`) has
-landed; C2 (Steps UI + reflection picker), C3 (12-keys preset, closes #46 and
-unblocks the #1107 twelve-key scaffold ladder) and C4 (step management) follow.
+mechanism + GRDB child table, spec in `specs/exercise-variants.md`) and C2
+(exercise-detail Steps section, reflection + builder step-picker) have
+landed; C3 (12-keys preset, closes #46 and unblocks the #1107 twelve-key
+scaffold ladder) and C4 (step management) follow.
 R (suggest the next session, #1082) remains queued. Workstream **A (capture a
 lesson in one pass, #1080) is on hold**: it's being rethought before more is
 built on it, and its merged core event was reverted (#1092). Check the


### PR DESCRIPTION
## Summary
- Roadmap wording update: C1+C2 of exercise steps (#1083) are landed (PR #1119); C3/C4 remain.

Tier 1 (doc-only wording change) — no gates/review needed per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)