### PR TITLE
chore(hooks): refresh the knowledge graph on git pull

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PRs merge on GitHub, so the main checkout only ever fast-forwards via
+# `git pull` — post-commit and post-checkout never fire there and the
+# knowledge graph goes stale. Reuse post-commit's refresh logic.
+exec "$(dirname "$0")/post-commit"


### PR DESCRIPTION
## Why

The graphify knowledge graph in the main checkout had gone 12 days / 35 commits stale, missing the entire coach-engine landing. Cause: PRs merge on GitHub, so the main checkout never commits locally; `git pull` fast-forwards fire neither post-commit nor post-checkout, so the auto-refresh documented in CLAUDE.md never ran.

## What

Adds `.githooks/post-merge` (5 lines) that execs the existing graphify post-commit hook. post-merge fires on every fast-forward pull, so the graph now refreshes whenever main is pulled. The refresh is the same detached, AST-only, no-LLM rebuild; worktrees still skip via the existing common-dir guard.

Tier 1; `just hygiene` green. Coverage: n/a (shell hook, no coverage-tracked code).

Deferred items tracked: none — all flagged items addressed inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)