### PR TITLE
Attempt segmentation spike: a pure-Rust engine module + findings note (PR 3)

### DIFF
--- a/crates/intrada-core/src/engine/grid.rs
+++ b/crates/intrada-core/src/engine/grid.rs
@@ -1,10 +1,9 @@
-use serde::{Deserialize, Serialize};
-
 const US_PER_MINUTE_MILLI: i64 = 60_000_000_000;
 
-/// The click grid, in microseconds from the anchor. `anchor_us` is bar 1 beat 1
-/// — the first beat *after* the count-in, not engine start.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// The click grid. Every time in the engine is microseconds from the anchor,
+/// which is bar 1 beat 1 — the first beat *after* the count-in, not engine
+/// start — so the anchor itself is always 0 and is not carried here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ClickGrid {
     pub bpm_milli: u32,
     pub beats_per_bar: u8,
@@ -48,7 +47,7 @@ impl ClickGrid {
 
     pub fn nearest_beat(&self, t_us: i64) -> BeatRef {
         let per_beat = self.us_per_beat();
-        let beat_index = (t_us * 2 + per_beat.signum() * per_beat).div_euclid(per_beat * 2);
+        let beat_index = (t_us * 2 + per_beat).div_euclid(per_beat * 2);
         let bpb = i64::from(self.beats_per_bar.max(1));
         BeatRef {
             beat_index,
@@ -58,13 +57,8 @@ impl ClickGrid {
         }
     }
 
-    /// Start of the count-in region. Anything at or after
-    /// `count_in_cutoff_us` is body playing, including a note that anticipates
-    /// beat 1 (two of the five real takes do this by 20-50ms).
-    pub fn count_in_start_us(&self) -> i64 {
-        -self.beat_time_us(i64::from(self.count_in_beats))
-    }
-
+    /// Anything at or after this is body playing, including a note that
+    /// anticipates beat 1 — two of the five real takes do that by 20-50ms.
     pub fn count_in_cutoff_us(&self) -> i64 {
         -self.us_per_beat() / 2
     }

--- a/crates/intrada-core/src/engine/grid.rs
+++ b/crates/intrada-core/src/engine/grid.rs
@@ -1,0 +1,71 @@
+use serde::{Deserialize, Serialize};
+
+const US_PER_MINUTE_MILLI: i64 = 60_000_000_000;
+
+/// The click grid, in microseconds from the anchor. `anchor_us` is bar 1 beat 1
+/// — the first beat *after* the count-in, not engine start.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClickGrid {
+    pub bpm_milli: u32,
+    pub beats_per_bar: u8,
+    pub count_in_beats: u8,
+}
+
+/// A grid position. `beat_index` is 0-based from the anchor and goes negative
+/// during the count-in; `bar`/`beat` are the musician's 1-based counting, so a
+/// count-in beat reads as bar 0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BeatRef {
+    pub beat_index: i64,
+    pub bar: i64,
+    pub beat: u8,
+    pub offset_us: i64,
+}
+
+impl ClickGrid {
+    pub fn new(bpm_milli: u32, beats_per_bar: u8, count_in_beats: u8) -> Self {
+        Self {
+            bpm_milli,
+            beats_per_bar,
+            count_in_beats,
+        }
+    }
+
+    pub fn us_per_beat(&self) -> i64 {
+        US_PER_MINUTE_MILLI / i64::from(self.bpm_milli.max(1))
+    }
+
+    /// Beats are expressed in thousandths throughout so the engine never
+    /// carries a float across a boundary (engine spec §6: integers where an
+    /// integer will do).
+    pub fn beats_milli_to_us(&self, beats_milli: i64) -> i64 {
+        beats_milli * self.us_per_beat() / 1000
+    }
+
+    pub fn beat_time_us(&self, beat_index: i64) -> i64 {
+        beat_index * self.us_per_beat()
+    }
+
+    pub fn nearest_beat(&self, t_us: i64) -> BeatRef {
+        let per_beat = self.us_per_beat();
+        let beat_index = (t_us * 2 + per_beat.signum() * per_beat).div_euclid(per_beat * 2);
+        let bpb = i64::from(self.beats_per_bar.max(1));
+        BeatRef {
+            beat_index,
+            bar: beat_index.div_euclid(bpb) + 1,
+            beat: (beat_index.rem_euclid(bpb) + 1) as u8,
+            offset_us: t_us - self.beat_time_us(beat_index),
+        }
+    }
+
+    /// Start of the count-in region. Anything at or after
+    /// `count_in_cutoff_us` is body playing, including a note that anticipates
+    /// beat 1 (two of the five real takes do this by 20-50ms).
+    pub fn count_in_start_us(&self) -> i64 {
+        -self.beat_time_us(i64::from(self.count_in_beats))
+    }
+
+    pub fn count_in_cutoff_us(&self) -> i64 {
+        -self.us_per_beat() / 2
+    }
+}

--- a/crates/intrada-core/src/engine/mod.rs
+++ b/crates/intrada-core/src/engine/mod.rs
@@ -1,0 +1,16 @@
+//! The practice-coach engine: attempt segmentation over a captured note
+//! stream. Pure functions on plain data — no `Model`, no `Effect`, no FFI
+//! surface yet (`docs/rebuild-review.md` §6, PR 3). What it can and cannot
+//! decide is recorded in `docs/segmentation-findings.md`.
+
+mod grid;
+mod note;
+mod phrase;
+mod segment;
+
+pub use grid::{BeatRef, ClickGrid};
+pub use note::{cluster_onsets, NoteEvent, Onset, TransportTier};
+pub use phrase::{PhraseStep, TargetPhrase};
+pub use segment::{
+    rest_spans, segment, Attempt, AttemptOutcome, Pause, SegmentConfig, Segmentation, TimingStats,
+};

--- a/crates/intrada-core/src/engine/mod.rs
+++ b/crates/intrada-core/src/engine/mod.rs
@@ -9,7 +9,7 @@ mod phrase;
 mod segment;
 
 pub use grid::{BeatRef, ClickGrid};
-pub use note::{cluster_onsets, NoteEvent, Onset, TransportTier};
+pub use note::{cluster_onsets, NoteEvent, Onset};
 pub use phrase::{PhraseStep, TargetPhrase};
 pub use segment::{
     rest_spans, segment, Attempt, AttemptOutcome, Pause, SegmentConfig, Segmentation, TimingStats,

--- a/crates/intrada-core/src/engine/note.rs
+++ b/crates/intrada-core/src/engine/note.rs
@@ -1,21 +1,7 @@
-use serde::{Deserialize, Serialize};
-
-/// What the input path can support, per design decision 7 (transport-tiered
-/// scoring): never issue a precision verdict the input can't carry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TransportTier {
-    /// Wired MIDI, ±1-3ms.
-    Wired,
-    /// Bluetooth MIDI, ±10-20ms connection-interval jitter.
-    Bluetooth,
-    /// Microphone plus transcription, ±20ms at best.
-    Acoustic,
-}
-
 /// One MIDI note event, timed from the click anchor. **Signed**: a note may
 /// legitimately precede the anchor (anticipating beat 1, or playing during the
 /// count-in), which `u64` cannot express.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoteEvent {
     pub pitch: u8,
     pub velocity: u8,
@@ -23,13 +9,12 @@ pub struct NoteEvent {
     pub t_us: i64,
 }
 
-/// Near-simultaneous note-ons collapsed into one musical event. A chord or a
-/// rolled voicing is one attempt step, not five.
+/// Near-simultaneous note-ons as one musical event: a chord or a rolled voicing
+/// is one attempt step, not five.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Onset {
     pub t_us: i64,
     pub pitches: Vec<u8>,
-    pub peak_velocity: u8,
 }
 
 impl Onset {
@@ -47,7 +32,7 @@ impl Onset {
 }
 
 /// Groups note-ons whose onsets fall within `window_us` of the group's first
-/// note. Measured spread on real rolled voicings is ~34ms (take 01), so the
+/// note. Measured spread on real rolled voicings is 34ms (take 01), so the
 /// default window is 50ms — see the findings note for why that ceiling collides
 /// with fast subdivisions.
 pub fn cluster_onsets(events: &[NoteEvent], window_us: i64) -> Vec<Onset> {
@@ -59,12 +44,10 @@ pub fn cluster_onsets(events: &[NoteEvent], window_us: i64) -> Vec<Onset> {
         match clusters.last_mut() {
             Some(current) if event.t_us - current.t_us <= window_us => {
                 current.pitches.push(event.pitch);
-                current.peak_velocity = current.peak_velocity.max(event.velocity);
             }
             _ => clusters.push(Onset {
                 t_us: event.t_us,
                 pitches: vec![event.pitch],
-                peak_velocity: event.velocity,
             }),
         }
     }

--- a/crates/intrada-core/src/engine/note.rs
+++ b/crates/intrada-core/src/engine/note.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+
+/// What the input path can support, per design decision 7 (transport-tiered
+/// scoring): never issue a precision verdict the input can't carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransportTier {
+    /// Wired MIDI, ±1-3ms.
+    Wired,
+    /// Bluetooth MIDI, ±10-20ms connection-interval jitter.
+    Bluetooth,
+    /// Microphone plus transcription, ±20ms at best.
+    Acoustic,
+}
+
+/// One MIDI note event, timed from the click anchor. **Signed**: a note may
+/// legitimately precede the anchor (anticipating beat 1, or playing during the
+/// count-in), which `u64` cannot express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoteEvent {
+    pub pitch: u8,
+    pub velocity: u8,
+    pub on: bool,
+    pub t_us: i64,
+}
+
+/// Near-simultaneous note-ons collapsed into one musical event. A chord or a
+/// rolled voicing is one attempt step, not five.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Onset {
+    pub t_us: i64,
+    pub pitches: Vec<u8>,
+    pub peak_velocity: u8,
+}
+
+impl Onset {
+    pub fn has_pitch_class(&self, pitch_class: u8) -> bool {
+        self.pitches.iter().any(|p| p % 12 == pitch_class % 12)
+    }
+
+    pub fn distinct_pitch_classes(&self) -> usize {
+        let mut mask: u16 = 0;
+        for pitch in &self.pitches {
+            mask |= 1 << (pitch % 12);
+        }
+        mask.count_ones() as usize
+    }
+}
+
+/// Groups note-ons whose onsets fall within `window_us` of the group's first
+/// note. Measured spread on real rolled voicings is ~34ms (take 01), so the
+/// default window is 50ms — see the findings note for why that ceiling collides
+/// with fast subdivisions.
+pub fn cluster_onsets(events: &[NoteEvent], window_us: i64) -> Vec<Onset> {
+    let mut ons: Vec<&NoteEvent> = events.iter().filter(|e| e.on).collect();
+    ons.sort_by_key(|e| e.t_us);
+
+    let mut clusters: Vec<Onset> = Vec::new();
+    for event in ons {
+        match clusters.last_mut() {
+            Some(current) if event.t_us - current.t_us <= window_us => {
+                current.pitches.push(event.pitch);
+                current.peak_velocity = current.peak_velocity.max(event.velocity);
+            }
+            _ => clusters.push(Onset {
+                t_us: event.t_us,
+                pitches: vec![event.pitch],
+                peak_velocity: event.velocity,
+            }),
+        }
+    }
+    clusters
+}

