### PR TITLE
chore(zed): add editor config for Rust + native iOS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ ios/build/
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/test_output/
+# xcode-build-server config for sourcekit-lsp in Zed — machine-local absolute
+# paths, regenerated per checkout (see .zed/settings.json / SETUP.md)
+buildServer.json
 # graphify knowledge-graph output: machine-local, never committed (a re-recorded
 # multi-MB graph.json compounds in history like snapshot PNGs). The canonical
 # graph lives in the main checkout; scope is controlled by the committed

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,26 @@
+{
+  "languages": {
+    "Rust": {
+      "format_on_save": "on"
+    },
+    "Swift": {
+      "tab_size": 2,
+      "format_on_save": "on",
+      "formatter": {
+        "external": {
+          "command": "swift",
+          "arguments": ["format"]
+        }
+      }
+    }
+  },
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "check": {
+          "command": "clippy"
+        }
+      }
+    }
+  }
+}

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,34 @@
+[
+  {
+    "label": "just check (pre-push gate)",
+    "command": "just check",
+    "reveal": "always",
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "just test",
+    "command": "just test"
+  },
+  {
+    "label": "just lint",
+    "command": "just lint"
+  },
+  {
+    "label": "just ios-test (fast tier)",
+    "command": "just ios-test",
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "just ios-run (build + launch sim)",
+    "command": "just ios-run",
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "just ios-fmt",
+    "command": "just ios-fmt"
+  },
+  {
+    "label": "cargo test -p intrada-core",
+    "command": "cargo test -p intrada-core"
+  }
+]


### PR DESCRIPTION
## Summary
- `.zed/settings.json`: clippy-on-save for rust-analyzer (matches `just lint`), swift format on save (matches `just ios-fmt`)
- `.zed/tasks.json`: exposes `just check`/`test`/`lint`/`ios-test`/`ios-run`/`ios-fmt` via Zed's task picker
- `.gitignore`: ignores `buildServer.json` (machine-local, generated per checkout by `xcode-build-server` for sourcekit-lsp Xcode project support)

Tier 1 (editor config only, no code/behaviour change) — gates run, `ship` review skipped per CLAUDE.md.

## Test plan
- [x] `just fmt-check` / `just lint` green (no source changes)
- [ ] Open repo in Zed, confirm tasks appear in the task picker
- [ ] Run `xcode-build-server config -scheme Intrada -project ios/Intrada.xcodeproj` locally and confirm sourcekit-lsp navigation works in `ios/`

Coverage: N/A (config only, no app code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)