### PR TITLE
Coach engine: the mastery store survives a restart (#1214)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -118,9 +118,12 @@ pub enum Event {
     SessionsStoreLoaded(PersistenceOutput),
     /// Session write result, kept separate so a failed save reloads sessions (not items).
     SessionStoreWritten(PersistenceOutput),
-    /// Coach evidence write result. Nothing reads these rows back, so a failure
-    /// has nothing to reload to: the batch is offered again once instead, and
-    /// only a second failure surfaces (#1181).
+    /// The persisted block records back at launch, replayed into the mastery
+    /// track; without this, overdue and the cold test reset every restart (#1214).
+    CoachRecordsLoaded(PersistenceOutput),
+    /// Coach evidence write result. A failed write means the row was never
+    /// stored, so a reload cannot recover it: the batch is offered again once
+    /// instead, and only a second failure surfaces (#1181).
     CoachStoreWritten(PersistenceOutput),
 }
 
@@ -194,7 +197,11 @@ impl Intrada {
                 model.api_base_url = api_base_url;
                 model.local_first = local_first;
                 if local_first {
-                    Command::all([persistence::load_items(), persistence::load_sessions()])
+                    Command::all([
+                        persistence::load_items(),
+                        persistence::load_sessions(),
+                        persistence::load_coach_records(),
+                    ])
                 } else {
                     Command::all([
                         http::fetch_items(&model.api_base_url),
@@ -372,7 +379,9 @@ impl Intrada {
                     model.items = items;
                     crux_core::render::render()
                 }
-                PersistenceOutput::Ack | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Ack
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed read: surface only — no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -381,7 +390,9 @@ impl Intrada {
             },
             Event::StoreWritten(output) => match output {
                 PersistenceOutput::Ack => Command::done(),
-                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed write → reload to roll back the un-persisted change (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -394,7 +405,9 @@ impl Intrada {
                     model.practice_summaries = build_practice_summaries(&model.sessions);
                     crux_core::render::render()
                 }
-                PersistenceOutput::Items(_) | PersistenceOutput::Ack => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Ack
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     crux_core::render::render()
@@ -402,17 +415,34 @@ impl Intrada {
             },
             Event::SessionStoreWritten(output) => match output {
                 PersistenceOutput::Ack => Command::done(),
-                PersistenceOutput::Items(_) | PersistenceOutput::Sessions(_) => Command::done(),
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
                 // Failed save → reload sessions to roll back the optimistic push (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     persistence::load_sessions()
                 }
             },
+            Event::CoachRecordsLoaded(output) => match output {
+                PersistenceOutput::CoachRecords(blocks) => {
+                    model.coach.rebuild_mastery(blocks);
+                    crux_core::render::render()
+                }
+                PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::Ack => Command::done(),
+                // Failed read: surface only, no reload (would loop a broken store).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    crux_core::render::render()
+                }
+            },
             Event::CoachStoreWritten(output) => match output {
                 PersistenceOutput::Ack
                 | PersistenceOutput::Items(_)
-                | PersistenceOutput::Sessions(_) => {
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => {
                     model.coach_write_in_flight = None;
                     Command::done()
                 }

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -51,6 +51,26 @@ impl CoachState {
         writes
     }
 
+    /// Rebuild the mastery track from the persisted evidence at launch (#1214):
+    /// the same one-way replay as the live path in [`Self::apply`]. Replaces
+    /// rather than adds, like every other load handler, so a repeated load can
+    /// never double-count.
+    pub fn rebuild_mastery(&mut self, mut records: Vec<BlockRecord>) {
+        self.mastery = MasteryStore::seeded_from(ContentIndex::shipped());
+        records.sort_by(|a, b| a.ended_at.cmp(&b.ended_at).then_with(|| a.id.cmp(&b.id)));
+        for record in records {
+            for attempt in &record.attempts {
+                self.mastery
+                    .record(&record.node, record.level, attempt.verdict, attempt.at);
+            }
+            if record.exit == Exit::GatePassed {
+                if let Some(next) = next_rung(&record) {
+                    self.mastery.level_up(&record.node, record.level, next);
+                }
+            }
+        }
+    }
+
     /// Only the two press-start events need a plan, and only `CoachState` can
     /// make one: the planner reads the mastery track, which the session does not
     /// hold. The clock seeds the dealer and is stored on the `Plan`, so the
@@ -836,6 +856,172 @@ mod tests {
             tempo_bpm: 80,
             click_level: ClickLevel::EveryBeat,
         }
+    }
+
+    // ── Rebuilt from the persisted evidence at launch (#1214) ──
+
+    fn closed_block(id: &str, verdicts: &[(bool, i64)], exit: Exit) -> BlockRecord {
+        use crate::engine::gate::EvidenceSource;
+        use crate::engine::plan::{Circle, Mode};
+        use crate::engine::session::AttemptSummary;
+        BlockRecord {
+            id: id.to_string(),
+            node: "rootless-a-b".to_string(),
+            drill: "rootless-under-melody".to_string(),
+            gate: "rootless-under-melody".to_string(),
+            level: fixture_level(),
+            circle: Circle::Hands,
+            mode: Mode::Keys,
+            started_at: at(0),
+            ended_at: at(verdicts.last().map(|(_, second)| *second).unwrap_or(0)),
+            attempts: verdicts
+                .iter()
+                .map(|(clean, second)| AttemptSummary {
+                    at: at(*second),
+                    verdict: if *clean {
+                        Verdict::Clean
+                    } else {
+                        Verdict::Missed
+                    },
+                    source: EvidenceSource::TapVerdict,
+                    cold: false,
+                    self_predicted: None,
+                })
+                .collect(),
+            attempts_to_pass: None,
+            gate_opened_at_attempt: None,
+            reps_after_gate: 0,
+            active_ms: 0,
+            escalation_fired: vec![],
+            exit,
+        }
+    }
+
+    #[test]
+    fn replaying_a_persisted_record_rebuilds_the_evidence_it_holds() {
+        let mut coach = CoachState::default();
+        coach.rebuild_mastery(vec![closed_block(
+            "b1",
+            &[(true, 9), (false, 18)],
+            Exit::SessionEnded,
+        )]);
+
+        let mastery = coach
+            .mastery
+            .get("rootless-a-b", fixture_level())
+            .expect("evidence at the rung the block ran");
+        assert!((mastery.evidence() - 2.0).abs() < 0.01, "both attempts");
+        assert_eq!(
+            mastery.last_attempt_at,
+            Some(at(18)),
+            "so overdue and the cold test read the real gap, not the launch"
+        );
+    }
+
+    #[test]
+    fn a_replayed_gate_pass_reseeds_the_rung_above_like_the_live_one_did() {
+        let mut coach = CoachState::default();
+        let seed = *coach
+            .mastery
+            .get("rootless-a-b", next_rung())
+            .expect("the content seeds every runnable rung");
+
+        coach.rebuild_mastery(vec![closed_block(
+            "b1",
+            &[(true, 9), (true, 18), (true, 27)],
+            Exit::GatePassed,
+        )]);
+
+        let above = coach.mastery.get("rootless-a-b", next_rung()).unwrap();
+        assert_ne!(above.prior, seed.prior, "the level-up replayed too");
+        assert_eq!(above.evidence(), 0.0, "inheritance is prior, not evidence");
+    }
+
+    #[test]
+    fn a_second_load_replaces_what_the_first_one_built() {
+        let record = closed_block("b1", &[(true, 9)], Exit::SessionEnded);
+        let mut coach = CoachState::default();
+        coach.rebuild_mastery(vec![record.clone()]);
+        let once = coach.mastery.clone();
+
+        coach.rebuild_mastery(vec![record]);
+
+        assert_eq!(
+            coach.mastery, once,
+            "a reload must never double the evidence"
+        );
+    }
+
+    #[test]
+    fn records_replay_in_time_order_however_the_store_returns_them() {
+        let earlier = closed_block("b1", &[(true, 9)], Exit::SessionEnded);
+        let later = closed_block("b2", &[(false, 100)], Exit::SessionEnded);
+
+        let mut coach = CoachState::default();
+        coach.rebuild_mastery(vec![later.clone(), earlier.clone()]);
+
+        let mut sorted = CoachState::default();
+        sorted.rebuild_mastery(vec![earlier, later]);
+        assert_eq!(coach.mastery, sorted.mastery);
+        assert_eq!(
+            coach
+                .mastery
+                .get("rootless-a-b", fixture_level())
+                .unwrap()
+                .last_attempt_at,
+            Some(at(100)),
+            "the newest attempt wins whatever order the rows arrive in"
+        );
+    }
+
+    #[test]
+    fn a_restart_rebuilds_the_store_the_live_session_left_behind() {
+        let mut live = CoachState::default();
+        live.session.start_fixture(at(0));
+        let mut records = Vec::new();
+        for second in [9, 18, 27] {
+            records.extend(tap_collect(&mut live, true, second));
+        }
+        records.extend(live.apply(&CoachEvent::Tick { now: at(40) }).blocks);
+        assert!(!records.is_empty(), "the run must have closed a block");
+
+        let mut rebuilt = CoachState::default();
+        rebuilt.rebuild_mastery(records);
+
+        assert_eq!(
+            rebuilt.mastery, live.mastery,
+            "a restart loses nothing the records hold"
+        );
+    }
+
+    /// `tap`, keeping the records the events closed.
+    fn tap_collect(coach: &mut CoachState, clean: bool, second: i64) -> Vec<BlockRecord> {
+        let mut records = Vec::new();
+        if coach.session.phase() == Some(&Phase::BlockEntry) {
+            records.extend(coach.apply(&CoachEvent::StartBlock { now: at(0) }).blocks);
+        }
+        if matches!(coach.session.phase(), Some(Phase::CountIn { .. })) {
+            records.extend(coach.apply(&CoachEvent::Beat { beat_index: 0 }).blocks);
+        }
+        let block = coach.session.block().expect("a running block");
+        let phrase = block.body_beats();
+        let boundary = (block.beat_index / phrase + 1) * phrase;
+        records.extend(
+            coach
+                .apply(&CoachEvent::Beat {
+                    beat_index: boundary,
+                })
+                .blocks,
+        );
+        records.extend(
+            coach
+                .apply(&CoachEvent::Tap {
+                    clean,
+                    now: at(second),
+                })
+                .blocks,
+        );
+        records
     }
 
     // ── The #846 hazard: every bridge type on the real wire ──

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -39,6 +39,9 @@ pub enum PersistenceOperation {
         wanders: Vec<WanderRecord>,
         updated_at: DateTime<Utc>,
     },
+    /// The closed blocks back, so the mastery track can rebuild at launch
+    /// (#1214). Wanders stay unread: they carry no `(node, level)` to score.
+    LoadCoachRecords,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -47,6 +50,7 @@ pub enum PersistenceOperation {
 pub enum PersistenceOutput {
     Items(Vec<Item>),
     Sessions(Vec<PracticeSession>),
+    CoachRecords(Vec<BlockRecord>),
     Ack,
     /// Local store failed the op — surfaced, not trusted as success (#816).
     Failed,
@@ -78,6 +82,11 @@ pub fn delete_item(id: String, deleted_at: DateTime<Utc>) -> Command<Effect, Eve
 /// same batch to offer again if the write fails (#1181).
 pub fn save_coach_records(batch: PersistenceOperation) -> Command<Effect, Event> {
     Command::request_from_shell(batch).then_send(Event::CoachStoreWritten)
+}
+
+pub fn load_coach_records() -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::LoadCoachRecords)
+        .then_send(Event::CoachRecordsLoaded)
 }
 
 pub fn load_sessions() -> Command<Effect, Event> {
@@ -875,7 +884,90 @@ mod tests {
             assert_eq!(block.gate_progress.filled(), 1);
         }
 
+        // ── Rebuilt from the persisted evidence at launch (#1214) ──
+
+        /// Run a session far enough to close one block, and keep what it wrote.
+        fn recorded_blocks(app: &Intrada, model: &mut Model) -> Vec<BlockRecord> {
+            let _ = send(app, model, CoachEvent::StartPlannedSession { now: at(0) });
+            rep(app, model, true, 9);
+            let mut cmd = send(app, model, CoachEvent::Tick { now: at(30) });
+            coach_records(&mut cmd).expect("a SaveCoachRecords op")
+        }
+
+        #[test]
+        fn the_launch_asks_the_store_for_the_coach_records() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            let mut cmd = app.update(
+                Event::StartApp {
+                    api_base_url: "http://localhost:3001".to_string(),
+                    local_first: true,
+                },
+                &mut model,
+            );
+
+            assert!(
+                cmd.effects().any(|e| matches!(e, Effect::Persistence(req)
+                    if req.operation == PersistenceOperation::LoadCoachRecords)),
+                "the mastery track rebuilds from the store at launch"
+            );
+            assert!(!has_http(&mut cmd), "and never from the network");
+        }
+
+        #[test]
+        fn the_loaded_records_rebuild_what_the_last_run_learned() {
+            let (app, mut model) = local_first();
+            let blocks = recorded_blocks(&app, &mut model);
+            let learned = model.coach.mastery.clone();
+
+            let (app, mut fresh) = local_first();
+            let _ = app.update(
+                Event::CoachRecordsLoaded(PersistenceOutput::CoachRecords(blocks.clone())),
+                &mut fresh,
+            );
+
+            assert_eq!(
+                fresh.coach.mastery, learned,
+                "the restart holds what the run left behind"
+            );
+            assert!(
+                fresh.coach.mastery.is_cold(
+                    &blocks[0].node,
+                    blocks[0].level,
+                    at(30) + chrono::TimeDelta::days(1)
+                ),
+                "so tomorrow's first rep is the cold test again (#1214's dead path)"
+            );
+        }
+
+        #[test]
+        fn a_failed_coach_read_surfaces_and_does_not_loop() {
+            let (app, mut model) = local_first();
+            let mut cmd = app.update(
+                Event::CoachRecordsLoaded(PersistenceOutput::Failed),
+                &mut model,
+            );
+
+            assert!(
+                model.last_error.is_some(),
+                "a broken read degrades the plan silently otherwise"
+            );
+            assert!(
+                !cmd.effects().any(|e| matches!(e, Effect::Persistence(_))),
+                "no reload against a store that is not having it"
+            );
+        }
+
         // ── The #846 hazard: the new payloads on the real wire ──
+
+        #[test]
+        fn the_records_read_survives_the_ffi_wire() {
+            let (app, mut model) = local_first();
+            let blocks = recorded_blocks(&app, &mut model);
+
+            crate::domain::types::assert_round_trips(PersistenceOperation::LoadCoachRecords);
+            crate::domain::types::assert_round_trips(PersistenceOutput::CoachRecords(blocks));
+        }
 
         #[test]
         fn the_evidence_op_survives_the_ffi_wire() {

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@ scope and timing detail on the
 [project board](https://github.com/users/jonyardley/projects/2). When this
 doc and the issues disagree, the issues are right.*
 
-> Last updated: 2026-08-07 (decision 20: acquisition before the clock)
+> Last updated: 2026-08-07 (#1214: the mastery store survives a restart)
 
 ## Where we are
 
@@ -22,6 +22,10 @@ countable criteria.
 
 ## Recently landed
 
+- #1214 — the mastery store survives a restart: a local-first launch reads the
+  persisted block records back (`LoadCoachRecords`) and replays them through
+  the mastery track in timestamp order, level-ups included. The planner's
+  overdue pull and the cold test now fire for a real user, not only in tests
 - Decision 20 — acquisition before the clock (design doc v8, T12): new material
   is learnt out of time before it is owned in time. The sparse-click ladder
   reaches l0 (no click, no tempo), material stages split into know-it and
@@ -74,8 +78,6 @@ countable criteria.
   4.9MB `design/intrada-design-system.html` is one BeatPosition paragraph behind
   the `.dc.html` as of #1175, deliberately: #1232 patched that bundle in place
   and the re-export should be a real export, done once, on this visit
-- #1214 — the mastery store survives a restart, which is what makes the
-  planner's overdue pull and the cold test real
 - #1190 — delete the session-builder machinery (2a close-out)
 - Phase 2b — steer and guard: declaration surfaces, back-chaining, gap read,
   circling check, grind trade, acquisition before the clock (#1244, #1245;

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -14,6 +14,9 @@ protocol ItemStore {
   /// Append coach evidence in one transaction — blocks, wanders and their
   /// attempts land together or not at all (#1181).
   func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws
+  /// The closed blocks back, so the core can rebuild the mastery track at
+  /// launch (#1214). Wanders stay write-only: no `(node, level)` to score.
+  func loadCoachRecords() throws -> [BlockRecord]
 }
 
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
@@ -186,6 +189,14 @@ final class LibraryStore: ItemStore {
       for wander in wanders {
         try Self.upsert(wander, updatedAt: updatedAt, in: db)
       }
+    }
+  }
+
+  func loadCoachRecords() throws -> [BlockRecord] {
+    try dbQueue.read { db in
+      try Row.fetchAll(
+        db, sql: "SELECT * FROM block_record WHERE deleted_at IS NULL ORDER BY ended_at, id"
+      ).map(Self.blockRecord(from:))
     }
   }
 
@@ -695,10 +706,9 @@ final class LibraryStore: ItemStore {
     }
   }
 
-  // ── BlockRecord / WanderRecord → row codec (#1181) ────────────────────
-  // Write-only: nothing reads coach evidence back yet, so there is no decoder
-  // here to go stale. The stored enum spellings are the format contract a
-  // future reader must match.
+  // ── BlockRecord / WanderRecord ↔ row codec (#1181, read side #1214) ───
+  // The stored enum spellings are the format contract both directions share.
+  // Wanders stay write-only: they carry no (node, level) for the rebuild.
 
   private struct StoredAttempt: Codable {
     var at: String
@@ -777,10 +787,127 @@ final class LibraryStore: ItemStore {
     return json
   }
 
+  private static func blockRecord(from row: Row) -> BlockRecord {
+    BlockRecord(
+      id: row["id"], node: row["node"], drill: row["drill"], gate: row["gate"],
+      level: ParameterLevel(
+        tempoBpm: UInt16(clamping: row["level_tempo_bpm"] as Int),
+        clickLevel: clickLevel(from: row["level_click_level"])),
+      circle: circle(from: row["circle"]), mode: mode(from: row["mode"]),
+      startedAt: row["started_at"], endedAt: row["ended_at"],
+      attempts: decodeAttempts(row["attempts"]),
+      attemptsToPass: (row["attempts_to_pass"] as Int?).map { UInt16(clamping: $0) },
+      gateOpenedAtAttempt: (row["gate_opened_at_attempt"] as Int?).map { UInt16(clamping: $0) },
+      repsAfterGate: UInt16(clamping: row["reps_after_gate"] as Int),
+      activeMs: UInt64(clamping: row["active_ms"] as Int64),
+      escalationFired: decodeRungs(row["escalation_fired"]),
+      exit: exit(from: row["exit"]))
+  }
+
+  private static func decodeAttempts(_ json: String) -> [AttemptSummary] {
+    guard let dtos = try? JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) else {
+      report(CoachCodecError(field: "attempts (decode)"), decodeContext)
+      return []
+    }
+    return dtos.map { d in
+      AttemptSummary(
+        at: d.at, verdict: verdict(from: d.verdict), source: evidenceSource(from: d.source),
+        cold: d.cold, selfPredicted: d.selfPredicted.map(verdict(from:)))
+    }
+  }
+
+  private static func decodeRungs(_ json: String) -> [Rung] {
+    guard let raw = try? JSONDecoder().decode([String].self, from: Data(json.utf8)) else {
+      report(CoachCodecError(field: "escalation_fired (decode)"), decodeContext)
+      return []
+    }
+    return raw.map(rung(from:))
+  }
+
   private static func verdictString(_ verdict: Verdict) -> String {
     switch verdict {
     case .clean: "clean"
     case .missed: "missed"
+    }
+  }
+
+  private static func verdict(from raw: String) -> Verdict {
+    switch raw {
+    case "clean": return .clean
+    case "missed": return .missed
+    default:
+      report(UnknownStoredEnum(kind: "Verdict", raw: raw), decodeContext)
+      return .missed  // conservative: an unknown verdict must not inflate mastery (#949)
+    }
+  }
+
+  private static func evidenceSource(from raw: String) -> EvidenceSource {
+    switch raw {
+    case "tap_verdict": return .tapVerdict
+    case "midi": return .midi
+    case "audio": return .audio
+    default:
+      report(UnknownStoredEnum(kind: "EvidenceSource", raw: raw), decodeContext)
+      return .tapVerdict  // conservative: the lowest-weight evidence class
+    }
+  }
+
+  private static func clickLevel(from raw: String) -> ClickLevel {
+    switch raw {
+    case "every_beat": return .everyBeat
+    case "two_and_four": return .twoAndFour
+    case "bar_downbeat": return .barDownbeat
+    case "every_other_bar": return .everyOtherBar
+    default:
+      report(UnknownStoredEnum(kind: "ClickLevel", raw: raw), decodeContext)
+      return .everyBeat
+    }
+  }
+
+  private static func circle(from raw: String) -> Circle {
+    switch raw {
+    case "head": return .head
+    case "hands": return .hands
+    case "bridge": return .bridge
+    default:
+      report(UnknownStoredEnum(kind: "Circle", raw: raw), decodeContext)
+      return .hands
+    }
+  }
+
+  private static func mode(from raw: String) -> Mode {
+    switch raw {
+    case "keys": return .keys
+    case "away": return .away
+    case "keys_to_away": return .keysToAway
+    default:
+      report(UnknownStoredEnum(kind: "Mode", raw: raw), decodeContext)
+      return .keys
+    }
+  }
+
+  private static func rung(from raw: String) -> Rung {
+    switch raw {
+    case "tempo_down": return .tempoDown
+    case "shrink_scope": return .shrinkScope
+    case "change_mode": return .changeMode
+    case "swap_drill": return .swapDrill
+    default:
+      report(UnknownStoredEnum(kind: "Rung", raw: raw), decodeContext)
+      return .tempoDown  // conservative: the mildest rung
+    }
+  }
+
+  private static func exit(from raw: String) -> Exit {
+    switch raw {
+    case "gate_passed": return .gatePassed
+    case "ceiling_hit": return .ceilingHit
+    case "skipped": return .skipped
+    case "escalated": return .escalated
+    case "session_ended": return .sessionEnded
+    default:
+      report(UnknownStoredEnum(kind: "Exit", raw: raw), decodeContext)
+      return .sessionEnded  // conservative: an unknown exit must not replay a level-up (#949)
     }
   }
 

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -177,6 +177,7 @@ final class Store {
       case .saveCoachRecords(let blocks, let wanders, let updatedAt):
         try store.saveCoachRecords(blocks: blocks, wanders: wanders, updatedAt: updatedAt)
         return .ack
+      case .loadCoachRecords: return .coachRecords(try store.loadCoachRecords())
       }
     } catch {
       report(error, "persistence")

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @testable import Intrada
 
-/// Coach evidence persistence (#1181, spec §4). The production codec is
-/// write-only, so the stored shape is pinned here: `DecodedAttempt` is the
-/// format contract a future reader has to match.
+/// Coach evidence persistence (#1181 writes, #1214 reads, spec §4).
+/// `DecodedAttempt` pins the stored shape independently of the production
+/// codec, so a drift in either direction fails here.
 @Suite("Coach evidence store")
 struct CoachRecordStoreTests {
 
@@ -53,8 +53,8 @@ struct CoachRecordStoreTests {
       attempts: attempts, keepAsDrill: keepAsDrill)
   }
 
-  /// A store plus its queue, so a write-only codec can still be read back in
-  /// tests with raw SQL rather than a production decoder nothing would call.
+  /// A store plus its queue, so the write tests can pin the stored rows with
+  /// raw SQL rather than trusting the production decoder they share (#1214).
   private func makeStore() throws -> (LibraryStore, DatabaseQueue) {
     let queue = try DatabaseQueue()
     return (try LibraryStore(queue), queue)
@@ -221,6 +221,69 @@ struct CoachRecordStoreTests {
     try store.saveCoachRecords(blocks: [record], wanders: [], updatedAt: Self.updatedAt)
 
     #expect(try count(queue, "block_record") == 1, "a retried write must not double-count evidence")
+  }
+
+  // ── Reads: the mastery rebuild at launch (#1214) ───────────────────────
+
+  @Test("a saved block reads back exactly as it was written")
+  func blockRoundTrip() throws {
+    let (store, _) = try makeStore()
+    let written = block(
+      attempts: [
+        attempt(clean: false, cold: true, at: "2026-08-04T10:00:09Z"),
+        attempt(clean: true, at: "2026-08-04T10:00:18Z", source: .midi, selfPredicted: .clean),
+      ],
+      escalations: [.tempoDown, .changeMode], exit: .ceilingHit)
+    try store.saveCoachRecords(blocks: [written], wanders: [], updatedAt: Self.updatedAt)
+
+    #expect(try store.loadCoachRecords() == [written])
+  }
+
+  @Test("nullable counters read back as nil, not zero")
+  func readNullableCounters() throws {
+    let (store, _) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block(exit: .escalated, attemptsToPass: nil, gateOpenedAtAttempt: nil)],
+      wanders: [], updatedAt: Self.updatedAt)
+
+    let loaded = try #require(try store.loadCoachRecords().first)
+    #expect(loaded.attemptsToPass == nil)
+    #expect(loaded.gateOpenedAtAttempt == nil)
+  }
+
+  @Test("a tombstoned block stays out of the rebuild")
+  func readSkipsTombstones() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block("b1"), block("b2")], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE block_record SET deleted_at = ? WHERE id = 'b1'",
+        arguments: [Self.updatedAt])
+    }
+
+    let loaded = try store.loadCoachRecords()
+    #expect(loaded.map(\.id) == ["b2"])
+  }
+
+  @Test("an empty store rebuilds from nothing")
+  func readEmptyStore() throws {
+    let (store, _) = try makeStore()
+    #expect(try store.loadCoachRecords().isEmpty)
+  }
+
+  @Test("an unknown stored exit falls back without claiming a gate pass")
+  func readUnknownExit() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE block_record SET exit = 'from_the_future' WHERE id = 'b1'")
+    }
+
+    let loaded = try #require(try store.loadCoachRecords().first)
+    #expect(
+      loaded.exit != .gatePassed,
+      "a spelling this binary doesn't know must not replay a level-up (#949)")
   }
 
   // ── Upgrade path (CLAUDE.md "Local data migrations") ───────────────────

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -812,6 +812,38 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().error)
   }
 