--- a/crates/intrada-core/src/engine/phrase.rs
+++ b/crates/intrada-core/src/engine/phrase.rs
@@ -1,23 +1,20 @@
-use serde::{Deserialize, Serialize};
-
 use super::note::Onset;
 
 /// One step of a target phrase. Matched by pitch class, so any octave counts —
 /// the spike's crude-on-purpose stance, inherited from the Swift gate drill.
 /// `beat_offset_milli` is thousandths of a beat from the phrase start.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PhraseStep {
     pub pitch_classes: Vec<u8>,
     pub beat_offset_milli: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetPhrase {
     pub steps: Vec<PhraseStep>,
 }
 
 impl TargetPhrase {
-    /// One pitch class per beat — the shape of every v1 drill phrase.
     pub fn crotchets(pitch_classes: &[u8]) -> Self {
         Self {
             steps: pitch_classes

--- a/crates/intrada-core/src/engine/phrase.rs
+++ b/crates/intrada-core/src/engine/phrase.rs
@@ -1,0 +1,83 @@
+use serde::{Deserialize, Serialize};
+
+use super::note::Onset;
+
+/// One step of a target phrase. Matched by pitch class, so any octave counts —
+/// the spike's crude-on-purpose stance, inherited from the Swift gate drill.
+/// `beat_offset_milli` is thousandths of a beat from the phrase start.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PhraseStep {
+    pub pitch_classes: Vec<u8>,
+    pub beat_offset_milli: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TargetPhrase {
+    pub steps: Vec<PhraseStep>,
+}
+
+impl TargetPhrase {
+    /// One pitch class per beat — the shape of every v1 drill phrase.
+    pub fn crotchets(pitch_classes: &[u8]) -> Self {
+        Self {
+            steps: pitch_classes
+                .iter()
+                .enumerate()
+                .map(|(index, class)| PhraseStep {
+                    pitch_classes: vec![*class],
+                    beat_offset_milli: index as i64 * 1000,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.steps.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.steps.is_empty()
+    }
+
+    /// Octave-tolerant, but **width-exact**: a one-note step needs a one-class
+    /// onset. Matching on "contains the pitch class" alone let a five-note
+    /// freeplay voicing satisfy 7 of the 8 gate-phrase steps (take 01).
+    /// Octave doublings still match, since they add no distinct class.
+    pub fn matches(&self, step: usize, onset: &Onset) -> bool {
+        self.steps.get(step).is_some_and(|expected| {
+            onset.distinct_pitch_classes() == expected.pitch_classes.len()
+                && expected
+                    .pitch_classes
+                    .iter()
+                    .all(|class| onset.has_pitch_class(*class))
+        })
+    }
+
+    /// The phrase's own note density, which is what pause and abandon
+    /// thresholds must scale against — a grid beat is the wrong unit for a
+    /// phrase in quavers.
+    pub fn step_spacing_milli(&self) -> i64 {
+        let mut gaps: Vec<i64> = self
+            .steps
+            .windows(2)
+            .map(|pair| pair[1].beat_offset_milli - pair[0].beat_offset_milli)
+            .filter(|gap| *gap > 0)
+            .collect();
+        if gaps.is_empty() {
+            return 1000;
+        }
+        gaps.sort_unstable();
+        gaps[gaps.len() / 2]
+    }
+
+    /// How many onsets from `from_onset` match consecutively if the player is
+    /// taken to be at `from_step`. The disambiguator for restart-versus-resume,
+    /// which no timing signal can settle (see the findings note).
+    pub fn consecutive_match_run(&self, onsets: &[Onset], from_step: usize) -> usize {
+        onsets
+            .iter()
+            .enumerate()
+            .take_while(|(offset, onset)| self.matches(from_step + offset, onset))
+            .count()
+    }
+}

--- a/crates/intrada-core/src/engine/segment.rs
+++ b/crates/intrada-core/src/engine/segment.rs
@@ -1,0 +1,338 @@
+use std::ops::Range;
+
+use super::grid::ClickGrid;
+use super::note::{cluster_onsets, NoteEvent, Onset};
+use super::phrase::TargetPhrase;
+
+/// Tunable thresholds. Everything time-shaped is a ratio of the target
+/// phrase's own step spacing, never an absolute millisecond count, so the same
+/// config works at 60 and 200 bpm and for quaver phrases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SegmentConfig {
+    pub chord_window_us: i64,
+    /// Silence beyond this multiple of step spacing is a pause.
+    pub pause_ratio_milli: i64,
+    /// Silence beyond this multiple ends the attempt unresumed.
+    pub abandon_ratio_milli: i64,
+    pub max_consecutive_deviations: u32,
+    /// How many steps must match before a start is believed. One matching note
+    /// is not an attempt — in take 03 the scale run crosses the phrase's first
+    /// note four times, and each crossing opened a spurious attempt at 1.
+    pub min_start_run_steps: usize,
+}
+
+impl Default for SegmentConfig {
+    fn default() -> Self {
+        Self {
+            chord_window_us: 50_000,
+            pause_ratio_milli: 1_750,
+            abandon_ratio_milli: 4_000,
+            max_consecutive_deviations: 2,
+            min_start_run_steps: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pause {
+    pub after_step: u32,
+    pub gap_us: i64,
+}
+
+/// Offsets of matched onsets against where the phrase wanted them. Per design
+/// decision 6 the spread is the error and the mean is the feel, so both are
+/// reported and neither is graded here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TimingStats {
+    pub count: u32,
+    pub mean_offset_us: i64,
+    pub stddev_offset_us: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttemptOutcome {
+    /// Every step matched, in order.
+    Completed,
+    /// The player went back to step 0 before finishing.
+    Restarted { at_step: u32 },
+    /// Diverged and stopped playing.
+    Collapsed { at_step: u32 },
+    /// Diverged and kept playing something else.
+    Diverged { at_step: u32 },
+    /// Fell silent past the abandon threshold and never resumed.
+    Abandoned { at_step: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attempt {
+    pub span: Range<usize>,
+    pub start_us: i64,
+    pub end_us: i64,
+    pub matched_steps: u32,
+    pub outcome: AttemptOutcome,
+    pub deviation_onsets: Vec<usize>,
+    pub pauses: Vec<Pause>,
+    pub timing: TimingStats,
+}
+
+impl Attempt {
+    /// A paused attempt's phrase timing is arithmetic about a phrase the player
+    /// didn't play continuously, so it is never a scoring input.
+    pub fn timing_is_scorable(&self) -> bool {
+        self.outcome == AttemptOutcome::Completed && self.pauses.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Segmentation {
+    pub onsets: Vec<Onset>,
+    /// Onsets played during the count-in, excluded from every attempt.
+    pub count_in: Range<usize>,
+    pub attempts: Vec<Attempt>,
+    /// Playing attributed to no attempt: noodling before, between, or after.
+    pub unattributed: Vec<Range<usize>>,
+}
+
+impl Segmentation {
+    pub fn completed(&self) -> impl Iterator<Item = &Attempt> {
+        self.attempts
+            .iter()
+            .filter(|a| a.outcome == AttemptOutcome::Completed)
+    }
+}
+
+struct InProgress {
+    first_onset: usize,
+    first_t_us: i64,
+    anchor_beat: i64,
+    step: usize,
+    last_onset: usize,
+    last_t_us: i64,
+    consecutive_deviations: u32,
+    deviation_onsets: Vec<usize>,
+    pauses: Vec<Pause>,
+    offsets_us: Vec<i64>,
+}
+
+/// Splits a note stream into attempts against a target phrase. With no target
+/// there are no attempts by construction — an attempt is defined by what it
+/// was an attempt *at*.
+pub fn segment(
+    events: &[NoteEvent],
+    grid: &ClickGrid,
+    target: Option<&TargetPhrase>,
+    config: &SegmentConfig,
+) -> Segmentation {
+    let onsets = cluster_onsets(events, config.chord_window_us);
+    let cutoff = grid.count_in_cutoff_us();
+    let body_start = onsets.partition_point(|o| o.t_us < cutoff);
+
+    let Some(target) = target.filter(|t| !t.is_empty()) else {
+        return Segmentation {
+            count_in: 0..body_start,
+            unattributed: span_if_nonempty(body_start..onsets.len()),
+            attempts: Vec::new(),
+            onsets,
+        };
+    };
+
+    let spacing_milli = target.step_spacing_milli();
+    let pause_us = grid.beats_milli_to_us(spacing_milli * config.pause_ratio_milli / 1000);
+    let abandon_us = grid.beats_milli_to_us(spacing_milli * config.abandon_ratio_milli / 1000);
+
+    let mut attempts: Vec<Attempt> = Vec::new();
+    let mut unattributed: Vec<Range<usize>> = Vec::new();
+    let mut current: Option<InProgress> = None;
+    let mut noodle_start: Option<usize> = None;
+
+    for index in body_start..onsets.len() {
+        let onset = &onsets[index];
+
+        if let Some(active) = current.as_ref() {
+            if onset.t_us - active.last_t_us > abandon_us {
+                let active = current.take().expect("checked above");
+                attempts.push(close(active, target, AttemptKind::Abandoned));
+            }
+        }
+
+        let Some(active) = current.as_mut() else {
+            if starts_here(&onsets[index..], target, config) {
+                current = Some(open(index, onset, grid, target));
+                if let Some(start) = noodle_start.take() {
+                    unattributed.push(start..index);
+                }
+            } else if noodle_start.is_none() {
+                noodle_start = Some(index);
+            }
+            continue;
+        };
+
+        let gap_us = onset.t_us - active.last_t_us;
+        let continues = target.matches(active.step, onset);
+        let restarts = active.step > 0
+            && starts_here(&onsets[index..], target, config)
+            && (!continues || prefers_restart(&onsets[index..], target, active.step));
+
+        if restarts {
+            let active = current.take().expect("checked above");
+            attempts.push(close(active, target, AttemptKind::Restarted));
+            current = Some(open(index, onset, grid, target));
+            continue;
+        }
+
+        if continues {
+            if gap_us > pause_us {
+                active.pauses.push(Pause {
+                    after_step: active.step as u32,
+                    gap_us,
+                });
+            }
+            let expected_us = grid.beat_time_us(active.anchor_beat)
+                + grid.beats_milli_to_us(target.steps[active.step].beat_offset_milli);
+            active.offsets_us.push(onset.t_us - expected_us);
+            active.step += 1;
+            active.consecutive_deviations = 0;
+            active.last_onset = index;
+            active.last_t_us = onset.t_us;
+
+            if active.step == target.len() {
+                let active = current.take().expect("checked above");
+                attempts.push(close(active, target, AttemptKind::Completed));
+            }
+            continue;
+        }
+
+        active.consecutive_deviations += 1;
+        active.deviation_onsets.push(index);
+        active.last_onset = index;
+        active.last_t_us = onset.t_us;
+        if active.consecutive_deviations >= config.max_consecutive_deviations {
+            let active = current.take().expect("checked above");
+            attempts.push(close(active, target, AttemptKind::Diverged));
+            noodle_start = Some(index + 1);
+        }
+    }
+
+    if let Some(active) = current.take() {
+        let kind = if active.deviation_onsets.is_empty() {
+            AttemptKind::Abandoned
+        } else {
+            AttemptKind::Collapsed
+        };
+        attempts.push(close(active, target, kind));
+    }
+    if let Some(start) = noodle_start {
+        unattributed.extend(span_if_nonempty(start..onsets.len()));
+    }
+
+    Segmentation {
+        count_in: 0..body_start,
+        attempts,
+        unattributed,
+        onsets,
+    }
+}
+
+/// Spans of playing separated by silence longer than `gap_us`. The only
+/// segmentation available with no target phrase — useful for logging off-piste
+/// playing (decision 16), never for scoring.
+pub fn rest_spans(onsets: &[Onset], gap_us: i64) -> Vec<Range<usize>> {
+    let mut spans: Vec<Range<usize>> = Vec::new();
+    for (index, onset) in onsets.iter().enumerate() {
+        match spans.last_mut() {
+            Some(current) if onset.t_us - onsets[current.end - 1].t_us <= gap_us => {
+                current.end = index + 1;
+            }
+            _ => spans.push(index..index + 1),
+        }
+    }
+    spans
+}
+
+enum AttemptKind {
+    Completed,
+    Restarted,
+    Collapsed,
+    Diverged,
+    Abandoned,
+}
+
+fn open(index: usize, onset: &Onset, grid: &ClickGrid, target: &TargetPhrase) -> InProgress {
+    let anchor_beat = grid.nearest_beat(onset.t_us).beat_index;
+    let expected_us =
+        grid.beat_time_us(anchor_beat) + grid.beats_milli_to_us(target.steps[0].beat_offset_milli);
+    InProgress {
+        first_onset: index,
+        first_t_us: onset.t_us,
+        anchor_beat,
+        step: 1,
+        last_onset: index,
+        last_t_us: onset.t_us,
+        consecutive_deviations: 0,
+        deviation_onsets: Vec::new(),
+        pauses: Vec::new(),
+        offsets_us: vec![onset.t_us - expected_us],
+    }
+}
+
+fn close(active: InProgress, target: &TargetPhrase, kind: AttemptKind) -> Attempt {
+    let at_step = active.step as u32;
+    let outcome = match kind {
+        AttemptKind::Completed => AttemptOutcome::Completed,
+        AttemptKind::Restarted => AttemptOutcome::Restarted { at_step },
+        AttemptKind::Collapsed => AttemptOutcome::Collapsed { at_step },
+        AttemptKind::Diverged => AttemptOutcome::Diverged { at_step },
+        AttemptKind::Abandoned => AttemptOutcome::Abandoned { at_step },
+    };
+    debug_assert!(active.step <= target.len());
+    Attempt {
+        span: active.first_onset..active.last_onset + 1,
+        start_us: active.first_t_us,
+        end_us: active.last_t_us,
+        matched_steps: at_step,
+        outcome,
+        timing: timing_stats(&active.offsets_us),
+        deviation_onsets: active.deviation_onsets,
+        pauses: active.pauses,
+    }
+}
+
+fn starts_here(tail: &[Onset], target: &TargetPhrase, config: &SegmentConfig) -> bool {
+    let required = config.min_start_run_steps.clamp(1, target.len());
+    target.consecutive_match_run(tail, 0) >= required
+}
+
+/// True when the tail matches the phrase better read as a fresh start than as a
+/// continuation. Both readings are timing-identical, so only content decides.
+fn prefers_restart(tail: &[Onset], target: &TargetPhrase, step: usize) -> bool {
+    target.consecutive_match_run(tail, 0) > target.consecutive_match_run(tail, step)
+}
+
+fn timing_stats(offsets_us: &[i64]) -> TimingStats {
+    if offsets_us.is_empty() {
+        return TimingStats::default();
+    }
+    let count = offsets_us.len() as i64;
+    let mean = offsets_us.iter().sum::<i64>() / count;
+    let variance = offsets_us
+        .iter()
+        .map(|offset| {
+            let delta = offset - mean;
+            delta * delta
+        })
+        .sum::<i64>()
+        / count;
+    TimingStats {
+        count: count as u32,
+        mean_offset_us: mean,
+        stddev_offset_us: (variance as f64).sqrt() as i64,
+    }
+}
+
+fn span_if_nonempty(range: Range<usize>) -> Vec<Range<usize>> {
+    if range.is_empty() {
+        Vec::new()
+    } else {
+        vec![range]
+    }
+}

--- a/crates/intrada-core/src/engine/segment.rs
+++ b/crates/intrada-core/src/engine/segment.rs
@@ -17,7 +17,7 @@ pub struct SegmentConfig {
     pub max_consecutive_deviations: u32,
     /// How many steps must match before a start is believed. One matching note
     /// is not an attempt — in take 03 the scale run crosses the phrase's first
-    /// note four times, and each crossing opened a spurious attempt at 1.
+    /// note five times, and each crossing opened a spurious one-step attempt.
     pub min_start_run_steps: usize,
 }
 
@@ -55,11 +55,12 @@ pub enum AttemptOutcome {
     Completed,
     /// The player went back to step 0 before finishing.
     Restarted { at_step: u32 },
-    /// Diverged and stopped playing.
+    /// Played a wrong note and stopped there.
     Collapsed { at_step: u32 },
-    /// Diverged and kept playing something else.
+    /// Left the phrase and kept playing something else.
     Diverged { at_step: u32 },
-    /// Fell silent past the abandon threshold and never resumed.
+    /// Stopped or fell silent mid-phrase while still playing it correctly.
+    /// Not evidence of failure — see the findings note.
     Abandoned { at_step: u32 },
 }
 
@@ -109,6 +110,7 @@ struct InProgress {
     last_onset: usize,
     last_t_us: i64,
     consecutive_deviations: u32,
+    ended_on_deviation: bool,
     deviation_onsets: Vec<usize>,
     pauses: Vec<Pause>,
     offsets_us: Vec<i64>,
@@ -147,19 +149,21 @@ pub fn segment(
 
     for index in body_start..onsets.len() {
         let onset = &onsets[index];
+        let tail = contiguous_tail(&onsets[index..], abandon_us);
 
-        if let Some(active) = current.as_ref() {
+        if let Some(active) = current.take() {
             if onset.t_us - active.last_t_us > abandon_us {
-                let active = current.take().expect("checked above");
-                attempts.push(close(active, target, AttemptKind::Abandoned));
+                attempts.push(close(active, AttemptKind::Abandoned));
+            } else {
+                current = Some(active);
             }
         }
 
         let Some(active) = current.as_mut() else {
-            if starts_here(&onsets[index..], target, config) {
+            if starts_here(tail, target, config) {
                 current = Some(open(index, onset, grid, target));
                 if let Some(start) = noodle_start.take() {
-                    unattributed.push(start..index);
+                    unattributed.extend(span_if_nonempty(start..index));
                 }
             } else if noodle_start.is_none() {
                 noodle_start = Some(index);
@@ -170,12 +174,12 @@ pub fn segment(
         let gap_us = onset.t_us - active.last_t_us;
         let continues = target.matches(active.step, onset);
         let restarts = active.step > 0
-            && starts_here(&onsets[index..], target, config)
-            && (!continues || prefers_restart(&onsets[index..], target, active.step));
+            && starts_here(tail, target, config)
+            && (!continues || prefers_restart(tail, target, active.step));
 
         if restarts {
-            let active = current.take().expect("checked above");
-            attempts.push(close(active, target, AttemptKind::Restarted));
+            let active = current.take().expect("matched as_mut above");
+            attempts.push(close(active, AttemptKind::Restarted));
             current = Some(open(index, onset, grid, target));
             continue;
         }
@@ -194,10 +198,11 @@ pub fn segment(
             active.consecutive_deviations = 0;
             active.last_onset = index;
             active.last_t_us = onset.t_us;
+            active.ended_on_deviation = false;
 
             if active.step == target.len() {
-                let active = current.take().expect("checked above");
-                attempts.push(close(active, target, AttemptKind::Completed));
+                let active = current.take().expect("matched as_mut above");
+                attempts.push(close(active, AttemptKind::Completed));
             }
             continue;
         }
@@ -206,20 +211,31 @@ pub fn segment(
         active.deviation_onsets.push(index);
         active.last_onset = index;
         active.last_t_us = onset.t_us;
+        active.ended_on_deviation = true;
         if active.consecutive_deviations >= config.max_consecutive_deviations {
-            let active = current.take().expect("checked above");
-            attempts.push(close(active, target, AttemptKind::Diverged));
+            let active = current.take().expect("matched as_mut above");
+            // Whether a divergence is noodling or a collapse is decided by what
+            // follows it, not by the wrong notes themselves.
+            let kept_playing = onsets
+                .get(index + 1)
+                .is_some_and(|next| next.t_us - onset.t_us <= abandon_us);
+            let kind = if kept_playing {
+                AttemptKind::Diverged
+            } else {
+                AttemptKind::Collapsed
+            };
+            attempts.push(close(active, kind));
             noodle_start = Some(index + 1);
         }
     }
 
     if let Some(active) = current.take() {
-        let kind = if active.deviation_onsets.is_empty() {
-            AttemptKind::Abandoned
-        } else {
+        let kind = if active.ended_on_deviation {
             AttemptKind::Collapsed
+        } else {
+            AttemptKind::Abandoned
         };
-        attempts.push(close(active, target, kind));
+        attempts.push(close(active, kind));
     }
     if let Some(start) = noodle_start {
         unattributed.extend(span_if_nonempty(start..onsets.len()));
@@ -258,9 +274,11 @@ enum AttemptKind {
 }
 
 fn open(index: usize, onset: &Onset, grid: &ClickGrid, target: &TargetPhrase) -> InProgress {
-    let anchor_beat = grid.nearest_beat(onset.t_us).beat_index;
-    let expected_us =
-        grid.beat_time_us(anchor_beat) + grid.beats_milli_to_us(target.steps[0].beat_offset_milli);
+    // The anchor is where step 0 *should* have fallen, so an upbeat phrase
+    // (non-zero first offset) doesn't skew every offset in the attempt.
+    let step_zero_us = grid.beats_milli_to_us(target.steps[0].beat_offset_milli);
+    let anchor_beat = grid.nearest_beat(onset.t_us - step_zero_us).beat_index;
+    let expected_us = grid.beat_time_us(anchor_beat) + step_zero_us;
     InProgress {
         first_onset: index,
         first_t_us: onset.t_us,
@@ -269,13 +287,14 @@ fn open(index: usize, onset: &Onset, grid: &ClickGrid, target: &TargetPhrase) ->
         last_onset: index,
         last_t_us: onset.t_us,
         consecutive_deviations: 0,
+        ended_on_deviation: false,
         deviation_onsets: Vec::new(),
         pauses: Vec::new(),
         offsets_us: vec![onset.t_us - expected_us],
     }
 }
 
-fn close(active: InProgress, target: &TargetPhrase, kind: AttemptKind) -> Attempt {
+fn close(active: InProgress, kind: AttemptKind) -> Attempt {
     let at_step = active.step as u32;
     let outcome = match kind {
         AttemptKind::Completed => AttemptOutcome::Completed,
@@ -284,7 +303,6 @@ fn close(active: InProgress, target: &TargetPhrase, kind: AttemptKind) -> Attemp
         AttemptKind::Diverged => AttemptOutcome::Diverged { at_step },
         AttemptKind::Abandoned => AttemptOutcome::Abandoned { at_step },
     };
-    debug_assert!(active.step <= target.len());
     Attempt {
         span: active.first_onset..active.last_onset + 1,
         start_us: active.first_t_us,
@@ -297,15 +315,31 @@ fn close(active: InProgress, target: &TargetPhrase, kind: AttemptKind) -> Attemp
     }
 }
 
+/// The tail up to the first silence long enough to end an attempt, so a
+/// confirming run can't be assembled from notes a minute apart.
+fn contiguous_tail(tail: &[Onset], abandon_us: i64) -> &[Onset] {
+    let end = tail
+        .windows(2)
+        .position(|pair| pair[1].t_us - pair[0].t_us > abandon_us)
+        .map_or(tail.len(), |index| index + 1);
+    &tail[..end]
+}
+
 fn starts_here(tail: &[Onset], target: &TargetPhrase, config: &SegmentConfig) -> bool {
     let required = config.min_start_run_steps.clamp(1, target.len());
     target.consecutive_match_run(tail, 0) >= required
 }
 
 /// True when the tail matches the phrase better read as a fresh start than as a
-/// continuation. Both readings are timing-identical, so only content decides.
+/// continuation. Both readings are timing-identical, so only content decides —
+/// and a continuation that explains everything available is never overruled,
+/// since its run is capped by the steps remaining while a restart's is not.
 fn prefers_restart(tail: &[Onset], target: &TargetPhrase, step: usize) -> bool {
-    target.consecutive_match_run(tail, 0) > target.consecutive_match_run(tail, step)
+    let continuing = target.consecutive_match_run(tail, step);
+    if step + continuing >= target.len() || continuing >= tail.len() {
+        return false;
+    }
+    target.consecutive_match_run(tail, 0) > continuing
 }
 
 fn timing_stats(offsets_us: &[i64]) -> TimingStats {
@@ -314,14 +348,15 @@ fn timing_stats(offsets_us: &[i64]) -> TimingStats {
     }
     let count = offsets_us.len() as i64;
     let mean = offsets_us.iter().sum::<i64>() / count;
+    // i128: squaring a whole-beat offset overflows i64 at slow tempi.
     let variance = offsets_us
         .iter()
         .map(|offset| {
-            let delta = offset - mean;
+            let delta = i128::from(offset - mean);
             delta * delta
         })
-        .sum::<i64>()
-        / count;
+        .sum::<i128>()
+        / i128::from(count);
     TimingStats {
         count: count as u32,
         mean_offset_us: mean,

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod analytics;
 pub mod app;
 pub mod domain;
+pub mod engine;
 pub mod error;
 pub mod http;
 pub mod model;

--- a/crates/intrada-core/tests/engine_segmentation.rs
+++ b/crates/intrada-core/tests/engine_segmentation.rs
@@ -6,8 +6,8 @@
 mod midi_take;
 
 use intrada_core::engine::{
-    cluster_onsets, rest_spans, segment, AttemptOutcome, ClickGrid, NoteEvent, SegmentConfig,
-    TargetPhrase,
+    cluster_onsets, rest_spans, segment, AttemptOutcome, ClickGrid, NoteEvent, PhraseStep,
+    SegmentConfig, TargetPhrase,
 };
 use midi_take::MidiTake;
 
@@ -42,7 +42,7 @@ fn take_02_pause_mid_phrase_is_one_completed_attempt_with_a_pause() {
 }
 
 #[test]
-fn take_04_restart_is_an_abandoned_attempt_then_a_clean_one() {
+fn take_04_restart_is_a_closed_attempt_then_a_clean_one() {
     let take = MidiTake::load("take-04-restart-bluetooth.jsonl");
     let result = segment(
         &take.events,
@@ -145,10 +145,12 @@ fn take_01_freeplay_yields_no_attempts_without_a_target() {
     assert_eq!(result.unattributed[0].len(), result.onsets.len());
 
     let spans = rest_spans(&result.onsets, take.grid.beats_milli_to_us(1_750));
-    assert!(
-        spans.len() > 1,
-        "freeplay should still split into rest-separated spans for off-piste logging"
+    assert_eq!(
+        spans.len(),
+        4,
+        "freeplay still splits into rest-separated spans for off-piste logging"
     );
+    assert_eq!(spans.last().expect("four spans").end, result.onsets.len());
 }
 
 /// The same freeplay take against a phrase the player never attempted.
@@ -248,32 +250,253 @@ fn a_note_anticipating_beat_one_belongs_to_the_attempt() {
     }
 }
 
-/// Design decision 6: a stable offset is feel, spread is the error. The steady
-/// on-the-beat passage in take 01 lays back consistently.
+/// Design decision 6: the mean offset is feel, the spread is the error. This
+/// pins the one clean repetition in the fixture set — the figures the findings
+/// note quotes as the evidence that decision 6 is measurable over Bluetooth.
+/// Negative is ahead of the click, so this rep pushes; it does not lay back.
 #[test]
-fn steady_playing_reads_as_consistent_lay_back_not_error() {
-    let take = MidiTake::load("take-01-freeplay-mixed-bluetooth.jsonl");
-    let phrase = TargetPhrase::crotchets(&[9, 9, 9, 9, 9, 9, 9, 9]);
+fn the_clean_repetition_pushes_consistently() {
+    let take = MidiTake::load("take-04-restart-bluetooth.jsonl");
     let result = segment(
         &take.events,
         &take.grid,
-        Some(&phrase),
+        Some(&gate_phrase()),
         &SegmentConfig::default(),
     );
+
+    let attempt = result.completed().next().expect("take 04's second rep");
+    assert_eq!(attempt.timing.count, 8);
+    assert!(
+        (-30_000..-18_000).contains(&attempt.timing.mean_offset_us),
+        "expected a consistent push around -24ms, got {}us",
+        attempt.timing.mean_offset_us
+    );
+    assert!(
+        attempt.timing.stddev_offset_us < 20_000,
+        "expected a spread under 20ms, got {}us",
+        attempt.timing.stddev_offset_us
+    );
+    assert!(
+        attempt.timing.stddev_offset_us < attempt.timing.mean_offset_us.abs(),
+        "the spread should be smaller than the offset it sits around"
+    );
+}
+
+/// A repeated pitch class makes every continuation also look like a fresh
+/// start. Two clean back-to-back reps of a one-note phrase must read as two
+/// attempts, not as a restart on every note.
+#[test]
+fn a_phrase_of_one_repeated_pitch_class_does_not_restart_on_every_note() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let phrase = TargetPhrase::crotchets(&[0, 0, 0, 0]);
+    let events: Vec<NoteEvent> = (0..8).map(|beat| note_on(60, beat * per_beat)).collect();
+
+    let result = segment(&events, &grid, Some(&phrase), &SegmentConfig::default());
+
+    assert_eq!(result.attempts.len(), 2, "{:?}", result.attempts);
+    assert!(result
+        .attempts
+        .iter()
+        .all(|a| a.outcome == AttemptOutcome::Completed));
+}
+
+/// The outcome says what the player did next, so a divergence that stops is a
+/// collapse and one that keeps going is noodling — the wrong notes alone don't
+/// tell them apart.
+#[test]
+fn stopping_and_carrying_on_are_different_outcomes() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let phrase = TargetPhrase::crotchets(&[0, 2, 4, 5]);
+    let opening = [note_on(60, 0), note_on(62, per_beat)];
+
+    let stopped: Vec<NoteEvent> = opening
+        .iter()
+        .copied()
+        .chain([note_on(66, 2 * per_beat), note_on(68, 3 * per_beat)])
+        .collect();
+    let carried_on: Vec<NoteEvent> = stopped
+        .iter()
+        .copied()
+        .chain((4..8).map(|beat| note_on(70, beat * per_beat)))
+        .collect();
+
+    let config = SegmentConfig::default();
+    let stopped = segment(&stopped, &grid, Some(&phrase), &config);
+    let carried_on = segment(&carried_on, &grid, Some(&phrase), &config);
+
+    assert_eq!(
+        stopped.attempts[0].outcome,
+        AttemptOutcome::Collapsed { at_step: 2 }
+    );
+    assert_eq!(
+        carried_on.attempts[0].outcome,
+        AttemptOutcome::Diverged { at_step: 2 }
+    );
+}
+
+/// Silence past the abandon threshold closes the attempt where it stood, and
+/// what follows is judged on its own.
+#[test]
+fn silence_abandons_an_attempt_that_was_going_correctly() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let phrase = TargetPhrase::crotchets(&[0, 2, 4, 5, 7]);
+    let events = vec![
+        note_on(60, 0),
+        note_on(62, per_beat),
+        note_on(64, 2 * per_beat),
+        note_on(60, 12 * per_beat),
+        note_on(62, 13 * per_beat),
+    ];
+
+    let result = segment(&events, &grid, Some(&phrase), &SegmentConfig::default());
+
+    assert_eq!(result.attempts.len(), 2, "{:?}", result.attempts);
+    assert_eq!(
+        result.attempts[0].outcome,
+        AttemptOutcome::Abandoned { at_step: 3 }
+    );
+    assert_eq!(
+        result.attempts[1].outcome,
+        AttemptOutcome::Abandoned { at_step: 2 }
+    );
+    assert!(!result.attempts[0].timing_is_scorable());
+}
+
+/// Two notes an age apart are not a confirming run, however well they match.
+#[test]
+fn a_start_is_not_confirmed_across_a_long_silence() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let phrase = TargetPhrase::crotchets(&[0, 2, 4, 5]);
+    let events = vec![note_on(60, 0), note_on(62, 120 * per_beat)];
+
+    let result = segment(&events, &grid, Some(&phrase), &SegmentConfig::default());
+
+    assert!(result.attempts.is_empty(), "{:?}", result.attempts);
+    assert_eq!(
+        result
+            .unattributed
+            .iter()
+            .map(|span| span.len())
+            .sum::<usize>(),
+        2
+    );
+}
+
+/// The thresholds are ratios of the phrase's own step spacing, so a quaver
+/// phrase tolerates half the silence a crotchet phrase does. Nothing else in
+/// the suite exercises a non-crotchet spacing.
+#[test]
+fn thresholds_scale_with_the_phrases_own_note_density() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let quavers = TargetPhrase {
+        steps: [0u8, 2, 4, 5]
+            .iter()
+            .enumerate()
+            .map(|(index, class)| PhraseStep {
+                pitch_classes: vec![*class],
+                beat_offset_milli: index as i64 * 500,
+            })
+            .collect(),
+    };
+    assert_eq!(quavers.step_spacing_milli(), 500);
+
+    let gap_us = per_beat; // one beat: fine for crotchets, a pause for quavers
+    let events = vec![
+        note_on(60, 0),
+        note_on(62, per_beat / 2),
+        note_on(64, per_beat / 2 + gap_us),
+        note_on(65, per_beat + gap_us),
+    ];
+
+    let quaver_result = segment(&events, &grid, Some(&quavers), &SegmentConfig::default());
+    assert_eq!(quaver_result.attempts[0].pauses.len(), 1);
+
+    let crotchet_events: Vec<NoteEvent> = [0u8, 2, 4, 5]
+        .iter()
+        .enumerate()
+        .map(|(index, class)| note_on(60 + class, index as i64 * per_beat))
+        .collect();
+    let crotchet_result = segment(
+        &crotchet_events,
+        &grid,
+        Some(&TargetPhrase::crotchets(&[0, 2, 4, 5])),
+        &SegmentConfig::default(),
+    );
+    assert!(crotchet_result.attempts[0].pauses.is_empty());
+}
+
+/// An upbeat phrase is anchored by where its first note *should* have fallen,
+/// not by the note itself, or every offset in the attempt inherits the skew.
+#[test]
+fn an_upbeat_phrase_is_not_offset_by_its_own_first_step() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let phrase = TargetPhrase {
+        steps: [0u8, 2, 4, 5]
+            .iter()
+            .enumerate()
+            .map(|(index, class)| PhraseStep {
+                pitch_classes: vec![*class],
+                beat_offset_milli: 500 + index as i64 * 1000,
+            })
+            .collect(),
+    };
+    let events: Vec<NoteEvent> = [0u8, 2, 4, 5]
+        .iter()
+        .enumerate()
+        .map(|(index, class)| note_on(60 + class, per_beat / 2 + index as i64 * per_beat))
+        .collect();
+
+    let result = segment(&events, &grid, Some(&phrase), &SegmentConfig::default());
 
     let attempt = result
         .completed()
         .next()
-        .expect("the repeated-A passage completes an eight-crotchet target");
-    assert!(
-        attempt.timing.mean_offset_us < -5_000,
-        "expected a lay-back, got mean {}us",
-        attempt.timing.mean_offset_us
+        .expect("played exactly as written");
+    assert_eq!(attempt.timing.mean_offset_us, 0);
+    assert_eq!(attempt.timing.stddev_offset_us, 0);
+}
+
+#[test]
+fn degenerate_input_segments_without_panicking() {
+    let grid = ClickGrid::new(120_000, 4, 4);
+    let config = SegmentConfig::default();
+    let phrase = gate_phrase();
+    let empty_phrase = TargetPhrase { steps: Vec::new() };
+    let note_offs = vec![NoteEvent {
+        pitch: 53,
+        velocity: 0,
+        on: false,
+        t_us: 0,
+    }];
+    let unsorted = vec![note_on(60, 2_000_000), note_on(53, 0)];
+
+    assert!(segment(&[], &grid, Some(&phrase), &config)
+        .attempts
+        .is_empty());
+    assert!(segment(&note_offs, &grid, Some(&phrase), &config)
+        .onsets
+        .is_empty());
+    assert!(segment(&unsorted, &grid, Some(&empty_phrase), &config)
+        .attempts
+        .is_empty());
+    assert_eq!(
+        segment(&unsorted, &grid, Some(&phrase), &config).onsets[0].t_us,
+        0,
+        "clustering sorts by time"
     );
-    assert!(
-        attempt.timing.stddev_offset_us < attempt.timing.mean_offset_us.abs(),
-        "spread {}us should be smaller than the offset it sits around",
-        attempt.timing.stddev_offset_us
+    let stopped_clock = ClickGrid::new(0, 0, 0);
+    assert_eq!(
+        segment(&unsorted, &stopped_clock, Some(&phrase), &config)
+            .onsets
+            .len(),
+        2,
+        "a zero bpm grid must not overflow or panic"
     );
 }
 

--- a/crates/intrada-core/tests/engine_segmentation.rs
+++ b/crates/intrada-core/tests/engine_segmentation.rs
@@ -1,0 +1,296 @@
+//! Segmentation against the five real MIDI takes recorded in PR 2
+//! (`tests/fixtures/midi_takes/README.md`). Each take is a named case from
+//! `docs/rebuild-review.md` §6; the findings note
+//! (`docs/segmentation-findings.md`) is written from what these assert.
+
+mod midi_take;
+
+use intrada_core::engine::{
+    cluster_onsets, rest_spans, segment, AttemptOutcome, ClickGrid, NoteEvent, SegmentConfig,
+    TargetPhrase,
+};
+use midi_take::MidiTake;
+
+/// The gate drill phrase from the Swift spike: Dm7 shell then G7 shell,
+/// arpeggiated one crotchet per beat. F C F C, B F B F.
+fn gate_phrase() -> TargetPhrase {
+    TargetPhrase::crotchets(&[5, 0, 5, 0, 11, 5, 11, 5])
+}
+
+#[test]
+fn take_02_pause_mid_phrase_is_one_completed_attempt_with_a_pause() {
+    let take = MidiTake::load("take-02-paused-mid-phrase-bluetooth.jsonl");
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert_eq!(result.attempts.len(), 1, "{:?}", result.attempts);
+    let attempt = &result.attempts[0];
+    assert_eq!(attempt.outcome, AttemptOutcome::Completed);
+    assert_eq!(attempt.matched_steps, 8);
+    assert_eq!(attempt.pauses.len(), 1);
+    assert_eq!(attempt.pauses[0].after_step, 6);
+    assert!(attempt.pauses[0].gap_us > 1_800_000);
+    assert!(
+        !attempt.timing_is_scorable(),
+        "a paused attempt is complete but its phrase timing is not a scoring input"
+    );
+    assert!(result.unattributed.is_empty());
+}
+
+#[test]
+fn take_04_restart_is_an_abandoned_attempt_then_a_clean_one() {
+    let take = MidiTake::load("take-04-restart-bluetooth.jsonl");
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert_eq!(result.attempts.len(), 2, "{:?}", result.attempts);
+    assert_eq!(
+        result.attempts[0].outcome,
+        AttemptOutcome::Restarted { at_step: 6 }
+    );
+    assert_eq!(result.attempts[1].outcome, AttemptOutcome::Completed);
+    assert!(result.attempts[1].pauses.is_empty());
+    assert!(result.attempts[1].timing_is_scorable());
+    assert!(result.unattributed.is_empty());
+}
+
+/// Takes 02 and 04 open with the same six notes and pause for the same ~1.9s.
+/// Only what follows the silence separates them, which is the spike's headline
+/// finding: no gap threshold can tell a resume from a restart.
+#[test]
+fn takes_02_and_04_have_indistinguishable_pauses() {
+    let paused = MidiTake::load("take-02-paused-mid-phrase-bluetooth.jsonl");
+    let restarted = MidiTake::load("take-04-restart-bluetooth.jsonl");
+    let config = SegmentConfig::default();
+
+    let paused_gap = largest_gap_us(&paused.events, config.chord_window_us);
+    let restarted_gap = largest_gap_us(&restarted.events, config.chord_window_us);
+    assert!(
+        (paused_gap - restarted_gap).abs() < 100_000,
+        "gaps differ by {}us — the takes were meant to be timing-alike",
+        (paused_gap - restarted_gap).abs()
+    );
+
+    let phrase = gate_phrase();
+    assert_eq!(
+        segment(&paused.events, &paused.grid, Some(&phrase), &config)
+            .attempts
+            .len(),
+        1
+    );
+    assert_eq!(
+        segment(&restarted.events, &restarted.grid, Some(&phrase), &config)
+            .attempts
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn take_03_noodling_ends_the_attempt_and_is_left_unattributed() {
+    let take = MidiTake::load("take-03-noodle-after-start-bluetooth.jsonl");
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert_eq!(result.attempts.len(), 1, "{:?}", result.attempts);
+    let attempt = &result.attempts[0];
+    assert_eq!(attempt.outcome, AttemptOutcome::Diverged { at_step: 5 });
+    assert_eq!(attempt.matched_steps, 5);
+
+    let noodled: usize = result.unattributed.iter().map(|span| span.len()).sum();
+    assert!(
+        noodled > 15,
+        "the scale run should be rejected wholesale, got {noodled} onsets"
+    );
+    assert!(result.completed().count() == 0);
+}
+
+#[test]
+fn take_05_collapse_keeps_the_wrong_note_and_scores_nothing() {
+    let take = MidiTake::load("take-05-collapse-bluetooth.jsonl");
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert_eq!(result.attempts.len(), 1, "{:?}", result.attempts);
+    let attempt = &result.attempts[0];
+    assert_eq!(attempt.outcome, AttemptOutcome::Collapsed { at_step: 5 });
+    assert_eq!(attempt.deviation_onsets.len(), 1);
+    assert!(!attempt.timing_is_scorable());
+}
+
+#[test]
+fn take_01_freeplay_yields_no_attempts_without_a_target() {
+    let take = MidiTake::load("take-01-freeplay-mixed-bluetooth.jsonl");
+    let config = SegmentConfig::default();
+    let result = segment(&take.events, &take.grid, None, &config);
+
+    assert!(result.attempts.is_empty());
+    assert_eq!(result.unattributed.len(), 1);
+    assert_eq!(result.unattributed[0].len(), result.onsets.len());
+
+    let spans = rest_spans(&result.onsets, take.grid.beats_milli_to_us(1_750));
+    assert!(
+        spans.len() > 1,
+        "freeplay should still split into rest-separated spans for off-piste logging"
+    );
+}
+
+/// The same freeplay take against a phrase the player never attempted.
+/// Prescribing a phrase does not conjure attempts out of noodling — and this is
+/// the case that caught both false-positive sources: a lone matching note
+/// opening an attempt, and a wide voicing satisfying a single-note step.
+#[test]
+fn take_01_freeplay_yields_no_attempts_against_the_gate_phrase() {
+    let take = MidiTake::load("take-01-freeplay-mixed-bluetooth.jsonl");
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert!(result.attempts.is_empty(), "{:?}", result.attempts);
+    assert_eq!(result.unattributed[0].len(), result.onsets.len());
+}
+
+#[test]
+fn a_voicing_never_satisfies_a_single_note_step_but_an_octave_does() {
+    let phrase = TargetPhrase::crotchets(&[5]);
+    let single = cluster_onsets(&[note_on(53, 0)], 50_000);
+    let octaves = cluster_onsets(&[note_on(53, 0), note_on(65, 10_000)], 50_000);
+    let voicing = cluster_onsets(&[note_on(53, 0), note_on(60, 10_000)], 50_000);
+
+    assert!(phrase.matches(0, &single[0]));
+    assert!(phrase.matches(0, &octaves[0]));
+    assert!(!phrase.matches(0, &voicing[0]));
+}
+
+#[test]
+fn chord_voicings_collapse_into_single_onsets() {
+    let take = MidiTake::load("take-01-freeplay-mixed-bluetooth.jsonl");
+    let note_ons = take.events.iter().filter(|e| e.on).count();
+    let onsets = cluster_onsets(&take.events, 50_000);
+
+    assert!(
+        onsets.len() < note_ons,
+        "the take's rolled voicings should collapse"
+    );
+    let widest = onsets.iter().map(|o| o.pitches.len()).max().unwrap_or(0);
+    assert!(widest >= 5, "five-note voicings are present, got {widest}");
+}
+
+/// No real take contains count-in playing — the Swift recorder anchors bar 1
+/// beat 1 after the count-in, and Jon waited. Synthetic, and flagged as such
+/// in the findings note.
+#[test]
+fn count_in_playing_is_excluded_from_attempts() {
+    let grid = ClickGrid::new(92_000, 4, 4);
+    let per_beat = grid.us_per_beat();
+    let mut events = vec![
+        note_on(60, -3 * per_beat),
+        note_on(62, -2 * per_beat),
+        note_on(64, -per_beat),
+    ];
+    for (step, class) in [5u8, 0, 5, 0, 11, 5, 11, 5].iter().enumerate() {
+        events.push(note_on(48 + class, step as i64 * per_beat));
+    }
+
+    let result = segment(
+        &events,
+        &grid,
+        Some(&gate_phrase()),
+        &SegmentConfig::default(),
+    );
+
+    assert_eq!(result.count_in.len(), 3);
+    assert_eq!(result.attempts.len(), 1);
+    assert_eq!(result.attempts[0].outcome, AttemptOutcome::Completed);
+    assert_eq!(result.attempts[0].span.start, 3);
+}
+
+/// Both real takes that anticipate beat 1 do so by tens of milliseconds. That
+/// note belongs to the attempt, not the count-in — and it needs a signed
+/// timestamp to exist at all.
+#[test]
+fn a_note_anticipating_beat_one_belongs_to_the_attempt() {
+    for name in [
+        "take-01-freeplay-mixed-bluetooth.jsonl",
+        "take-03-noodle-after-start-bluetooth.jsonl",
+    ] {
+        let take = MidiTake::load(name);
+        assert!(
+            take.events.iter().any(|e| e.on && e.t_us < 0),
+            "{name} was recorded with a note before the anchor"
+        );
+        let result = segment(
+            &take.events,
+            &take.grid,
+            Some(&gate_phrase()),
+            &SegmentConfig::default(),
+        );
+        assert!(result.count_in.is_empty(), "{name}");
+    }
+}
+
+/// Design decision 6: a stable offset is feel, spread is the error. The steady
+/// on-the-beat passage in take 01 lays back consistently.
+#[test]
+fn steady_playing_reads_as_consistent_lay_back_not_error() {
+    let take = MidiTake::load("take-01-freeplay-mixed-bluetooth.jsonl");
+    let phrase = TargetPhrase::crotchets(&[9, 9, 9, 9, 9, 9, 9, 9]);
+    let result = segment(
+        &take.events,
+        &take.grid,
+        Some(&phrase),
+        &SegmentConfig::default(),
+    );
+
+    let attempt = result
+        .completed()
+        .next()
+        .expect("the repeated-A passage completes an eight-crotchet target");
+    assert!(
+        attempt.timing.mean_offset_us < -5_000,
+        "expected a lay-back, got mean {}us",
+        attempt.timing.mean_offset_us
+    );
+    assert!(
+        attempt.timing.stddev_offset_us < attempt.timing.mean_offset_us.abs(),
+        "spread {}us should be smaller than the offset it sits around",
+        attempt.timing.stddev_offset_us
+    );
+}
+
+fn note_on(pitch: u8, t_us: i64) -> NoteEvent {
+    NoteEvent {
+        pitch,
+        velocity: 64,
+        on: true,
+        t_us,
+    }
+}
+
+fn largest_gap_us(events: &[NoteEvent], chord_window_us: i64) -> i64 {
+    let onsets = cluster_onsets(events, chord_window_us);
+    onsets
+        .windows(2)
+        .map(|pair| pair[1].t_us - pair[0].t_us)
+        .max()
+        .unwrap_or(0)
+}

--- a/crates/intrada-core/tests/midi_take/mod.rs
+++ b/crates/intrada-core/tests/midi_take/mod.rs
@@ -1,0 +1,74 @@
+//! Loads a PR 2 capture JSONL into engine types. Host-time ticks are converted
+//! to microseconds from the click anchor using the take's own mach timebase.
+
+use intrada_core::engine::{ClickGrid, NoteEvent};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Header {
+    bpm: f64,
+    beats_per_bar: u8,
+    count_in_beats: u8,
+    start_host_time: u64,
+    host_timebase_numer: u64,
+    host_timebase_denom: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Line {
+    #[serde(rename = "type")]
+    kind: String,
+    host_time: Option<u64>,
+    midi_note: Option<u8>,
+    velocity: Option<u8>,
+    is_note_on: Option<bool>,
+}
+
+pub struct MidiTake {
+    pub grid: ClickGrid,
+    pub events: Vec<NoteEvent>,
+}
+
+impl MidiTake {
+    pub fn load(name: &str) -> Self {
+        let path = format!(
+            "{}/tests/fixtures/midi_takes/{name}",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        let mut lines = raw.lines().filter(|line| !line.trim().is_empty());
+
+        let header: Header = serde_json::from_str(lines.next().expect("take header line"))
+            .expect("take header parses");
+        let grid = ClickGrid::new(
+            (header.bpm * 1000.0).round() as u32,
+            header.beats_per_bar,
+            header.count_in_beats,
+        );
+
+        let events = lines
+            .map(|line| serde_json::from_str::<Line>(line).expect("note line parses"))
+            .filter(|line| line.kind == "note")
+            .map(|line| NoteEvent {
+                pitch: line.midi_note.expect("note line has midiNote"),
+                velocity: line.velocity.expect("note line has velocity"),
+                on: line.is_note_on.expect("note line has isNoteOn"),
+                t_us: ticks_to_us(
+                    line.host_time.expect("note line has hostTime"),
+                    header.start_host_time,
+                    header.host_timebase_numer,
+                    header.host_timebase_denom,
+                ),
+            })
+            .collect();
+
+        Self { grid, events }
+    }
+}
+
+fn ticks_to_us(host_time: u64, anchor: u64, numer: u64, denom: u64) -> i64 {
+    let delta = host_time as i128 - anchor as i128;
+    (delta * numer as i128 / denom as i128 / 1_000) as i64
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,7 +56,7 @@ coach work** — this is.
 | Phase | What lands | State |
 |---|---|---|
 | **0 · Paper teacher** | Content authored (`content/`); the fortnight of practice + four logs | Content done; fortnight outstanding (#1143) |
-| **1 · The listening gate** | Capture harness + click → segmentation spike → lick-transposition scoring → one drill screen | PR 2 merged (jonyardley/intrada#1157) — capture harness, click, gate drill. USB-vs-Bluetooth timing numbers held open-ended pending a USB cable (#1156, not a blocker). Next: PR 3, attempt segmentation |
+| **1 · The listening gate** | Capture harness + click → segmentation spike → lick-transposition scoring → one drill screen | PR 2 merged (jonyardley/intrada#1157) — capture harness, click, gate drill. USB-vs-Bluetooth timing numbers held open-ended pending a USB cable (#1156, not a blocker). PR 3 done — the `engine` module segments all five real takes; findings in [`segmentation-findings.md`](segmentation-findings.md), which is the spec input for the scoring gate. Next: lick-transposition scoring |
 | **2a · Prescribe and run** | Planner as a pure function, press-start, gated blocks, stuck ladder, soft-landing exit, builder deleted | Needs the mastery function specified first (#1148) |
 | **2b · Steer and guard** | Declaration surfaces (goal / campaign / steer), back-chaining, gap read, circling check, grind trade, off-piano queue, unmonitored play, circle tally, the judgement track | After 2a |
 | **3 · The voice** | LLM behind Axum: summaries, whys, stuck coaching, goal interpretation | Deliberately late |

--- a/docs/segmentation-findings.md
+++ b/docs/segmentation-findings.md
@@ -1,0 +1,168 @@
+# Attempt segmentation: what timing can and cannot decide
+
+> Findings from the PR 3 spike (`docs/rebuild-review.md` §6). Code:
+> `crates/intrada-core/src/engine/`. Evidence: the five real MIDI takes in
+> `crates/intrada-core/tests/fixtures/midi_takes/`, recorded on a Roland LX-706
+> over Bluetooth MIDI at 92 bpm. Tests: `tests/engine_segmentation.rs`.
+> Written 4 Aug 2026. This note is the spec input for the scoring gate.
+
+## Verdict
+
+Segmentation works, and it works on **content plus timing, never timing alone**.
+Every one of the five takes segments correctly. Two of the five cannot be
+segmented at all without the target phrase, and one of those two —
+resume-versus-restart — is not merely hard from timing but *provably
+undecidable*, because the two cases are timing-identical by construction.
+
+So the spike passes, with a condition attached: **an attempt is defined by what
+it was an attempt at.** Segmentation is not a preprocessing step that hands
+tidy attempts to a scorer; it is already scoring, and it must be given the
+prescribed phrase as an input. Design decision 2 (click-always) is necessary
+but not sufficient — a shared clock gives bar/beat alignment, not attempt
+boundaries.
+
+## What timing alone decides
+
+| Decision | Signal | Evidence |
+|---|---|---|
+| Bar/beat of a note | grid arithmetic from the click anchor | all takes |
+| Chord vs melody | onsets within a 50ms window are one event | take 01: 5-note voicings spread ≤34ms |
+| Silence long enough to matter | gap > 1.75× the phrase's step spacing | takes 02, 04: ~1.93s gaps against a 652ms step |
+| Consistent feel vs erratic time | mean offset vs spread over an attempt | take 04's clean rep: mean −24ms, spread 17ms |
+| Phrase-ish grouping with no target | rest-separated spans | take 01 splits into 4 spans |
+
+The feel-vs-error split is the one that matters most for scoring, and it holds
+on real Bluetooth data: take 04's clean repetition sits at a mean −24ms with a
+17ms spread. Design decision 6 is measurable — a stable lay-back reads as
+stable, not as eight late notes.
+
+## What timing alone cannot decide
+
+**1. Resume versus restart. Undecidable.** Takes 02 and 04 open with the same
+six correct notes and pause for the same length (1.930s and 1.980s — 50ms
+apart, less than one BLE jitter window). Take 02 then plays notes 7–8; take 04
+goes back to note 1. No gap threshold, at any tolerance, separates them. Only
+the pitch content after the silence does.
+
+Worse, content sometimes does not either. The gate phrase is F C F C **B F** B
+F: pause after note 5 (B) and the next expected note is F — which is also note
+1. Resuming and restarting produce an identical note at an identical time. The
+engine resolves this by looking ahead and taking whichever reading matches more
+of the phrase (`prefers_restart`), which is a heuristic on *later* content, not
+a decision at the boundary. **Consequence for the gate:** a restart must not be
+inferred in real time. Either the attempt window is closed by the click (fixed
+rep length, the Swift gate drill's approach) or the verdict lags until enough
+following content arrives.
+
+**2. Where an attempt starts.** One matching note is not an attempt. Take 03's
+scale run crosses the phrase's first note four times, and each crossing opened
+a spurious one-step attempt until starts required a confirming run of 2 matched
+steps. **Consequence:** an attempt that fails on its second note is
+indistinguishable from noodling and will not be recorded as an attempt at all.
+For a mastery model fed by pass/fail evidence this is a *bias*, not just a gap:
+the worst attempts are silently dropped, so the failure rate is understated.
+Either the gate opens attempts on the click rather than on content, or
+attempts-to-pass instrumentation (design challenge 4) is measuring a filtered
+population.
+
+**3. Collapse versus walking away.** Take 05 plays five notes, hits E instead
+of F, and stops. The engine calls it `Collapsed` only because the wrong note
+came first; an attempt that simply stops mid-phrase is `Abandoned`. Neither
+distinguishes "gave up" from "the doorbell rang". Timing cannot supply intent,
+and the app should not guess: an abandoned attempt is not evidence of failure
+and must not feed the mastery update.
+
+**4. Whether noodling was an attempt.** Take 01 is 101 notes of unstructured
+playing. Against no target it yields no attempts, correctly. Against the gate
+phrase it also yields none — but only after two false-positive sources were
+closed (see below). The general problem is unsolved: free playing that happens
+to contain the phrase's notes is not an attempt at the phrase, and only
+intention distinguishes them. This is design decision 3 (deploy-gates are
+self-confirmed) arriving early, at the segmentation layer.
+
+**5. Timing of a paused attempt.** Take 02 completes all eight notes, so it is
+`Completed` — and its phrase timing is arithmetic about a phrase that was never
+played continuously (mean +324ms, spread 557ms). The two post-pause notes are
+in fact dead on the click, three beats late relative to the phrase. Both facts
+are true; neither is a score. `Attempt::timing_is_scorable()` gates on
+`Completed && pauses.is_empty()` for exactly this reason. **A pause is a
+fluency failure, and it must be detected before any timing verdict is
+computed, not after.**
+
+## Two false positives worth remembering
+
+Both were found by running the freeplay take against a phrase it never
+attempted — the case with no expected answer, which is why it is the most
+useful fixture in the set.
+
+- **Pitch-class matching is too permissive with chords.** Octave tolerance was
+  implemented as "the onset contains this pitch class", and a five-note
+  freeplay voicing satisfied **7 of the 8** gate-phrase steps. Fixed by
+  matching pitch-class *width* exactly: a one-note step needs a one-class
+  onset, so octave doublings still pass and voicings do not.
+- **Single-note attempt starts.** As above: four spurious attempts inside one
+  scale run.
+
+Both would have shipped as "gate passes on noodling" bugs in a UI, and neither
+is visible in a clean take. Fixture value is inversely proportional to
+tidiness.
+
+## Thresholds, and why none of them are milliseconds
+
+Every time-shaped threshold is a ratio of **the target phrase's own step
+spacing**, not of a grid beat and not an absolute duration
+(`SegmentConfig`). The gate phrase is crotchets, so its step spacing is one
+beat; take 03's noodle runs at half that. A pause threshold in beats would
+misread a quaver phrase, and one in milliseconds would misread every tempo but
+92.
+
+| Threshold | Default | Basis |
+|---|---|---|
+| `chord_window_us` | 50ms | measured 34ms max spread on real rolled voicings |
+| `pause_ratio_milli` | 1.75× step spacing | separates 1.93s pauses from 652ms crotchets |
+| `abandon_ratio_milli` | 4× step spacing | untested by the fixtures — provisional |
+| `max_consecutive_deviations` | 2 | take 03 diverges for good after 2 |
+| `min_start_run_steps` | 2 | minimum that kills take 03's false starts |
+
+The 50ms chord window is the one that will break first. At 200 bpm a
+semiquaver is 75ms, so a 50ms window is a third of the subdivision it must
+resolve — chord clustering and fast subdivisions collide, and the window will
+have to scale with the phrase's step spacing like everything else. It does not
+yet.
+
+## Corrections to the engine spec's FFI contract
+
+`specs/intrada-coach-engine.md` §6 needs two amendments before it is built:
+
+1. **`t_us` must be signed (`i64`, not `u64`).** Two of the five real takes
+   open with a note *before* the click anchor (−22ms and −47ms), anticipating
+   beat 1. A `u64` cannot represent them, and clamping to zero silently
+   destroys the early-note case — the exact thing timing feedback exists to
+   measure.
+2. **Count-in is beats, not bars.** The capture harness records
+   `countInBeats`; a 2-beat count-in is ordinary. `ClickGrid.count_in_bars: u8`
+   should be `count_in_beats: u8`.
+
+Also worth stating in the spec: **count-in playing is untested against real
+data.** All five takes have Jon waiting through the count-in, so the count-in
+exclusion path is covered by a synthetic stream only. It needs one real take of
+someone playing over their own count-in.
+
+## What the scoring gate should therefore assume
+
+1. Segmentation takes the prescribed phrase as an input. There is no
+   target-free attempt detection.
+2. Attempt boundaries come from the click, not from content, wherever the drill
+   allows it. Content-derived boundaries are a fallback with known bias.
+3. Only `Completed && pauses.is_empty()` attempts produce a timing verdict.
+   Pauses, restarts, collapses and abandons are *outcomes*, reported as
+   outcomes.
+4. Abandoned attempts are excluded from the mastery update, not counted as
+   failures.
+5. Attempts that die before `min_start_run_steps` are invisible. Until
+   boundaries come from the click, the observed failure rate is understated and
+   the calibration instrument in design challenge 4 knows it.
+6. Timing consistency (mean and spread) is reportable on Bluetooth; per-note
+   verdicts are not, which is design decision 7 already established and now
+   confirmed against 17–27ms measured spreads on clean repetitions — the same
+   order as BLE's own jitter.

--- a/docs/segmentation-findings.md
+++ b/docs/segmentation-findings.md
@@ -28,21 +28,24 @@ boundaries.
 | Bar/beat of a note | grid arithmetic from the click anchor | all takes |
 | Chord vs melody | onsets within a 50ms window are one event | take 01: 5-note voicings spread ≤34ms |
 | Silence long enough to matter | gap > 1.75× the phrase's step spacing | takes 02, 04: ~1.93s gaps against a 652ms step |
-| Consistent feel vs erratic time | mean offset vs spread over an attempt | take 04's clean rep: mean −24ms, spread 17ms |
+| Consistent feel vs erratic time | mean offset vs spread over an attempt | take 04's clean rep: mean −24ms (ahead of the click), spread 17ms |
 | Phrase-ish grouping with no target | rest-separated spans | take 01 splits into 4 spans |
 
 The feel-vs-error split is the one that matters most for scoring, and it holds
 on real Bluetooth data: take 04's clean repetition sits at a mean −24ms with a
-17ms spread. Design decision 6 is measurable — a stable lay-back reads as
-stable, not as eight late notes.
+17ms spread. Offsets are signed `onset − expected`, so that rep is consistently
+**ahead** of the click, not laying back. Design decision 6 is measurable either
+way — a stable displacement reads as stable, not as eight badly-timed notes —
+but the sign has to reach the user's screen the right way round: reporting a
+push as a lay-back is precisely the never-bluff failure.
 
 ## What timing alone cannot decide
 
 **1. Resume versus restart. Undecidable.** Takes 02 and 04 open with the same
 six correct notes and pause for the same length (1.930s and 1.980s — 50ms
-apart, less than one BLE jitter window). Take 02 then plays notes 7–8; take 04
-goes back to note 1. No gap threshold, at any tolerance, separates them. Only
-the pitch content after the silence does.
+apart, under a tenth of the 652ms crotchet the silence interrupts). Take 02
+then plays notes 7–8; take 04 goes back to note 1. No gap threshold, at any
+tolerance, separates them. Only the pitch content after the silence does.
 
 Worse, content sometimes does not either. The gate phrase is F C F C **B F** B
 F: pause after note 5 (B) and the next expected note is F — which is also note
@@ -55,7 +58,7 @@ rep length, the Swift gate drill's approach) or the verdict lags until enough
 following content arrives.
 
 **2. Where an attempt starts.** One matching note is not an attempt. Take 03's
-scale run crosses the phrase's first note four times, and each crossing opened
+scale run crosses the phrase's first note five times, and each crossing opened
 a spurious one-step attempt until starts required a confirming run of 2 matched
 steps. **Consequence:** an attempt that fails on its second note is
 indistinguishable from noodling and will not be recorded as an attempt at all.
@@ -66,11 +69,12 @@ attempts-to-pass instrumentation (design challenge 4) is measuring a filtered
 population.
 
 **3. Collapse versus walking away.** Take 05 plays five notes, hits E instead
-of F, and stops. The engine calls it `Collapsed` only because the wrong note
-came first; an attempt that simply stops mid-phrase is `Abandoned`. Neither
-distinguishes "gave up" from "the doorbell rang". Timing cannot supply intent,
-and the app should not guess: an abandoned attempt is not evidence of failure
-and must not feed the mastery update.
+of F, and stops. `Collapsed` versus `Diverged` is decided by whether playing
+*continued* after the wrong note, and `Abandoned` covers stopping while still
+on track — so the outcomes describe what followed, which is the only thing
+observable. None of them distinguishes "gave up" from "the doorbell rang".
+Timing cannot supply intent, and the app should not guess: an abandoned attempt
+is not evidence of failure and must not feed the mastery update.
 
 **4. Whether noodling was an attempt.** Take 01 is 101 notes of unstructured
 playing. Against no target it yields no attempts, correctly. Against the gate
@@ -83,8 +87,8 @@ self-confirmed) arriving early, at the segmentation layer.
 **5. Timing of a paused attempt.** Take 02 completes all eight notes, so it is
 `Completed` — and its phrase timing is arithmetic about a phrase that was never
 played continuously (mean +324ms, spread 557ms). The two post-pause notes are
-in fact dead on the click, three beats late relative to the phrase. Both facts
-are true; neither is a score. `Attempt::timing_is_scorable()` gates on
+in fact dead on the click, two beats late relative to the phrase (the silence
+itself runs to 2.96 beats). Both facts are true; neither is a score. `Attempt::timing_is_scorable()` gates on
 `Completed && pauses.is_empty()` for exactly this reason. **A pause is a
 fluency failure, and it must be detected before any timing verdict is
 computed, not after.**
@@ -96,11 +100,15 @@ attempted — the case with no expected answer, which is why it is the most
 useful fixture in the set.
 
 - **Pitch-class matching is too permissive with chords.** Octave tolerance was
-  implemented as "the onset contains this pitch class", and a five-note
-  freeplay voicing satisfied **7 of the 8** gate-phrase steps. Fixed by
-  matching pitch-class *width* exactly: a one-note step needs a one-class
-  onset, so octave doublings still pass and voicings do not.
-- **Single-note attempt starts.** As above: four spurious attempts inside one
+  implemented as "the onset contains this pitch class", which a wide voicing
+  satisfies almost by accident: the gate phrase asks only for F, C or B, and
+  each of take 01's five-note voicings contains enough of them to satisfy
+  between 4 and all 8 of its steps. A run of **seven consecutive** unrelated
+  voicings therefore carried an attempt to seven matched steps before it
+  abandoned. Fixed by matching pitch-class *width* exactly: a one-note step
+  needs a one-class onset, so octave doublings still pass and voicings do
+  not.
+- **Single-note attempt starts.** As above: five spurious attempts inside one
   scale run.
 
 Both would have shipped as "gate passes on noodling" bugs in a UI, and neither
@@ -120,7 +128,7 @@ misread a quaver phrase, and one in milliseconds would misread every tempo but
 |---|---|---|
 | `chord_window_us` | 50ms | measured 34ms max spread on real rolled voicings |
 | `pause_ratio_milli` | 1.75× step spacing | separates 1.93s pauses from 652ms crotchets |
-| `abandon_ratio_milli` | 4× step spacing | untested by the fixtures — provisional |
+| `abandon_ratio_milli` | 4× step spacing | no fixture reaches it — synthetic test only, provisional |
 | `max_consecutive_deviations` | 2 | take 03 diverges for good after 2 |
 | `min_start_run_steps` | 2 | minimum that kills take 03's false starts |
 
@@ -143,6 +151,11 @@ yet.
    `countInBeats`; a 2-beat count-in is ordinary. `ClickGrid.count_in_bars: u8`
    should be `count_in_beats: u8`.
 
+A third point is forward-looking rather than a correction: `Attempt.span` and
+`Segmentation.count_in` are `Range<usize>`, which will not survive facet
+typegen. Whatever crosses the bridge carries plain start/len integers, and the
+`Range` stays core-side.
+
 Also worth stating in the spec: **count-in playing is untested against real
 data.** All five takes have Jon waiting through the count-in, so the count-in
 exclusion path is covered by a synthetic stream only. It needs one real take of
@@ -164,5 +177,7 @@ someone playing over their own count-in.
    the calibration instrument in design challenge 4 knows it.
 6. Timing consistency (mean and spread) is reportable on Bluetooth; per-note
    verdicts are not, which is design decision 7 already established and now
-   confirmed against 17–27ms measured spreads on clean repetitions — the same
-   order as BLE's own jitter.
+   confirmed against a 17ms spread on the one clean repetition in the set (23ms
+   and 27ms on the diverged and collapsed attempts) — the same order as BLE's
+   own ±10–20ms jitter, which is exactly why the spread is reportable and a
+   single note's offset is not.

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -287,15 +287,20 @@ rebuilds the whole `ViewModel`, so per-note crossing is architecture abuse at
 playing speed. The entire engine bridge surface, and it does not grow:
 
 ```rust
-struct NoteEvent { pitch: u8, velocity: u8, on: bool, t_us: u64 }  // from the click anchor
+struct NoteEvent { pitch: u8, velocity: u8, on: bool, t_us: i64 }  // from the click anchor
 struct NoteBatch { session: Ulid, seq: u32, anchor_us: u64,
                    events: Vec<NoteEvent>, transport: TransportTier }
-struct ClickGrid { bpm_milli: u32, beats_per_bar: u8, count_in_bars: u8,
+struct ClickGrid { bpm_milli: u32, beats_per_bar: u8, count_in_beats: u8,
                    click_level: ClickLevel, anchor_us: u64 }
 enum  CoachOperation { ScheduleClick(ClickGrid), StopClick, StartCapture, StopCapture }
 enum  EngineEvent    { NotesCaptured(NoteBatch), … }   // one ingest event
 struct CoachView     { … }                             // one ViewModel field
 ```
+
+Two of those signatures were corrected by the PR 3 segmentation spike
+(`docs/segmentation-findings.md`): `t_us` is **signed**, because two of five
+real takes open with a note before the click anchor, and the count-in is
+counted in **beats**, which is what the capture harness records.
 
 Rules, from the #846 bincode hazard and review §3.2:
 


### PR DESCRIPTION
The named spike from [`docs/rebuild-review.md`](docs/rebuild-review.md) §6: can we
segment real playing into attempts? **Yes — but only with the prescribed phrase as
an input.** Timing alone cannot do it, and one case is provably undecidable from
timing.

Pure Rust. A new `engine` module in `intrada-core` with no `Model` dependency, no
`Effect`, and no FFI surface. Nothing in the shipping app changes.

## What's here

- `ClickGrid` (integer microseconds from the anchor, beats in thousandths),
  `NoteEvent`, chord clustering into `Onset`s, `TargetPhrase` with pitch-class
  matching, and a segmentation state machine producing `Attempt`s.
- Outcomes: `Completed` / `Restarted` / `Collapsed` / `Diverged` / `Abandoned`,
  plus per-attempt pauses and timing stats (mean = feel, spread = error, per
  design decision 6 — neither graded here).
- All five real MIDI takes from PR 2 segment correctly. 19 tests.
- [`docs/segmentation-findings.md`](docs/segmentation-findings.md) — the actual
  deliverable, and the spec input for the scoring gate.

## The findings, in one paragraph

Takes 02 and 04 open with the same six correct notes and pause for the same ~1.9s
(50ms apart). One resumes, one restarts. **No gap threshold separates them**, and
where the phrase repeats a pitch class even the content is ambiguous — so a
restart must never be inferred in real time. Attempt starts need a confirming run
of matched steps, which means an attempt that fails on its second note is
invisible: the observed failure rate is understated, which matters for the
calibration instrument in design challenge 4. A paused attempt completes but its
timing is meaningless. An abandoned attempt is not evidence of failure. The
recommendation to the scoring gate is to take attempt boundaries from the click
wherever the drill allows, and treat content-derived boundaries as a fallback
with known bias.

## Spec corrections

`specs/intrada-coach-engine.md` §6's FFI contract had two wrong signatures,
amended here: `t_us` must be **signed** (two of five real takes open with a note
*before* the click anchor, anticipating beat 1), and the count-in is counted in
**beats**, not bars, which is what the capture harness records.

## Self-review

Ran as part of `ship`; findings and fixes are in the review comment below. The
second commit is entirely review fixes — four real defects, each with a
regression test.

Coverage: full for the new module — every public function is exercised by the
fixture tests plus synthetic cases for the paths no real take reaches (count-in
playing, the abandon threshold, quaver spacing, upbeat phrases, degenerate
input). The docs and spec changes are not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)