### PR TITLE
content: Phase 0 paper teacher — 5 nodes, 2 method packs, 1 phrase, gates as data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ crates/
   intrada-api/           # REST API — Axum 0.8 + Turso (libsql)
 ios/                     # Native SwiftUI app (Intrada.xcodeproj via xcodegen)
   Reference/             #   Reference Swift preserved from the removed Tauri shell (not built)
+content/                 # Practice-coach authored content (Phase 0 paper teacher; no code reads it yet)
 design/                  # Claude Design system (intrada-design-system.dc.html)
 docs/                    # Product roadmap (single source of truth)
 specs/                   # Spec docs for major features (Tier 3 only — see Workflow)

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,55 @@
+# Phase 0 content — the paper teacher
+
+The minimal content set from
+[`specs/intrada-practice-coach-design.md`](../specs/intrada-practice-coach-design.md)
+(Build plan, Phase 0): 5 skill-graph nodes, 2 method packs, 1 phrase with
+per-key state, gate criteria as data, and the tune-pipeline position for the
+test fixture. No code reads these files yet. For a fortnight, **you** are the
+app: run your practice from this content and keep the four logs. The logs are
+the deliverable; the content is the instrument.
+
+## Files
+
+| File | What it is |
+|---|---|
+| [`nodes.md`](nodes.md) | The 5 fully-specified skill-graph nodes + stubs for the rest of the improvisation branch |
+| [`method-packs/voicing-traversal.md`](method-packs/voicing-traversal.md) | How to attack shell + rootless voicing work |
+| [`method-packs/phrase-transposition.md`](method-packs/phrase-transposition.md) | How to take a phrase through the keys |
+| [`phrases/p001-flat9-turnaround.md`](phrases/p001-flat9-turnaround.md) | The one in-flight phrase: notation, devices, pipeline stage, per-key state |
+| [`gates.toml`](gates.toml) | Every gate criterion as tunable data — day-one guesses, calibrated from the gate-attempt log |
+| [`tunes.md`](tunes.md) | Strasbourg / St. Denis tune-pipeline position |
+| [`logs.md`](logs.md) | Templates for the four Phase 0 logs (divergence, gate-attempt, why, wander) |
+
+## Circle tags (the fluency frame)
+
+Every node and drill carries two tags from the spec's fluency-frame
+subsection:
+
+- **Circle**: `head` (music you can hear/imagine), `hands` (what you can
+  execute), or `bridge` (grows the overlap — the point of the whole thing).
+- **Mode**: `keys` or `away` (no instrument needed).
+
+Known imbalance, stated up front: this v1 set is 2× hands, 2× bridge,
+1× head — measurable-first content leans hands-circle exactly as the frame
+warns. The fortnight's wander and why logs should watch for head-circle
+starvation; the long-term fix (time-by-circle Track view, planner bias) is
+recorded Phase 4 debt.
+
+## Day-one checklist
+
+1. Correct the **seed mastery values** in `nodes.md` and the per-key table in
+   `phrases/p001-flat9-turnaround.md` — they are plausible guesses, not
+   measurements. Ten minutes at the piano settles each one.
+2. If the phrase you're actually working on isn't the ♭9 turnaround, replace
+   the notation in `p001` and keep the file's structure — the structure is
+   the schema.
+3. Fill the `TODO(jon)` rows in `tunes.md` from where Strasbourg actually is.
+4. Print or open `logs.md` where you practise. A log you can't reach doesn't
+   get written.
+
+## The fortnight's writing tasks (besides the logs)
+
+From the spec's Phase 0 list, to be written during/after the fortnight, not
+on day one: the failure stories and desired app responses; what the app
+should have done on the inevitable bad day; the placement session as a
+thought experiment, checking the criteria aren't jon-shaped.

--- a/content/README.md
+++ b/content/README.md
@@ -22,12 +22,13 @@ the deliverable; the content is the instrument.
 
 ## Circle tags (the fluency frame)
 
