### PR TITLE
design(coach): recover the July wireframe bundle + project sync log

### DIFF
--- a/design/github.md
+++ b/design/github.md
@@ -1,0 +1,18 @@
+repo: jonyardley/intrada
+branch: main
+path: design/, specs/intrada-practice-coach-design.md
+
+## Last sync
+date: 2026-08-04T07:00:03Z
+
+### Updated in this project
+- Rebuilt `Drill Loop.dc.html` A2/A3 around spec v7 / decision 18 (machine listening deferred): A3 now uses the tap-verdict pattern (wide primary "Yes — clean" / ghost secondary "No — missed it") instead of the old pass/miss/unsure/gate-open machine-scored states.
+- Dropped the "unsure — app isn't sure" A3 variant entirely (no machine confidence exists to be uncertain about).
+- Added the "no microphone yet" dashed note to A2 (phone default, AX5, iPad).
+- Resolved the RepCounter/GateDots collision: GateDots is now user-tapped (fills on tap-verdict), same mechanism as RepCounter — no more collision. Gate counting is cumulative, not consecutive, per decision 17's self-correction argument.
+
+## Screen map
+| Project screen | Repo source |
+|---|---|
+| Drill Loop.dc.html — A2/A3 | design/briefs/2026-08-coach-drill-loop.md, specs/intrada-practice-coach-design.md (v7, decisions 18–19) |
+| Intrada Design System.dc.html | design/intrada-design-system.dc.html, ios/Intrada/DesignSystem/Theme.swift |

