### PR TITLE
ios: show the Gate Drill phrase on the Capture screen too

### DIFF
--- a/ios/Intrada/MidiSpike/MidiDebugScreen.swift
+++ b/ios/Intrada/MidiSpike/MidiDebugScreen.swift
@@ -105,6 +105,14 @@ struct MidiDebugScreen: View {
       }
       .disabled(model.isRunning)
 
+      VStack(alignment: .leading, spacing: 2) {
+        Text("For fixture takes, play the same phrase as Gate Drill:")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+        Text(GatePhrase.displaySequence)
+          .font(.system(.caption, design: .monospaced))
+      }
+
       Button(model.isRunning ? "Stop" : "Start") {
         model.isRunning ? model.stop() : model.start()
       }


### PR DESCRIPTION
Tier 1 follow-up to #1157. Recording comparable PR 3 fixture takes (clean/restarted/noodle-then-play/collapse) on the free-play Capture screen means playing the same known phrase Gate Drill uses — but Capture never displayed it, so you had to remember it. Reuses `GatePhrase.displaySequence`, same string Gate Drill already shows.

Verified: `just ios-fmt-check` clean, real build succeeds (`xcodebuild build` on a temp sim).