### PR TITLE
chore(agents): agent-teams ground rules + /team-vertical briefing command

### DIFF
--- a/.claude/commands/team-vertical.md
+++ b/.claude/commands/team-vertical.md
@@ -1,0 +1,33 @@
+---
+description: Brief an agent team on a core+iOS vertical slice (one team = one stream)
+argument-hint: <issue numbers or a one-line slice description>
+---
+
+Create an agent team for this vertical slice: $ARGUMENTS
+
+Read the issue(s) with `gh issue view` before briefing the teammates, and
+follow CLAUDE.md, Parallel work streams, Agent teams. Team shape:
+
+- First, create a feature branch from fresh `origin/main`. The whole team
+  works on that one branch and ships one PR.
+- Teammate **core** owns `crates/intrada-core` (and any bindings regen).
+  Works TDD (superpowers:test-driven-development). Before writing code,
+  it publishes the Event/Effect/ViewModel contract for the slice as a task
+  note and messages it to **ios**.
+- Teammate **ios** owns `ios/Intrada` and `ios/IntradaTests`. Builds from
+  the design-system primitives (check `ios/Intrada/DesignSystem/` and
+  `Views/Components/` before drawing anything new). May scaffold UI against
+  stub data immediately, but waits for the core contract before wiring the
+  store.
+- Single-writer files: only **core** touches
+  `crates/intrada-core/src/app.rs` and `domain/*`; only **ios** touches
+  `ios/IntradaTests/ScreenSnapshotTests.swift` and `ios/project.yml`.
+  Any change to a bridge-crossing type is messaged to the team before it
+  lands.
+- Gates before a teammate marks a task done: `just check` for core;
+  `just ios-fmt-check` and `just ios-test` for ios. Use the test-runner
+  subagent to keep the logs out of context.
+- Finish with one PR via the `ship` skill. Never merge; a human reviews.
+
+If the slice is core-only or ios-only, collapse to one teammate plus a
+reviewer teammate rather than forcing the two-role split.

--- a/.claude/skills/plan-team/SKILL.md
+++ b/.claude/skills/plan-team/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: plan-team
+description: Use when Jon asks to plan the next vertical slice, pick work for an agent team, or asks for the team command to paste into a terminal
+---
+
+# plan-team
+
+Plan one core+iOS vertical slice and hand back a paste-ready team command.
+`/team-vertical` (the command in the output) runs *inside* the terminal
+session and starts the team; this skill only plans and hands over.
+
+## Steps
+
+1. `gh issue list -R jonyardley/intrada --label horizon:now` (plus the
+   project board if that's thin). Candidates = issues forming ONE vertical
+   slice; sequencing beats bundling when issues block each other.
+2. Decompose by ownership: core teammate owns `crates/intrada-core`, ios
+   teammate owns `ios/Intrada` + `ios/IntradaTests`. An issue that needs
+   both teammates writing one serialisation-point file (CLAUDE.md, Parallel
+   work streams) gets queued, not bundled.
+3. Tier check: auth, DB schema, or FFI-contract redesign is Tier 3. Cite the
+   spec section that already covers it, or say a spec is needed first —
+   never hand back a command for unspecced Tier 3 work.
+4. A core-only or ios-only slice is fine — say the team collapses to one
+   builder plus a reviewer rather than forcing a fake split.
+
+## Output (exactly this shape)
+
+1. One line of rationale per chosen issue; one line per rejected near-miss.
+2. The command, as a runnable block:
+
+   ```bash
+   cd ~/Dev/intrada && git pull && claude "/team-vertical <issue numbers>"
+   ```
+
+   Substitute a fresh worktree for `~/Dev/intrada` if another session is
+   live in the main checkout, and say which path you chose.
+3. Close with the model line: lead on Opus/Fable high; teammates come from
+   the terminal session's `/config` default (Sonnet).

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 .claude/*
 !.claude/agents/
 !.claude/commands/
+!.claude/skills/
 !.claude/settings.json
 # settings.local.json stays ignored (per-machine permission grants)
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -904,6 +904,26 @@ Evidence base: coupling analysis of the last 400 commits (2026-08).
   shared-simulator rule under Commands. Close the second session when its task
   ships; do not keep it warm.
 
+### Agent teams (in-session teammates)
+
+An agent team (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, terminal sessions only)
+counts as **one** stream: the whole team shares a single checkout and one
+feature branch, so a core+iOS team satisfies the one-vertical-stream rule by
+itself. Never run a second vertical session beside it. Start one with
+`/team-vertical <issues>` (`.claude/commands/team-vertical.md`).
+
+- **Shared checkout, no file locking.** Teams lock task claiming, not file
+  edits. Every file gets exactly one writing teammate, fixed in the brief;
+  the serialisation-point files above are single-owner by definition.
+- **Contract before code.** The core teammate publishes the
+  Event/Effect/ViewModel contract for the slice before either side wires it.
+  A bridge-type change is messaged to the team, never landed silently.
+- **Per-teammate gates.** Each teammate runs its gates (`just check` for
+  core; `just ios-fmt-check` + `just ios-test` for `ios/`) before marking a
+  task done.
+- **One PR, via `ship`, human merges** — the definition of done below applies
+  to the team as a whole, not per teammate.
+
 ### Definition of done (every stream, before requesting review)
 
 - [ ] `just check` green locally; `just ios-fmt-check` too if `ios/` touched


### PR DESCRIPTION
## What

Trial setup for Claude Code agent teams (experimental, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`):

- **CLAUDE.md, Parallel work streams**: new *Agent teams* subsection. A team counts as one stream (shared checkout, one branch, one PR); single-writer file ownership because teams lock task claiming but not file edits; contract-before-code across the FFI bridge; per-teammate gates; ship + human merge unchanged.
- **`.claude/commands/team-vertical.md`**: `/team-vertical <issues>` briefs a core+iOS team with those rules baked in, so the brief does not have to be retyped (or half-remembered) each time.

## Why

First team trial targets the three `horizon:now` coach issues (#1180, #1181 core; #1182 iOS), which decompose cleanly into a two-teammate vertical. The rules live in CLAUDE.md rather than only the brief because teammates inherit project context but not the lead's conversation.

Tier 1 (docs + command file, no code). Coverage: n/a, no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)