--- a/design/practice-coach-wireframes/Practice Coach Wireframes.dc.html
+++ b/design/practice-coach-wireframes/Practice Coach Wireframes.dc.html
@@ -1,0 +1,553 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics>
+<meta name="design_doc_mode" content="canvas">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@500;600&family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&display=swap" rel="stylesheet">
+<style>
+*{box-sizing:border-box}
+body{margin:0;background:#EFEBE0;font-family:'Inter',system-ui,sans-serif}
+a{color:#4C3FA6}a:hover{color:#372c7d}
+.dv-turn{padding:40px 44px 32px;border-bottom:1px solid rgba(43,42,38,.12);scroll-margin-top:16px}
+.dv-thd{display:flex;align-items:baseline;gap:10px;margin:0 0 20px}
+.dv-tid{font:600 10px ui-monospace,Menlo,monospace;padding:3px 7px;background:#2B2A26;color:#fff;border-radius:4px;text-decoration:none}
+.dv-tname{font:600 13px/1.2 'Inter',system-ui,sans-serif;color:#2B2A26}
+.dv-opts{display:flex;flex-wrap:wrap;gap:28px;align-items:flex-start}
+.dv-opt{flex:none;display:flex;flex-direction:column;gap:9px;scroll-margin-top:16px}
+.dv-oid{font:600 10.5px ui-monospace,Menlo,monospace;padding:3px 7px;background:rgba(43,42,38,.1);color:#2B2A26;border-radius:5px;text-decoration:none}
+.dv-olabel{display:flex;align-items:baseline;gap:8px;font:400 11px/1.3 'Inter',system-ui,sans-serif;color:rgba(43,42,38,.6)}
+.dv-card{max-width:100%;background:#FBFAF3;border:1px solid rgba(43,42,38,.12);border-radius:8px;box-shadow:0 1px 3px rgba(43,42,38,.07);overflow:hidden}
+.dv-opt:target .dv-oid{background:#4C3FA6;color:#fff}
+.dv-next{margin:22px 0 0;font:12px/1.5 'Inter',system-ui,sans-serif;color:rgba(43,42,38,.55)}
+.wf-row{display:flex;flex-wrap:wrap;gap:26px;padding:26px}
+.wf-fr{flex:none;display:flex;flex-direction:column;gap:8px;width:300px}
+.wf-ph{width:300px;height:600px;border:2px solid #2B2A26;border-radius:20px;background:#FBFAF3;padding:15px 14px;display:flex;flex-direction:column;gap:11px;overflow:hidden;position:relative}
+.wf-ph.sm{width:262px;height:500px}
+.wf-fr.sm{width:262px}
+.wf-cap{font:500 15px/1.25 'Caveat',cursive;color:#5C5646}
+.wf-cap b{font-weight:600;color:#2B2A26}
+.wf-n{display:inline-flex;align-items:center;justify-content:center;width:19px;height:19px;border:1.5px solid #2B2A26;border-radius:50%;font:600 10px 'Inter',sans-serif;color:#2B2A26;flex:none}
+.wf-lbl{font:600 8.5px 'Inter',sans-serif;letter-spacing:1.1px;text-transform:uppercase;color:#9A927F}
+.wf-h{font:400 24px/1.15 'Source Serif 4',serif;color:#2B2A26}
+.wf-h2{font:400 18px/1.2 'Source Serif 4',serif;color:#2B2A26}
+.wf-t{font:400 12px/1.5 'Inter',sans-serif;color:#5C5646}
+.wf-ts{font:400 10.5px/1.45 'Inter',sans-serif;color:#9A927F}
+.wf-box{border:1.5px dashed #C4BCA6;border-radius:9px;background:rgba(43,42,38,.02)}
+.wf-solid{border:1.5px solid #2B2A26;border-radius:9px;background:#fff}
+.wf-btn{border:1.5px solid #2B2A26;border-radius:10px;background:#2B2A26;color:#FBFAF3;font:600 12.5px 'Inter',sans-serif;padding:12px;text-align:center}
+.wf-btn.ghost{background:transparent;color:#2B2A26}
+.wf-chip{display:inline-flex;align-items:center;gap:4px;border:1px solid #C4BCA6;border-radius:999px;padding:3px 8px;font:500 9.5px 'Inter',sans-serif;color:#7A7360;background:#fff}
+.wf-tick{font:400 22px/1 'Inter',sans-serif}
+.wf-note{font:500 13px/1.3 'Caveat',cursive;color:#8A6A1F}
+.wf-bar{height:6px;border-radius:999px;background:#E2DCCB;overflow:hidden}
+.wf-bar i{display:block;height:100%;background:#2B2A26;border-radius:999px}
+.wf-top{display:flex;align-items:center;justify-content:space-between}
+.wf-sheet{position:absolute;left:0;right:0;bottom:0;background:#FBFAF3;border-top:2px solid #2B2A26;border-radius:18px 18px 0 0;padding:16px 14px;display:flex;flex-direction:column;gap:10px}
+</style>
+</helmet>
+
+<section class="dv-turn" id="t1">
+<div class="dv-thd"><a class="dv-tid" href="#t1">1</a><span class="dv-tname">Practice Coach — first wireframes (Strasbourg / St. Denis, 20 min)</span></div>
+<div class="dv-opts">
+
+<div class="dv-opt" id="1a">
+<div class="dv-olabel"><a class="dv-oid" href="#1a">1a</a>The full run · one session end to end, 13 frames</div>
+<div class="dv-card">
+<div class="wf-row">
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Intrada</div><div style="display:flex;gap:5px;"><span class="wf-chip">midi ✓</span><span class="wf-chip">library</span></div></div>
+<div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;text-align:center;">
+<div class="wf-lbl">Tonight</div>
+<div class="wf-h">Strasbourg / St. Denis</div>
+<div class="wf-ts">20 minutes · 4 blocks · ends on the head</div>
+<div style="width:150px;height:150px;border:2.5px solid #2B2A26;border-radius:50%;display:flex;align-items:center;justify-content:center;font:600 20px 'Inter',sans-serif;letter-spacing:2px;margin:6px 0;">START</div>
+<div class="wf-t" style="max-width:230px;">Rootless voicings are due — six days since you last touched the A section.</div>
+<div class="wf-ts" style="text-decoration:underline;">why this?</div>
+</div>
+<div class="wf-ts" style="text-align:center;">not tonight? →</div>
+</div>
+<div class="wf-cap"><span class="wf-n">1</span> <b>Home.</b> One screen, one decision. The why is one line, not a briefing.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div style="opacity:.32;display:flex;flex-direction:column;gap:11px;">
+<div class="wf-top"><div class="wf-lbl">Intrada</div><span class="wf-chip">midi ✓</span></div>
+<div class="wf-h" style="margin-top:40px;">Strasbourg / St. Denis</div>
+</div>
+<div class="wf-sheet" style="height:452px;">
+<div class="wf-lbl">Why this session</div>
+<div class="wf-box" style="padding:10px;">
+<div style="font:600 11.5px 'Inter',sans-serif;color:#2B2A26;">0–3 · warm-up · pattern over the changes</div>
+<div class="wf-ts">Mastered. Opens warm, and it drops today's tempo read before anything hurts.</div>
+</div>
+<div class="wf-solid" style="padding:10px;">
+<div style="font:600 11.5px 'Inter',sans-serif;color:#2B2A26;">3–9 · frontier · rootless voicings, A section</div>
+<div class="wf-ts">Due. Estimate 0.42, confidence still wide, six days cold.</div>
+<div style="display:flex;gap:5px;margin-top:6px;"><span class="wf-chip">graph node</span><span class="wf-chip">grind</span></div>
+</div>
+<div class="wf-box" style="padding:10px;">
+<div style="font:600 11.5px 'Inter',sans-serif;color:#2B2A26;">9–14 · the Rollins lick → Db</div>
+<div class="wf-ts">2 of 12 keys clean. One phrase in flight.</div>
+</div>
+<div class="wf-box" style="padding:10px;">
+<div style="font:600 11.5px 'Inter',sans-serif;color:#2B2A26;">14–19 · restricted improv on the form</div>
+<div class="wf-ts">Hard rule: every session touches real music.</div>
+</div>
+<div class="wf-box" style="flex:1;display:flex;align-items:center;justify-content:center;"><span class="wf-ts">graph state · tap to open</span></div>
+<div class="wf-btn">Got it</div>
+</div>
+</div>
+<div class="wf-cap"><span class="wf-n">2</span> <b>Why panel.</b> Progressive disclosure — the reasoning is available, never forced.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Block 1 of 4 · warm-up</div><span class="wf-chip">19:04 left</span></div>
+<div class="wf-bar"><i style="width:11%"></i></div>
+<div class="wf-h2" style="margin-top:8px;">Pattern over the changes</div>
+<div class="wf-ts">1-2-3-5 cells · 100 bpm · the whole form</div>
+<div class="wf-box" style="flex:1;margin-top:12px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;">
+<div style="font:400 52px/1 'Source Serif 4',serif;color:#2B2A26;">A♭7</div>
+<div class="wf-ts">bar 9 of 32</div>
+<div style="display:flex;gap:6px;margin-top:10px;">
+<span style="width:9px;height:9px;border-radius:50%;background:#2B2A26;"></span>
+<span style="width:9px;height:9px;border-radius:50%;border:1.5px solid #C4BCA6;"></span>
+<span style="width:9px;height:9px;border-radius:50%;border:1.5px solid #C4BCA6;"></span>
+<span style="width:9px;height:9px;border-radius:50%;border:1.5px solid #C4BCA6;"></span>
+</div>
+</div>
+<div class="wf-ts" style="text-align:center;">scored quietly — nothing to clear here</div>
+<div class="wf-btn ghost">Stuck</div>
+<div class="wf-ts" style="text-align:center;">end early · banks what you've done</div>
+</div>
+<div class="wf-cap"><span class="wf-n">3</span> <b>Warm-up.</b> A guaranteed win. Scored, but no feedback shown — momentum first.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Block 2 of 4 · frontier</div><span class="wf-chip">grind · 3 weeks</span></div>
+<div class="wf-bar"><i style="width:34%"></i></div>
+<div class="wf-h2" style="margin-top:8px;">Rootless voicings — A section</div>
+<div class="wf-ts">A position · 120 bpm · left hand leads</div>
+<div style="display:flex;align-items:baseline;gap:9px;margin-top:14px;">
+<div style="font:400 44px/1 'Source Serif 4',serif;color:#2B2A26;">2</div>
+<div class="wf-t" style="padding-bottom:6px;">of 3 clean passes at 120</div>
+</div>
+<div style="display:flex;gap:7px;">
+<span style="flex:1;height:8px;border-radius:999px;background:#2B2A26;"></span>
+<span style="flex:1;height:8px;border-radius:999px;background:#2B2A26;"></span>
+<span style="flex:1;height:8px;border-radius:999px;background:#E2DCCB;"></span>
+</div>
+<div class="wf-solid" style="flex:1;margin-top:14px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;">
+<div style="display:flex;gap:16px;align-items:center;">
+<span class="wf-tick" style="color:#7A7360;">✓</span><span class="wf-tick" style="color:#7A7360;">✓</span>
+<span class="wf-tick" style="font-size:44px;color:#2B2A26;">✕</span>
+</div>
+<div style="font:600 17px 'Inter',sans-serif;color:#2B2A26;">Late into bar 3</div>
+<div class="wf-ts">that's the pass gone — go again</div>
+</div>
+<div class="wf-btn" style="padding:16px;">Stuck</div>
+<div class="wf-ts" style="text-align:center;">midi listening · 120 bpm click</div>
+</div>
+<div class="wf-cap"><span class="wf-n">4</span> <b>Active drill.</b> One mark, one fact, huge type. Grind is labelled as grind, with the horizon attached.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-lbl">Block 2 · rootless voicings</div>
+<div class="wf-h2" style="margin-top:6px;">Three in a row.<br>Let's make it smaller.</div>
+<div class="wf-t" style="margin-top:2px;">Bar 3 every time — it's the change, not the chords.</div>
+<div style="display:flex;flex-direction:column;gap:9px;margin-top:14px;">
+<div class="wf-solid" style="padding:13px;">
+<div style="font:600 13px 'Inter',sans-serif;">Drop to 96 bpm</div>
+<div class="wf-ts">most likely to unstick this one</div>
+</div>
+<div class="wf-box" style="padding:13px;">
+<div style="font:600 13px 'Inter',sans-serif;">Bars 1–4 only</div>
+<div class="wf-ts">practise the change, not the chords</div>
+</div>
+<div class="wf-box" style="padding:13px;">
+<div style="font:600 13px 'Inter',sans-serif;">Left hand alone</div>
+<div class="wf-ts">shape first, then add the right</div>
+</div>
+<div class="wf-box" style="padding:13px;">
+<div style="font:600 13px 'Inter',sans-serif;">Sing the top line</div>
+<div class="wf-ts">hear it before you play it</div>
+</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-note">Everyone's A-position feels like knitting for about three weeks. You're two in.</div>
+<div class="wf-ts" style="text-align:center;margin-top:8px;">or carry on as you were</div>
+</div>
+<div class="wf-cap"><span class="wf-n">5</span> <b>Stuck ladder.</b> Fires on the pattern, not one failure. No guilt, no ceremony, one recommendation.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-lbl">Block 2 cleared</div>
+<div style="display:flex;align-items:baseline;gap:10px;margin-top:6px;">
+<div style="font:400 52px/1 'Source Serif 4',serif;">3<span style="font-size:26px;color:#9A927F;">/3</span></div>
+<div class="wf-t" style="padding-bottom:8px;">clean at 120</div>
+</div>
+<div class="wf-solid" style="padding:13px;margin-top:12px;">
+<div class="wf-t">The tempo drop worked — you cleared at 96, came back and held 120 twice. Second time this week the ladder has paid.</div>
+</div>
+<div class="wf-lbl" style="margin-top:14px;">A-position, last 4 weeks</div>
+<div class="wf-box" style="height:96px;display:flex;align-items:flex-end;gap:7px;padding:10px;">
+<span style="flex:1;height:24%;background:#C4BCA6;border-radius:3px 3px 0 0;"></span>
+<span style="flex:1;height:38%;background:#C4BCA6;border-radius:3px 3px 0 0;"></span>
+<span style="flex:1;height:34%;background:#C4BCA6;border-radius:3px 3px 0 0;"></span>
+<span style="flex:1;height:61%;background:#C4BCA6;border-radius:3px 3px 0 0;"></span>
+<span style="flex:1;height:78%;background:#2B2A26;border-radius:3px 3px 0 0;"></span>
+</div>
+<div class="wf-ts">90 → 120 bpm clean. Your trend says roughly four more sessions to the full-cycle gate.</div>
+<div style="flex:1;"></div>
+<div class="wf-lbl">Next, listen for</div>
+<div class="wf-t">Hear the next chord before your hands leave this one.</div>
+<div class="wf-btn" style="margin-top:10px;">Next block →</div>
+</div>
+<div class="wf-cap"><span class="wf-n">6</span> <b>Block boundary.</b> The only place prose is allowed. Praises the tactic, not the talent. Horizon from your own trend.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Block 3 of 4 · vocabulary</div><span class="wf-chip">11:20 left</span></div>
+<div class="wf-h2" style="margin-top:8px;">The Rollins lick</div>
+<div class="wf-ts">one phrase in flight</div>
+<div style="display:flex;gap:3px;margin-top:14px;align-items:center;">
+<span class="wf-chip" style="background:#2B2A26;color:#FBFAF3;border-color:#2B2A26;">learn ✓</span>
+<span style="flex:1;height:1.5px;background:#C4BCA6;"></span>
+<span class="wf-chip" style="border-color:#2B2A26;border-width:1.5px;color:#2B2A26;font-weight:600;">keys</span>
+<span style="flex:1;height:1.5px;background:#E2DCCB;"></span>
+<span class="wf-chip">analyse</span>
+</div>
+<div style="display:flex;gap:3px;margin-top:6px;align-items:center;">
+<span class="wf-chip">extract</span>
+<span style="flex:1;height:1.5px;background:#E2DCCB;"></span>
+<span class="wf-chip">generate</span>
+<span style="flex:1;height:1.5px;background:#E2DCCB;"></span>
+<span class="wf-chip">deploy</span>
+</div>
+<div class="wf-lbl" style="margin-top:16px;">Keys · 2 of 12 clean</div>
+<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:6px;">
+<span class="wf-solid" style="padding:9px 0;text-align:center;font:600 11px 'Inter',sans-serif;background:#2B2A26;color:#FBFAF3;">C</span>
+<span class="wf-solid" style="padding:9px 0;text-align:center;font:600 11px 'Inter',sans-serif;background:#2B2A26;color:#FBFAF3;">F</span>
+<span class="wf-solid" style="padding:9px 0;text-align:center;font:600 11px 'Inter',sans-serif;">B♭</span>
+<span class="wf-solid" style="padding:9px 0;text-align:center;font:600 11px 'Inter',sans-serif;">E♭</span>
+<span class="wf-box" style="padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;color:#9A927F;">A♭</span>
+<span class="wf-box" style="padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;color:#9A927F;">D♭</span>
+<span class="wf-box" style="padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;color:#9A927F;">G♭</span>
+<span class="wf-box" style="padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;color:#9A927F;">B</span>
+</div>
+<div class="wf-ts">…and four more</div>
+<div class="wf-solid" style="padding:12px;margin-top:14px;">
+<div style="font:600 12.5px 'Inter',sans-serif;">Today: B♭ and E♭, over the turnaround</div>
+<div class="wf-ts">gate: 2 clean in both · around the cycle, not chromatically</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-btn">Start the drill</div>
+</div>
+<div class="wf-cap"><span class="wf-n">7</span> <b>Lick pipeline.</b> "All 12 keys" is never a session goal — two new keys, the rest as maintenance.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-lbl">After the drill</div>
+<div class="wf-h2" style="margin-top:6px;">Why does it sound like that?</div>
+<div class="wf-box" style="height:76px;margin-top:10px;display:flex;align-items:center;justify-content:center;"><span class="wf-ts">notation of the phrase, bar 3 highlighted</span></div>
+<div class="wf-solid" style="padding:12px;margin-top:10px;">
+<div class="wf-t">B♮ over the B♭7 — a ♭9, resolving down a semitone onto the 5th. That crunch-then-release is the sound you like.</div>
+<div class="wf-ts" style="text-decoration:underline;margin-top:7px;">90-second lesson on ♭9 resolutions</div>
+</div>
+<div class="wf-lbl" style="margin-top:16px;">Adds to your devices</div>
+<div class="wf-solid" style="padding:11px;display:flex;align-items:center;gap:10px;">
+<div class="wf-box" style="width:38px;height:30px;flex:none;"></div>
+<div style="flex:1;">
+<div style="font:600 12px 'Inter',sans-serif;">♭9 → 5 resolution</div>
+<div class="wf-ts">new · carried by the Rollins lick</div>
+</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-note">The lick was the carrier. The device is the vocabulary.</div>
+<div class="wf-btn" style="margin-top:10px;">Keep it</div>
+</div>
+<div class="wf-cap"><span class="wf-n">8</span> <b>Analyse → extract.</b> Theory only at the point of use, on a sound you already want.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Your devices</div><span class="wf-chip">14</span></div>
+<div class="wf-h2" style="margin-top:6px;">The vocabulary,<br>visible and growing</div>
+<div style="display:flex;flex-direction:column;gap:8px;margin-top:14px;">
+<div class="wf-solid" style="padding:11px;display:flex;gap:10px;align-items:center;">
+<div class="wf-box" style="width:36px;height:28px;flex:none;"></div>
+<div style="flex:1;">
+<div style="font:600 12px 'Inter',sans-serif;">Enclosure (3-note)</div>
+<div class="wf-ts">from 4 phrases · deployed unprompted ×3</div>
+<div class="wf-bar" style="margin-top:6px;"><i style="width:82%"></i></div>
+</div>
+</div>
+<div class="wf-solid" style="padding:11px;display:flex;gap:10px;align-items:center;">
+<div class="wf-box" style="width:36px;height:28px;flex:none;"></div>
+<div style="flex:1;">
+<div style="font:600 12px 'Inter',sans-serif;">♭9 → 5 resolution</div>
+<div class="wf-ts">generate ladder 1 of 4 · vary the rhythm</div>
+<div class="wf-bar" style="margin-top:6px;"><i style="width:22%"></i></div>
+</div>
+</div>
+<div class="wf-box" style="padding:11px;display:flex;gap:10px;align-items:center;">
+<div class="wf-box" style="width:36px;height:28px;flex:none;background:#fff;"></div>
+<div style="flex:1;">
+<div style="font:600 12px 'Inter',sans-serif;color:#5C5646;">Rhythmic displacement</div>
+<div class="wf-ts">learned · not used in 6 weeks</div>
+<div class="wf-bar" style="margin-top:6px;"><i style="width:54%;background:#C4BCA6;"></i></div>
+</div>
+</div>
+<div class="wf-box" style="padding:11px;display:flex;gap:10px;align-items:center;">
+<div class="wf-box" style="width:36px;height:28px;flex:none;background:#fff;"></div>
+<div style="flex:1;">
+<div style="font:600 12px 'Inter',sans-serif;color:#5C5646;">Chromatic approach from below</div>
+<div class="wf-ts">from 2 phrases</div>
+<div class="wf-bar" style="margin-top:6px;"><i style="width:66%;background:#C4BCA6;"></i></div>
+</div>
+</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-ts">Bar = the generate ladder: vary · transplant · compose · deploy.</div>
+</div>
+<div class="wf-cap"><span class="wf-n">9</span> <b>Device inventory.</b> The strongest progress surface — this is the thing that is actually growing.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Block 4 of 4 · integration</div><span class="wf-chip">1:40 left</span></div>
+<div class="wf-h2" style="margin-top:8px;">Restricted improv</div>
+<div class="wf-ts">the form, chord-tone targets, land the ♭9 once</div>
+<div class="wf-lbl" style="margin-top:16px;">What the app heard</div>
+<div class="wf-solid" style="padding:12px;">
+<div style="display:flex;justify-content:space-between;"><span class="wf-t">Landed on target chord tones</span><span style="font:600 13px 'Inter',sans-serif;">27 of 32</span></div>
+<div style="display:flex;justify-content:space-between;margin-top:5px;"><span class="wf-t">Time held</span><span style="font:600 13px 'Inter',sans-serif;">±18 ms</span></div>
+<div style="display:flex;justify-content:space-between;margin-top:5px;"><span class="wf-t">♭9 device, bar 12</span><span style="font:600 13px 'Inter',sans-serif;">probably</span></div>
+<div class="wf-ts" style="margin-top:7px;">Not certain about that last one — free improv is hard to read.</div>
+</div>
+<div class="wf-lbl" style="margin-top:16px;">What only you can hear</div>
+<div class="wf-box" style="padding:12px;">
+<div class="wf-t">Did that sound like the record?</div>
+<div style="display:flex;gap:5px;margin-top:9px;">
+<span class="wf-solid" style="flex:1;padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;">Stiff</span>
+<span class="wf-solid" style="flex:1;padding:9px 0;text-align:center;font:500 11px 'Inter',sans-serif;">Getting there</span>
+<span class="wf-solid" style="flex:1;padding:9px 0;text-align:center;font:600 11px 'Inter',sans-serif;background:#2B2A26;color:#FBFAF3;">Felt good</span>
+</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-note">Never bluff: stated when certain, asked when not.</div>
+<div class="wf-btn" style="margin-top:8px;">Close on the head →</div>
+</div>
+<div class="wf-cap"><span class="wf-n">10</span> <b>Measured vs felt.</b> An extra screen I've added — the self-assessment boundary made literal.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-lbl">Session banked</div>
+<div class="wf-h" style="margin-top:6px;">19 minutes.<br>One gate cleared.</div>
+<div style="display:flex;flex-direction:column;gap:7px;margin-top:16px;">
+<div style="display:flex;gap:9px;align-items:center;"><span class="wf-tick" style="font-size:14px;">✓</span><span class="wf-t">Warm-up pattern · whole form, clean</span></div>
+<div style="display:flex;gap:9px;align-items:center;"><span class="wf-tick" style="font-size:14px;">✓</span><span class="wf-t">Rootless A · 3 of 3 at 120</span></div>
+<div style="display:flex;gap:9px;align-items:center;"><span class="wf-tick" style="font-size:14px;">✓</span><span class="wf-t">Rollins lick · B♭ and E♭ clean</span></div>
+<div style="display:flex;gap:9px;align-items:center;"><span class="wf-tick" style="font-size:14px;color:#9A927F;">·</span><span class="wf-t">♭9 → 5 added to your devices</span></div>
+</div>
+<div class="wf-solid" style="padding:12px;margin-top:14px;">
+<div class="wf-lbl">In your words, two weeks ago</div>
+<div style="font:400 14px/1.4 'Source Serif 4',serif;color:#2B2A26;margin-top:4px;">"bridge still rushing"</div>
+<div class="wf-ts" style="margin-top:6px;">Tonight the bridge held at 120. That's the delta.</div>
+</div>
+<div class="wf-lbl" style="margin-top:16px;">Tomorrow, drafted</div>
+<div class="wf-box" style="padding:12px;">
+<div class="wf-t">Rootless A maintenance · Rollins lick → A♭ and D♭ · restricted improv, ♭9 twice per chorus.</div>
+<div class="wf-ts" style="margin-top:6px;">In flight: one phrase, one tune. Nothing added.</div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-btn">Done</div>
+</div>
+<div class="wf-cap"><span class="wf-n">11</span> <b>Session close.</b> Ends on competence. Tomorrow is drafted before the lid shuts — the when-then plan.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-lbl">Off piste</div>
+<div class="wf-h2" style="margin-top:6px;">No plan. Still listening.</div>
+<div class="wf-box" style="flex:1;margin-top:14px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;">
+<div style="font:400 40px/1 'Source Serif 4',serif;">11:20</div>
+<div style="display:flex;gap:3px;align-items:flex-end;height:44px;width:80%;">
+<span style="flex:1;height:30%;background:#C4BCA6;"></span><span style="flex:1;height:70%;background:#C4BCA6;"></span><span style="flex:1;height:45%;background:#C4BCA6;"></span><span style="flex:1;height:90%;background:#C4BCA6;"></span><span style="flex:1;height:55%;background:#C4BCA6;"></span><span style="flex:1;height:80%;background:#C4BCA6;"></span><span style="flex:1;height:35%;background:#C4BCA6;"></span><span style="flex:1;height:65%;background:#C4BCA6;"></span>
+</div>
+<div class="wf-ts">logged, unscored, no gates</div>
+</div>
+<div class="wf-solid" style="padding:13px;margin-top:12px;">
+<div class="wf-t">You spent seven minutes circling a IV–iv–I in E♭. Keep it as a drill?</div>
+<div style="display:flex;gap:7px;margin-top:10px;">
+<span class="wf-btn" style="flex:1;padding:10px;">Keep it</span>
+<span class="wf-btn ghost" style="flex:1;padding:10px;">Just playing</span>
+</div>
+</div>
+<div class="wf-ts" style="text-align:center;margin-top:8px;">counts towards tonight either way</div>
+</div>
+<div class="wf-cap"><span class="wf-n">12</span> <b>Off piste.</b> Wandering is honoured and still feeds diagnosis. Some wanders are the graph revealing a gap.</div>
+</div>
+
+<div class="wf-fr">
+<div class="wf-ph">
+<div class="wf-top"><div class="wf-lbl">Intrada</div><span class="wf-chip">midi ✓</span></div>
+<div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;text-align:center;">
+<div class="wf-h">Ten minutes?</div>
+<div class="wf-t" style="max-width:225px;">Lighter tonight. The pattern, one key of the lick, then the head.</div>
+<div style="width:150px;height:150px;border:2.5px solid #2B2A26;border-radius:50%;display:flex;align-items:center;justify-content:center;font:600 20px 'Inter',sans-serif;letter-spacing:2px;margin:6px 0;">START</div>
+<div style="display:flex;gap:6px;">
+<span class="wf-chip">2 blocks</span><span class="wf-chip">no grind</span><span class="wf-chip">ends on music</span>
+</div>
+<div class="wf-ts" style="text-decoration:underline;">or the full twenty →</div>
+</div>
+<div class="wf-note" style="text-align:center;">Lighter on a bad day, not heavier. No mention of what you're skipping.</div>
+</div>
+<div class="wf-cap"><span class="wf-n">13</span> <b>Bad day.</b> Same screen, less of it. The grind block is the first thing dropped.</div>
+</div>
+
+</div>
+</div>
+</div>
+
+<div class="dv-opt" id="1b">
+<div class="dv-olabel"><a class="dv-oid" href="#1b">1b</a>Home · three ways to kill the choice</div>
+<div class="dv-card">
+<div class="wf-row">
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div style="flex:1;display:flex;align-items:center;justify-content:center;">
+<div style="width:170px;height:170px;border:2.5px solid #2B2A26;border-radius:50%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px;">
+<span style="font:600 22px 'Inter',sans-serif;letter-spacing:2px;">START</span>
+<span class="wf-ts">20 min</span>
+</div>
+</div>
+<div class="wf-ts" style="text-align:center;">why · library · off piste</div>
+</div>
+<div class="wf-cap"><b>The button.</b> Maximum kill-the-choice. Risk: no reason to trust it, and no cue for the bad day.</div>
+</div>
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div class="wf-lbl">Tonight · 20 min</div>
+<div class="wf-h2" style="margin-top:4px;">Strasbourg / St. Denis</div>
+<div style="display:flex;flex-direction:column;gap:7px;margin-top:14px;">
+<div class="wf-box" style="padding:10px;"><div style="font:600 11.5px 'Inter',sans-serif;">Warm-up · pattern</div><div class="wf-ts">3 min · mastered</div></div>
+<div class="wf-solid" style="padding:10px;"><div style="font:600 11.5px 'Inter',sans-serif;">Rootless voicings, A</div><div class="wf-ts">6 min · due, six days cold</div></div>
+<div class="wf-box" style="padding:10px;"><div style="font:600 11.5px 'Inter',sans-serif;">Rollins lick → B♭, E♭</div><div class="wf-ts">5 min · 2 of 12 keys</div></div>
+<div class="wf-box" style="padding:10px;"><div style="font:600 11.5px 'Inter',sans-serif;">Restricted improv</div><div class="wf-ts">5 min · then the head</div></div>
+</div>
+<div style="flex:1;"></div>
+<div class="wf-btn" style="padding:15px;">Start</div>
+<div class="wf-ts" style="text-align:center;margin-top:6px;">swap a block →</div>
+</div>
+<div class="wf-cap"><b>The plan.</b> Trust through transparency. Risk: it's a list, and a list invites deciding.</div>
+</div>
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div class="wf-lbl">Tonight</div>
+<div style="flex:1;display:flex;flex-direction:column;justify-content:center;gap:20px;">
+<div style="font:400 25px/1.3 'Source Serif 4',serif;color:#2B2A26;">Tonight we fix the A-section voicings, then put the new lick into two more keys.</div>
+<div class="wf-t">Twenty minutes. Ends on the head.</div>
+</div>
+<div class="wf-btn" style="padding:15px;">Start</div>
+<div class="wf-ts" style="text-align:center;margin-top:6px;">not tonight? · why this?</div>
+</div>
+<div class="wf-cap"><b>The sentence.</b> One plain-language claim, no list to scan. Closest to a teacher speaking. My pick.</div>
+</div>
+
+</div>
+</div>
+</div>
+
+<div class="dv-opt" id="1c">
+<div class="dv-olabel"><a class="dv-oid" href="#1c">1c</a>Active drill · what you see at arm's length</div>
+<div class="dv-card">
+<div class="wf-row">
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div class="wf-lbl">Rootless A · 120 bpm</div>
+<div style="display:flex;flex-direction:column;gap:9px;margin-top:12px;">
+<div class="wf-box" style="padding:10px;display:flex;justify-content:space-between;"><span class="wf-t">Accuracy</span><span style="font:600 15px 'Inter',sans-serif;">94%</span></div>
+<div class="wf-box" style="padding:10px;display:flex;justify-content:space-between;"><span class="wf-t">Timing</span><span style="font:600 15px 'Inter',sans-serif;">+31 ms</span></div>
+<div class="wf-box" style="padding:10px;display:flex;justify-content:space-between;"><span class="wf-t">Swing</span><span style="font:600 15px 'Inter',sans-serif;">1.42</span></div>
+<div class="wf-box" style="padding:10px;display:flex;justify-content:space-between;"><span class="wf-t">Tempo drift</span><span style="font:600 15px 'Inter',sans-serif;">−2%</span></div>
+</div>
+<div class="wf-lbl" style="margin-top:14px;">Passes</div>
+<div style="display:flex;gap:6px;"><span style="flex:1;height:7px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:7px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:7px;background:#E2DCCB;border-radius:9px;"></span></div>
+<div style="flex:1;"></div>
+<div class="wf-btn ghost">Stuck</div>
+</div>
+<div class="wf-cap"><b>Numbers forward.</b> Everything measured, on screen. Fails the one-second test — this is reading, not glancing.</div>
+</div>
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div class="wf-lbl">Rootless A · 120</div>
+<div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;">
+<span style="font:400 92px/1 'Inter',sans-serif;">✕</span>
+<div style="font:600 19px 'Inter',sans-serif;text-align:center;">Late into bar 3</div>
+</div>
+<div style="display:flex;align-items:baseline;gap:8px;justify-content:center;">
+<span style="font:400 30px/1 'Source Serif 4',serif;">2</span><span class="wf-t">of 3 clean</span>
+</div>
+<div style="display:flex;gap:6px;margin-top:8px;"><span style="flex:1;height:8px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:8px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:8px;background:#E2DCCB;border-radius:9px;"></span></div>
+<div class="wf-btn" style="margin-top:10px;padding:15px;">Stuck</div>
+</div>
+<div class="wf-cap"><b>Gate forward.</b> One mark, one fact, one count. Readable across a room. Used in <a class="dv-oid" href="#1a">1a</a>.</div>
+</div>
+
+<div class="wf-fr sm">
+<div class="wf-ph sm">
+<div class="wf-lbl">Rootless A · 120</div>
+<div class="wf-h2" style="margin-top:4px;">A section</div>
+<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:5px;margin-top:14px;">
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;background:#2B2A26;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+<span class="wf-solid" style="height:44px;"></span>
+</div>
+<div class="wf-ts" style="margin-top:8px;">bar 3, every pass</div>
+<div class="wf-solid" style="padding:11px;margin-top:14px;"><div class="wf-t">The change into bar 3 is the whole problem. Everything else is clean.</div></div>
+<div style="flex:1;"></div>
+<div style="display:flex;gap:6px;"><span style="flex:1;height:8px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:8px;background:#2B2A26;border-radius:9px;"></span><span style="flex:1;height:8px;background:#E2DCCB;border-radius:9px;"></span></div>
+<div class="wf-btn ghost" style="margin-top:9px;">Stuck</div>
+</div>
+<div class="wf-cap"><b>Bar map.</b> Shows <em>where</em>, not just <em>what</em>. Strongest diagnostically; needs a glance at a block boundary, not mid-rep.</div>
+</div>
+
+</div>
+</div>
+</div>
+
+</div>
+<p class="dv-next">Try next: "take <a class="dv-oid" href="#1b">1b</a>'s sentence home into <a class="dv-oid" href="#1a">1a</a> and re-run the flow" · "give me three versions of the stuck ladder" · "now make <a class="dv-oid" href="#1a">1a</a> hi-fi in Paper &amp; Score"</p>
+</section>
+
+</x-dc>
+</body>
+</html>

--- a/design/practice-coach-wireframes/README.md
+++ b/design/practice-coach-wireframes/README.md
@@ -1,0 +1,245 @@
+# Handoff: Intrada — The Practice Coach (first wireframes)
+
+> **Provenance note (added at repo import, 2026-08-04):** this bundle is the
+> July 2026 first-wireframe pass, built against
+> `specs/intrada-practice-coach-design.md` **v2** — before decisions 17–19
+> (tap-verdicts, machine listening deferred, user-created items). It is kept as
+> provenance, like `design/light-mode-exploration.md`. The current design
+> source is `design/Drill Loop.dc.html` (spec v7) and the wireframes in
+> `docs/coach-orientation.html`. Do not design or build from this file.
+
+> **This is a review request, not a build request.** The primary ask for the
+> Claude Code session receiving this bundle is: *does this design align with the
+> intended thinking captured in the repo's own documents?* Implementation is a
+> later conversation. Section 8 lists the specific questions to answer.
+
+---
+
+## 1. Overview
+
+A first wireframe pass at the **Practice Coach** direction — the pivot described
+in `specs/intrada-practice-coach-design.md` (v2, 18 July 2026): an app that
+decides what you practise, listens while you play, tells you when you're done,
+gets you unstuck, and adjusts the plan from what it hears.
+
+The wireframes walk one complete 20-minute session using the doc's own worked
+example (Strasbourg / St. Denis; rootless voicings, A section; the Rollins lick
+entering new keys), plus alternates for the two screens the product hinges on.
+
+**Source documents this was built from** (all read in full):
+
+| Document | What was taken from it |
+|---|---|
+| `specs/intrada-practice-coach-design.md` | The whole structure: product principles, the 10 UX design principles, session template, feedback cadence, stuck ladder, lick pipeline, devices, off-piste, behavioural-research alignment |
+| `VISION.md` | Reflection-closes-every-loop, celebrate-comeback-not-streak, designed-for-every-mind, one-tap-to-start |
+| `docs/journeys.md` | The ten steps; the companion-loop priority ordering |
+| `specs/design-refresh-2026.md` | Read for token/visual history — deliberately **not** applied (see §3) |
+| `design/CLAUDE.md`, `design/design-process.md`, `design/HANDOVER.md` | Design-file process, theme decision, the shared-DC import pattern |
+| `design/intrada-design-system.dc.html` | Paper & Score palette and type, used for the wireframe ground |
+
+---
+
+## 2. About the design files
+
+The file in this bundle is a **design reference created in HTML** — a wireframe
+prototype showing structure, flow, and copy. It is **not production code** and
+nothing in it should be copied into the app.
+
+If this direction is approved and later implemented, the target is the native
+SwiftUI iOS app (`ios/Intrada/`), using the existing `DesignSystem/Theme.swift`
+tokens and component set. The HTML is a thinking artefact only.
+
+The file is a Design Component (`.dc.html`) — open it in a browser directly
+(`support.js` sits alongside it and is required). It uses a pan/zoom canvas:
+the three options are laid out side by side.
+
+---
+
+## 3. Fidelity — **low-fidelity, deliberately**
+
+These are **wireframes**, chosen over hi-fi at the user's explicit direction:
+get the flow right first, then style. Specifically:
+
+- Structure, hierarchy, and **copy** are the deliverable. Read the copy closely —
+  it is doing most of the design work, and it is where the doc's tone principles
+  ("plain language, musician's language", "never bluff", "honest about the
+  grind") either hold or don't.
+- Colour is intentionally near-absent: paper (`#FBFAF3` / `#EFEBE0`), ink
+  (`#2B2A26`), and a single warm annotation colour. This is the **Paper & Score**
+  ground from the existing design system, but no accent bars, no gradients, no
+  final type scale.
+- Boxes with a **dashed** border are placeholders (notation, waveform, graph
+  view). Solid-bordered boxes are real intended surfaces.
+- Handwriting-font captions **below** each frame are my annotations to you, not
+  UI. Handwriting captions **inside** a frame (warm brown) are design notes about
+  the principle that frame is testing.
+- The `design-refresh-2026.md` visual language (neutral-dark background, 4px
+  gradient AccentRow, Inter/Source Serif) was **not** applied — that refresh
+  predates the Practice Coach pivot and is dark-mode-only, whereas
+  `design/CLAUDE.md` records light Paper & Score as the MVP default. Flag if
+  that's the wrong call.
+
+---
+
+## 4. What's in the file
+
+One turn (`t1`), three options. Every option has a stable id shown as a badge.
+
+### Option `1a` — the full run (13 frames, left to right)
+
+| # | Frame | Purpose | Principle being tested |
+|---|---|---|---|
+| 1 | **Home** | Tonight's session; one decision | "Kill the choice"; one screen, one action; the why is one line |
+| 2 | **Why panel** | Per-block reasoning, citing node state | "The why is always one tap away"; prescription trust (challenge 5) |
+| 3 | **Warm-up (block 1)** | Comfortable opener, scored silently | Anti-abandonment; endowed progress; guidance hypothesis |
+| 4 | **Active drill (block 2)** | Gate progress, per-rep marks, one fact | Glanceable over readable; honest about the grind |
+| 5 | **Stuck ladder** | Escalation after 3 fails | "Make it smaller before they give up"; name the wall |
+| 6 | **Block boundary** | The coaching voice, trend, horizon | Praise the tactic not the talent; self-trend horizons (decision 4) |
+| 7 | **Lick pipeline** | Phrase stages + key traversal | "All 12 keys is never a session goal"; one phrase in flight |
+| 8 | **Analyse → extract** | Why the phrase works; device captured | Theory just-in-time, never a curriculum |
+| 9 | **Device inventory** | The growing vocabulary | "The device is the vocabulary; the lick was its carrier" |
+| 10 | **Measured vs felt** | What the app heard / what only you can hear | "Never bluff, visibly"; measure prerequisites, coach judgement |
+| 11 | **Session close** | Banked, in your own words, tomorrow drafted | Peak-end rule; Zeigarnik; implementation intentions |
+| 12 | **Off piste** | Wander logged, "keep as a drill?" | Autonomy (SDT); the graph revealing a gap |
+| 13 | **Bad day** | The lighter ten minutes | "Design for the bad day"; lighter, not heavier |
+
+### Option `1b` — Home, three treatments
+
+- **The button** — a start circle and nothing else. Maximum kill-the-choice; no
+  trust cue, no bad-day affordance.
+- **The plan** — the four blocks listed with times and reasons. Transparent, but
+  a list invites deciding, which is the failure mode the doc names.
+- **The sentence** — one plain-language claim ("Tonight we fix the A-section
+  voicings, then put the new lick into two more keys"), then start. Closest to a
+  teacher speaking. **My recommendation.**
+
+### Option `1c` — Active drill, three feedback treatments
+
+- **Numbers forward** — accuracy %, timing ms, swing ratio, drift. Everything
+  measurable on screen. Fails the one-second glance test; included as the
+  strawman.
+- **Gate forward** — one mark, one fact, one count, huge type. Readable at
+  arm's length. **Used in `1a`.**
+- **Bar map** — an 8-bar strip with the failing bar lit. Diagnostically the
+  strongest (it answers *where*), but it asks for a real look — proposed for
+  block boundaries rather than mid-rep.
+
+---
+
+## 5. Design decisions I made (and want checked)
+
+The user answered "decide for me" on several questions. These are my calls, all
+of them overrulable:
+
+1. **Relationship to the existing app.** Coach-first: the home screen *is* the
+   start button. The existing Library / Practice / Routines / Progress tabs are
+   demoted to a small header affordance ("library"), not a tab bar. This follows
+   "the home screen is a start button" but conflicts with the shipped four-pillar
+   IA and with `docs/journeys.md` steps 1–3, which assume the library is a
+   first-class surface. **Needs a ruling.**
+2. **MIDI visibility.** Quiet — a small `midi ✓` chip in the header, never a
+   headline. Backed up by one explicit low-confidence state (frame 10, "probably")
+   rather than a connection-status UI.
+3. **An extra screen.** Frame 10 (measured vs felt) is not one of the surfaces
+   asked for. I added it because "never bluff, visibly" and challenge 2
+   (pedagogical authority) had nowhere else to live, and it is where the honest
+   scope of the claim becomes visible to the user.
+4. **Grind labelling made literal.** Frame 4 carries a `grind · 3 weeks` chip —
+   the label, the payoff and the horizon on the drill itself, per principle 4.
+   This is the riskiest copy decision in the set; it could read as deflating.
+5. **No streak anywhere.** Not on home, not at close. "Banked" and "counts
+   towards tonight either way" carry the consistency framing instead.
+6. **The close quotes the user's own words** ("bridge still rushing") against
+   tonight's data — pulling `docs/journeys.md` step 9 (narrative progress) into
+   the coach loop rather than leaving it on a separate Progress tab.
+7. **No numbers invented from population data.** The one horizon shown reads
+   "your trend suggests roughly four more sessions", per decision 4.
+
+---
+
+## 6. Deliberate omissions
+
+Things in the doc that are **not** drawn, so you can tell whether their absence
+is a gap or correct scoping:
+
+- Placement / cold start (parked behind the personal-tool-first decision).
+- Count-in, restart detection, attempt segmentation UI — the Phase 1 spike
+  outcome should shape this, not a wireframe.
+- Listening blocks (no-instrument items) — mentioned in the why panel only.
+- Tune pipeline stages (form / melody / shells / rootless / arpeggiate / guide
+  tones) as a browsable surface; only the lick pipeline is drawn.
+- The graduation arc (principle 8) — no depiction of the UI becoming less
+  prescriptive as mastery climbs. **Probably the biggest hole.**
+- Goals as an input to planning (`VISION.md`, journeys step 4).
+- Any settings, onboarding, or MIDI setup UX (challenge 10).
+
+---
+
+## 7. Design tokens used
+
+Wireframe-level only — not a proposed palette. Lifted from
+`design/intrada-design-system.dc.html` (Paper & Score, light).
+
+| Token | Value | Use |
+|---|---|---|
+| Canvas | `#EFEBE0` | Page ground |
+| Paper | `#FBFAF3` | Device surface, cards |
+| Ink | `#2B2A26` | Text, borders, filled states |
+| Ink muted | `#5C5646` | Body copy |
+| Ink faint | `#9A927F` | Labels, secondary |
+| Rule | `#C4BCA6` (solid) / dashed | Borders, placeholder outlines |
+| Track | `#E2DCCB` | Unfilled progress |
+| Annotation | `#8A6A1F` | In-frame design notes only |
+| Accent | `#4C3FA6` | Links and the active option badge only |
+| Display type | Source Serif 4, 18–52px, weight 400 | Headings, big numerals |
+| UI type | Inter, 8.5–19px, weights 400/500/600 | Everything else |
+| Annotation type | Caveat, 13–15px | Captions (not UI) |
+| Frame | 300×600 (`1a`), 262×500 (`1b`/`1c`), 2px ink border, 20px radius | Phone stand-in |
+
+Minimum in-frame UI text is 8.5px only for uppercase tracked labels; body copy
+is 10.5px+ at wireframe scale. **These are not real iOS sizes** — do not read a
+type scale out of this file.
+
+---
+
+## 8. Questions for the review session
+
+Answer these against the repo's own documents, not against taste:
+
+1. **Does the session shape match the doc?** Frames 3/4/7/10 map to the 0–3 /
+   3–9 / 9–14 / 14–19 blocks and 11 to the 19–20 close. Are the gates as
+   specified ("3 clean passes at 120", "2 clean in both keys")?
+2. **Principle audit.** Walk the 10 UX design principles in
+   `intrada-practice-coach-design.md` and name any that no frame serves — and
+   any frame that violates one. Principle 8 (graduation arc) is the one I know
+   is missing.
+3. **Is the coach-first IA right?** See §5.1. Does killing the tab bar break
+   `docs/journeys.md` steps 1–3, or is the library correctly a background
+   surface now?
+4. **Copy tone.** Read every string. Does any of it slip into gamification
+   vocabulary, cheerleading, ability praise, or guilt? Frame 5 ("Three in a row.
+   Let's make it smaller.") and frame 4's grind chip are the ones I'd challenge
+   first.
+5. **Honesty of the numbers.** Anything on screen that implies population data,
+   false precision, or a confidence the deterministic MIDI analysis in
+   `intrada-core` couldn't actually produce?
+6. **Data model fit.** Frames 7, 8 and 9 assume `Phrase` (stage + per-key
+   mastery), `Device` (referenced by many phrases, own mastery via the generate
+   ladder) and `MethodPack` cues. Does the sketch in the doc's technical
+   architecture section support what's drawn, and what's missing?
+7. **Phase alignment.** Which frames are Phase 1 (listening gate), which Phase 2
+   (prescribed session), which Phase 3 (the voice), which Phase 4? Frame 6 is
+   pure Phase 3 — is showing it this early misleading about what v1 is?
+8. **Theme call.** §3 — Paper & Score light over the 2026 dark refresh. Right?
+9. **What would you cut?** The doc's own content-burden warning (challenge 3)
+   says v1 is 5 nodes, 2 method packs, 1 phrase. Do 13 frames overstate v1?
+
+---
+
+## 9. Files in this bundle
+
+- `Practice Coach Wireframes.dc.html` — the wireframes. Open in a browser.
+- `support.js` — required runtime for the `.dc.html` file. Not design content.
+- `README.md` — this file.
+
+No image assets are used. Screenshots are not included; ask if you'd like them.

--- a/design/practice-coach-wireframes/support.js
+++ b/design/practice-coach-wireframes/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
## Summary
Follow-up to #1173 — a full sync audit of the Claude Design project against `design/`, so nothing lives only in the cloud project:

- **Verified byte-identical** (no changes needed): `Linked Exercises.dc.html`, `linked-exercises-mock.dc.html`, `Intrada Concepts.dc.html`, `Reflection Narrative.dc.html`, `Focus Player.dc.html`, `Session Summary.dc.html`, `HANDOVER.md`, `light-mode-exploration.md`, `design-process.md`, all three `assets/app-icon-*.png`, and the handoff-folder duplicates.
- **Recovered — existed only in the project**:
  - `design/practice-coach-wireframes/` — the July 2026 first-wireframes bundle (13-frame session walk, Home/drill alternates, review-request README). Built against spec v2, pre-decisions 17–19; imported as provenance with a note saying so.
  - `design/github.md` — the project's sync-state log (what the 4 Aug session changed, screen-to-repo map).
- **Deliberately not mirrored**: the project's `_ds/` bundle and `.thumbnail` — app-generated Design System pane artifacts, regenerated on upload.

Tier 1 (design-asset recovery, no code); Coverage: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)