-Every node and drill carries two tags from the spec's fluency-frame
-subsection:
+Every node carries two tags from the spec's fluency-frame subsection
+(drills inherit their node's tags unless marked otherwise):
 
 - **Circle**: `head` (music you can hear/imagine), `hands` (what you can
   execute), or `bridge` (grows the overlap — the point of the whole thing).
-- **Mode**: `keys` or `away` (no instrument needed).
+- **Mode**: `keys`, `away` (no instrument needed), or `keys→away` (a
+  difficulty ladder from the instrument toward pure audiation).
 
 Known imbalance, stated up front: this v1 set is 2× hands, 2× bridge,
 1× head — measurable-first content leans hands-circle exactly as the frame

--- a/content/gates.toml
+++ b/content/gates.toml
@@ -1,0 +1,179 @@
+# Gate criteria as data — the tunable half of the paper teacher.
+# Every number is a day-one guess; the gate-attempt log (logs.md) is what
+# calibrates them. Schema is the point: Phase 2's planner reads this shape.
+#
+# Timing is always consistency/trend, never absolute deviation (decision 6).
+# "clean" = zero wrong notes + timing consistent within the rep.
+
+schema_version = "0.1"
+
+[defaults]
+clean_max_wrong_notes = 0
+clean_timing = "consistent"      # variance-based; a stable lay-back is style, not error
+time_ceiling_min = 6             # no block spirals past this
+transport = "paper"              # Phase 0: user zero is the sensor (self-confirmed)
+
+# Sparse-click ladder — gate levels *within* click-always (decision 2).
+[click_levels]
+l1 = "click on every beat"
+l2 = "click on 2 and 4"
+l3 = "click on beat 1 of each bar"
+l4 = "click on beat 1 of every other bar"
+
+# What each input path may honestly claim (decision 7). Phase 0 uses paper.
+[transport_tiers]
+wired = ["note-accuracy", "timing-consistency", "tempo-drift", "swing-report"]
+bluetooth = ["note-accuracy", "swing-report", "trend"]
+paper = ["self-confirmed"]
+
+# Feedback cadence by drill maturity (feedback choreography; guidance
+# hypothesis). Fade-out is data, not code.
+[feedback]
+new_drill = "verdict every rep"
+solid_drill = "summary every 3 reps"
+mature_drill = "predict-then-reveal"
+single_failure = "cross plus one fact, nothing else"
+
+[escalation]
+fail_trigger = 3                 # consecutive fails of the same thing
+ladder = ["tempo-down-20pct", "shrink-scope", "change-mode", "swap-drill"]
+name_the_wall_max_times = 1      # the second encouragement is a nag
+
+# ── shells-ii-v-i ──
+
+[gates.shells-cycle]
+node = "shells-ii-v-i"
+criterion = "ii–V–I shells through the full cycle of fourths, no stops"
+clean_passes = 1
+tempo_bpm = 100
+click_level = "l2"
+
+[gates.shells-under-melody]
+node = "shells-ii-v-i"
+criterion = "Strasbourg A section, melody over shells, hands together"
+clean_passes = 3
+tempo_bpm = 90
+click_level = "l1"
+
+[gates.shells-random-key]
+node = "shells-ii-v-i"
+criterion = "shuffled key cards: ii–V–I shells cold, within one bar of thinking time"
+keys_required = 12
+max_think_bars = 1
+tempo_bpm = 80
+click_level = "l1"
+
+# ── rootless-a-b ──
+
+[gates.rootless-one-key]
+node = "rootless-a-b"
+criterion = "ii–V–I, A/B forms alternating, LH alone, one bar per chord"
+clean_passes = 3
+tempo_bpm = 60
+click_level = "l1"
+per_key = true                   # passed independently in each key
+
+[gates.rootless-transition]
+node = "rootless-a-b"
+criterion = "looped two-chord change (ii→V, then V→I), no gap at the change"
+clean_passes = 4
+tempo_bpm = 60
+click_level = "l1"
+per_key = true
+
+[gates.rootless-traversal]
+node = "rootless-a-b"
+criterion = "session goal: 2–3 new keys at current rung + maintenance pass on all landed keys"
+new_keys_per_session_min = 2
+new_keys_per_session_max = 3
+
+[gates.rootless-under-melody]
+node = "rootless-a-b"
+criterion = "Strasbourg A section, melody over rootless LH"
+clean_passes = 2
+tempo_bpm = 80
+click_level = "l1"
+
+[gates.rootless-cycle]                     # the node's done-criterion
+node = "rootless-a-b"
+criterion = "full cycle of fourths, A/B alternating, no stops"
+clean_passes = 1
+tempo_bpm = 80
+click_level = "l1"
+
+# ── phrase-transposition (parameterised by the in-flight phrase) ──
+
+[gates.phrase-home-key]
+node = "phrase-transposition"
+criterion = "phrase over its ii–V–I loop in the home key"
+clean_passes = 3
+tempo_bpm = 120                  # p001 target tempo
+click_level = "l2"
+
+[gates.phrase-nearby-keys]
+node = "phrase-transposition"
+criterion = "clean in both whole-step neighbours, resolution lands on beat 1"
+clean_passes = 2                 # per key
+keys_required = 2
+tempo_bpm = 90
+click_level = "l1"
+
+[gates.phrase-cycle]
+node = "phrase-transposition"
+criterion = "phrase chained through 4+ consecutive cycle keys, ii–V links, no stops"
+clean_passes = 1
+keys_chained_min = 4
+tempo_bpm = 90
+click_level = "l1"
+
+[gates.phrase-random-key]
+node = "phrase-transposition"
+criterion = "dealt key, one count-in, clean first attempt"
+keys_required = 12
+first_attempt = true
+tempo_bpm = 100
+click_level = "l2"
+
+# ── chord-tone-targeting ──
+
+[gates.targeting-skeleton]
+node = "chord-tone-targeting"
+criterion = "whole-note guide-tone line, full form, 3rds/7ths connected by step"
+clean_passes = 2
+tempo_bpm = 90
+click_level = "l1"
+
+[gates.targeting-approach]
+node = "chord-tone-targeting"
+criterion = "two-bar cells: free bar, then target chord tone on beat 1 of the change"
+clean_passes = 4                 # consecutive cells landed
+tempo_bpm = 90
+click_level = "l1"
+
+[gates.targeting-full-form]
+node = "chord-tone-targeting"
+criterion = "full form: 3rd or 7th on beat 1 of every change; feel self-rated alongside, not gated"
+clean_passes = 2
+consecutive = true
+tempo_bpm = 100
+click_level = "l2"
+self_rating_logged = true
+
+# ── micro-transcription (paper tier: self-confirmed against the record) ──
+
+[gates.transcription-entry]
+node = "micro-transcription"
+criterion = "1–2 bar phrase matched at the keys within 5 listens"
+max_listens = 5
+self_confirmed = true
+
+[gates.transcription-sing]
+node = "micro-transcription"
+criterion = "phrase sung (contour + rhythm) before touching the keys"
+self_confirmed = true
+
+[gates.transcription-audiation]
+node = "micro-transcription"
+criterion = "phrase worked out fully away from the piano; first attempt at the keys matches"
+first_attempt = true
+self_confirmed = true

--- a/content/gates.toml
+++ b/content/gates.toml
@@ -4,6 +4,9 @@
 #
 # Timing is always consistency/trend, never absolute deviation (decision 6).
 # "clean" = zero wrong notes + timing consistent within the rep.
+# Recognised optional gate fields: per_key, consecutive, keys_required,
+# keys_chained_min, first_attempt, max_think_bars, max_listens,
+# self_confirmed, self_rating_logged, new_keys_per_session_min/_max.
 
 schema_version = "0.1"
 
@@ -35,7 +38,7 @@ mature_drill = "predict-then-reveal"
 single_failure = "cross plus one fact, nothing else"
 
 [escalation]
-fail_trigger = 3                 # consecutive fails of the same thing
+consecutive_fail_trigger = 3
 ladder = ["tempo-down-20pct", "shrink-scope", "change-mode", "swap-drill"]
 name_the_wall_max_times = 1      # the second encouragement is a nag
 
@@ -94,7 +97,7 @@ clean_passes = 2
 tempo_bpm = 80
 click_level = "l1"
 
-[gates.rootless-cycle]                     # the node's done-criterion
+[gates.rootless-cycle]
 node = "rootless-a-b"
 criterion = "full cycle of fourths, A/B alternating, no stops"
 clean_passes = 1
@@ -113,7 +116,8 @@ click_level = "l2"
 [gates.phrase-nearby-keys]
 node = "phrase-transposition"
 criterion = "clean in both whole-step neighbours, resolution lands on beat 1"
-clean_passes = 2                 # per key
+clean_passes = 2
+per_key = true
 keys_required = 2
 tempo_bpm = 90
 click_level = "l1"
@@ -146,7 +150,8 @@ click_level = "l1"
 [gates.targeting-approach]
 node = "chord-tone-targeting"
 criterion = "two-bar cells: free bar, then target chord tone on beat 1 of the change"
-clean_passes = 4                 # consecutive cells landed
+clean_passes = 4
+consecutive = true
 tempo_bpm = 90
 click_level = "l1"
 

--- a/content/logs.md
+++ b/content/logs.md
@@ -1,0 +1,42 @@
+# The four Phase 0 logs
+
+One table each, one line per entry, filled at the piano or immediately
+after. These logs are the actual Phase 0 deliverable: they spec the
+self-assessment boundary, the first tolerance numbers, the graph's
+completeness, and the size of off-piste mode. Example rows are italicised —
+delete them once real rows exist.
+
+## 1. Divergence log — machine-score vs felt-score
+
+One line whenever what the criteria say and what your ears say disagree.
+
+| Date | Drill | Criteria verdict | Felt verdict | The one-line difference |
+|---|---|---|---|---|
+| *2026-08-03* | *phrase-nearby-keys (D)* | *clean* | *stiff* | *notes right, swing died at the resolution — criteria can't hear feel* |
+
+## 2. Gate-attempt log — pass/fail plus felt difficulty
+
+Every gate attempt, pass or fail. Felt difficulty 1–5 (3 ≈ the desirable-
+difficulty band). This log is what recalibrates `gates.toml`.
+
+| Date | Gate | Tempo | Pass? | Felt (1–5) | Note |
+|---|---|---|---|---|---|
+| *2026-08-03* | *rootless-transition (F)* | *60* | *no* | *5* | *third fail — ladder fired, dropped to 48* |
+
+## 3. Why log — every block's one-line why
+
+Written before the block, citing node state. A why that can't be written is
+a missing node — flag it.
+
+| Date | Block | The why |
+|---|---|---|
+| *2026-08-03* | *rootless R2 in F* | *frontier node at 0.3/low; F is next in whole-step order; transition rung is where it broke yesterday* |
+
+## 4. Wander log — off-plan time
+
+Trigger, duration, and the keep-as-drill answer. Some wanders are the graph
+revealing a gap.
+
+| Date | Minutes | Trigger | Keep as drill? |
+|---|---|---|---|
+| *2026-08-03* | *8* | *avoided the grind block, played the head instead* | *no — comfort loop, already templated* |

--- a/content/method-packs/phrase-transposition.md
+++ b/content/method-packs/phrase-transposition.md
@@ -1,0 +1,74 @@
+# Method pack: phrase transposition
+
+Applies to: `phrase-transposition` — the front half of the lick pipeline,
+one phrase in flight at a time, a few minutes per session over a fortnight.
+Phase 1's first scored drill type, so this pack also defines what the
+machine will eventually check.
+
+## 1. Decomposition recipe (the ladder up)
+
+1. **Sing it.** In the home key, with the record, then without. A phrase
+   you can't sing isn't in the head circle yet — you'd be transposing
+   finger patterns, which is the failure mode this whole pack exists to
+   prevent.
+2. **Name the function.** Each note as interval-against-chord ("♭9 over the
+   V, falling to the 5th"), not as letter names. The function list is what
+   transposes; letters don't.
+3. **New key, RH alone, no click, slow.** Find it from the function list,
+   not by sliding the shape.
+4. **Add the LH.** Shells under it (the `shells-ii-v-i` node earning its
+   keep), click L1.
+5. **Tempo, then context.** Up in ~10 bpm steps to the phrase's target
+   tempo, then drop it into the tune's turnaround.
+
+Stuck ladder is the reverse: breaks at tempo → last clean tempo; breaks
+hands-together → RH alone; can't find it in the new key → back to singing
+it in that key first.
+
+## 2. Key-traversal strategy
+
+- **Nearby keys first (learning):** whole step up, whole step down from
+  home. Different hand shape, same ear distance — close enough to transfer,
+  far enough to force the function list.
+- **Cycle of fourths (fluency):** chain the phrase through consecutive keys
+  with the ii–V motion linking them; the resolution of one key is the
+  pickup into the next. One continuous exercise, not twelve starts.
+- **Random retrieval (proof):** deal a key card, one count-in, play. This
+  is the `phrase-random-key` gate and the honest definition of "in all 12
+  keys".
+
+## 3. Thinking cues — one per stage
+
+| Stage | Cue |
+|---|---|
+| Sing | "If you can't sing it, you don't have it yet" |
+| Function | "Think ♭9-falls-to-5, never A♭-goes-to-G" |
+| New key | "Hear the target note of the resolution before you start" |
+| Tempo | "The phrase ends on beat 1 — aim the whole line at that landing" |
+
+## 4. The all-in-one-go schedule
+
+Per session: **2 new keys** at the current rung plus **one maintenance
+pass** in each previously-solid key (they decay — a failed maintenance pass
+demotes the key to `learning` in the phrase file, no drama). Full-cycle
+solid is a multi-week outcome; at 2 keys per session it's roughly a
+fortnight, which is exactly the pipeline's designed cadence. The app
+carries this schedule later; the phrase file's per-key table carries it now.
+
+## 5. The audiation rung (away from the keys)
+
+The fluency frame's advanced rung, borrowed here until an ear-training pack
+exists (`interval-recognition` / `micro-transcription` will own it): do the
+transposition entirely away from the instrument — sing the phrase in the new
+key, name its functions, hear it against imagined changes — and let the
+first physical attempt be the test, not the search. Commute-slot compatible;
+this is head-circle time inside a hands-circle drill.
+
+## 6. Escalation overrides (stuck ladder, this drill type)
+
+1. Tempo down 20%.
+2. Shrink scope: full phrase → just the resolution (last 3 notes onto
+   beat 1).
+3. Change mode: sing it in the target key, away from the keys.
+4. Swap drill: park this key, run a maintenance pass in a solid key (end on
+   a win), take the parked key first next session.

--- a/content/method-packs/voicing-traversal.md
+++ b/content/method-packs/voicing-traversal.md
@@ -1,0 +1,63 @@
+# Method pack: voicing traversal
+
+Applies to: `shells-ii-v-i`, `rootless-a-b` (and later `upper-structures`).
+How to attack any "voicing set × all twelve keys" job. The four sections
+mirror the spec's method-pack schema: decomposition, traversal, cues,
+schedule — plus the escalation overrides the stuck ladder reads from.
+
+## 1. Decomposition recipe (the ladder up)
+
+1. **LH alone, one key, slow.** Whole bar per chord, click L1. No RH until
+   the shapes land without looking.
+2. **The change, not the chords.** Loop just the two-chord transition
+   (ii→V, then V→I). The hard part is never the voicing; it's the move
+   between voicings. This rung is where the time goes.
+3. **Add the RH.** Melody or a held guide tone above. The LH must survive
+   divided attention before it counts.
+4. **Tempo.** Only now. Raise in steps of ~10 bpm; a step that breaks
+   cleanliness rolls back one step for the rest of the session.
+
+The stuck ladder is this recipe read in reverse: fell apart hands-together →
+back to LH alone; fell apart mid-change → loop the change; fell apart on
+shapes → slower, one key.
+
+## 2. Key-traversal strategy
+
+- **Learning: whole steps.** New keys arrive a whole step apart (C, D, E …
+  then the odd set) so consecutive new keys don't share fingerings and each
+  forces a fresh read of the shape.
+- **Fluency: cycle of fourths.** The ii–V motion chains the keys into one
+  continuous exercise — the end of each ii–V–I is a pivot to the next. This
+  is the gate ordering, not the learning ordering.
+- **Proof: random retrieval.** Shuffled key cards, cold starts. Retrieval
+  without the scaffolding of a sequence is the only evidence the key is
+  yours. The three orderings are themselves a gate sequence.
+
+## 3. Thinking cues — one per stage, never a lecture
+
+| Stage | Cue |
+|---|---|
+| Shapes | "See the A-form as a shape off the 3rd" |
+| The change | "Find the fingers that don't move first" |
+| Hands together | "Hear the next chord before your hands leave this one" |
+| Tempo | "The click is the other musician — lock to it, don't chase it" |
+
+## 4. The all-in-one-go schedule
+
+"All 12 keys" is never a session goal. Per session: **2–3 new keys** at the
+current decomposition rung, plus **maintenance passes** (one clean pass
+each) over every previously-landed key. Full-cycle-clean is a node gate
+reached over weeks; the schedule, not willpower, carries you there. Track
+which keys are landed in the gate-attempt log — in-app this is per-key node
+state, same shape as the phrase file's table.
+
+## 5. Escalation overrides (stuck ladder, this drill type)
+
+On the third failed rep of the same thing, in order — framed as the plan,
+never as remediation:
+
+1. Tempo down 20%.
+2. Shrink scope: this key only → this change only → LH only.
+3. Change mode: say the chord tones aloud away from the keys, then play.
+4. Swap drill: back to the shells equivalent of the same key (for
+   `rootless-a-b`) or park the key and take the next scheduled one.

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -80,7 +80,7 @@ traversal schedule, never in one session.
 
 ## 3. Phrase transposition — `phrase-transposition`
 
-**Circle:** bridge (head → hands) · **Mode:** keys; advanced rung away
+**Circle:** bridge (head → hands) · **Mode:** keys→away
 
 **What.** The front half of the lick pipeline: take the current phrase
 ([`p001`](phrases/p001-flat9-turnaround.md)) from its home key through all
@@ -148,7 +148,7 @@ self-rating is logged alongside, not gated on.
 
 ## 5. Micro-transcription — `micro-transcription`
 
-**Circle:** head · **Mode:** ladder from keys to away
+**Circle:** head · **Mode:** keys→away
 
 **What.** Lifting 1–2 bar phrases from records by ear — never whole solos.
 The modes are a difficulty ladder (per the fluency frame): listen-and-repeat

--- a/content/nodes.md
+++ b/content/nodes.md
@@ -1,0 +1,199 @@
+# Skill-graph nodes — the first five
+
+Schema per node: what it is, why it matters, prerequisites, 2–4 drills,
+machine-checkable done-criteria (referenced from [`gates.toml`](gates.toml)),
+and mastery as **(estimate, confidence)** — never a boolean. Circle and mode
+tags per the fluency frame (see [`README.md`](README.md)).
+
+In Phase 0 "machine-checkable" means *a machine could check it*: the
+criterion is stated in notes, beats, tempos, and counts, with no judgement
+words. Until the listening gate exists, you check it yourself — honestly.
+
+Mastery seeds are day-one guesses. Correct them at the piano (README
+checklist), then let the gate-attempt log move them.
+
+---
+
+## 1. Shell voicings through ii–V–I — `shells-ii-v-i`
+
+**Circle:** hands · **Mode:** keys
+
+**What.** Two-note left-hand shells (root+3rd or root+7th), chosen per chord
+so the 3rds and 7ths resolve by step through a ii–V–I. The minimum viable
+statement of the harmony.
+
+**Why.** Shells are the floor under everything: enough harmony to support
+any melody or solo line, the hand shapes rootless voicings are built from,
+and a physical map of where the 3rds and 7ths live — which is exactly the
+raw material `chord-tone-targeting` needs. Mastered shells are also the
+designated warm-up material: comfortable, scoreable, low-stakes.
+
+**Prerequisites:** `diatonic-7ths` (stub — name the 7th chords in any major key).
+
+**Drills.**
+
+| Id | Drill | Gate |
+|---|---|---|
+| S1 | ii–V–I shells around the cycle of fourths, LH alone, sustained whole-bar hits | `shells-cycle` |
+| S2 | Shells under the melody, Strasbourg A section, hands together | `shells-under-melody` |
+| S3 | Random-key retrieval: shuffle 12 key cards, land the ii–V–I shells cold | `shells-random-key` |
+
+**Done-criteria.** All three gates in `gates.toml` passed within the same
+week: full cycle clean at 100 bpm on click level L2, tune application clean,
+and 12/12 random-key retrieval within one bar of thinking time.
+
+**Mastery seed:** estimate 0.7, confidence medium.
+
+---
+
+## 2. Rootless voicings, A and B positions — `rootless-a-b`
+
+**Circle:** hands · **Mode:** keys
+
+**What.** Four-note rootless left-hand voicings for the ii–V–I: A-form built
+up from the 3rd (for Dm7: 3-5-7-9 → F–A–C–E), B-form built up from the 7th
+(for G7: 7-9-3-13 → F–A–B–E), alternating forms so the voice leading moves
+by step or not at all. The bass player owns the root; you own the colour.
+
+**Why.** The modern LH comping sound, and the current frontier. Minimal-
+motion voice leading between these forms is the engine of comping; every
+hour here pays out in every tune. Honest label: the middle keys are grind.
+
+**Prerequisites:** `shells-ii-v-i`.
+
+**Drills.**
+
+| Id | Drill | Gate |
+|---|---|---|
+| R1 | One key, LH alone, slow loop: ii–V–I with a full bar on each chord | `rootless-one-key` |
+| R2 | The change, not the chords: loop just ii→V, then just V→I, minimal motion | `rootless-transition` |
+| R3 | Key traversal per the method pack: 2–3 new keys per session, whole-step order | `rootless-traversal` |
+| R4 | Application: rootless LH under the melody, Strasbourg A section | `rootless-under-melody` |
+
+**Done-criteria.** `rootless-cycle` gate: full cycle of fourths, both forms
+alternating, clean at 80 bpm, click L1 — reached over weeks via the
+traversal schedule, never in one session.
+
+**Mastery seed:** estimate 0.3, confidence low.
+
+---
+
+## 3. Phrase transposition — `phrase-transposition`
+
+**Circle:** bridge (head → hands) · **Mode:** keys; advanced rung away
+
+**What.** The front half of the lick pipeline: take the current phrase
+([`p001`](phrases/p001-flat9-turnaround.md)) from its home key through all
+twelve, per the
+[phrase-transposition method pack](method-packs/phrase-transposition.md).
+One phrase in flight at a time.
+
+**Why.** Transposition is micro-transcription digested: it converts a lick
+you can quote into language you own in any key, and proves you learned the
+*device* (intervals against the chord), not a fingering. This is the bridge
+between the circles, built out — and Phase 1's first scored drill type.
+
+**Prerequisites:** `micro-transcription` (entry rung), `swing-click-time` (stub).
+
+**Drills.**
+
+| Id | Drill | Gate |
+|---|---|---|
+| P1 | Home-key consolidation: phrase over its ii–V–I loop with click | `phrase-home-key` |
+| P2 | Nearby keys: whole step up and down from home | `phrase-nearby-keys` |
+| P3 | Cycle chain: phrase through consecutive cycle-of-fourths keys, ii–V motion linking them | `phrase-cycle` |
+| P4 | Random-key retrieval: deal a key card, one count-in, play it | `phrase-random-key` |
+
+**Done-criteria.** Per-key state in the phrase file reaches `solid` in all
+12 keys and `phrase-random-key` passes — then the phrase advances to the
+analyse/extract stages of its pipeline.
+
+**Mastery seed** (node-level — running the pipeline as a skill; per-key
+state lives in the phrase file): estimate 0.4, confidence low.
+
+---
+
+## 4. Chord-tone targeting — `chord-tone-targeting`
+
+**Circle:** bridge (head + hands intersection) · **Mode:** keys
+
+**What.** Restricted improvisation over the tune form with one rule: land
+the 3rd or 7th of the new chord on beat 1 of every change. Everything else
+is free.
+
+**Why.** The smallest unit of "making the changes". It forces the ear to
+hear the next chord before the hands leave this one, and it's where scale
+knowledge stops being weather and starts being intent. The worked-example
+session's integration block is this node parameterised by the tune.
+
+**Prerequisites:** `shells-ii-v-i` (you must know where the 3rds and 7ths
+live before you can aim at them), `swing-click-time` (stub).
+
+**Drills.**
+
+| Id | Drill | Gate |
+|---|---|---|
+| C1 | Guide-tone skeleton: whole notes only, 3rds and 7ths connected by step through the full form | `targeting-skeleton` |
+| C2 | Approach and land: one free bar, then land the target on beat 1 of the next change; loop two-bar cells | `targeting-approach` |
+| C3 | Full form, restricted improv, click L2; self-rate the feel 1–5 after each pass | `targeting-full-form` |
+
+**Done-criteria.** `targeting-full-form` is deliberately the softer gate the
+spec prescribes for integration work: the landing rule is machine-checkable
+(target chord tone on beat 1, every change, 2 consecutive passes), the feel
+self-rating is logged alongside, not gated on.
+
+**Mastery seed:** estimate 0.35, confidence low.
+
+---
+
+## 5. Micro-transcription — `micro-transcription`
+
+**Circle:** head · **Mode:** ladder from keys to away
+
+**What.** Lifting 1–2 bar phrases from records by ear — never whole solos.
+The modes are a difficulty ladder (per the fluency frame): listen-and-repeat
+at the keys is the entry rung; the advanced rung is working the phrase out
+*away* from the instrument, hearing it fully before playing a note — pure
+audiation, no trial-and-error from the hands.
+
+**Why.** This node grows the head circle, and it is the intake valve for the
+whole vocabulary pipeline: every `p00N` phrase enters through here. Skipping
+it is how the content set collapses into hands-only exercises.
+
+**Prerequisites:** none. (`interval-recognition` stub accelerates it but
+doesn't gate it.)
+
+**Drills.**
+
+| Id | Drill | Gate |
+|---|---|---|
+| M1 | Entry rung: pick a 1–2 bar phrase from the current listening record; ≤5 listens, match it at the keys | `transcription-entry` |
+| M2 | Sing first: sing the phrase accurately (pitch contour + rhythm) before touching the keys | `transcription-sing` |
+| M3 | Audiation rung: work the phrase out entirely away from the piano (commute slot); first attempt at the keys is the test | `transcription-audiation` |
+
+**Done-criteria.** Paper-tier honesty: these gates are self-confirmed
+against the record in Phase 0 (`transport = paper` in `gates.toml`), the
+same stance the spec takes on deploy-gates. They become machine-suggestable
+only once capture exists.
+
+**Mastery seed:** estimate 0.4, confidence low.
+
+---
+
+## Stubs — the rest of the improvisation branch
+
+Named so gates and whys can reference them; deliberately unspecified until
+the loop is proven. Circle tag on each so the branch-level balance stays
+visible.
+
+| Stub | Circle | One line |
+|---|---|---|
+| `diatonic-7ths` | hands | Name and play the seven 7th chords of any major key |
+| `swing-click-time` | hands | Swing eighths held against the sparse-click ladder |
+| `interval-recognition` | head | Hear and name intervals, then 3rds-and-7ths inside voicings |
+| `guide-tone-lines` | bridge | Compose/play continuous guide-tone lines through full forms |
+| `device-generate-ladder` | bridge | The back half of the lick pipeline: vary, transplant, compose, deploy |
+| `comping-rhythms` | hands | Charleston and its displacements under a recorded soloist |
+| `upper-structures` | hands | Triads over rootless voicings; the pipeline after A/B forms |
+| `listening-assignments` | head | Album-per-week structured listening; the no-instrument block |
+| `tune-form-memory` | head | Form and changes from memory, away from the keys |

--- a/content/phrases/p001-flat9-turnaround.md
+++ b/content/phrases/p001-flat9-turnaround.md
@@ -1,0 +1,76 @@
+# Phrase p001 — the ♭9 turnaround
+
+**Status:** in flight (the one allowed in-flight phrase) ·
+**Pipeline stage:** 2 of 7 (nearby keys) ·
+**Method pack:** [`phrase-transposition`](../method-packs/phrase-transposition.md)
+
+**Source.** Generic bebop language, authored as the template instance. If
+the phrase currently under your fingers from the record is a different one,
+replace the notation and devices below and keep the structure — the
+structure is the schema (README, day-one checklist).
+
+## The phrase
+
+Two bars over a ii–V–I, eighth notes, shown in the home key of C:
+
+```text
+   Dm7           G7            Cmaj7
+| F  E  D  C  | B  D  F  A♭ | G — |
+```
+
+Descending scalar line from the 3rd of Dm7; up the G7♭9 arpeggio from its
+3rd; the A♭ (♭9 of G7) resolves down a semitone to G, the 5th of Cmaj7,
+landing on beat 1. Target tempo: 120 bpm, swing eighths, click L2.
+
+**Generate-ladder rung 1 (preview, not yet in flight):** same line, enclosed
+ending — replace the landing with F–D♯–E so it resolves to the 3rd instead
+of the 5th. Stays parked until this phrase reaches stage 5.
+
+## Analysis (stage 4 preview — the annotation the app will one day write)
+
+The crunch-then-release you like is the ♭9: maximally tense against the V,
+resolving by the smallest possible move onto the most stable colour tone of
+the I. The first bar is plain vocabulary; the second bar is the device.
+
+## Devices carried (extract stage, 5, will formalise these)
+
+| Device | What it is |
+|---|---|
+| `d-flat9-to-5` | ♭9 over the V resolving down a semitone to the 5th of the I |
+| `d-v7b9-arpeggio` | Ascending V7♭9 arpeggio from the 3rd |
+| `d-scalar-from-3rd` | Scalar descent starting on the 3rd of the ii |
+
+## Pipeline position
+
+| Stage | Name | State |
+|---|---|---|
+| 1 | Learn (home key) | done |
+| 2 | Nearby keys | **in progress** |
+| 3 | Full cycle | — |
+| 4 | Analyse | — |
+| 5 | Extract | — |
+| 6 | Generate | — |
+| 7 | Integrate (over Strasbourg) | — |
+
+## Per-key state
+
+Key = key of the resolution chord. Status ladder: `untouched` → `learning`
+(found it, not clean) → `solid` (passed `phrase-nearby-keys`/`phrase-cycle`
+criterion in that key) → `proven` (passed cold in a `phrase-random-key`
+deal). Solid keys get a maintenance pass each session; a failed maintenance
+pass demotes to `learning`. Seeds below are day-one guesses — correct them.
+
+| Key | Status | Top clean tempo | Last practised | Notes |
+|---|---|---|---|---|
+| C | solid | 120 | seed | home key |
+| D | learning | 90 | seed | whole step up |
+| B♭ | learning | 90 | seed | whole step down |
+| E♭ | untouched | — | — | |
+| E | untouched | — | — | |
+| F | untouched | — | — | |
+| F♯ | untouched | — | — | |
+| G | untouched | — | — | |
+| A♭ | untouched | — | — | |
+| A | untouched | — | — | |
+| B | untouched | — | — | |
+| D♭ | untouched | — | — | |

--- a/content/phrases/p001-flat9-turnaround.md
+++ b/content/phrases/p001-flat9-turnaround.md
@@ -11,11 +11,13 @@ structure is the schema (README, day-one checklist).
 
 ## The phrase
 
-Two bars over a ii–V–I, eighth notes, shown in the home key of C:
+Two bars over a ii–V–I (two beats each on the ii and V), shown in the home
+key of C. Eight consecutive swing eighths from beat 1; the A♭ falls on the
+and-of-4, and the G lands on beat 1 of bar 2:
 
 ```text
-   Dm7           G7            Cmaj7
-| F  E  D  C  | B  D  F  A♭ | G — |
+   Dm7        G7           Cmaj7
+| F E D C    B D F A♭    | G — — — |
 ```
 
 Descending scalar line from the 3rd of Dm7; up the G7♭9 arpeggio from its
@@ -24,7 +26,8 @@ landing on beat 1. Target tempo: 120 bpm, swing eighths, click L2.
 
 **Generate-ladder rung 1 (preview, not yet in flight):** same line, enclosed
 ending — replace the landing with F–D♯–E so it resolves to the 3rd instead
-of the 5th. Stays parked until this phrase reaches stage 5.
+of the 5th. Stays parked until extract (stage 5) is done and generate
+(stage 6) opens.
 
 ## Analysis (stage 4 preview — the annotation the app will one day write)
 

--- a/content/tunes.md
+++ b/content/tunes.md
@@ -1,0 +1,21 @@
+# Tune pipeline — Strasbourg / St. Denis
+
+The test fixture (Roy Hargrove). The tune is the vehicle, the skill is the
+cargo: drills in [`nodes.md`](nodes.md) are parameterised by this tune
+("rootless under the melody, Strasbourg A section"), and the in-flight
+phrase integrates over it at its stage 7.
+
+Seeds marked `TODO(jon)` — fill from where the tune actually is (README,
+day-one checklist).
+
+| Stage | Done gate | State |
+|---|---|---|
+| 1. Form | form + changes named from memory, away from the keys | TODO(jon) |
+| 2. Melody | head played from memory, click L2, 2 clean passes | TODO(jon) |
+| 3. Shells | melody over shells, full form — `shells-under-melody` extended past the A section | TODO(jon) |
+| 4. Rootless | melody over rootless LH, full form — `rootless-under-melody` extended | — |
+| 5. Arpeggiate changes | 1-3-5-7 up each chord in time through the form | — |
+| 6. Guide tones | continuous guide-tone line through the form (`guide-tone-lines` stub graduates here) | — |
+
+Cap check: one phrase (p001) + one tune in flight. Within budget (the
+anti-overwhelm cap is one phrase, one or two tunes).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,9 +24,10 @@ and [open issues](https://github.com/jonyardley/intrada/issues).*
 > the pivot plan. Keep-column assets (chord theory in `chart.rs`, the GRDB
 > persistence pattern, the design system, the FFI toolchain) carry forward.
 >
-> Current phase: **Phase 0** (paper teacher — content authoring + practice
-> logs, no code) in parallel with **Phase 1** (MIDI capture harness →
-> attempt-segmentation spike → lick-transposition scoring).
+> Current phase: **Phase 0** (paper teacher — content authored under
+> [`content/`](../content/README.md), practice logs in progress, no code) in
+> parallel with **Phase 1** (MIDI capture harness → attempt-segmentation
+> spike → lick-transposition scoring).
 
 ---
 


### PR DESCRIPTION
## What

The Phase 0 minimal content set from `specs/intrada-practice-coach-design.md`, authored under a new `content/` directory (no code reads it yet — for a fortnight, user zero is the app):

- **5 skill-graph nodes** (`content/nodes.md`): shells + rootless A/B (hands), phrase transposition + chord-tone targeting (bridge), micro-transcription (head) — each with what/why/prereqs/2–4 drills/machine-checkable done-criteria and mastery as (estimate, confidence). Rest of the improvisation branch as circle-tagged stubs.
- **2 method packs**: voicing traversal and phrase transposition — decomposition recipe, key-traversal strategy, one thinking cue per stage, the all-in-one-go schedule, escalation overrides.
- **1 phrase with per-key state** (`p001-flat9-turnaround.md`): notation, device extraction preview, pipeline stage, 12-key status table.
- **Gate criteria as data** (`gates.toml`): 18 gates plus click-level ladder, transport tiers, feedback cadence, escalation — every number a day-one guess to be calibrated from the gate-attempt log.
- Strasbourg / St. Denis tune-pipeline position, the four Phase 0 log templates, and pointers from CLAUDE.md + the roadmap banner.

## Why

Phase 0 is the current phase (roadmap banner): prove the pedagogy loop on paper before Phase 1's listening gate scores it. Content is circle-tagged per the fluency frame (#1142); the known hands-circle lean is stated in `content/README.md` rather than hidden.

## Notes for review

- Recorded spec decisions are encoded, not contradicted: sparse-click levels within click-always, timing as consistency-never-absolute, transport tiers (`paper` for Phase 0), swing report-only, self-confirmed head-circle gates.
- Self-review run (see comment); both Important findings fixed in the second commit (gate semantics moved from comments into TOML fields; p001 rhythm placement pinned).

Coverage: docs/content only — no code, no tests expected. `just check` green.

Deferred items tracked: #1143, #1144

Follow-up: the spec v3 revision (intent as a first-class mechanism) and `content/intent.md` land in a separate PR — see below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)