### PR TITLE
Coach: the mastery store survives a restart, rebuilt from the persisted evidence (#1214)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -447,9 +447,12 @@ impl Intrada {
             // The mastery track is a projection of this evidence, so the replay
             // is the whole of the read: nothing is stored twice (#1214).
             Event::CoachStoreLoaded(output) => match output {
+                // No render: nothing in `ViewModel` derives from the mastery
+                // track. It reaches a screen only through the plan, which is
+                // computed on `PlanSession`, after this has already run.
                 PersistenceOutput::CoachRecords(records) => {
                     model.coach.rebuild_mastery(&records);
-                    crux_core::render::render()
+                    Command::done()
                 }
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -118,10 +118,13 @@ pub enum Event {
     SessionsStoreLoaded(PersistenceOutput),
     /// Session write result, kept separate so a failed save reloads sessions (not items).
     SessionStoreWritten(PersistenceOutput),
-    /// Coach evidence write result. Nothing reads these rows back, so a failure
-    /// has nothing to reload to: the batch is offered again once instead, and
-    /// only a second failure surfaces (#1181).
+    /// Coach evidence write result. A failure has nothing to reload to — the
+    /// rows are append-only and the model already holds them — so the batch is
+    /// offered again once instead, and only a second failure surfaces (#1181).
     CoachStoreWritten(PersistenceOutput),
+    /// Every closed block, read back at launch to rebuild the mastery track
+    /// (#1214).
+    CoachStoreLoaded(PersistenceOutput),
 }
 
 /// Side effects the core requests from shells.
@@ -194,7 +197,11 @@ impl Intrada {
                 model.api_base_url = api_base_url;
                 model.local_first = local_first;
                 if local_first {
-                    Command::all([persistence::load_items(), persistence::load_sessions()])
+                    Command::all([
+                        persistence::load_items(),
+                        persistence::load_sessions(),
+                        persistence::load_coach_records(),
+                    ])
                 } else {
                     Command::all([
                         http::fetch_items(&model.api_base_url),
@@ -372,7 +379,9 @@ impl Intrada {
                     model.items = items;
                     crux_core::render::render()
                 }
-                PersistenceOutput::Ack | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Ack
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed read: surface only — no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -381,7 +390,9 @@ impl Intrada {
             },
             Event::StoreWritten(output) => match output {
                 PersistenceOutput::Ack => Command::done(),
-                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed write → reload to roll back the un-persisted change (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -394,7 +405,9 @@ impl Intrada {
                     model.practice_summaries = build_practice_summaries(&model.sessions);
                     crux_core::render::render()
                 }
-                PersistenceOutput::Items(_) | PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Ack
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     crux_core::render::render()
@@ -402,7 +415,9 @@ impl Intrada {
             },
             Event::SessionStoreWritten(output) => match output {
                 PersistenceOutput::Ack => Command::done(),
-                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed save → reload sessions to roll back the optimistic push (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -412,14 +427,15 @@ impl Intrada {
             Event::CoachStoreWritten(output) => match output {
                 PersistenceOutput::Ack
                 | PersistenceOutput::Items(_)
-                | PersistenceOutput::Sessions(_) => {
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => {
                     model.coach_write_in_flight = None;
                     Command::done()
                 }
-                // Nothing reads these rows back, so a failure has nothing to
-                // reload to and the block would simply be gone. Offer the batch
-                // again first (the store upserts by id, so a repeat is safe) and
-                // surface only if that fails too.
+                // A failure has nothing to reload to — the rows are append-only
+                // and the block would simply be gone. Offer the batch again first
+                // (the store upserts by id, so a repeat is safe) and surface only
+                // if that fails too.
                 PersistenceOutput::Failed => match model.coach_write_in_flight.take() {
                     Some(batch) => persistence::save_coach_records(batch),
                     None => {
@@ -427,6 +443,22 @@ impl Intrada {
                         crux_core::render::render()
                     }
                 },
+            },
+            // The mastery track is a projection of this evidence, so the replay
+            // is the whole of the read: nothing is stored twice (#1214).
+            Event::CoachStoreLoaded(output) => match output {
+                PersistenceOutput::CoachRecords(records) => {
+                    model.coach.rebuild_mastery(&records);
+                    crux_core::render::render()
+                }
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::Ack => Command::done(),
+                // No reload: a read that just failed would loop (as `StoreLoaded`).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't read back what you've practised.");
+                    crux_core::render::render()
+                }
             },
         }
     }

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -51,6 +51,38 @@ impl CoachState {
         writes
     }
 
+    /// The persisted `BlockRecord`s are the log and the mastery track is a
+    /// projection of them (#1214), so the store is never persisted itself: it is
+    /// re-seeded from content and replayed. Idempotent by construction — the
+    /// seed is where every replay starts, so reading the rows twice cannot
+    /// double-count the evidence.
+    pub fn rebuild_mastery(&mut self, records: &[BlockRecord]) {
+        self.mastery = MasteryStore::seeded_from(ContentIndex::shipped());
+        let mut replay = Vec::new();
+        for record in records {
+            for attempt in &record.attempts {
+                replay.push((attempt.at, Replay::Attempt(attempt.verdict), record));
+            }
+            // A pass banked in a previous run still owes its level-up, and
+            // `level_up` declines a rung that already has evidence — so it has
+            // to reach the store in the order it happened.
+            if record.exit == Exit::GatePassed {
+                if let Some(next) = next_rung(record) {
+                    replay.push((record.ended_at, Replay::LevelUp(next), record));
+                }
+            }
+        }
+        replay.sort_by_key(|(at, _, _)| *at);
+        for (at, step, record) in replay {
+            match step {
+                Replay::Attempt(verdict) => {
+                    self.mastery.record(&record.node, record.level, verdict, at)
+                }
+                Replay::LevelUp(to) => self.mastery.level_up(&record.node, record.level, to),
+            }
+        }
+    }
+
     /// Only the two press-start events need a plan, and only `CoachState` can
     /// make one: the planner reads the mastery track, which the session does not
     /// hold. The clock seeds the dealer and is stored on the `Plan`, so the
@@ -184,6 +216,11 @@ impl CoachState {
             gate_target: block.gate_progress.target(),
         })
     }
+}
+
+enum Replay {
+    Attempt(Verdict),
+    LevelUp(ParameterLevel),
 }
 
 /// A gate pass moves the cursor to the next rung of the node's ladder the loop
@@ -836,6 +873,261 @@ mod tests {
             tempo_bpm: 80,
             click_level: ClickLevel::EveryBeat,
         }
+    }
+
+    // ── The mastery track, rebuilt from the persisted records (#1214) ──
+
+    fn rung(tempo_bpm: u16) -> ParameterLevel {
+        ParameterLevel {
+            tempo_bpm,
+            click_level: ClickLevel::EveryBeat,
+        }
+    }
+
+    fn day(day: i64) -> DateTime<Utc> {
+        at(0) + TimeDelta::days(day)
+    }
+
+    fn attempt(clean: bool, at: DateTime<Utc>) -> crate::engine::AttemptSummary {
+        crate::engine::AttemptSummary {
+            at,
+            verdict: if clean {
+                Verdict::Clean
+            } else {
+                Verdict::Missed
+            },
+            source: crate::engine::EvidenceSource::TapVerdict,
+            cold: false,
+            self_predicted: None,
+        }
+    }
+
+    fn record(
+        id: &str,
+        drill: &str,
+        level: ParameterLevel,
+        exit: Exit,
+        attempts: Vec<crate::engine::AttemptSummary>,
+    ) -> BlockRecord {
+        record_on("rootless-a-b", id, drill, level, exit, attempts)
+    }
+
+    fn record_on(
+        node: &str,
+        id: &str,
+        drill: &str,
+        level: ParameterLevel,
+        exit: Exit,
+        attempts: Vec<crate::engine::AttemptSummary>,
+    ) -> BlockRecord {
+        let ended_at = attempts.last().map(|a| a.at).unwrap_or(day(0));
+        BlockRecord {
+            id: id.to_string(),
+            node: node.to_string(),
+            drill: drill.to_string(),
+            gate: drill.to_string(),
+            level,
+            circle: crate::engine::Circle::Hands,
+            mode: crate::engine::Mode::Keys,
+            started_at: attempts.first().map(|a| a.at).unwrap_or(ended_at),
+            ended_at,
+            attempts,
+            attempts_to_pass: None,
+            gate_opened_at_attempt: None,
+            reps_after_gate: 0,
+            active_ms: 0,
+            escalation_fired: vec![],
+            exit,
+        }
+    }
+
+    #[test]
+    fn a_store_rebuilt_from_the_records_knows_when_the_material_was_last_played() {
+        let records = vec![record(
+            "b1",
+            "rootless-one-key",
+            rung(60),
+            Exit::CeilingHit,
+            vec![attempt(true, day(0))],
+        )];
+        let mut coach = CoachState::default();
+        assert_eq!(
+            coach
+                .mastery
+                .reading("rootless-a-b", rung(60), day(3))
+                .overdue,
+            0.0,
+            "a launch re-seeded from content has nothing to be overdue against"
+        );
+
+        coach.rebuild_mastery(&records);
+
+        let reading = coach.mastery.reading("rootless-a-b", rung(60), day(3));
+        assert!(
+            reading.overdue > 1.0,
+            "three days after the last clean pass, the pull that puts maintenance \
+             ahead of new keys has something to fire on: {}",
+            reading.overdue
+        );
+        assert!(
+            coach.mastery.is_cold("rootless-a-b", rung(60), day(3)),
+            "and the first rep of the day on material played three days ago is a cold test"
+        );
+    }
+
+    #[test]
+    fn rebuilding_twice_does_not_double_count_the_evidence() {
+        let records = vec![record(
+            "b1",
+            "rootless-one-key",
+            rung(60),
+            Exit::CeilingHit,
+            vec![attempt(true, day(0)), attempt(false, day(0))],
+        )];
+        let mut coach = CoachState::default();
+
+        coach.rebuild_mastery(&records);
+        let once = coach.mastery.clone();
+        coach.rebuild_mastery(&records);
+
+        assert_eq!(
+            coach.mastery, once,
+            "the store is a projection of the records, so replaying them is not \
+             an append"
+        );
+    }
+
+    #[test]
+    fn records_read_back_in_any_order_rebuild_the_same_store() {
+        // The rung above only inherits from the one below while it has no
+        // evidence of its own, so a gate pass and the attempts that followed it
+        // land differently if the replay takes them in the order the rows arrived.
+        let passed = record(
+            "b1",
+            "rootless-transition",
+            rung(60),
+            Exit::GatePassed,
+            vec![attempt(true, day(0))],
+        );
+        let after = record(
+            "b2",
+            "rootless-under-melody",
+            rung(80),
+            Exit::CeilingHit,
+            vec![attempt(true, day(1))],
+        );
+
+        let mut chronological = CoachState::default();
+        chronological.rebuild_mastery(&[passed.clone(), after.clone()]);
+        let mut reversed = CoachState::default();
+        reversed.rebuild_mastery(&[after, passed]);
+
+        assert_eq!(
+            reversed.mastery, chronological.mastery,
+            "the store must not depend on the order SQLite handed the rows back"
+        );
+        let above = reversed
+            .mastery
+            .get("rootless-a-b", rung(80))
+            .expect("the rung the pass moved the cursor to");
+        assert!(
+            above.prior.0 + above.prior.1 > 2.0,
+            "and the level-up ran before the attempts above it, so the rung \
+             above holds an inherited prior rather than the content seed: {:?}",
+            above.prior
+        );
+    }
+
+    #[test]
+    fn a_gate_pass_in_the_records_moves_the_cursor_up_the_ladder() {
+        let seeded = *CoachState::default()
+            .mastery
+            .get("rootless-a-b", rung(80))
+            .expect("the content seeds every runnable rung");
+        let mut coach = CoachState::default();
+
+        coach.rebuild_mastery(&[record(
+            "b1",
+            "rootless-transition",
+            rung(60),
+            Exit::GatePassed,
+            vec![attempt(true, day(0))],
+        )]);
+
+        let above = coach.mastery.get("rootless-a-b", rung(80)).unwrap();
+        assert_ne!(
+            above.prior, seeded.prior,
+            "a pass banked in a previous run is still a pass: the rebuild owes \
+             the level-up it earned"
+        );
+    }
+
+    /// The consequence #1214 is about, end to end: what the store holds decides
+    /// what today's plan opens with. Without the read side this ordering was
+    /// only ever reachable by a test writing straight to the mastery track.
+    #[test]
+    fn evidence_from_a_previous_run_reorders_todays_plan() {
+        let phrase = ParameterLevel {
+            tempo_bpm: 120,
+            click_level: ClickLevel::TwoAndFour,
+        };
+        // The last node in the authored route, so route order alone leaves it
+        // last: only being overdue can pull it forward.
+        let records: Vec<_> = (0..12)
+            .map(|d| {
+                record_on(
+                    "phrase-transposition",
+                    &format!("b{d}"),
+                    "phrase-home-key",
+                    phrase,
+                    Exit::CeilingHit,
+                    vec![attempt(true, day(d))],
+                )
+            })
+            .collect();
+        let mut coach = CoachState::default();
+
+        coach.rebuild_mastery(&records);
+        coach.apply(&CoachEvent::PlanSession {
+            now: day(60),
+            available_minutes: Some(30),
+        });
+
+        let SessionState::Planned { plan } = &coach.session.state else {
+            panic!("a planned session");
+        };
+        let overdue = plan
+            .blocks
+            .iter()
+            .position(|block| block.spec.node == "phrase-transposition")
+            .expect("the overdue node");
+        let new_ground = plan
+            .blocks
+            .iter()
+            .position(|block| block.spec.node == "chord-tone-targeting")
+            .expect("a node with nothing behind it");
+        assert!(
+            overdue < new_ground,
+            "maintenance that fell due while the app was closed outranks new keys \
+             (journey 7): {:?}",
+            plan.blocks
+                .iter()
+                .map(|block| block.spec.node.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn a_rebuild_with_nothing_recorded_leaves_the_content_seeds_alone() {
+        let mut coach = CoachState::default();
+
+        coach.rebuild_mastery(&[]);
+
+        assert_eq!(
+            coach.mastery,
+            CoachState::default().mastery,
+            "a first launch has no evidence and must not lose its priors"
+        );
     }
 
     // ── The #846 hazard: every bridge type on the real wire ──

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -53,15 +53,20 @@ impl CoachState {
 
     /// The persisted `BlockRecord`s are the log and the mastery track is a
     /// projection of them (#1214), so the store is never persisted itself: it is
-    /// re-seeded from content and replayed. Idempotent by construction — the
-    /// seed is where every replay starts, so reading the rows twice cannot
-    /// double-count the evidence.
+    /// re-seeded from content and replayed. Every replay starts from that seed,
+    /// so reading the same rows twice cannot double-count — but for the same
+    /// reason this discards anything recorded since, which is why it belongs at
+    /// launch and nowhere else.
     pub fn rebuild_mastery(&mut self, records: &[BlockRecord]) {
         self.mastery = MasteryStore::seeded_from(ContentIndex::shipped());
         let mut replay = Vec::new();
         for record in records {
             for attempt in &record.attempts {
-                replay.push((attempt.at, Replay::Attempt(attempt.verdict), record));
+                replay.push((
+                    attempt.at,
+                    Replay::Attempt(attempt.verdict, attempt.level),
+                    record,
+                ));
             }
             // A pass banked in a previous run still owes its level-up, and
             // `level_up` declines a rung that already has evidence — so it has
@@ -75,9 +80,11 @@ impl CoachState {
         replay.sort_by_key(|(at, _, _)| *at);
         for (at, step, record) in replay {
             match step {
-                Replay::Attempt(verdict) => {
-                    self.mastery.record(&record.node, record.level, verdict, at)
+                Replay::Attempt(verdict, level) => {
+                    self.mastery.record(&record.node, level, verdict, at)
                 }
+                // The gate was passed at the level the block closed on, whatever
+                // the ladder did on the way there.
                 Replay::LevelUp(to) => self.mastery.level_up(&record.node, record.level, to),
             }
         }
@@ -219,7 +226,7 @@ impl CoachState {
 }
 
 enum Replay {
-    Attempt(Verdict),
+    Attempt(Verdict, ParameterLevel),
     LevelUp(ParameterLevel),
 }
 
@@ -888,6 +895,8 @@ mod tests {
         at(0) + TimeDelta::days(day)
     }
 
+    /// Level-less: `record_on` stamps each attempt with the block's own level,
+    /// which is what a block the ladder never touched looks like.
     fn attempt(clean: bool, at: DateTime<Utc>) -> crate::engine::AttemptSummary {
         crate::engine::AttemptSummary {
             at,
@@ -899,6 +908,7 @@ mod tests {
             source: crate::engine::EvidenceSource::TapVerdict,
             cold: false,
             self_predicted: None,
+            level: rung(60),
         }
     }
 
@@ -920,6 +930,10 @@ mod tests {
         exit: Exit,
         attempts: Vec<crate::engine::AttemptSummary>,
     ) -> BlockRecord {
+        let attempts: Vec<_> = attempts
+            .into_iter()
+            .map(|attempt| crate::engine::AttemptSummary { level, ..attempt })
+            .collect();
         let ended_at = attempts.last().map(|a| a.at).unwrap_or(day(0));
         BlockRecord {
             id: id.to_string(),
@@ -1114,6 +1128,44 @@ mod tests {
                 .iter()
                 .map(|block| block.spec.node.as_str())
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// The strongest statement the replay can make, and the one that catches a
+    /// whole class of loss rather than one instance: run a block through the live
+    /// path, then rebuild from the record it wrote and assert the two stores
+    /// agree. A block that escalated is the case that matters, because the
+    /// ladder's first rung drops the tempo mid-block, so the attempts before the
+    /// drop and the attempts after it belong to different rungs.
+    #[test]
+    fn a_rebuild_reproduces_the_store_the_live_run_held() {
+        let mut live = playing();
+        for second in [9, 18, 27] {
+            tap(&mut live, false, second);
+        }
+        assert!(
+            !live
+                .session
+                .block()
+                .expect("a running block")
+                .escalation_fired
+                .is_empty(),
+            "three misses fire the ladder, which is what puts two rungs in one block"
+        );
+        tap(&mut live, true, 36);
+        let writes = live.apply(&CoachEvent::LeaveSession { now: at(40) });
+        let record = writes
+            .blocks
+            .first()
+            .expect("the block it ended is written down");
+
+        let mut rebuilt = CoachState::default();
+        rebuilt.rebuild_mastery(std::slice::from_ref(record));
+
+        assert_eq!(
+            rebuilt.mastery, live.mastery,
+            "the record has to carry what the live path told the mastery track, or \
+             the rung the user was actually stuck at comes back as untouched"
         );
     }
 

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -212,6 +212,12 @@ pub struct AttemptSummary {
     /// First rep of the block: the highest-information tap-verdict.
     pub cold: bool,
     pub self_predicted: Option<Verdict>,
+    /// The rung this attempt was played at, which is not always the block's:
+    /// `Rung::TempoDown` drops the tempo mid-block, so a block that escalated
+    /// holds attempts belonging to two rungs. The mastery track is keyed by
+    /// `(node, level)`, so the level has to travel with the attempt or a rebuild
+    /// puts the pre-drop evidence on the post-drop rung (#1214).
+    pub level: ParameterLevel,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -788,6 +794,7 @@ impl EngineSession {
             source: EvidenceSource::TapVerdict,
             cold: block.cold && block.attempts.is_empty(),
             self_predicted: None,
+            level: block.level,
         });
         let scored = ScoredAttempt {
             node,

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -895,15 +895,16 @@ mod tests {
                 AttemptSummary, Circle, ClickLevel, EvidenceSource, Exit, Mode, ParameterLevel,
             };
             let played = at(0) - chrono::TimeDelta::days(days_ago);
+            let level = ParameterLevel {
+                tempo_bpm: 60,
+                click_level: ClickLevel::EveryBeat,
+            };
             vec![BlockRecord {
                 id: "b1".into(),
                 node: "rootless-a-b".into(),
                 drill: "rootless-one-key".into(),
                 gate: "rootless-one-key".into(),
-                level: ParameterLevel {
-                    tempo_bpm: 60,
-                    click_level: ClickLevel::EveryBeat,
-                },
+                level,
                 circle: Circle::Hands,
                 mode: Mode::Keys,
                 started_at: played,
@@ -914,6 +915,7 @@ mod tests {
                     source: EvidenceSource::TapVerdict,
                     cold: true,
                     self_predicted: None,
+                    level,
                 }],
                 attempts_to_pass: None,
                 gate_opened_at_attempt: None,

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -39,6 +39,11 @@ pub enum PersistenceOperation {
         wanders: Vec<WanderRecord>,
         updated_at: DateTime<Utc>,
     },
+    /// Every closed block, tombstones excluded (#1214). Read once at a
+    /// local-first launch: the mastery track is a projection of this evidence,
+    /// so it is rebuilt from it rather than persisted alongside it. Wanders are
+    /// not read — they carry no node or level, so nothing to replay.
+    LoadCoachRecords,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -47,6 +52,7 @@ pub enum PersistenceOperation {
 pub enum PersistenceOutput {
     Items(Vec<Item>),
     Sessions(Vec<PracticeSession>),
+    CoachRecords(Vec<BlockRecord>),
     Ack,
     /// Local store failed the op — surfaced, not trusted as success (#816).
     Failed,
@@ -78,6 +84,11 @@ pub fn delete_item(id: String, deleted_at: DateTime<Utc>) -> Command<Effect, Eve
 /// same batch to offer again if the write fails (#1181).
 pub fn save_coach_records(batch: PersistenceOperation) -> Command<Effect, Event> {
     Command::request_from_shell(batch).then_send(Event::CoachStoreWritten)
+}
+
+pub fn load_coach_records() -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::LoadCoachRecords)
+        .then_send(Event::CoachStoreLoaded)
 }
 
 pub fn load_sessions() -> Command<Effect, Event> {
@@ -875,7 +886,134 @@ mod tests {
             assert_eq!(block.gate_progress.filled(), 1);
         }
 
+        // ── The read half: mastery rebuilt from the records (#1214) ──
+
+        /// One closed block's worth of evidence, as the store would hand it
+        /// back: a clean pass on `rootless-a-b`, three days ago.
+        fn stored_records(days_ago: i64) -> Vec<BlockRecord> {
+            use crate::engine::{
+                AttemptSummary, Circle, ClickLevel, EvidenceSource, Exit, Mode, ParameterLevel,
+            };
+            let played = at(0) - chrono::TimeDelta::days(days_ago);
+            vec![BlockRecord {
+                id: "b1".into(),
+                node: "rootless-a-b".into(),
+                drill: "rootless-one-key".into(),
+                gate: "rootless-one-key".into(),
+                level: ParameterLevel {
+                    tempo_bpm: 60,
+                    click_level: ClickLevel::EveryBeat,
+                },
+                circle: Circle::Hands,
+                mode: Mode::Keys,
+                started_at: played,
+                ended_at: played,
+                attempts: vec![AttemptSummary {
+                    at: played,
+                    verdict: crate::engine::Verdict::Clean,
+                    source: EvidenceSource::TapVerdict,
+                    cold: true,
+                    self_predicted: None,
+                }],
+                attempts_to_pass: None,
+                gate_opened_at_attempt: None,
+                reps_after_gate: 0,
+                active_ms: 30_000,
+                escalation_fired: vec![],
+                exit: Exit::CeilingHit,
+            }]
+        }
+
+        fn sixty() -> crate::engine::ParameterLevel {
+            crate::engine::ParameterLevel {
+                tempo_bpm: 60,
+                click_level: crate::engine::ClickLevel::EveryBeat,
+            }
+        }
+
+        #[test]
+        fn load_coach_records_requests_the_load_operation() {
+            let mut cmd = load_coach_records();
+            assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+                if req.operation == PersistenceOperation::LoadCoachRecords)));
+        }
+
+        #[test]
+        fn a_local_first_launch_reads_the_evidence_back() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            let mut cmd = app.update(
+                Event::StartApp {
+                    api_base_url: "http://x".into(),
+                    local_first: true,
+                },
+                &mut model,
+            );
+            assert!(cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+                if req.operation == PersistenceOperation::LoadCoachRecords)));
+            assert!(!has_http(&mut cmd), "the evidence never comes over HTTP");
+        }
+
+        #[test]
+        fn the_records_read_back_give_the_planner_something_overdue_to_pull() {
+            let (app, mut model) = local_first();
+            assert_eq!(
+                model
+                    .coach
+                    .mastery
+                    .reading("rootless-a-b", sixty(), at(0))
+                    .overdue,
+                0.0,
+                "a launch re-seeded from content has nothing to be overdue against"
+            );
+
+            let _ = app.update(
+                Event::CoachStoreLoaded(PersistenceOutput::CoachRecords(stored_records(3))),
+                &mut model,
+            );
+
+            assert!(
+                model
+                    .coach
+                    .mastery
+                    .reading("rootless-a-b", sixty(), at(0))
+                    .overdue
+                    > 1.0,
+                "stage 3's maintenance pull fires for a real user, not only in tests"
+            );
+            assert!(
+                model.coach.mastery.is_cold("rootless-a-b", sixty(), at(0)),
+                "and the first rep of the day on it is the cold test the design wants"
+            );
+        }
+
+        #[test]
+        fn a_failed_evidence_read_surfaces_rather_than_vanishing() {
+            let (app, mut model) = local_first();
+            let mut cmd = app.update(
+                Event::CoachStoreLoaded(PersistenceOutput::Failed),
+                &mut model,
+            );
+            assert!(
+                model.last_error.is_some(),
+                "a failed local read is never a silent success (invariant 5)"
+            );
+            assert!(
+                !cmd.effects().any(|e| matches!(e, Effect::Persistence(_))),
+                "and it is not retried: a read that just failed would loop"
+            );
+            assert!(!has_http(&mut cmd), "nor does it fall back to the network");
+        }
+
         // ── The #846 hazard: the new payloads on the real wire ──
+
+        #[test]
+        fn the_evidence_read_survives_the_ffi_wire() {
+            crate::domain::types::assert_round_trips(PersistenceOperation::LoadCoachRecords);
+            crate::domain::types::assert_round_trips(PersistenceOutput::CoachRecords(
+                stored_records(3),
+            ));
+        }
 
         #[test]
         fn the_evidence_op_survives_the_ffi_wire() {

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@ scope and timing detail on the
 [project board](https://github.com/users/jonyardley/projects/2). When this
 doc and the issues disagree, the issues are right.*
 
-> Last updated: 2026-08-06 (#1231, #1236, #1175, #1239 follow-ups)
+> Last updated: 2026-08-06 (#1214)
 
 ## Where we are
 
@@ -22,6 +22,12 @@ countable criteria.
 
 ## Recently landed
 
+- #1214 — the mastery store survives a restart, rebuilt at launch by replaying
+  the persisted `BlockRecord`s in timestamp order. The store is never persisted
+  itself: the records already hold the evidence it derives. This makes two
+  designed behaviours real for the first time rather than test-only — planner
+  stage 3's overdue pull, and the cold test on the first rep of the day.
+  Contract: `specs/coach-2a-slice-contract.md` §7.
 - #1223, #1224, #1225 — the loop's choreography, corrected from Phase 0 play:
   the click runs unbroken for a whole block (one count-in at block entry, and
   a restart only where a parameter actually changed), every block opens on an
@@ -65,8 +71,6 @@ countable criteria.
   4.9MB `design/intrada-design-system.html` is one BeatPosition paragraph behind
   the `.dc.html` as of #1175, deliberately: #1232 patched that bundle in place
   and the re-export should be a real export, done once, on this visit
-- #1214 — the mastery store survives a restart, which is what makes the
-  planner's overdue pull and the cold test real
 - #1190 — delete the session-builder machinery (2a close-out)
 - Phase 2b — steer and guard: declaration surfaces, back-chaining, gap read,
   circling check, grind trade (see the phase plan in `roadmap.md`)

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -721,6 +721,10 @@ final class LibraryStore: ItemStore {
     var source: String
     var cold: Bool
     var selfPredicted: String?
+    /// Optional because rows written before #1214 have no per-attempt level.
+    /// The decoder falls back to the block's, which is all those rows ever knew.
+    var levelTempoBpm: UInt16?
+    var levelClickLevel: String?
   }
 
   private struct CoachCodecError: Error, CustomStringConvertible {
@@ -781,7 +785,9 @@ final class LibraryStore: ItemStore {
         StoredAttempt(
           at: attempt.at, verdict: verdictString(attempt.verdict),
           source: evidenceSourceString(attempt.source), cold: attempt.cold,
-          selfPredicted: attempt.selfPredicted.map(verdictString))
+          selfPredicted: attempt.selfPredicted.map(verdictString),
+          levelTempoBpm: attempt.level.tempoBpm,
+          levelClickLevel: clickLevelString(attempt.level.clickLevel))
       }, field: "attempts")
   }
 
@@ -852,43 +858,54 @@ final class LibraryStore: ItemStore {
     }
   }
 
-  private static func blockRecord(from row: Row) -> BlockRecord {
-    BlockRecord(
+  /// Throws rather than substituting a partial record: a block whose evidence
+  /// failed to decode would replay as a block nobody played, which the mastery
+  /// track then reads as material never practised. The op resolves `.failed` and
+  /// the core surfaces it, matching what the writer does with the same data
+  /// (invariant 5). An unrecognised *enum spelling* is different — the row is
+  /// still readable, so those report and fall back (#949).
+  private static func blockRecord(from row: Row) throws -> BlockRecord {
+    let level = ParameterLevel(
+      tempoBpm: UInt16(clamping: row["level_tempo_bpm"] as Int64),
+      clickLevel: clickLevel(from: row["level_click_level"]))
+    return BlockRecord(
       id: row["id"], node: row["node"], drill: row["drill"], gate: row["gate"],
-      level: ParameterLevel(
-        tempoBpm: UInt16(row["level_tempo_bpm"] as Int),
-        clickLevel: clickLevel(from: row["level_click_level"])),
+      level: level,
       circle: circle(from: row["circle"]), mode: mode(from: row["mode"]),
       startedAt: row["started_at"], endedAt: row["ended_at"],
-      attempts: decodeAttempts(row["attempts"]),
-      attemptsToPass: (row["attempts_to_pass"] as Int?).map { UInt16($0) },
-      gateOpenedAtAttempt: (row["gate_opened_at_attempt"] as Int?).map { UInt16($0) },
-      repsAfterGate: UInt16(row["reps_after_gate"] as Int),
-      activeMs: UInt64(row["active_ms"] as Int64),
-      escalationFired: decodeRungs(row["escalation_fired"]),
+      attempts: try decodeAttempts(row["attempts"], blockLevel: level),
+      attemptsToPass: (row["attempts_to_pass"] as Int64?).map { UInt16(clamping: $0) },
+      gateOpenedAtAttempt: (row["gate_opened_at_attempt"] as Int64?).map { UInt16(clamping: $0) },
+      repsAfterGate: UInt16(clamping: row["reps_after_gate"] as Int64),
+      activeMs: UInt64(clamping: row["active_ms"] as Int64),
+      escalationFired: try decodeRungs(row["escalation_fired"]),
       exit: exit(from: row["exit"]))
   }
 
-  /// Reports rather than returning empty silently: an attempts blob that failed
-  /// to decode would replay as a block nobody played, which the mastery track
-  /// then reads as material never practised.
-  private static func decodeAttempts(_ json: String) -> [AttemptSummary] {
-    guard let stored = try? JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) else {
-      report(CoachCodecError(field: "attempts", phase: "decode"), decodeContext)
-      return []
+  private static func decodeAttempts(_ json: String, blockLevel: ParameterLevel) throws
+    -> [AttemptSummary]
+  {
+    let stored: [StoredAttempt]
+    do { stored = try JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "attempts", phase: "decode")
     }
     return stored.map { attempt in
       AttemptSummary(
         at: attempt.at, verdict: verdict(from: attempt.verdict),
         source: evidenceSource(from: attempt.source), cold: attempt.cold,
-        selfPredicted: attempt.selfPredicted.map(verdict(from:)))
+        selfPredicted: attempt.selfPredicted.map(verdict(from:)),
+        // Pre-#1214 rows knew only the block's level, which for a block the
+        // ladder never touched is the same thing.
+        level: ParameterLevel(
+          tempoBpm: attempt.levelTempoBpm ?? blockLevel.tempoBpm,
+          clickLevel: attempt.levelClickLevel.map(clickLevel(from:)) ?? blockLevel.clickLevel))
     }
   }
 
-  private static func decodeRungs(_ json: String) -> [Rung] {
-    guard let raw = try? JSONDecoder().decode([String].self, from: Data(json.utf8)) else {
-      report(CoachCodecError(field: "escalation_fired", phase: "decode"), decodeContext)
-      return []
+  private static func decodeRungs(_ json: String) throws -> [Rung] {
+    let raw: [String]
+    do { raw = try JSONDecoder().decode([String].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "escalation_fired", phase: "decode")
     }
     return raw.map(rung(from:))
   }

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -14,6 +14,9 @@ protocol ItemStore {
   /// Append coach evidence in one transaction — blocks, wanders and their
   /// attempts land together or not at all (#1181).
   func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws
+  /// Every closed block, oldest first — the core replays them to rebuild the
+  /// mastery track (#1214).
+  func loadCoachRecords() throws -> [BlockRecord]
 }
 
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
@@ -186,6 +189,19 @@ final class LibraryStore: ItemStore {
       for wander in wanders {
         try Self.upsert(wander, updatedAt: updatedAt, in: db)
       }
+    }
+  }
+
+  func loadCoachRecords() throws -> [BlockRecord] {
+    try dbQueue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT * FROM block_record WHERE deleted_at IS NULL
+          ORDER BY started_at, id
+          """
+      )
+      .map(Self.blockRecord(from:))
     }
   }
 
@@ -695,10 +711,9 @@ final class LibraryStore: ItemStore {
     }
   }
 
-  // ── BlockRecord / WanderRecord → row codec (#1181) ────────────────────
-  // Write-only: nothing reads coach evidence back yet, so there is no decoder
-  // here to go stale. The stored enum spellings are the format contract a
-  // future reader must match.
+  // ── Row ↔ BlockRecord / WanderRecord codec (#1181 writes, #1214 reads) ─
+  // A wander has no decoder: it carries no node or level, so it holds nothing
+  // the mastery replay is keyed by and nothing reads it back.
 
   private struct StoredAttempt: Codable {
     var at: String
@@ -710,7 +725,8 @@ final class LibraryStore: ItemStore {
 
   private struct CoachCodecError: Error, CustomStringConvertible {
     let field: String
-    var description: String { "coach \(field) failed to encode" }
+    let phase: String
+    var description: String { "coach \(field) failed to \(phase)" }
   }
 
   private static func upsert(_ record: BlockRecord, updatedAt: String, in db: Database) throws {
@@ -772,7 +788,7 @@ final class LibraryStore: ItemStore {
   private static func encodeJSON<T: Encodable>(_ value: T, field: String) throws -> String {
     let data = try JSONEncoder().encode(value)
     guard let json = String(data: data, encoding: .utf8) else {
-      throw CoachCodecError(field: field)
+      throw CoachCodecError(field: field, phase: "encode")
     }
     return json
   }
@@ -833,6 +849,129 @@ final class LibraryStore: ItemStore {
     case .shrinkScope: "shrink_scope"
     case .changeMode: "change_mode"
     case .swapDrill: "swap_drill"
+    }
+  }
+
+  private static func blockRecord(from row: Row) -> BlockRecord {
+    BlockRecord(
+      id: row["id"], node: row["node"], drill: row["drill"], gate: row["gate"],
+      level: ParameterLevel(
+        tempoBpm: UInt16(row["level_tempo_bpm"] as Int),
+        clickLevel: clickLevel(from: row["level_click_level"])),
+      circle: circle(from: row["circle"]), mode: mode(from: row["mode"]),
+      startedAt: row["started_at"], endedAt: row["ended_at"],
+      attempts: decodeAttempts(row["attempts"]),
+      attemptsToPass: (row["attempts_to_pass"] as Int?).map { UInt16($0) },
+      gateOpenedAtAttempt: (row["gate_opened_at_attempt"] as Int?).map { UInt16($0) },
+      repsAfterGate: UInt16(row["reps_after_gate"] as Int),
+      activeMs: UInt64(row["active_ms"] as Int64),
+      escalationFired: decodeRungs(row["escalation_fired"]),
+      exit: exit(from: row["exit"]))
+  }
+
+  /// Reports rather than returning empty silently: an attempts blob that failed
+  /// to decode would replay as a block nobody played, which the mastery track
+  /// then reads as material never practised.
+  private static func decodeAttempts(_ json: String) -> [AttemptSummary] {
+    guard let stored = try? JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) else {
+      report(CoachCodecError(field: "attempts", phase: "decode"), decodeContext)
+      return []
+    }
+    return stored.map { attempt in
+      AttemptSummary(
+        at: attempt.at, verdict: verdict(from: attempt.verdict),
+        source: evidenceSource(from: attempt.source), cold: attempt.cold,
+        selfPredicted: attempt.selfPredicted.map(verdict(from:)))
+    }
+  }
+
+  private static func decodeRungs(_ json: String) -> [Rung] {
+    guard let raw = try? JSONDecoder().decode([String].self, from: Data(json.utf8)) else {
+      report(CoachCodecError(field: "escalation_fired", phase: "decode"), decodeContext)
+      return []
+    }
+    return raw.map(rung(from:))
+  }
+
+  private static func verdict(from raw: String) -> Verdict {
+    switch raw {
+    case "clean": return .clean
+    case "missed": return .missed
+    default:
+      report(UnknownStoredEnum(kind: "Verdict", raw: raw), decodeContext)
+      return .missed  // conservative: an unknown verdict must not inflate mastery (#949)
+    }
+  }
+
+  private static func evidenceSource(from raw: String) -> EvidenceSource {
+    switch raw {
+    case "tap_verdict": return .tapVerdict
+    case "midi": return .midi
+    case "audio": return .audio
+    default:
+      report(UnknownStoredEnum(kind: "EvidenceSource", raw: raw), decodeContext)
+      return .tapVerdict
+    }
+  }
+
+  private static func clickLevel(from raw: String) -> ClickLevel {
+    switch raw {
+    case "every_beat": return .everyBeat
+    case "two_and_four": return .twoAndFour
+    case "bar_downbeat": return .barDownbeat
+    case "every_other_bar": return .everyOtherBar
+    default:
+      report(UnknownStoredEnum(kind: "ClickLevel", raw: raw), decodeContext)
+      return .everyBeat
+    }
+  }
+
+  private static func circle(from raw: String) -> Circle {
+    switch raw {
+    case "head": return .head
+    case "hands": return .hands
+    case "bridge": return .bridge
+    default:
+      report(UnknownStoredEnum(kind: "Circle", raw: raw), decodeContext)
+      return .hands
+    }
+  }
+
+  private static func mode(from raw: String) -> Mode {
+    switch raw {
+    case "keys": return .keys
+    case "away": return .away
+    case "keys_to_away": return .keysToAway
+    default:
+      report(UnknownStoredEnum(kind: "Mode", raw: raw), decodeContext)
+      return .keys
+    }
+  }
+
+  private static func exit(from raw: String) -> Exit {
+    switch raw {
+    case "gate_passed": return .gatePassed
+    case "ceiling_hit": return .ceilingHit
+    case "skipped": return .skipped
+    case "escalated": return .escalated
+    case "session_ended": return .sessionEnded
+    default:
+      report(UnknownStoredEnum(kind: "Exit", raw: raw), decodeContext)
+      // Never `.gatePassed`: the core replays a pass as a level-up, so guessing
+      // one here would invent a rung the hands never earned.
+      return .sessionEnded
+    }
+  }
+
+  private static func rung(from raw: String) -> Rung {
+    switch raw {
+    case "tempo_down": return .tempoDown
+    case "shrink_scope": return .shrinkScope
+    case "change_mode": return .changeMode
+    case "swap_drill": return .swapDrill
+    default:
+      report(UnknownStoredEnum(kind: "Rung", raw: raw), decodeContext)
+      return .tempoDown
     }
   }
 

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -177,6 +177,7 @@ final class Store {
       case .saveCoachRecords(let blocks, let wanders, let updatedAt):
         try store.saveCoachRecords(blocks: blocks, wanders: wanders, updatedAt: updatedAt)
         return .ack
+      case .loadCoachRecords: return .coachRecords(try store.loadCoachRecords())
       }
     } catch {
       report(error, "persistence")

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -23,11 +23,12 @@ struct CoachRecordStoreTests {
 
   private func attempt(
     clean: Bool, cold: Bool = false, at: String = "2026-08-04T10:00:09Z",
-    source: EvidenceSource = .tapVerdict, selfPredicted: Verdict? = nil
+    source: EvidenceSource = .tapVerdict, selfPredicted: Verdict? = nil,
+    level: ParameterLevel = ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour)
   ) -> AttemptSummary {
     AttemptSummary(
       at: at, verdict: clean ? .clean : .missed, source: source, cold: cold,
-      selfPredicted: selfPredicted)
+      selfPredicted: selfPredicted, level: level)
   }
 
   private func block(
@@ -280,6 +281,82 @@ struct CoachRecordStoreTests {
 
     let read = try #require(try store.loadCoachRecords().first)
     #expect(read.exit == .sessionEnded, "an unknown exit reads as the neutral one")
+  }
+
+  @Test("an attempt keeps the rung it was played at, not the one the block closed on")
+  func readBackPerAttemptLevel() throws {
+    // The ladder's first rung drops the tempo mid-block, so a block that
+    // escalated holds attempts belonging to two rungs. Losing that puts the
+    // pre-drop evidence on the post-drop rung (#1214).
+    let (store, _) = try makeStore()
+    let before = ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour)
+    let after = ParameterLevel(tempoBpm: 96, clickLevel: .twoAndFour)
+    try store.saveCoachRecords(
+      blocks: [
+        block(
+          attempts: [
+            attempt(clean: false, at: "2026-08-04T10:00:09Z", level: before),
+            attempt(clean: true, at: "2026-08-04T10:00:18Z", level: after),
+          ], escalations: [.tempoDown], exit: .gatePassed)
+      ], wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(read.attempts.map(\.level) == [before, after])
+  }
+
+  @Test("every click level survives the round trip, since it is half the mastery key")
+  func readBackEveryClickLevel() throws {
+    let (store, _) = try makeStore()
+    let levels: [ClickLevel] = [.everyBeat, .twoAndFour, .barDownbeat, .everyOtherBar]
+    try store.saveCoachRecords(
+      blocks: levels.enumerated().map { index, level in
+        block(
+          "b\(index)",
+          attempts: [
+            attempt(
+              clean: true, at: "2026-08-04T10:0\(index):09Z",
+              level: ParameterLevel(tempoBpm: 80, clickLevel: level))
+          ])
+      }, wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try store.loadCoachRecords()
+    #expect(
+      read.compactMap { $0.attempts.first?.level.clickLevel } == levels,
+      "a decoder that drifts from its encoder relocates evidence silently")
+  }
+
+  @Test("a row written before the per-attempt level falls back to the block's")
+  func readBackLegacyAttemptWithoutLevel() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE block_record SET attempts = ? WHERE id = 'b1'",
+        arguments: [
+          """
+          [{"at":"2026-08-04T10:00:09Z","verdict":"clean","source":"tap_verdict","cold":false}]
+          """
+        ])
+    }
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(
+      read.attempts.first?.level == read.level,
+      "the block's level is all a pre-#1214 row ever knew; it must not be dropped")
+  }
+
+  @Test("an attempts blob that will not decode fails the read rather than emptying it")
+  func readBackCorruptAttemptsThrows() throws {
+    // Returning [] would replay as a block nobody played, which the mastery
+    // track then reads as material never practised (invariant 5).
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block(attempts: [attempt(clean: true)])], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE block_record SET attempts = 'not json' WHERE id = 'b1'")
+    }
+
+    #expect(throws: (any Error).self) { try store.loadCoachRecords() }
   }
 
   @Test("blocks read back oldest first, whatever order they were written")

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @testable import Intrada
 
-/// Coach evidence persistence (#1181, spec §4). The production codec is
-/// write-only, so the stored shape is pinned here: `DecodedAttempt` is the
-/// format contract a future reader has to match.
+/// Coach evidence persistence (#1181 writes, #1214 reads; spec §4). The writes
+/// are asserted against raw SQL rather than through the decoder, so the stored
+/// shape stays pinned independently of it: `DecodedAttempt` is that contract.
 @Suite("Coach evidence store")
 struct CoachRecordStoreTests {
 
@@ -221,6 +221,85 @@ struct CoachRecordStoreTests {
     try store.saveCoachRecords(blocks: [record], wanders: [], updatedAt: Self.updatedAt)
 
     #expect(try count(queue, "block_record") == 1, "a retried write must not double-count evidence")
+  }
+
+  // ── Reads (#1214) ─────────────────────────────────────────────────────
+
+  @Test("a written block reads back with every field the mastery replay needs")
+  func readBackRoundTrips() throws {
+    let (store, _) = try makeStore()
+    let attempts = [
+      attempt(clean: false, cold: true, at: "2026-08-04T10:00:09Z"),
+      attempt(clean: true, at: "2026-08-04T10:00:18Z", source: .midi, selfPredicted: .clean),
+    ]
+    let written = block(
+      attempts: attempts, escalations: [.tempoDown, .swapDrill], exit: .ceilingHit,
+      attemptsToPass: 4, gateOpenedAtAttempt: 2, repsAfterGate: 1, activeMs: 42_000)
+    try store.saveCoachRecords(blocks: [written], wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(read == written, "the decoder must give the core back what it wrote")
+  }
+
+  @Test("a block that never passed reads its nullable counters back as nil")
+  func readBackNullableCounters() throws {
+    let (store, _) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block(exit: .escalated, attemptsToPass: nil, gateOpenedAtAttempt: nil)],
+      wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(read.attemptsToPass == nil, "NULL reads back as never-passed, not 0")
+    #expect(read.gateOpenedAtAttempt == nil)
+  }
+
+  @Test("a tombstoned block is not replayed into the mastery track")
+  func readBackSkipsTombstones() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block("b1"), block("b2")], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE block_record SET deleted_at = ? WHERE id = 'b2'",
+        arguments: [Self.updatedAt])
+    }
+
+    #expect(try store.loadCoachRecords().map(\.id) == ["b1"])
+  }
+
+  @Test("an unrecognised stored enum is reported rather than silently defaulted")
+  func readBackUnknownEnum() throws {
+    // An older binary reading a row a newer version wrote (#949). The row must
+    // still decode — losing a whole block's evidence is worse than one field
+    // falling back — but it must not do so silently.
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE block_record SET exit = 'teleported' WHERE id = 'b1'")
+    }
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(read.exit == .sessionEnded, "an unknown exit reads as the neutral one")
+  }
+
+  @Test("blocks read back oldest first, whatever order they were written")
+  func readBackOrder() throws {
+    let (store, _) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [lateBlock, block("b-early")], wanders: [], updatedAt: Self.updatedAt)
+
+    #expect(try store.loadCoachRecords().map(\.id) == ["b-early", "b-late"])
+  }
+
+  private var lateBlock: BlockRecord {
+    BlockRecord(
+      id: "b-late", node: "rootless-a-b", drill: "rootless-one-key",
+      gate: "rootless-one-key",
+      level: ParameterLevel(tempoBpm: 60, clickLevel: .everyBeat),
+      circle: .hands, mode: .keys,
+      startedAt: "2026-08-05T10:00:00Z", endedAt: "2026-08-05T10:00:30Z",
+      attempts: [], attemptsToPass: nil, gateOpenedAtAttempt: nil, repsAfterGate: 0,
+      activeMs: 0, escalationFired: [], exit: .skipped)
   }
 
   // ── Upgrade path (CLAUDE.md "Local data migrations") ───────────────────

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -168,6 +168,35 @@ final class StoreEffectLoopTests: XCTestCase {
       "a lost block must surface as .failed, never a phantom .ack (#816)")
   }
 
+  func testCoachRecordsReadResolvesWhatWasWritten() throws {
+    let libraryStore = try LibraryStore.inMemory()
+    try libraryStore.saveCoachRecords(
+      blocks: [Self.coachBlock], wanders: [], updatedAt: "2026-08-04T10:00:30Z")
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [Request(id: 22, effect: .persistence(.loadCoachRecords))]
+    }
+    let store = Store(bridge: bridge, session: mockSession(), store: libraryStore)
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.first?.output, .coachRecords([Self.coachBlock]),
+      "the launch read hands the core back the evidence it wrote (#1214)")
+  }
+
+  func testCoachRecordsReadFailureResolvesFailed() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in [Request(id: 23, effect: .persistence(.loadCoachRecords))] }
+    let store = Store(bridge: bridge, session: mockSession(), store: FailingStore())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.first?.output, .failed,
+      "a failed read surfaces, so the core never rebuilds mastery from a lie (#816)")
+  }
+
   /// The session the core just snapshotted for crash recovery — also the only
   /// route to its `EngineConfig`, which `CoachView` does not carry.
   private func coachSession(in requests: [Request]) throws -> EngineSession {
@@ -535,6 +564,26 @@ final class StoreEffectLoopTests: XCTestCase {
       afterEdit.items.first?.title, "Renamed",
       "edited title should apply (err=\(afterEdit.error ?? "nil"))")
     XCTAssertEqual(afterEdit.items.first?.itemType, .exercise, "edited type should apply")
+  }
+
+  /// Real-bridge evidence read-back (#846, #1214): `PersistenceOutput` carries
+  /// a `Vec<BlockRecord>` back to the core, which a stub bridge can't exercise.
+  /// A wire break here would leave the mastery track silently unrebuilt — the
+  /// exact dead-path this closes — so drive the resolve through LiveBridge,
+  /// where a serialization failure throws instead of being swallowed.
+  func testRealBridgeCoachRecordsResolveOnTheWire() throws {
+    let bridge = LiveBridge()
+    let launch = try bridge.update(
+      .startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let id = try XCTUnwrap(
+      launch.first { request in
+        if case .persistence(.loadCoachRecords) = request.effect { return true }
+        return false
+      }?.id, "a local-first launch must ask for the coach records")
+
+    _ = try bridge.resolve(id, persistenceOutput: .coachRecords([Self.coachBlock]))
+
+    XCTAssertNil(try bridge.view().error, "a clean read leaves nothing to surface")
   }
 
   /// Real-bridge step round-trip (#846, #1083): `AddVariant` pushes a `Variant`
@@ -1281,6 +1330,7 @@ private struct FailingStore: ItemStore {
   func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws {
     throw TestError()
   }
+  func loadCoachRecords() throws -> [BlockRecord] { throw TestError() }
 }
 
 final class MockURLProtocol: URLProtocol {

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -130,7 +130,7 @@ final class StoreEffectLoopTests: XCTestCase {
     attempts: [
       AttemptSummary(
         at: "2026-08-04T10:00:09Z", verdict: .clean, source: .tapVerdict, cold: true,
-        selfPredicted: nil)
+        selfPredicted: nil, level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour))
     ],
     attemptsToPass: 3, gateOpenedAtAttempt: 3, repsAfterGate: 0, activeMs: 30_000,
     escalationFired: [], exit: .gatePassed)
@@ -569,9 +569,11 @@ final class StoreEffectLoopTests: XCTestCase {
   /// Real-bridge evidence read-back (#846, #1214): `PersistenceOutput` carries
   /// a `Vec<BlockRecord>` back to the core, which a stub bridge can't exercise.
   /// A wire break here would leave the mastery track silently unrebuilt — the
-  /// exact dead-path this closes — so drive the resolve through LiveBridge,
-  /// where a serialization failure throws instead of being swallowed.
-  func testRealBridgeCoachRecordsResolveOnTheWire() throws {
+  /// exact dead path this closes — so drive the resolve through LiveBridge,
+  /// where a serialization failure throws instead of being swallowed, and read
+  /// the outcome off the plan, which is the only ViewModel surface the mastery
+  /// track reaches.
+  func testRealBridgeCoachRecordsRebuildMasteryOnTheWire() throws {
     let bridge = LiveBridge()
     let launch = try bridge.update(
       .startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
@@ -581,9 +583,41 @@ final class StoreEffectLoopTests: XCTestCase {
         return false
       }?.id, "a local-first launch must ask for the coach records")
 
-    _ = try bridge.resolve(id, persistenceOutput: .coachRecords([Self.coachBlock]))
+    _ = try bridge.resolve(id, persistenceOutput: .coachRecords(Self.overdueEvidence))
+    _ = try bridge.update(
+      .coach(.planSession(now: "2026-09-20T10:00:00Z", availableMinutes: 30)))
 
+    let plan = try XCTUnwrap(try bridge.view().coach.plan, "a planned session")
     XCTAssertNil(try bridge.view().error, "a clean read leaves nothing to surface")
+    // "is due back" is written only where `overdue_pct >= 100`, which nothing can
+    // reach without a `last_attempt_at` — so this sentence appearing on screen is
+    // the proof the records crossed the wire and were replayed.
+    XCTAssertTrue(
+      plan.blocks.contains { $0.why.contains("is due back") },
+      "the plan must say what fell due while the app was closed: "
+        + "\(plan.blocks.map(\.why))")
+  }
+
+  /// A fortnight of clean passes on the last node of the authored route, far
+  /// enough back to be overdue by the time the plan is asked for.
+  private static var overdueEvidence: [BlockRecord] {
+    (0..<12).map { day in
+      BlockRecord(
+        id: "b\(day)", node: "phrase-transposition", drill: "phrase-home-key",
+        gate: "phrase-home-key",
+        level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour),
+        circle: .head, mode: .keys,
+        startedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:00Z",
+        endedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:30Z",
+        attempts: [
+          AttemptSummary(
+            at: "2026-08-\(String(format: "%02d", day + 1))T10:00:09Z", verdict: .clean,
+            source: .tapVerdict, cold: false, selfPredicted: nil,
+            level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour))
+        ],
+        attemptsToPass: nil, gateOpenedAtAttempt: nil, repsAfterGate: 0, activeMs: 30_000,
+        escalationFired: [], exit: .ceilingHit)
+    }
   }
 
   /// Real-bridge step round-trip (#846, #1083): `AddVariant` pushes a `Variant`

--- a/specs/coach-2a-slice-contract.md
+++ b/specs/coach-2a-slice-contract.md
@@ -268,6 +268,32 @@ pub enum Event {
 Blocks only. A `WanderRecord` has no node and no level (§4), so it carries
 nothing the mastery track is keyed by and nothing to replay.
 
+`AttemptSummary` gains the level it was played at, which is a change to a
+persisted shape as well as a bridged one:
+
+```rust
+pub struct AttemptSummary {
+    // … unchanged …
+    /// Not always the block's: `Rung::TempoDown` drops the tempo mid-block, so
+    /// a block that escalated holds attempts belonging to two rungs.
+    pub level: ParameterLevel,
+}
+```
+
+`BlockRecord::level` is the level the block *closed* on, so without this a
+rebuild puts the pre-drop attempts on the post-drop rung, and the rung the user
+was actually stuck at comes back looking untouched — `overdue == 0`,
+`is_cold == false`, which is the dead path this was meant to close. The ladder's
+first rung is a tempo drop at three consecutive misses, so that is the common
+case, not a corner. `escalation_fired` carries no timestamp, so the row cannot be
+repaired after the fact: the level has to travel with the attempt.
+
+The stored `attempts` blob is JSON, so the two new keys are additive and no table
+migration follows. Rows written before this read back with the block's level,
+which is all they ever knew. The level-up replay still uses `BlockRecord::level`:
+the gate was passed at the level the block closed on, whatever the ladder did on
+the way there.
+
 `Event::StartApp { local_first: true }` requests it alongside `LoadItems` and
 `LoadSessions`. `CoachStoreLoaded(CoachRecords(blocks))` calls:
 

--- a/specs/coach-2a-slice-contract.md
+++ b/specs/coach-2a-slice-contract.md
@@ -231,8 +231,78 @@ pub struct PlanContext {
   `gates.toml`: the file authors none of them yet (#1188 permits this
   explicitly). `MasteryConstants` is the single place they live, and moving
   them into the file is a follow-up.
-- **The mastery store is not persisted.** It lives on `CoachState` for the app's
-  lifetime and is re-seeded from content at launch, so "returning material" and
-  `overdue` are within-run facts for now. Rebuilding it from the persisted
-  `BlockRecord`s needs a read side the persistence layer does not have. Tracked
-  as a follow-up.
+- **The mastery store is still not persisted, and never will be.** It is rebuilt
+  at launch from the persisted `BlockRecord`s instead (§7, #1214): the records
+  already hold every fact the store derives, so storing the store as well would
+  be a second source of truth for the same evidence.
+
+## 7. The read half of the evidence: rebuilding mastery at launch (#1214)
+
+`SaveCoachRecords` (§4 of the engine spec) has written every attempt with its
+verdict, level and timestamp since #1181, and nothing read them back. So
+`last_attempt_at` only existed for attempts made since launch, which made
+planner stage 3's overdue pull and the cold test dead paths for a real user.
+
+The store itself is **not** persisted. It is a projection of the records, and
+the records are the log:
+
+```rust
+pub enum PersistenceOperation {
+    // … unchanged …
+    /// Every closed block, tombstones excluded. Read once at a local-first
+    /// launch; the core replays the attempts through the mastery track.
+    LoadCoachRecords,
+}
+
+pub enum PersistenceOutput {
+    // … unchanged …
+    CoachRecords(Vec<BlockRecord>),
+}
+
+pub enum Event {
+    // … unchanged …
+    CoachStoreLoaded(PersistenceOutput),
+}
+```
+
+Blocks only. A `WanderRecord` has no node and no level (§4), so it carries
+nothing the mastery track is keyed by and nothing to replay.
+
+`Event::StartApp { local_first: true }` requests it alongside `LoadItems` and
+`LoadSessions`. `CoachStoreLoaded(CoachRecords(blocks))` calls:
+
+```rust
+impl CoachState {
+    /// Re-seed from content, then replay every attempt in timestamp order.
+    /// Idempotent by construction: the seed is the starting point each time,
+    /// so calling it twice cannot double-count evidence.
+    pub fn rebuild_mastery(&mut self, records: &[BlockRecord])
+}
+```
+
+Replay is a projection, in one ordered pass:
+
+- Every attempt of every block becomes `mastery.record(node, level, verdict, at)`.
+- A block whose `exit` is `GatePassed` becomes a `level_up` at its `ended_at`.
+- The whole stream sorts by timestamp before it runs, stably. Order matters —
+  `level_up` declines to overwrite a rung that already has evidence — so a store
+  that read the rows back in a different order would hold different priors.
+
+Reconciliation stays in the core (offline-first invariant 4): the shell runs the
+typed read and nothing else. `CoachStoreLoaded(Failed)` surfaces an error and
+reloads nothing, like `StoreLoaded(Failed)` — a retry against a store that just
+failed a read is a loop.
+
+In Swift, the read is a decoder for rows the codec has only ever written:
+
+```swift
+protocol ItemStore {
+  // … unchanged …
+  func loadCoachRecords() throws -> [BlockRecord]
+}
+```
+
+`SELECT … WHERE deleted_at IS NULL`. The stored enum spellings (`"clean"`,
+`"two_and_four"`, `"gate_passed"`, …) that #1181 pinned as the format contract
+are now read by production code, and an unrecognised one is reported through
+`report(_:)` rather than silently defaulting (#949).

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -243,6 +243,12 @@ pre-play prediction against a tap-verdict — considered and cut, design doc v6.
 > `CoachEvent::RecoverSession` re-anchors the clock, so a recovered block keeps
 > the minutes already spent against its ceiling and a wander banks none of the
 > outage.
+>
+> **Read back 6 Aug 2026 (#1214).** `PersistenceOperation::LoadCoachRecords`
+> returns every closed `BlockRecord`, and a local-first launch replays their
+> attempts through the mastery track in timestamp order. The records are the log
+> and the mastery store is a projection of them, so the store is never persisted
+> itself. Contract: `specs/coach-2a-slice-contract.md` §7.
 
 > **Rebuilt 6 Aug 2026 (#1223), from a fortnight of playing it.** Three
 > transitions changed and one state was added; the table below reads through
@@ -427,6 +433,13 @@ non-empty why citing the destination whenever one is declared (principle 7).
 > until the session-end narrative. A stub target and a rung with no click both
 > land in `Plan::deferred` rather than vanishing, and the session length comes
 > from `[defaults]` until press-start (#1182) can ask for it.
+
+> **Stage 3 fires for a real user from 6 Aug 2026 (#1214).** The live mastery
+> store arrived with #1188, but nothing read the persisted evidence back, so
+> `last_attempt_at` existed only for attempts made since launch: the `overdue`
+> pull above and the cold test were covered by tests and dead in production. The
+> store is now rebuilt at launch by replaying the persisted `BlockRecord`s (§4's
+> read-back note).
 
 ## 6. The FFI contract
 


### PR DESCRIPTION
Closes #1214.

`PersistenceOperation::SaveCoachRecords` has written every attempt with its
verdict, level and timestamp since #1181, and nothing read them back. So
`MasteryStore::last_attempt_at` only existed for attempts made since launch,
which meant two designed behaviours were covered by tests and dead for a real
user:

- **`overdue` was effectively always 0**, so planner stage 3's pull that puts
  overdue maintenance ahead of new keys never fired. Today's plan was ordered by
  maturity alone.
- **`is_cold` was effectively always false.** A practice session usually *is* the
  first thing after a launch, so the highest-information tap-verdict in the
  design was never marked as one, and the `cold` column was being written
  truthfully and uselessly.

Both are real from this PR. The evidence was never lost; only the read side was
missing.

## Approach

The records are the log and the mastery store is a projection of them, so the
store is **not** persisted: it is re-seeded from the authored content at launch
and the persisted attempts are replayed through it in timestamp order. Persisting
the store as well would be a second source of truth for facts the records already
hold. Reconciliation stays in the core (offline-first invariant 4); the shell runs
the typed read and nothing else. No HTTP on the path.

- `PersistenceOperation::LoadCoachRecords` and
  `PersistenceOutput::CoachRecords(Vec<BlockRecord>)`, following
  `LoadSessions`/`Sessions` exactly. Blocks only: a `WanderRecord` has no node and
  no level, so it carries nothing the mastery track is keyed by.
- `Event::CoachStoreLoaded`, requested at a local-first launch beside `LoadItems`
  and `LoadSessions`. A failed read surfaces and reloads nothing, since a read
  that just failed would loop.
- `CoachState::rebuild_mastery` replays each attempt through `MasteryStore::record`,
  with a gate pass replayed as the level-up it earned. Order matters, because
  `level_up` declines a rung that already has evidence, so the whole stream sorts
  by timestamp before it runs.
- iOS: `LibraryStore.loadCoachRecords`, which turns the #1181 write-only codec
  into a round trip.

Contract first, per CLAUDE.md: `specs/coach-2a-slice-contract.md` §7, plus the
read-back note in `specs/intrada-coach-engine.md` §4 and the §5 note recording
that stage 3 now fires. The deferred caveats those two files carried are gone,
not softened.

Tier 3 by the domain-sensitivity override (a new bridge-contract variant), but no
new spec doc: the contract is appended to the existing slice contract, in this PR.

## The blocker the self-review caught

Worth calling out because it changes a persisted shape. `Rung::TempoDown` drops
the tempo *mid-block*, but `BlockRecord::level` is only the level the block
**closed** on. The first version of the replay therefore put every pre-drop
attempt on the post-drop rung, and the rung the user was actually stuck at came
back looking untouched — `overdue == 0`, `is_cold == false`, which is the dead
path this PR exists to close, still dead for exactly the blocks a struggling user
produces. The ladder's first rung fires at three consecutive misses, so that is
the common case, not a corner.

`escalation_fired` carries no timestamp, so the row could not be repaired after
the fact. `AttemptSummary` gains `level: ParameterLevel` instead, which is where
it belonged: the mastery track is keyed by `(node, level)`, so the level is a
property of the attempt. The stored `attempts` blob is JSON, so the two new keys
are additive and no table migration follows; rows written before this read back
with the block's level, which is all they ever knew.

## Tests

TDD throughout for the core, and every load-bearing line mutation-tested (break
the line, watch the named test fail) rather than assumed:

- **A rebuild reproduces the store the live run held.** Run a block through the
  live path to escalation and back, then rebuild from the record it wrote and
  assert the two mastery stores are equal. This is what caught the blocker above,
  and it catches the class rather than the instance.
- Replay is order-independent: records fed in reverse rebuild the same store, and
  the rung above still holds its inherited prior. Fails without the sort.
- Replay is not an append: rebuilding twice leaves the store unchanged.
- A rebuilt store makes `overdue` non-zero and `is_cold` true where a
  content-seeded one cannot.
- **The end-to-end claim the issue makes**: evidence from a previous run reorders
  today's plan, with the overdue node ahead of new ground. Fails without the
  rebuild.
- A failed read resolves `PersistenceOutput::Failed`, surfaces, and does not
  retry or fall back to HTTP.
- The #846 hazard: `assert_round_trips` on both new payloads, plus a real-bridge
  test that resolves the records through the actual bincode wire and reads the
  outcome off the plan ("is due back", a sentence no seeded store can produce).
- Swift: a written block reads back equal to what was written; tombstones are
  skipped; a pre-#1214 attempts row falls back to the block's level; an
  undecodable attempts blob fails the read rather than emptying it; every click
  level round-trips, since it is half the mastery key.

Gates: `just check` green (1001 tests), `just ios-fmt-check` green,
`just ios-test-full` green (261/261).

Coverage: full for the new core paths (the replay, the launch wiring, both
`PersistenceOutput` arms and the round-trips). The new Swift decoder is in `ios/`,
which `codecov.yml` ignores by design, and is covered by the Swift suite above.

Deferred items tracked: #1241, #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)