### PR TITLE
chore(justfile): xcodegen cache, XCUITest retry, and a check green-stamp

### DIFF
--- a/.claude/commands/team-vertical.md
+++ b/.claude/commands/team-vertical.md
@@ -34,9 +34,9 @@ follow CLAUDE.md, Parallel work streams, Agent teams. Team shape:
   `just ios-test`/`ios-test-full` again after another teammate already ran
   one green at the current HEAD on a clean tree (#1199) — their green-stamp
   (#1192) already skips a same-HEAD rerun automatically, so doing it by hand
-  only wastes a build. `just check` has no such stamp; re-running it is
-  cheap (Rust-only) but still redundant once another teammate has run it
-  green at the same HEAD.
+  only wastes a build. `just check` has the same green-stamp (#1204): a
+  same-HEAD rerun on a clean tree skips automatically too, so don't hand-run
+  it again once another teammate has already run it green.
 - **Idle teammate drafts ship work.** Whoever finishes their task list first
   doesn't sit idle waiting for the other — it drafts the PR body, any
   deferred-issue text, and the roadmap edit as task notes for the lead

--- a/justfile
+++ b/justfile
@@ -46,8 +46,23 @@ hygiene:
     typos
     cargo-shear
 
-# Check everything (fmt → clippy → test → hygiene, cheapest first)
-check: fmt-check lint test hygiene
+# Check everything (fmt → clippy → test → hygiene, cheapest first). Skips
+# entirely when HEAD is clean and already stamped green — mirrors the iOS
+# test-tier stamp (#1200) — so a lead re-running a gate a teammate already
+# ran green on the same commit costs nothing (#1204). Delete
+# `target/.check-stamp` to force a re-run.
+check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    stamp=target/.check-stamp
+    sha="$(git rev-parse HEAD)"
+    if [ -z "$(git status --porcelain)" ] && [ -f "$stamp" ] && [ "$(cat "$stamp")" = "$sha" ]; then
+        echo "✓ HEAD $sha already green — skipping. Delete $stamp to force a re-run."
+        exit 0
+    fi
+    just fmt-check lint test hygiene
+    mkdir -p target
+    echo "$sha" > "$stamp"
 
 # Alias for check — catches errors before the 3-min CI roundtrip
 pre-push: check
@@ -88,17 +103,21 @@ ports:
 # the Swift bindings ONLY when the core changed, so they stay in sync without
 # slowing pure-Swift edits. ios/generated is a build precondition (gitignored,
 # regenerated) — never hand-edit it; fix the Rust type and regenerate.
+# `xcodegen generate --use-cache` (#1202) skips the project rewrite when
+# project.yml is unchanged; verified it also invalidates on a changed
+# SENTRY_DSN_NATIVE (xcodegen hashes the spec post env-substitution), so it's
+# safe on every call site here, not just the test path.
 
 # Open the app in Xcode (regenerates bindings first if the core changed).
 [group('iOS')]
 ios: _ios-sync
-    cd ios && xcodegen generate
+    cd ios && xcodegen generate --use-cache
     xed ios/Intrada.xcodeproj
 
 # Build + launch on a simulator and screenshot (regen if the core changed).
 [group('iOS')]
 ios-run: _ios-sync
-    cd ios && xcodegen generate
+    cd ios && xcodegen generate --use-cache
     bash scripts/ios-run-sim.sh
 
 # Stream the app's logs from the booted simulator, filtered to our subsystem —
@@ -124,7 +143,7 @@ ios-gen: ios-typegen (ios-package "debug")
 # (never link a release core into a routine debug run).
 [group('iOS')]
 ios-release: ios-typegen (ios-package "release")
-    cd ios && xcodegen generate
+    cd ios && xcodegen generate --use-cache
     rm -f ios/generated/.gen-stamp
     @echo "✓ release core ready — opening Xcode. Select your device, then Product → Profile (⌘I). Next 'just ios' rebuilds the debug core."
     xed ios/Intrada.xcodeproj
@@ -135,7 +154,7 @@ ios-release: ios-typegen (ios-package "release")
 # one-time `fastlane match appstore` bootstrap. See specs/ios-testflight-cicd.md.
 [group('iOS')]
 testflight: ios-typegen (ios-package "release")
-    cd ios && xcodegen generate
+    cd ios && xcodegen generate --use-cache
     rm -f ios/generated/.gen-stamp
     bundle exec fastlane ios beta
 
@@ -201,12 +220,23 @@ _ios-test-run tier:
     fi
     just _ios-test-guard
     cd ios
-    xcodegen generate
+    xcodegen generate --use-cache
     name="$(just _ios-test-sim-name)"
     udid="$(just _ios-test-sim-udid)"
     [ -n "$udid" ] || udid=$(xcrun simctl create "$name" "iPhone 16" "iOS26.5")
     only=""
-    if [ "{{tier}}" = "fast" ]; then only="-only-testing:IntradaTests"; fi
+    retry=""
+    if [ "{{tier}}" = "fast" ]; then
+        only="-only-testing:IntradaTests"
+    else
+        # Retries relaunch in a new process (not in-process): the observed
+        # XCUITest flake ("crashed with signal kill") kills the runner
+        # process, so an in-process retry wouldn't recover it. Fast tier
+        # stays strict — unit/snapshot tests are deterministic, so a flake
+        # there is signal, not noise. If a specific test starts passing
+        # only-on-retry regularly, that's a bug to fix, not a retry to keep.
+        retry="-retry-tests-on-failure -test-iterations 2 -test-repetition-relaunch-enabled YES"
+    fi
     xcodebuild build-for-testing -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
         -destination "id=$udid" -derivedDataPath build/dd \
         -clonedSourcePackagesDirPath build/spm -quiet \
@@ -214,7 +244,7 @@ _ios-test-run tier:
     xcodebuild test-without-building -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
         -destination "id=$udid" -derivedDataPath build/dd \
         -clonedSourcePackagesDirPath build/spm -quiet \
-        $only \
+        $only $retry \
         COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
     cd ..
     printf '%s %s\n' "$sha" "{{tier}}" > "$stamp"

--- a/justfile
+++ b/justfile
@@ -46,11 +46,9 @@ hygiene:
     typos
     cargo-shear
 
-# Check everything (fmt → clippy → test → hygiene, cheapest first). Skips
-# entirely when HEAD is clean and already stamped green — mirrors the iOS
-# test-tier stamp (#1200) — so a lead re-running a gate a teammate already
-# ran green on the same commit costs nothing (#1204). Delete
-# `target/.check-stamp` to force a re-run.
+# Check everything (fmt → clippy → test → hygiene, cheapest first). Mirrors
+# the iOS test-tier green-stamp (#1200): skips on a clean, already-green HEAD
+# (#1204). Delete `target/.check-stamp` to force a re-run.
 check:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -103,10 +101,9 @@ ports:
 # the Swift bindings ONLY when the core changed, so they stay in sync without
 # slowing pure-Swift edits. ios/generated is a build precondition (gitignored,
 # regenerated) — never hand-edit it; fix the Rust type and regenerate.
-# `xcodegen generate --use-cache` (#1202) skips the project rewrite when
-# project.yml is unchanged; verified it also invalidates on a changed
-# SENTRY_DSN_NATIVE (xcodegen hashes the spec post env-substitution), so it's
-# safe on every call site here, not just the test path.
+# `--use-cache` (#1202) skips the project rewrite when project.yml is
+# unchanged; verified it also invalidates on a changed SENTRY_DSN_NATIVE, so
+# it's safe on every call site here.
 
 # Open the app in Xcode (regenerates bindings first if the core changed).
 [group('iOS')]
@@ -229,12 +226,9 @@ _ios-test-run tier:
     if [ "{{tier}}" = "fast" ]; then
         only="-only-testing:IntradaTests"
     else
-        # Retries relaunch in a new process (not in-process): the observed
-        # XCUITest flake ("crashed with signal kill") kills the runner
-        # process, so an in-process retry wouldn't recover it. Fast tier
-        # stays strict — unit/snapshot tests are deterministic, so a flake
-        # there is signal, not noise. If a specific test starts passing
-        # only-on-retry regularly, that's a bug to fix, not a retry to keep.
+        # Relaunch-in-new-process, not in-process: the flake this recovers
+        # from kills the runner process (#1203). Fast tier (unit/snapshot,
+        # deterministic) stays strict.
         retry="-retry-tests-on-failure -test-iterations 2 -test-repetition-relaunch-enabled YES"
     fi
     xcodebuild build-for-testing -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \


### PR DESCRIPTION
## Summary

Three quick wins from the 2026-08-05 dev-cycle review, shipped together since all touch the justfile:

- **#1202** — `xcodegen generate --use-cache` on every xcodegen call site (was unconditional), so an unchanged `project.yml` skips the project rewrite instead of invalidating xcodebuild's incremental state. Verified locally the cache also invalidates on a changed `SENTRY_DSN_NATIVE` (xcodegen hashes the spec post env-substitution), so extended it beyond the originally-scoped `_ios-test-run` recipe to the interactive `ios`/`ios-run`/`ios-release`/`testflight` recipes too.
- **#1203** — `just ios-test-full`'s XCUITest run now retries a failed test once, relaunching in a new process (the observed flake kills the runner process, so an in-process retry wouldn't recover it). The fast tier (unit + snapshot, deterministic) is untouched.
- **#1204** — `just check` gets the same green-stamp `just ios-test`/`ios-test-full` already have (#1200): a clean, already-verified HEAD skips the Rust gates too. `.claude/commands/team-vertical.md` updated to stop claiming `just check` has no such stamp.

## Verification (all run for real, not asserted)

- **#1202**: two consecutive `xcodegen generate --use-cache` runs with no spec change — second logged "Project Intrada has not changed since cache was written" and `Intrada.xcodeproj`'s mtime was unchanged. Ran again with `SENTRY_DSN_NATIVE` set to a test value — cache invalidated and regenerated with the new value baked in; re-running with the same value hit cache again. Confirms env changes are safely covered.
- **#1203**: added a temporary XCUITest that fails on its first invocation (state persisted to a tmp file so it survives the process relaunch) and passes on retry. Ran `just ios-test-full` for real — log showed "Retrying tests on failure. Running tests repeatedly up to 2 times.", the run went green, and the marker file was gone afterwards (first iteration ran + failed, second iteration ran + passed). Test file removed before commit.
- **#1204**: ran `just check` for real (880/880 tests, clippy, fmt, hygiene all green) and confirmed the stamp was written at HEAD. Re-ran on the same clean HEAD — skipped in ~0.25s instead of the full gate. Dirtied the tree (scratch edit + revert) — confirmed it ran the full gates rather than skipping. Confirmed `target/` and `ios/build/` are both already gitignored.

No `ios/` source changed (diff is justfile + `.claude/commands/team-vertical.md` only), so `ios-fmt-check` and snapshot hygiene don't apply — confirmed via diff-stat rather than assumed.

## Self-review

A code-review pass flagged one blocker (the retry-workaround comment lacked a tracked-issue citation per the comment policy) and one nit (two new comments over the two-line smell-test cap) — both fixed inline in a follow-up commit; `just check` re-verified green afterwards.

Coverage: N/A — justfile/tooling change only, no application code (ignored by `codecov.yml`).

Deferred items tracked: none — all flagged items addressed inline.

Closes #1202, #1203, #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)