+  /// Real-bridge rebuild round-trip (#846, #1214): the launch's
+  /// `LoadCoachRecords` request decodes in Swift, and a full `BlockRecord`
+  /// batch rides back across the bincode wire into the core's replay. A wire
+  /// break here would silently reset mastery on every restart.
+  func testRealBridgeLaunchLoadsCoachRecordsAndDecodesOnTheRealWire() throws {
+    let bridge = LiveBridge()
+    let requests = try bridge.update(
+      .startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let request = try XCTUnwrap(
+      requests.first {
+        if case .persistence(.loadCoachRecords) = $0.effect { return true }
+        return false
+      }, "a local-first launch asks the store for the coach records")
+
+    let block = BlockRecord(
+      id: "b1", node: "rootless-a-b", drill: "rootless-under-melody",
+      gate: "rootless-under-melody",
+      level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour),
+      circle: .hands, mode: .keys,
+      startedAt: "2026-08-04T10:00:00Z", endedAt: "2026-08-04T10:00:30Z",
+      attempts: [
+        AttemptSummary(
+          at: "2026-08-04T10:00:09Z", verdict: .clean, source: .tapVerdict, cold: true,
+          selfPredicted: nil)
+      ],
+      attemptsToPass: 1, gateOpenedAtAttempt: 1, repsAfterGate: 0, activeMs: 30_000,
+      escalationFired: [], exit: .gatePassed)
+
+    _ = try bridge.resolve(request.id, persistenceOutput: .coachRecords([block]))
+    XCTAssertNil(try bridge.view().error, "a decoded batch is not a storage error")
+  }
+
   /// Real-bridge escalation (#846, #1176): "I'm stuck" is the core's decision —
   /// the ladder drops the tempo and the criterion follows it. The old Swift
   /// harness did this arithmetic itself.
