### PR TITLE
docs(spec): record the two-circle fluency frame in the pedagogy model

### DIFF
--- a/specs/intrada-practice-coach-design.md
+++ b/specs/intrada-practice-coach-design.md
@@ -82,6 +82,37 @@ The pattern worth noticing: the gamification playbook (points, streak-loss, badg
 
 ## The pedagogy model
 
+### The fluency frame (added 2 Aug 2026)
+
+From a lesson-notes sketch by user zero's teacher. What comes out as **music**
+is the intersection of two circles: the **music in your head** (what you can
+hear and imagine) and **technique** (what your hands can execute on demand).
+Fluency is the growth of the overlap — either circle alone produces exercises
+or frustration.
+
+The frame organises the taxonomy along two axes the flat list doesn't show:
+
+- **Head vs hands.** Listening, transcription, and the front half of the
+  vocabulary pipeline grow the head circle; technique, voicings, and harmonic
+  patterns grow the hands circle. Vocabulary is the bridge between them — a
+  transcribed phrase (head) becomes a device drilled through the keys (hands).
+  The lick pipeline is that bridge, built out.
+- **At the keys vs away from them.** Listening and transcription need no
+  instrument (already the no-instrument session blocks); everything else is
+  keyboard time making music or building the hands.
+
+This is explicitly a portfolio model, not a session template: proficiency
+comes from accumulated time across both circles over months, not from every
+session touching everything. The planner's interleaving already rotates
+categories, but it rotates by node due-ness — nothing detects a starved
+circle. A user could pass gates for months with 90% of their time in the
+hands circle, and v1's measurable-first content leans exactly that way. The
+check this frame adds, once the session data exists: a long-horizon
+time-by-circle view (Track pillar) and a planner bias when one circle
+starves. Cheap, because every block is already tagged with its taxonomy
+category. Phase 4 material; recorded now so the imbalance is a known debt,
+not a surprise.
+
 ### Activity taxonomy (seven categories, engine room only)
 
 1. **Technique and foundations.** Scales, modes, arpeggios, digital patterns (1-2-3-5 cells), finger independence.

--- a/specs/intrada-practice-coach-design.md
+++ b/specs/intrada-practice-coach-design.md
@@ -97,9 +97,15 @@ The frame organises the taxonomy along two axes the flat list doesn't show:
   patterns grow the hands circle. Vocabulary is the bridge between them — a
   transcribed phrase (head) becomes a device drilled through the keys (hands).
   The lick pipeline is that bridge, built out.
-- **At the keys vs away from them.** Listening and transcription need no
-  instrument (already the no-instrument session blocks); everything else is
-  keyboard time making music or building the hands.
+- **At the keys vs away from them.** Listening needs no instrument (already
+  the prescribable no-instrument session blocks). Transcription spans both
+  modes, and the modes are a difficulty ladder: listen-and-repeat at the keys
+  is the entry rung; working the phrase out away from the instrument, hearing
+  it fully in the head before playing a note, is the advanced rung — pure
+  audiation, no trial-and-error from the hands. That ladder belongs in the
+  ear-training method pack, the same shape as sparse-click levels within
+  click-always. Everything else is keyboard time making music or building
+  the hands.
 
 This is explicitly a portfolio model, not a session template: proficiency
 comes from accumulated time across both circles over months, not from every


### PR DESCRIPTION
## What

Adds a short **'The fluency frame'** subsection to the pedagogy-model section of `specs/intrada-practice-coach-design.md`, capturing the model Jon's jazz piano teacher sketched: music is the intersection of **music in your head** (what you can hear) and **technique** (what your hands can execute), and fluency is the growth of the overlap.

## Why

Cross-referencing the sketch against the spec showed the seven-category taxonomy already covers every item in it (transcription, language/lick pipeline, restricted improv, repertoire, melodic/harmonic fundamentals, ii-V-I patterns). What the spec lacked was the frame itself and the check it implies:

- It's a **portfolio model, not a session template** — proficiency comes from accumulated time across both circles over months.
- The planner rotates by node due-ness; **nothing detects a starved circle**. v1's measurable-first content leans hands-circle, so this is a real risk.
- The fix is cheap when the data exists (blocks are already taxonomy-tagged): a time-by-circle Track view + planner bias. Recorded as Phase 4 debt so it's known, not a surprise.

## Coverage

Docs-only change — no code, no tests expected. `just hygiene` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)