### PR TITLE
fix(deps): jsonwebtoken 11 — replace the deleted patch-fork pin (CI blocker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,8 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
-source = "git+https://github.com/kp-timo-beyel/jsonwebtoken.git?branch=fix/header-extras-non-string-values#9bca28c470339d46a8437f03f488131d1f3a9eee"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2088,6 +2089,7 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -5309,6 +5311,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,6 @@ ulid = "2"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 
-# jsonwebtoken v10.3.0 has a bug (#489): Header.extras is
-# HashMap<String, String> with #[serde(flatten)], so non-string header
-# fields (like Clerk's `oiat: <number>`) fail deserialization. PR #496
-# fixes this by changing extras to HashMap<String, serde_json::Value>.
-# Remove this patch once the fix lands in a released version.
-[patch.crates-io]
-jsonwebtoken = { git = "https://github.com/kp-timo-beyel/jsonwebtoken.git", branch = "fix/header-extras-non-string-values" }
-
 [profile.dev.package."*"]
 debug = false
 

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -26,7 +26,10 @@ serde_json = { workspace = true }
 ulid = { workspace = true }
 chrono = { workspace = true }
 
-jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto", "use_pem"] }
+# v11: Header.extras became a typed `Extras` map of serde_json::Value, fixing
+# upstream #489 (Clerk's numeric `oiat` header field failed deserialization).
+# v10 needed a git-forked patch for this; the fork was later deleted (broke CI).
+jsonwebtoken = { version = "11", default-features = false, features = ["rust_crypto", "use_pem"] }
 reqwest = { version = "0.13", default-features = false, features = ["native-tls", "json", "multipart"] }
 rust-s3 = { version = "0.37", default-features = false, features = ["tokio-native-tls"] }
 


### PR DESCRIPTION
## Summary

CI is broken for any job with a cold cargo cache: the `[patch.crates-io]` pin for jsonwebtoken pointed at `kp-timo-beyel/jsonwebtoken` (the fork carrying upstream PR #496 for issue #489 — `Header.extras: HashMap<String, String>` rejected Clerk's numeric `oiat` header). **That fork has been deleted from GitHub**, so cargo resolution 404s. First surfaced as the Security & hygiene failure on #1134; every PR will hit it as caches rotate.

Fix: bump to jsonwebtoken **11.0.0**, which fixes #489 properly (`extras` is now a typed map of `serde_json::Value`), and drop the patch block. Zero code changes — the `decode`/`Validation`/`DecodingKey`/`JwkSet` surface we use is unchanged in v11.

## Test plan

- [x] `cargo test -p intrada-api` — 189 passed, including `decode_header_accepts_non_string_extras`, the regression test written for exactly the #489 bug (now passing against upstream v11 instead of the fork)
- [x] `just fmt-check`, `just lint`, `just test` — green
- [ ] `just hygiene` — typos/shear blocked locally by unrelated leftover build artefacts; CI's hygiene job is the verification (it's also the job this PR fixes)

Coverage: n/a — dependency bump, no new logic; the existing regression test covers the behavioural contract.

## Sensitivity note

Auth path (JWT validation). The claim-validation config (`RS256`, `validate_aud` handling, issuer check) is untouched; v11's changes to our surface are additive. The regression test plus the full auth test suite passing is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)