### PR TITLE
spec: the coach engine — mastery, planner, FFI and one interruption budget

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -41,7 +41,11 @@ recorded Phase 4 debt.
 
 1. Correct the **seed mastery values** in `nodes.md` and the per-key table in
    `phrases/p001-flat9-turnaround.md` — they are plausible guesses, not
-   measurements. Ten minutes at the piano settles each one.
+   measurements. Ten minutes at the piano settles each one. Rate the rung
+   you're actually on, not the node as a whole: the engine reads each seed as
+   the prior for the *current parameter level*, so "0.3 / low" means the F
+   voicings you're working now, not an average across twelve keys
+   ([`intrada-coach-engine.md`](../specs/intrada-coach-engine.md) §2).
 2. Rewrite [`intent.md`](intent.md) in your own words — the goal, and the
    campaign's target set as you'd actually state it (a lesson's list is the
    ideal source). Mine is a worked example, not your intent. Then check the

--- a/specs/README.md
+++ b/specs/README.md
@@ -8,7 +8,8 @@ answer to "can I implement from this document?"**
 
 | Spec | Scope |
 |---|---|
-| [`intrada-practice-coach-design.md`](intrada-practice-coach-design.md) | **The governing design.** Vision, decisions 1–16, pedagogy model, intent, session design, architecture, build plan. v4. |
+| [`intrada-practice-coach-design.md`](intrada-practice-coach-design.md) | **The governing design.** Vision, decisions 1–17, pedagogy model, intent, session design, architecture, build plan. v5. |
+| [`intrada-coach-engine.md`](intrada-coach-engine.md) | **The engine's technical design.** Mastery update, judgement track, session state machine, planner order, FFI contract, interruption arbitration, gate schema. Rides with Phase 1's first PR |
 | [`native-ios.md`](native-ios.md) | The SwiftUI shell on the Crux core — the only shell |
 | [`design-system.md`](design-system.md) · [`design-refresh-2026.md`](design-refresh-2026.md) | The Paper & Score system; `Theme.swift` is canonical |
 | [`ios-testflight-cicd.md`](ios-testflight-cicd.md) | Signing, match, the release lane |

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -1,0 +1,350 @@
+# The coach engine
+
+Technical design spec, Tier 3, 3 August 2026. Rides with Phase 1's first
+implementation PR, not its own. Resolves [#1148](https://github.com/jonyardley/intrada/issues/1148)
+and [#1147](https://github.com/jonyardley/intrada/issues/1147).
+
+**Scope:** the seven mechanisms Phase 1 and 2a cannot be built without — mastery
+update, judgement track, session state machine, planner resolution order, FFI
+contract, interruption arbitration, gate schema. **Not here:** architecture
+([`docs/rebuild-review.md`](../docs/rebuild-review.md)), pedagogy and decisions
+1–17 ([the design doc](intrada-practice-coach-design.md), v5), scenarios
+([`docs/coach-user-journeys.md`](../docs/coach-user-journeys.md)), UI. §9 lists
+what this spec contradicts in those sources — fix them there.
+
+## 1. Boundaries
+
+One quarantined module, `intrada-core/src/engine/`. The gravity risk (review §4)
+is held off structurally, not by discipline.
+
+```rust
+Model     { …existing…, pub coach: CoachState }
+ViewModel { …existing…, pub coach: CoachView }
+CoachState { mastery: MasteryStore, judgement: JudgementStore,
+             session: EngineSession, ledger: InterruptionLedger, content: ContentIndex }
+```
+
+- `engine/` never imports the self-report path (`score: Option<u8>`,
+  `ItemPracticeSummary`, `analytics.rs`). One test asserts it; a diff adding one
+  is a blocker.
+- The single permitted history read is `seed_priors_from_archive()` — one-way,
+  once, at migration, never on the live path (review §5's priors note).
+- No `local_first` branch in `engine/`: local-first only, dual-mode retired.
+- Authored content is `include_str!`-embedded and parsed at startup, so the
+  engine does no I/O and the planner stays pure.
+
+## 2. Mastery update (#1148)
+
+Inputs settled by decision 17: **measured attempts only**. Evidence unit is one
+**scored attempt**, not one gate — a gate ("3 clean passes at 120") is composed
+of attempts, and its pass is a derived event triggering a level-up. State is per
+`(node, parameter_level)`; there is no node-level scalar (§9.2).
+
+```rust
+struct Mastery { alpha: f32, beta: f32, prior: (f32, f32), last_attempt_at: Timestamp }
+```
+
+**#1148.1 — Beta, confirmed, with three amendments.** Per-attempt pass/fail is
+Bernoulli and Beta is its conjugate, so estimate and confidence fall out of one
+state with no second mechanism to keep in sync. Rejected: Elo/Glicko (needs an
+item-difficulty scale we lack), Bayesian Knowledge Tracing (slip/guess
+parameters need population data — decision 4 forbids inventing it), EWMA (no
+confidence for free). Amendments: discounted counts (#1148.2); an evidence cap
+`alpha + beta <= 40` so a mastered node can still change its mind (velocity,
+lever 4, needs that); and three readings defined once, so display, planner and
+tests agree:
+
+```
+estimate   = alpha / (alpha + beta)
+evidence   = (alpha + beta) - (alpha_0 + beta_0)   // attempts beyond the prior
+confidence = evidence / (evidence + k)             // k = 8
+```
+
+Content's `(estimate, band)` seeds become priors: band strength `low 2 /
+medium 5 / high 10` pseudo-counts, split by the seeded estimate.
+
+**#1148.2 — Decay and spacing are one mechanism read twice.** Elapsed time pulls
+counts toward the prior, never toward zero:
+
+```
+alpha ← alpha_0 + (alpha - alpha_0) · λ^Δdays          (same for beta)
+λ = 0.5 ^ (1 / retention_half_life_days)               (per node family, authored)
+interval_days = base_interval · g(estimate, evidence)  // expanding: both raise it
+overdue = days_since_last_attempt / interval_days      // due at ≥ 1.0
+```
+
+Decay shrinks evidence and moves the estimate toward "we don't really know",
+never toward failure — journey 7's requirement, and honest: absence of practice
+is absence of evidence. **Decay never manufactures failure evidence.** Spacing is
+derived from that same state rather than a second schedule, so the two cannot
+disagree. Half-lives and `base_interval` are `gates.toml` data (lever 2: SM-2 is
+a heuristic, not gospel).
+
+**#1148.3 — Level-ups shift, never reset.** A new parameter level starts from a
+discounted inheritance of the level below, `transfer ≈ 0.35`:
+
+```
+prior' = (1 + transfer · evidence_below · estimate_below,
+          1 + transfer · evidence_below · (1 - estimate_below))
+```
+
+Reset discards real transfer *and* makes every level-up read as a regression —
+"I got better and my score dropped" is a trust-ender (UX principle 8). Full
+carry-over is equally wrong: a new tempo genuinely is less certain. The level
+below is left untouched, so a level-down is a cursor move, not a rewrite.
+
+**#1148.4 — Attempts-to-pass and time-share feed the circling check only.**
+Attempts-to-pass *is* the attempt-level Bernoulli sequence seen from the other
+end; feeding it in double-counts one piece of evidence. Time-share measures how
+the **planner** allocated minutes, and the planner reads mastery — feeding it
+back would make mastery partly a record of the app's own choices. Both stay
+first-class recorded data (§4), read by the circling check against the user's own
+distribution and by gate calibration (challenge 4) as authoring input.
+
+**#1148's fourth listed question** — one mastery estimate or two — was closed by
+decision 17 before the issue was read; close it as answered.
+
+## 3. The judgement track
+
+Deliberately smaller: no level, no distribution, no aggregation.
+
+```rust
+struct JudgementTarget {
+    target: TargetRef,        // Node | PipelineStage | Opaque(String)
+    completion: Completion,   // Open | RetiredByYou { at, return_after_days }
+    feel: Vec<FeelRating>,    // { at, value: 1..=5, context: BlockId }
+}
+```
+
+Asymmetric powers (decision 17). **May retire a target** — `RetiredByYou` stops
+prescription and schedules a spaced return, which is a prompt, not a gate. **May
+never satisfy a prerequisite** — enforced by signature, not convention:
+`fn prerequisites_met(node: NodeId, mastery: &MasteryStore) -> bool` cannot see
+`JudgementStore`. One test asserts a fully-retired, top-rated target leaves every
+downstream node blocked. Opaque targets (decision 13) live here by construction:
+no node, so no mastery; a count per normalised string makes the authoring queue
+data rather than memory.
+
+**Predict-then-reveal writes to neither track.** A mature-drill attempt carries
+`self_predicted: Option<Verdict>` beside its measured verdict; the pair is the
+divergence log automated and the evidence base for how much weight the track
+eventually earns. It never updates a distribution.
+
+## 4. The session state machine
+
+New machine in `engine/`, beside the legacy `SessionStatus` that Phase 2a
+deletes. Off-piste and unmonitored are **peers** of `Running`, not sub-states,
+because `Running` implies a plan and gates: `Idle` → `Planned(Plan)` →
+`Running { plan, cursor, block }` → `Closing(Summary)`, plus
+`OffPiste { started_at }` (no plan, still capturing) and
+`Unmonitored { started_at }` (nothing captured, nothing inferred — decision 16).
+
+| From | Event | To | Note |
+|---|---|---|---|
+| `CountIn` | grid complete | `Listening` | Layer 0: no verdict during play |
+| `Listening` | attempt segmented | `Verdict` | one glance, ~1s |
+| `Verdict` | fails < trigger, gate unmet | `CountIn` | hands never leave the keys |
+| `Verdict` | consecutive fails = trigger | `Escalating { rung }` | acts, doesn't narrate; **no budget spent** (§9.3) |
+| `Verdict` | gate satisfied | `GateOpen` | stamps `gate_opened_at_attempt` |
+| `GateOpen` | auto-advance / user continues | `Boundary` / `Listening` | continuing is what `reps_after_gate` counts |
+| any | ceiling reached | `Boundary` | ceiling shown throughout (decision 15) |
+| `Boundary` | arbitration (§7) | next `CountIn` / `Closing` | the only place an interruption may fire |
+
+**Recorded from the first build.** Cheap now, impossible to reconstruct from an
+aggregate row later; the circling check, horizons and gate calibration all
+depend on them.
+
+```rust
+struct BlockRecord {
+    id: Ulid, node: NodeId, drill: DrillId, gate: GateId, level: ParameterLevel,
+    started_at: Timestamp, ended_at: Timestamp,
+    attempts: Vec<AttemptSummary>,     // ordered: verdict, timing facts, self_predicted
+    attempts_to_pass: Option<u16>,     // None if never passed
+    gate_opened_at_attempt: Option<u16>, reps_after_gate: u16,
+    active_ms: u64,                    // time attributed to this node
+    escalation_fired: Vec<Rung>,
+    exit: Exit,                        // GatePassed | CeilingHit | Skipped | Escalated | SessionEnded
+    circle: Circle, mode: Mode,        // the Phase 2 time-by-circle tally, free at write time
+}
+```
+
+Persistence per the invariants: client-minted ulid (3), append-only with
+`updated_at` + `deleted_at` (2), `BlockRecord`s in GRDB, the in-progress
+`EngineSession` in `crux_kv` for crash recovery (8).
+
+## 5. Planner resolution order
+
+```rust
+fn plan(state: &CoachState, ctx: PlanContext) -> Plan
+// ctx: available_minutes, now, steer: Option<Steer>, transport: TransportTier, rng_seed
+```
+
+Pure: the clock is a parameter, and the only randomness is a seeded dealer for
+random-key gates whose seed is stored on the `Plan`, so any session replays in a
+test. Five ordered stages, and **each may only remove or reorder candidates,
+never add** — that monotonicity is what makes the why generable by construction.
+
+1. **Resolve declared intent.** Goal → campaign target set → today's steer, each
+   defaulted so a user who declared nothing still gets a session (decision 9).
+   Opaque targets pass through carrying `scored: false`.
+2. **Back-chain.** Through graph prerequisites and pipeline stage order to a
+   frontier of `(node, level)` candidates. Ambition beyond the hands returns the
+   prerequisite plus an honest distance from the user's own trend (decision 10)
+   — never obedience, never refusal. The **structural gap read is this stage's
+   byproduct**; the statistical read waits for Phase 4 (decision 4).
+3. **Block or interleave, by node maturity.** Low `evidence` at the frontier =
+   acquisition, so one longer uninterrupted block; matured = shorter interleaved
+   passes (lever 1). `overdue >= 1` pulls maintenance ahead of new keys, which is
+   how journey 7 falls out rather than being special-cased.
+4. **Grind cap.** `grind`-tagged nodes capped by `grind_max_minutes_per_session`
+   and `grind_max_blocks`, always parameterised by the in-flight tune, never
+   practised in the abstract (principle 4). A grind trade is a logged debt the
+   *next* plan reads, not a silent skip.
+5. **Template constraints — last, and overriding.** Warm-up on owned material;
+   at least one new-or-applied music block; close on music; in-flight caps (one
+   phrase, one–two tunes) and time ceilings. **Caps and template outrank declared
+   intent**: an over-full campaign is accepted and *sequenced*, and the plan must
+   report what it queued. Silent dropping is a defect.
+
+Each `PlannedBlock` carries `why { destination: Option<TargetRef>, node_state,
+placed_by: Stage }`, written by the stage that placed it. Test: every block has a
+non-empty why citing the destination whenever one is declared (principle 7).
+
+## 6. The FFI contract
+
+Note events cross **in batches, never per-note** (review §3.1): every event
+rebuilds the whole `ViewModel`, so per-note crossing is architecture abuse at
+playing speed. The entire engine bridge surface, and it does not grow:
+
+```rust
+struct NoteEvent { pitch: u8, velocity: u8, on: bool, t_us: u64 }  // from the click anchor
+struct NoteBatch { session: Ulid, seq: u32, anchor_us: u64,
+                   events: Vec<NoteEvent>, transport: TransportTier }
+struct ClickGrid { bpm_milli: u32, beats_per_bar: u8, count_in_bars: u8,
+                   click_level: ClickLevel, anchor_us: u64 }
+enum  CoachOperation { ScheduleClick(ClickGrid), StopClick, StartCapture, StopCapture }
+enum  EngineEvent    { NotesCaptured(NoteBatch), … }   // one ingest event
+struct CoachView     { … }                             // one ViewModel field
+```
+
+Rules, from the #846 bincode hazard and review §3.2:
+
+- **No JSON-only serde attributes** on any engine bridge type: no
+  `deserialize_with` / `serialize_with`, no `skip_serializing_if`, no
+  `Option<Option<T>>`. bincode has no "absent"; a three-state field is an
+  explicit enum.
+- **Integers where an integer will do** (`bpm_milli`, `t_us`), so timing is exact
+  and reproducible rather than rounding-dependent.
+- **Bounded batches.** The shell splits at `events.len() <= 512` and delivers per
+  beat, per ~250ms, or per attempt window — whichever comes first. An unbounded
+  `Vec` on the render path is a latency and allocation hazard.
+- **Render coalescing.** `NotesCaptured` returns `Command::done()` unless the
+  batch closed an attempt or moved gate progress, so the view rebuild stays as
+  low-frequency as the bridge.
+- **Round-trip before wiring.** `assert_round_trips` on every bridge type before
+  it reaches a screen, plus one `LiveBridge` test pushing a real `NoteBatch`
+  through the actual Swift↔Rust wire. A stub bridge cannot catch a wire break.
+
+## 7. Interruption arbitration (#1147)
+
+One budget, one order, one place: five per-feature "once per session" limits are
+five interruptions.
+
+```rust
+fn arbitrate(candidates: &[Candidate], at: Boundary,
+             budget: &mut InterruptionBudget, ledger: &mut InterruptionLedger)
+    -> Option<Interruption>
+```
+
+- **Budget** 1 per session, 2 when planned minutes ≥ 30. `gates.toml` data.
+- **Priority** `StuckWall` > `CirclingCheck` > `GrindTrade` > `CoachVoice` >
+  `GapRead` — safety, cost, retention, value, then what can wait (#1147's order,
+  adopted).
+- **Called from the `Boundary` transition only** (§4), so "never mid-rep" is
+  structural rather than a rule each feature has to remember.
+- **Losers degrade to the summary** via `Summary.deferred`; nothing fires late.
+- **Suppression is persisted**, because the anti-nag rules span sessions:
+  `InterruptionLedger` keeps `(kind, subject, last_fired_at, times_fired,
+  declined_at)`. Name-the-wall fires once ever per `(node, wall)`; a circling
+  notice never repeats for the same node in a later session; a declined offer
+  stands without a second ask.
+- **Cold start** (journey 1) is one predicate here, not per-feature:
+  `baseline_ready(kind)`, an `evidence` minimum, gates everything needing a
+  personal baseline ("above your norm", session horizons, the circling check).
+  *Which* mechanism switches on *when* is still open in the journeys doc; this
+  predicate is where it gets answered.
+
+The escalation ladder's **action** (tempo down, shrink scope, change mode, swap
+drill) spends no budget — the doc's own rule is that it acts rather than
+narrates, so it is the plan changing. Only the spoken name-the-wall competes
+(§9.3).
+
+## 8. The gate criteria schema
+
+Formalised from [`content/gates.toml`](../content/gates.toml). The gain over its
+flat bag of recognised-optional fields: the requirement becomes a closed enum, so
+an unrepresentable gate fails to parse instead of silently losing a field.
+
+```rust
+struct GateCriteria {
+    id: GateId, node: NodeId, criterion: String,     // prose, display only
+    requirement: Requirement,
+    tempo_bpm: u16, click_level: ClickLevel,
+    judge: Judge,                                    // Machine | SelfConfirmed
+    transport_min: TransportTier, time_ceiling_min: u8, self_rating_logged: bool,
+}
+enum Requirement {
+    CleanPasses   { count: u8, consecutive: bool },
+    KeyCoverage   { keys_required: u8, per_key_passes: u8, first_attempt: bool },
+    Chained       { min_keys: u8 },
+    SelfConfirmed { max_listens: Option<u8>, first_attempt: bool },
+}
+struct Clean { max_wrong_notes: u8, timing: TimingRule }
+enum TimingRule { Consistent { max_cv: f32, max_drift: f32 } }   // decision 6
+```
+
+- **Timing is variance and drift only.** A stable 30ms lay-back passes; mean
+  offset is *reported* beside swing ratio and never gated (decisions 6, 8).
+  `TimingRule` has one variant on purpose — an absolute-deviation variant would
+  be a design change, not a config change.
+- **Transport gating is a capability check.** `requirement.capabilities_needed()
+  ⊆ transport.capabilities()`, else the verdict is `Ask` — never a pass or a
+  fail. Decision 7 and never-bluff, in one function.
+- **Validation at load** (`validation.rs` idiom): unknown fields error rather
+  than being ignored, `schema_version` must match, every `node`/`gate` reference
+  must resolve. A dangling reference is a startup failure, because an unreachable
+  gate is otherwise invisible.
+- Feedback cadence, escalation ladder, circling thresholds, decay half-lives and
+  the interruption budget are all data in the same file. Nothing here hard-codes
+  a threshold.
+
+## 9. What this contradicts in the source docs
+
+Fix at the source rather than letting the documents diverge.
+
+1. **The mastery-function paragraph** (design doc, Technical architecture) should
+   become a pointer here. Its three claims survive; the *how* changed — decay
+   applies to the pseudo-counts toward the prior rather than as a separate
+   confidence term, and spacing derives from that same state.
+2. **Node-level mastery.** "Three mechanisms" reads as a node-level `(estimate,
+   confidence)`; the mastery-function line says per `(node, parameter level)`.
+   This spec holds **no node-level scalar** — a node figure is derived, for
+   display. So `content/nodes.md`'s seeds are *frontier-level* priors and
+   `content/README.md`'s checklist should say so.
+3. **The escalation ladder is not an interruption.** The design doc says it
+   "acts, not narrates", yet the journeys doc and #1147 both give the stuck
+   ladder a once-per-session slot. Under §7 only name-the-wall spends budget —
+   amend the feedback-choreography section and #1147's list.
+4. **The circling check has no free slot.** Layer 2 grants the coaching voice one
+   slot "plus whenever the circling check has something to say" — an unbudgeted
+   exemption contradicting the journeys doc's "every journey obeys the
+   one-interruption budget". Under §7 it competes at its own priority.
+5. **`rootless-traversal` is not a gate.** No pass/fail: it is a per-session
+   scheduling quota (`new_keys_per_session_min/_max`), unrepresentable as a
+   `Requirement`. Move it out of `[gates.*]` into a planner constraint.
+6. **`transport = "paper"` conflates two axes** — paper is the absence of a
+   transport plus a change of judge. §8 splits them: `transport: Wired |
+   Bluetooth | Mic | None` and `judge: Machine | SelfConfirmed`, Phase 0 being
+   `(None, SelfConfirmed)`. `[transport_tiers]` should follow.
+7. **#1148's fourth question is stale** — decision 17 closed it before the issue
+   was read.

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -1,8 +1,14 @@
 # The coach engine
 
-Technical design spec, Tier 3, 3 August 2026. Rides with Phase 1's first
-implementation PR, not its own. Resolves [#1148](https://github.com/jonyardley/intrada/issues/1148)
-and [#1147](https://github.com/jonyardley/intrada/issues/1147).
+Technical design spec, Tier 3, 3 August 2026. Resolves
+[#1148](https://github.com/jonyardley/intrada/issues/1148) and
+[#1147](https://github.com/jonyardley/intrada/issues/1147).
+
+CLAUDE.md's Tier 3 rule has a spec ride with its first implementation PR. This
+one shipped alone (#1155), ahead of any Phase 1 code, because it unblocks two
+issues Phase 2a waits on and because 400 lines of design argument review better
+as a file than as the opening commit of a segmentation PR. A deliberate
+exception, recorded rather than inherited.
 
 **Scope:** the seven mechanisms Phase 1 and 2a cannot be built without — mastery
 update, judgement track, session state machine, planner resolution order, FFI
@@ -85,9 +91,20 @@ decayed(alpha) = alpha_0 + (alpha - alpha_0) · λ^Δdays        (same for beta)
 λ = 0.5 ^ (1 / retention_half_life_days)                     (per node family, authored)
 
 // spacing, computed from the STORED (undecayed) counts
-interval_days = base_interval · (1 + estimate) ^ (evidence / e_scale)   // e_scale = 8
-overdue       = days_since_last_attempt / interval_days                // due at ≥ 1.0
+interval_days = base_interval · (1 + estimate) ^ (evidence / e_scale)
+overdue       = days_since_last_attempt / interval_days     // due at ≥ 1.0
+// base_interval = 2 days, e_scale = 8   (both gates.toml data)
 ```
+
+What those defaults produce, at four points taken from `content/nodes.md` — the
+table is the calibration target, not the formula:
+
+| Node state | estimate | evidence | Comes back every |
+|---|---|---|---|
+| Brand new, no attempts | seed | 0 | 2 days |
+| `rootless-a-b`, current frontier | 0.3 | 8 | ~3 days |
+| `shells-ii-v-i`, solid | 0.7 | 16 | ~6 days |
+| Fully mastered, at the evidence cap | 0.9 | 38 | ~6 weeks |
 
 Decay shrinks evidence and moves the estimate toward "we don't really know",
 never toward failure — journey 7's requirement, and honest: absence of practice

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -44,6 +44,11 @@ of attempts, and its pass is a derived event triggering a level-up. State is per
 struct Mastery { alpha: f32, beta: f32, prior: (f32, f32), last_attempt_at: Timestamp }
 ```
 
+`alpha`/`beta` are the counts **as of `last_attempt_at`**, never rewritten by the
+passage of time. Decay is a read (`decayed_at(now)`), not a stored mutation —
+which is what keeps elapsed time out of the spacing calculation twice over
+(#1148.2).
+
 **#1148.1 — Beta, confirmed, with three amendments.** Per-attempt pass/fail is
 Bernoulli and Beta is its conjugate, so estimate and confidence fall out of one
 state with no second mechanism to keep in sync. Rejected: Elo/Glicko (needs an
@@ -60,6 +65,14 @@ evidence   = (alpha + beta) - (alpha_0 + beta_0)   // attempts beyond the prior
 confidence = evidence / (evidence + k)             // k = 8
 ```
 
+The cap is enforced **on increment, by proportional scale-down** — on reaching
+`evidence_max` both counts are scaled to hold `alpha + beta` at the cap, which
+preserves `estimate` exactly and discards the oldest evidence implicitly. Two
+consequences worth stating rather than discovering: `confidence` therefore
+saturates below 1 (at `38/(38+8) ≈ 0.83` with these defaults) and a node is never
+certain, which is correct; and a capped node responds to new evidence at a fixed
+rate forever, which is what makes three bad sessions visible (lever 4).
+
 Content's `(estimate, band)` seeds become priors: band strength `low 2 /
 medium 5 / high 10` pseudo-counts, split by the seeded estimate.
 
@@ -67,31 +80,48 @@ medium 5 / high 10` pseudo-counts, split by the seeded estimate.
 counts toward the prior, never toward zero:
 
 ```
-alpha ← alpha_0 + (alpha - alpha_0) · λ^Δdays          (same for beta)
-λ = 0.5 ^ (1 / retention_half_life_days)               (per node family, authored)
-interval_days = base_interval · g(estimate, evidence)  // expanding: both raise it
-overdue = days_since_last_attempt / interval_days      // due at ≥ 1.0
+// read-time decay of the stored counts, for display and success prediction
+decayed(alpha) = alpha_0 + (alpha - alpha_0) · λ^Δdays        (same for beta)
+λ = 0.5 ^ (1 / retention_half_life_days)                     (per node family, authored)
+
+// spacing, computed from the STORED (undecayed) counts
+interval_days = base_interval · (1 + estimate) ^ (evidence / e_scale)   // e_scale = 8
+overdue       = days_since_last_attempt / interval_days                // due at ≥ 1.0
 ```
 
 Decay shrinks evidence and moves the estimate toward "we don't really know",
 never toward failure — journey 7's requirement, and honest: absence of practice
-is absence of evidence. **Decay never manufactures failure evidence.** Spacing is
-derived from that same state rather than a second schedule, so the two cannot
-disagree. Half-lives and `base_interval` are `gates.toml` data (lever 2: SM-2 is
-a heuristic, not gospel).
+is absence of evidence. **Decay never manufactures failure evidence.**
+
+**The interval is computed from the stored counts, not the decayed ones.** Using
+decayed values would put elapsed time on both sides of `overdue` — once
+shrinking evidence, which shortens the interval, and again in the numerator — so
+a long gap would compound into "wildly overdue" rather than "due". One state,
+two readings: the stored counts drive spacing, the decayed read drives display
+and the planner's success prediction. `base_interval`, `e_scale` and the
+half-lives are `gates.toml` data (lever 2: SM-2 is a heuristic, not gospel), and
+the interval form above is the starting shape — expanding in both estimate and
+evidence — to be recalibrated against observed decay rather than trusted.
 
 **#1148.3 — Level-ups shift, never reset.** A new parameter level starts from a
 discounted inheritance of the level below, `transfer ≈ 0.35`:
 
 ```
-prior' = (1 + transfer · evidence_below · estimate_below,
-          1 + transfer · evidence_below · (1 - estimate_below))
+inherited = min(transfer · evidence_below, inherit_max)     // inherit_max = 6
+prior'    = (1 + inherited · estimate_below,
+             1 + inherited · (1 - estimate_below))
 ```
 
 Reset discards real transfer *and* makes every level-up read as a regression —
 "I got better and my score dropped" is a trust-ender (UX principle 8). Full
 carry-over is equally wrong: a new tempo genuinely is less certain. The level
 below is left untouched, so a level-down is a cursor move, not a rewrite.
+
+`inherit_max` matters more than it looks: without it, a capped level below hands
+down `0.35 × 38 ≈ 13` pseudo-counts, so the new level needs a dozen contrary
+attempts before it will admit the tempo is too fast — an inherited prior that
+overrides what the hands are currently saying. Capped at 6, the new level starts
+optimistic and is movable within a session.
 
 **#1148.4 — Attempts-to-pass and time-share feed the circling check only.**
 Attempts-to-pass *is* the attempt-level Bernoulli sequence seen from the other
@@ -150,6 +180,15 @@ because `Running` implies a plan and gates: `Idle` → `Planned(Plan)` →
 | any | ceiling reached | `Boundary` | ceiling shown throughout (decision 15) |
 | `Boundary` | arbitration (§7) | next `CountIn` / `Closing` | the only place an interruption may fire |
 
+Entering and leaving the peer states, which the block table doesn't cover:
+`Planned`/`Running` → `OffPiste` on one tap, and `Idle`/`Planned` → `Unmonitored`
+(never from mid-`Running`: switching to unmonitored part-way through would make
+the already-captured half of the session retrospectively unconsented). Both
+return to `Closing`, so a wander still banks its time and still closes the
+session — abandoning must never be what the app teaches. `OffPiste` → `Closing`
+carries the *keep this as a drill?* prompt; `Unmonitored` → `Closing` carries
+nothing but a duration.
+
 **Recorded from the first build.** Cheap now, impossible to reconstruct from an
 aggregate row later; the circling check, horizons and gate calibration all
 depend on them.
@@ -167,6 +206,20 @@ struct BlockRecord {
     circle: Circle, mode: Mode,        // the Phase 2 time-by-circle tally, free at write time
 }
 ```
+
+**Off-piste needs its own record, not an optional-everything `BlockRecord`.** A
+wander has no node, drill, gate or level, so every id above would have to become
+`Option` — which would then let a *planned* block persist with no gate and lose
+the type's only real guarantee. Separate type instead:
+
+```rust
+struct WanderRecord { id: Ulid, started_at: Timestamp, ended_at: Timestamp,
+                      attempts: Vec<AttemptSummary>,   // still captured, still scored
+                      keep_as_drill: Option<bool> }    // None = not yet asked
+```
+
+`Unmonitored` writes neither — a duration on the session row and nothing else,
+which is the whole point of decision 16. Nothing in the engine may infer from it.
 
 Persistence per the invariants: client-minted ulid (3), append-only with
 `updated_at` + `deleted_at` (2), `BlockRecord`s in GRDB, the in-progress
@@ -269,8 +322,12 @@ fn arbitrate(candidates: &[Candidate], at: Boundary,
   notice never repeats for the same node in a later session; a declined offer
   stands without a second ask.
 - **Cold start** (journey 1) is one predicate here, not per-feature:
-  `baseline_ready(kind)`, an `evidence` minimum, gates everything needing a
-  personal baseline ("above your norm", session horizons, the circling check).
+  `baseline_ready(kind)` gates everything needing a personal baseline ("above
+  your norm", session horizons, the circling check). Note its input is **not**
+  per-node `evidence`: the circling check compares an attempts-to-pass figure
+  against the user's own *cross-node* distribution, and horizons need completed
+  sessions. So the predicate reads corpus-level counts — gates attempted,
+  sessions completed — per `kind`, not the `Mastery` of the node in front of you.
   *Which* mechanism switches on *when* is still open in the journeys doc; this
   predicate is where it gets answered.
 
@@ -292,6 +349,7 @@ struct GateCriteria {
     tempo_bpm: u16, click_level: ClickLevel,
     judge: Judge,                                    // Machine | SelfConfirmed
     transport_min: TransportTier, time_ceiling_min: u8, self_rating_logged: bool,
+    clean: Option<Clean>,                            // None = inherit [defaults]
 }
 enum Requirement {
     CleanPasses   { count: u8, consecutive: bool },
@@ -302,6 +360,12 @@ enum Requirement {
 struct Clean { max_wrong_notes: u8, timing: TimingRule }
 enum TimingRule { Consistent { max_cv: f32, max_drift: f32 } }   // decision 6
 ```
+
+- **`Clean` is what "a pass" means**, resolved per gate: `clean` overrides,
+  otherwise the file's `[defaults]` (`clean_max_wrong_notes`, `clean_timing`)
+  apply. Every requirement variant except `SelfConfirmed` is counting *clean
+  attempts*, so leaving this implicit would let a gate mean different things in
+  two readers.
 
 - **Timing is variance and drift only.** A stable 30ms lay-back passes; mean
   offset is *reported* beside swing ratio and never gated (decisions 6, 8).

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -318,33 +318,44 @@ enum TimingRule { Consistent { max_cv: f32, max_drift: f32 } }   // decision 6
   the interruption budget are all data in the same file. Nothing here hard-codes
   a threshold.
 
-## 9. What this contradicts in the source docs
+## 9. Divergence from the source docs
 
-Fix at the source rather than letting the documents diverge.
+### Fixed at the source, in the same commit series
 
-1. **The mastery-function paragraph** (design doc, Technical architecture) should
-   become a pointer here. Its three claims survive; the *how* changed — decay
-   applies to the pseudo-counts toward the prior rather than as a separate
-   confidence term, and spacing derives from that same state.
-2. **Node-level mastery.** "Three mechanisms" reads as a node-level `(estimate,
-   confidence)`; the mastery-function line says per `(node, parameter level)`.
-   This spec holds **no node-level scalar** — a node figure is derived, for
-   display. So `content/nodes.md`'s seeds are *frontier-level* priors and
-   `content/README.md`'s checklist should say so.
-3. **The escalation ladder is not an interruption.** The design doc says it
-   "acts, not narrates", yet the journeys doc and #1147 both give the stuck
-   ladder a once-per-session slot. Under §7 only name-the-wall spends budget —
-   amend the feedback-choreography section and #1147's list.
-4. **The circling check has no free slot.** Layer 2 grants the coaching voice one
-   slot "plus whenever the circling check has something to say" — an unbudgeted
-   exemption contradicting the journeys doc's "every journey obeys the
-   one-interruption budget". Under §7 it competes at its own priority.
+1. **The mastery-function paragraph** (design doc, Technical architecture) now
+   points here and says what this spec settled. Its three original claims
+   survive; the *how* changed — decay applies to the pseudo-counts toward the
+   prior rather than as a separate confidence term, and spacing derives from
+   that same state.
+2. **Node-level mastery.** "Three mechanisms" read as a node-level `(estimate,
+   confidence)`; the mastery-function line said per `(node, parameter level)`.
+   Both now state per-level, with any node-wide figure marked display-only.
+   `content/README.md`'s day-one checklist says to rate the current rung, since
+   the seeds are read as frontier-level priors.
+3. **The circling check's free slot is withdrawn.** Layer 2 granted the coaching
+   voice one slot "plus whenever the circling check has something to say" — an
+   unbudgeted exemption contradicting the journeys doc's "every journey obeys
+   the one-interruption budget". It now competes at its own priority (§7). A cap
+   with one exception is how five polite features become four interruptions.
+4. **The escalation ladder spends no allowance.** The design doc's own rule is
+   that it acts rather than narrates, so a silent tempo drop or scope shrink is
+   the plan changing, not the app talking. Only the spoken name-the-wall moment
+   costs a slot. Stated explicitly in the anti-nag rules; **#1147's list still
+   counts the stuck ladder as an interruption and needs the same correction.**
+
+### Still outstanding
+
 5. **`rootless-traversal` is not a gate.** No pass/fail: it is a per-session
    scheduling quota (`new_keys_per_session_min/_max`), unrepresentable as a
-   `Requirement`. Move it out of `[gates.*]` into a planner constraint.
+   `Requirement`. It belongs outside `[gates.*]`, as a planner constraint.
 6. **`transport = "paper"` conflates two axes** — paper is the absence of a
    transport plus a change of judge. §8 splits them: `transport: Wired |
    Bluetooth | Mic | None` and `judge: Machine | SelfConfirmed`, Phase 0 being
-   `(None, SelfConfirmed)`. `[transport_tiers]` should follow.
+   `(None, SelfConfirmed)`.
+
+   Both are restructures of `content/gates.toml`, deliberately **deferred to
+   Phase 2a**, when the parser that reads the file actually lands. No code reads
+   it today, and it is the file being practised from during the Phase 0
+   fortnight — churning its structure now costs the reader and buys nothing.
 7. **#1148's fourth question is stale** — decision 17 closed it before the issue
-   was read.
+   was read. Close as answered rather than answering twice.

--- a/specs/intrada-practice-coach-design.md
+++ b/specs/intrada-practice-coach-design.md
@@ -157,7 +157,7 @@ The graph says what exists and in what order; the pipelines say what is in
 flight; intent says where the user is pointing. The planner is the function
 that reads all three.
 
-- **Skill graph.** Jazz improvisation as a dependency graph, not a list. Each node: what it is, why it matters, prerequisites, 2-4 drills, machine-checkable done-criteria. Mastery is (estimate, confidence), never a boolean.
+- **Skill graph.** Jazz improvisation as a dependency graph, not a list. Each node: what it is, why it matters, prerequisites, 2-4 drills, machine-checkable done-criteria. Mastery is (estimate, confidence), never a boolean — and it is held per (node, parameter level), not per node: a single node-wide figure is derived for display only, never an input to the planner (see [`intrada-coach-engine.md`](intrada-coach-engine.md) §2).
 - **Intent.** Declared destinations at three altitudes — goal, campaign, today's steer — each optional, each defaulted, none of them a route. Detailed below; the short version is that the graph and the pipelines already encode *ordering*, so the user only ever has to name a target.
 - **Pipelines.** Tunes and phrases are instances moving through stages.
   - Tune pipeline: form, melody, shells, rootless, arpeggiate changes, guide tones. Clear "done" gate per stage.
@@ -364,9 +364,16 @@ Four layers, organised by *when*, not what:
   paragraph. **Not every boundary** (revised 3 Aug 2026): five blocks in twenty
   minutes would mean five coaching moments, which is a lot of talking from
   something designed not to nag. Default to one per session — where it will land
-  hardest, usually the frontier block — plus on demand, plus whenever the
-  circling check has something to say. Silence at a boundary is a valid choice
-  and should be the common one.
+  hardest, usually the frontier block — plus on demand. **The voice holds no
+  reserved slot, and neither does anything else** (settled 3 Aug 2026, closing
+  the interruption-budget question): it competes for the session's single
+  spoken-moment allowance against the stuck wall, the circling check, the grind
+  trade and the gap read, and whatever loses is written into the session summary
+  rather than fired late. An earlier draft of this bullet exempted the circling
+  check; that exemption is withdrawn, because a cap with one exception is how
+  five polite features become four interruptions. Arbitration lives in one place
+  in the core — see [`intrada-coach-engine.md`](intrada-coach-engine.md) §7.
+  Silence at a boundary is a valid choice and should be the common one.
 - **Layer 3 — session end: the narrative.** Trends, the thread ("Monday's
   voicing drill is what your left hand just did in bar 5"), what's next,
   tomorrow's draft. Readable now or in the morning.
@@ -380,7 +387,9 @@ Anti-nag rules (where the naggy/useful balance is actually won):
   shrink scope (A section, one hand, one key), change mode (sing it, tap it,
   listen), swap the drill. Framed as the plan ("Let's take it to 100"),
   never as remediation. A teacher doesn't narrate your failure; they quietly
-  make the next attempt winnable.
+  make the next attempt winnable. Because it acts rather than speaks, the
+  ladder **spends no part of the interruption allowance** — only the spoken
+  name-the-wall moment does.
 - **Name the wall — once.** At the quit-point, normalise plus a smaller
   step: "everyone's enclosures sound mechanical for the first three weeks;
   here's the smaller version." Never repeat the same encouragement twice;
@@ -450,7 +459,7 @@ Stack fit: Crux core holds the session state machine, MIDI event stream, analysi
 
 Data model sketch: `Tune` (pipeline stage), `Skill` (graph node, mastery as estimate plus confidence), `Phrase` (per-key mastery, pipeline stage), `Device` (reusable musical device, referenced by many phrases, with theory annotation and its own mastery via the generate ladder), `Drill` = (skill x tune x parameters) referencing a `MethodPack` (decomposition stages, traversal orderings, cues by stage, escalation overrides), `Gate` criteria as tunable data (JSON/TOML), `Judgement` (per target: completion state, spaced-return interval, feel-rating series — never a level, never a prerequisite satisfier), `Goal` and `Campaign` (declared destinations — a campaign names graph nodes and/or a pipeline stage as its target, plus a horizon derived from the user's own trend), session planner as a pure function of (tune stages, skill mastery, pipeline states, declared intent, available minutes).
 
-Mastery update function (first crude version, to be refined): per (node, parameter level), **measured** attempt outcomes update a Beta distribution (pass/fail as evidence), giving estimate and confidence for free; confidence decays with time-since-practice to drive spacing; level-ups shift the distribution rather than resetting it. Whatever the final form, this function is the planner's engine and must be specified before Phase 2a, not discovered inside it.
+Mastery update function — **now specified in [`intrada-coach-engine.md`](intrada-coach-engine.md) §2**, which is the one answer; this paragraph is the summary. Per (node, parameter level), **measured** attempt outcomes update a Beta distribution (pass/fail as evidence), giving estimate and confidence for free; confidence decays with time-since-practice to drive spacing; level-ups shift the distribution rather than resetting it. The engine spec settles the three things this sentence left open: decay pulls the pseudo-counts back toward the prior (never toward failure), the review interval derives from that same state rather than a second schedule, and a level-up inherits a discounted share of the level below. Attempts-to-pass and time-share are recorded but feed the circling check only, never mastery.
 
 Its inputs are now settled (decision 17): measured attempts only. Self-report does not enter this function at all. The **judgement track** sits beside it as a deliberately simpler structure — per target, a completion state (open / retired-by-you, with a spaced return interval) plus a time series of feel ratings for trend display. No distribution, no level, no contribution to prerequisite satisfaction. Keeping it structurally smaller is the point: a parallel mastery model would create two numbers competing to answer one question, and the planner would have to arbitrate between them on every block.
 


### PR DESCRIPTION
Specifies the seven mechanisms Phase 1 and 2a cannot be built without, and settles the two open architecture questions blocking Phase 2a. Closes #1148 and #1147.

Docs only — no Rust or Swift touched.

## Why this is a standalone PR

CLAUDE.md's Tier 3 rule says a spec rides with its first implementation PR rather than shipping alone, and `specs/intrada-coach-engine.md` says the same in its own header. This PR breaks that deliberately, at Jon's request, because the spec resolves two issues that block Phase 2a and because 425 lines of design argument reviews better as a file than as the first commit of a segmentation PR. **The header line should be corrected on merge** — it now describes something that did not happen.

## What it settles

**#1148, the mastery update function.** The design doc has carried this as a "first crude version, to be refined" since v1, with its own note that it must be specified *before* Phase 2a, not discovered inside it. Its four open points, resolved in §2:

- **Beta per `(node, parameter level)` confirmed**, with an evidence cap and three readings defined once so display, planner and tests cannot disagree. Elo/Glicko rejected (needs an item-difficulty scale we lack), BKT rejected (slip/guess parameters need population data, which decision 4 forbids inventing), EWMA rejected (no confidence for free).
- **Decay and spacing are one mechanism read twice.** Elapsed time pulls the pseudo-counts toward the *prior*, never toward failure — absence of practice is absence of evidence, not evidence of collapse. The review interval derives from the same state rather than a second schedule, so the two cannot drift apart.
- **Level-ups shift via discounted inheritance, never reset.** A reset both discards real transfer and reads to the user as a regression, which is a trust-ender.
- **Attempts-to-pass and time-share feed the circling check only.** The first is the attempt-level Bernoulli sequence seen from the other end, so feeding it in double-counts one piece of evidence; the second measures how the *planner* allocated minutes, and the planner reads mastery, so it would make mastery partly a record of the app's own choices.

#1148's fourth listed question — one mastery estimate or two — was already closed by decision 17 before the issue was read.

**#1147, the interruption budget.** §7: one allowance (1 per session, 2 at 30+ minutes), one priority order, arbitrated in one function called only from the block-boundary transition, so "never mid-rep" is structural rather than a rule five features each have to remember. Losers degrade to the session summary instead of firing late. Suppression is persisted, because the anti-nag rules span sessions.

Two rulings taken during review, both applied to the design doc in ff57fe6:

- **The circling check's exemption is withdrawn.** Layer 2 granted the coaching voice one slot "plus whenever the circling check has something to say", which contradicted the journeys doc's claim that every journey obeys one budget. A cap with one exception is how five polite features become four interruptions.
- **The escalation ladder's action costs nothing.** Dropping 120 → 100bpm involves no words; the doc's own rule is that the ladder acts rather than narrates. Only the spoken name-the-wall moment spends the allowance. **#1147's issue text still counts the stuck ladder as an interruption** and is corrected in a comment there.

**The other five mechanisms:** the judgement track's asymmetry enforced by signature rather than convention (§3 — `prerequisites_met` cannot see `JudgementStore`, so "may never satisfy a prerequisite" is a compile error, not a code-review catch); the session state machine and the `BlockRecord` that must be written from the first build because none of it survives as an aggregate row (§4); the planner's five monotonic stages, where each may only remove or reorder candidates, which is what makes every block's *why* generable by construction (§5); the batched FFI surface with the #846 serde rules (§6); and `gates.toml` formalised into a closed `Requirement` enum (§8).

## Self-review found four real defects

Fixed in 41292bf, all in §2 and §4, all of which would otherwise have been discovered inside Phase 2a — the thing this spec exists to prevent:

1. **Elapsed time entered the spacing calculation twice.** The interval was computed from *decayed* estimate and evidence, then compared against days-since-practice — so a gap both shortened the interval and grew the numerator, compounding into "wildly overdue" instead of "due". Fixed by storing counts as of the last attempt and making decay a read.
2. **An inherited prior could override the hands.** A capped level below handed down ~13 pseudo-counts, so a new tempo needed a dozen contrary attempts before the model would admit it was too fast. Inheritance now capped at 6.
3. **`BlockRecord` could not represent off-piste.** A wander has no node, drill, gate or level, and making all four `Option` would have let a *planned* block persist with no gate. Separate `WanderRecord`; unmonitored writes neither.
4. **`baseline_ready()` read the wrong scope** — per-node evidence, when the circling check needs a cross-node attempts-to-pass distribution.

Plus four things specified rather than left to the implementer: how the evidence cap is enforced (proportional scale-down, so confidence saturates ≈0.83 and a node is never certain), the interval's functional form instead of a hand-waved `g()`, the missing transitions into and out of off-piste and unmonitored, and how `Clean` resolves per gate — it was defined but wired to nothing, so "a pass" had no single meaning.

## Coverage

None expected or possible — three markdown files, no executable code. `just check` and `just hygiene` both green.

## Divergence recorded, not hidden

§9 splits what was fixed at source in this series from what is still outstanding. Two `content/gates.toml` restructures are deliberately deferred to Phase 2a (#1152): `rootless-traversal` is a scheduling quota rather than a gate, and `transport = "paper"` conflates the input device with who judges. No code reads that file today and it is the file being practised from during the Phase 0 fortnight — restructuring it now costs the reader and buys nothing.

Deferred items tracked: #1152, #1153, #1154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)