@@ -1281,6 +1313,7 @@ private struct FailingStore: ItemStore {
   func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws {
     throw TestError()
   }
+  func loadCoachRecords() throws -> [BlockRecord] { throw TestError() }
 }
 
 final class MockURLProtocol: URLProtocol {


### PR DESCRIPTION
Closes #1214.

Until now the \`MasteryStore\` lived only for the app process: planner stage 3's maintenance pull and the cold-test flag were dead paths in production, because \`last_attempt_at\` only existed for attempts made since launch. This adds the read side the evidence already had a write side for.

## What changed

**Core** (\`crates/intrada-core\`)
- \`PersistenceOperation::LoadCoachRecords\` and \`PersistenceOutput::CoachRecords(Vec<BlockRecord>)\`, requested alongside items and sessions on a local-first \`StartApp\`.
- \`Event::CoachRecordsLoaded\` replays the records through \`CoachState::rebuild_mastery\`: the store is re-seeded from content, then each block's attempts feed \`MasteryStore::record\` in timestamp order and a \`GatePassed\` exit replays the level-up, mirroring the live path in \`apply\`. Replace-not-add semantics, like every other load handler, so a repeated load can never double-count.
- A failed read surfaces the storage error and does not retry, matching the other read paths.

**iOS** (\`ios/\`)
- \`LibraryStore.loadCoachRecords()\`: row-to-\`BlockRecord\` decoder, tombstoned rows excluded, unknown stored enum spellings report and take a conservative fallback per the #949 convention (an unknown \`exit\` can never replay a level-up).
- The \`Store\` dispatch case resolving \`.loadCoachRecords\` to \`.coachRecords\`, \`.failed\` on throw as before (#816).
- Wanders stay write-only: they carry no \`(node, level)\` to score.

## Deliberate choices

- **Replay attributes a block's attempts to \`record.level\`** (the level at close). A mid-block \`TempoDown\` means live evidence landed at the pre-drop level while replay uses the final one; the record carries one level by design (the issue: "a read/write side, not a remodel") and the escalated level is the conservative attribution.
- **The shell's \`ORDER BY ended_at, id\` is convenience, not contract**: the core re-sorts before replaying (offline-first invariant 4), the SQL just keeps reads deterministic for tests.

## Tests

TDD throughout (\`intrada-core\` first). Core: replay rebuilds evidence and \`last_attempt_at\`; level-ups replay; out-of-order rows replay in time order; a second load replaces rather than doubles; a live run's records rebuild a byte-identical store; launch requests the read with zero HTTP; a failed read surfaces without looping; bincode round-trips for both new bridge variants. iOS: save-then-load round-trip, nullable counters, tombstone exclusion, unknown-exit fallback, and a real-bridge decode test (#846 rule). \`just check\` and \`just ios-test-full\` green locally.

Coverage: full — the new core paths (replay, wiring, failure, ordering) all have unit tests; \`ios/\` is coverage-ignored by \`codecov.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)