### PR TITLE
fix(coach): an attempt carries the rung it was played at, so an escalated block replays truthfully (#1214 follow-up)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -425,16 +425,18 @@ impl Intrada {
                 }
             },
             Event::CoachRecordsLoaded(output) => match output {
+                // No render: nothing in `ViewModel` derives from the mastery
+                // track; it reaches a screen only through the plan, computed later.
                 PersistenceOutput::CoachRecords(blocks) => {
                     model.coach.rebuild_mastery(blocks);
-                    crux_core::render::render()
+                    Command::done()
                 }
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)
                 | PersistenceOutput::Ack => Command::done(),
                 // Failed read: surface only, no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
-                    model.surface_error("Couldn't access local storage.");
+                    model.surface_error("Couldn't read back what you've practised.");
                     crux_core::render::render()
                 }
             },

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -55,18 +55,33 @@ impl CoachState {
     /// the same one-way replay as the live path in [`Self::apply`]. Replaces
     /// rather than adds, like every other load handler, so a repeated load can
     /// never double-count.
-    pub fn rebuild_mastery(&mut self, mut records: Vec<BlockRecord>) {
+    pub fn rebuild_mastery(&mut self, records: Vec<BlockRecord>) {
         self.mastery = MasteryStore::seeded_from(ContentIndex::shipped());
-        records.sort_by(|a, b| a.ended_at.cmp(&b.ended_at).then_with(|| a.id.cmp(&b.id)));
-        for record in records {
+        let mut replay = Vec::new();
+        for record in &records {
             for attempt in &record.attempts {
-                self.mastery
-                    .record(&record.node, record.level, attempt.verdict, attempt.at);
+                replay.push((
+                    attempt.at,
+                    Replay::Attempt(attempt.verdict, attempt.level),
+                    record,
+                ));
             }
+            // `level_up` declines a rung that already has evidence, so a banked
+            // pass has to reach the store in the order it happened.
             if record.exit == Exit::GatePassed {
-                if let Some(next) = next_rung(&record) {
-                    self.mastery.level_up(&record.node, record.level, next);
+                if let Some(next) = next_rung(record) {
+                    replay.push((record.ended_at, Replay::LevelUp(next), record));
                 }
+            }
+        }
+        replay.sort_by_key(|(at, _, _)| *at);
+        for (at, step, record) in replay {
+            match step {
+                Replay::Attempt(verdict, level) => {
+                    self.mastery.record(&record.node, level, verdict, at)
+                }
+                // The gate was passed at the level the block closed on.
+                Replay::LevelUp(to) => self.mastery.level_up(&record.node, record.level, to),
             }
         }
     }
@@ -204,6 +219,11 @@ impl CoachState {
             gate_target: block.gate_progress.target(),
         })
     }
+}
+
+enum Replay {
+    Attempt(Verdict, ParameterLevel),
+    LevelUp(ParameterLevel),
 }
 
 /// A gate pass moves the cursor to the next rung of the node's ladder the loop
@@ -886,6 +906,7 @@ mod tests {
                     source: EvidenceSource::TapVerdict,
                     cold: false,
                     self_predicted: None,
+                    level: fixture_level(),
                 })
                 .collect(),
             attempts_to_pass: None,
@@ -991,6 +1012,38 @@ mod tests {
         assert_eq!(
             rebuilt.mastery, live.mastery,
             "a restart loses nothing the records hold"
+        );
+    }
+
+    /// Live-vs-rebuilt equality through an escalation: the ladder's first rung
+    /// drops the tempo mid-block, so the block holds attempts on two rungs and
+    /// a replay keyed only by the block's closing level loses one (#1214).
+    #[test]
+    fn a_rebuild_reproduces_the_store_an_escalated_block_left_behind() {
+        let mut live = playing();
+        for second in [9, 18, 27] {
+            tap(&mut live, false, second);
+        }
+        assert!(
+            !live
+                .session
+                .block()
+                .expect("a running block")
+                .escalation_fired
+                .is_empty(),
+            "three misses fire the ladder, which is what puts two rungs in one block"
+        );
+        let mut records = tap_collect(&mut live, true, 36);
+        records.extend(live.apply(&CoachEvent::LeaveSession { now: at(40) }).blocks);
+        assert!(!records.is_empty(), "the block it ended is written down");
+
+        let mut rebuilt = CoachState::default();
+        rebuilt.rebuild_mastery(records);
+
+        assert_eq!(
+            rebuilt.mastery, live.mastery,
+            "the record has to carry what the live path told the mastery track, or \
+             the rung the user was actually stuck at comes back as untouched"
         );
     }
 

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -212,6 +212,10 @@ pub struct AttemptSummary {
     /// First rep of the block: the highest-information tap-verdict.
     pub cold: bool,
     pub self_predicted: Option<Verdict>,
+    /// The rung this attempt was played at, not always the block's:
+    /// `Rung::TempoDown` drops the tempo mid-block, and a rebuild without this
+    /// puts the pre-drop evidence on the post-drop rung (#1214, spec §7).
+    pub level: ParameterLevel,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -788,6 +792,7 @@ impl EngineSession {
             source: EvidenceSource::TapVerdict,
             cold: block.cold && block.attempts.is_empty(),
             self_predicted: None,
+            level: block.level,
         });
         let scored = ScoredAttempt {
             node,

--- a/docs/status.md
+++ b/docs/status.md
@@ -7,7 +7,7 @@ scope and timing detail on the
 [project board](https://github.com/users/jonyardley/projects/2). When this
 doc and the issues disagree, the issues are right.*
 
-> Last updated: 2026-08-07 (#1214: the mastery store survives a restart)
+> Last updated: 2026-08-07 (#1214 follow-up: an attempt carries its rung)
 
 ## Where we are
 
@@ -22,6 +22,12 @@ countable criteria.
 
 ## Recently landed
 
+- #1214 follow-up — an attempt carries the rung it was played at
+  (`AttemptSummary::level`), so an escalated block replays truthfully: the
+  ladder's tempo drop puts two rungs in one block, and without this the rebuild
+  relocated the pre-drop evidence onto the post-drop rung. Also: a corrupt
+  attempts blob fails the read instead of replaying as a block nobody played
+  (invariant 5), and the spec gained the read-side contract (§7)
 - #1214 — the mastery store survives a restart: a local-first launch reads the
   persisted block records back (`LoadCoachRecords`) and replays them through
   the mastery track in timestamp order, level-ups included. The planner's

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -716,11 +716,16 @@ final class LibraryStore: ItemStore {
     var source: String
     var cold: Bool
     var selfPredicted: String?
+    /// Optional because rows written before #1214 have no per-attempt level.
+    /// The decoder falls back to the block's, which is all those rows ever knew.
+    var levelTempoBpm: UInt16?
+    var levelClickLevel: String?
   }
 
   private struct CoachCodecError: Error, CustomStringConvertible {
     let field: String
-    var description: String { "coach \(field) failed to encode" }
+    let phase: String
+    var description: String { "coach \(field) failed to \(phase)" }
   }
 
   private static func upsert(_ record: BlockRecord, updatedAt: String, in db: Database) throws {
@@ -775,51 +780,65 @@ final class LibraryStore: ItemStore {
         StoredAttempt(
           at: attempt.at, verdict: verdictString(attempt.verdict),
           source: evidenceSourceString(attempt.source), cold: attempt.cold,
-          selfPredicted: attempt.selfPredicted.map(verdictString))
+          selfPredicted: attempt.selfPredicted.map(verdictString),
+          levelTempoBpm: attempt.level.tempoBpm,
+          levelClickLevel: clickLevelString(attempt.level.clickLevel))
       }, field: "attempts")
   }
 
   private static func encodeJSON<T: Encodable>(_ value: T, field: String) throws -> String {
     let data = try JSONEncoder().encode(value)
     guard let json = String(data: data, encoding: .utf8) else {
-      throw CoachCodecError(field: field)
+      throw CoachCodecError(field: field, phase: "encode")
     }
     return json
   }
 
-  private static func blockRecord(from row: Row) -> BlockRecord {
-    BlockRecord(
+  /// Throws rather than substituting a partial record: evidence that failed to
+  /// decode would replay as a block nobody played (invariant 5). An unrecognised
+  /// enum spelling is different: the row is still readable, so those report and
+  /// fall back (#949).
+  private static func blockRecord(from row: Row) throws -> BlockRecord {
+    let level = ParameterLevel(
+      tempoBpm: UInt16(clamping: row["level_tempo_bpm"] as Int),
+      clickLevel: clickLevel(from: row["level_click_level"]))
+    return BlockRecord(
       id: row["id"], node: row["node"], drill: row["drill"], gate: row["gate"],
-      level: ParameterLevel(
-        tempoBpm: UInt16(clamping: row["level_tempo_bpm"] as Int),
-        clickLevel: clickLevel(from: row["level_click_level"])),
+      level: level,
       circle: circle(from: row["circle"]), mode: mode(from: row["mode"]),
       startedAt: row["started_at"], endedAt: row["ended_at"],
-      attempts: decodeAttempts(row["attempts"]),
+      attempts: try decodeAttempts(row["attempts"], blockLevel: level),
       attemptsToPass: (row["attempts_to_pass"] as Int?).map { UInt16(clamping: $0) },
       gateOpenedAtAttempt: (row["gate_opened_at_attempt"] as Int?).map { UInt16(clamping: $0) },
       repsAfterGate: UInt16(clamping: row["reps_after_gate"] as Int),
       activeMs: UInt64(clamping: row["active_ms"] as Int64),
-      escalationFired: decodeRungs(row["escalation_fired"]),
+      escalationFired: try decodeRungs(row["escalation_fired"]),
       exit: exit(from: row["exit"]))
   }
 
-  private static func decodeAttempts(_ json: String) -> [AttemptSummary] {
-    guard let dtos = try? JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) else {
-      report(CoachCodecError(field: "attempts (decode)"), decodeContext)
-      return []
+  private static func decodeAttempts(_ json: String, blockLevel: ParameterLevel) throws
+    -> [AttemptSummary]
+  {
+    let stored: [StoredAttempt]
+    do { stored = try JSONDecoder().decode([StoredAttempt].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "attempts", phase: "decode")
     }
-    return dtos.map { d in
+    return stored.map { attempt in
       AttemptSummary(
-        at: d.at, verdict: verdict(from: d.verdict), source: evidenceSource(from: d.source),
-        cold: d.cold, selfPredicted: d.selfPredicted.map(verdict(from:)))
+        at: attempt.at, verdict: verdict(from: attempt.verdict),
+        source: evidenceSource(from: attempt.source), cold: attempt.cold,
+        selfPredicted: attempt.selfPredicted.map(verdict(from:)),
+        // Pre-#1214 rows knew only the block's level.
+        level: ParameterLevel(
+          tempoBpm: attempt.levelTempoBpm ?? blockLevel.tempoBpm,
+          clickLevel: attempt.levelClickLevel.map(clickLevel(from:)) ?? blockLevel.clickLevel))
     }
   }
 
-  private static func decodeRungs(_ json: String) -> [Rung] {
-    guard let raw = try? JSONDecoder().decode([String].self, from: Data(json.utf8)) else {
-      report(CoachCodecError(field: "escalation_fired (decode)"), decodeContext)
-      return []
+  private static func decodeRungs(_ json: String) throws -> [Rung] {
+    let raw: [String]
+    do { raw = try JSONDecoder().decode([String].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "escalation_fired", phase: "decode")
     }
     return raw.map(rung(from:))
   }

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -23,11 +23,12 @@ struct CoachRecordStoreTests {
 
   private func attempt(
     clean: Bool, cold: Bool = false, at: String = "2026-08-04T10:00:09Z",
-    source: EvidenceSource = .tapVerdict, selfPredicted: Verdict? = nil
+    source: EvidenceSource = .tapVerdict, selfPredicted: Verdict? = nil,
+    level: ParameterLevel = ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour)
   ) -> AttemptSummary {
     AttemptSummary(
       at: at, verdict: clean ? .clean : .missed, source: source, cold: cold,
-      selfPredicted: selfPredicted)
+      selfPredicted: selfPredicted, level: level)
   }
 
   private func block(
@@ -284,6 +285,84 @@ struct CoachRecordStoreTests {
     #expect(
       loaded.exit != .gatePassed,
       "a spelling this binary doesn't know must not replay a level-up (#949)")
+  }
+
+  @Test("an attempt keeps the rung it was played at, not the one the block closed on")
+  func readBackPerAttemptLevel() throws {
+    // An escalated block holds attempts on two rungs (#1214, spec §7).
+    let (store, _) = try makeStore()
+    let before = ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour)
+    let after = ParameterLevel(tempoBpm: 96, clickLevel: .twoAndFour)
+    try store.saveCoachRecords(
+      blocks: [
+        block(
+          attempts: [
+            attempt(clean: false, at: "2026-08-04T10:00:09Z", level: before),
+            attempt(clean: true, at: "2026-08-04T10:00:18Z", level: after),
+          ], escalations: [.tempoDown], exit: .gatePassed)
+      ], wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(read.attempts.map(\.level) == [before, after])
+  }
+
+  @Test("every click level survives the round trip, since it is half the mastery key")
+  func readBackEveryClickLevel() throws {
+    let (store, _) = try makeStore()
+    let levels: [ClickLevel] = [.everyBeat, .twoAndFour, .barDownbeat, .everyOtherBar]
+    try store.saveCoachRecords(
+      blocks: levels.enumerated().map { index, level in
+        block(
+          "b\(index)",
+          attempts: [
+            attempt(
+              clean: true, at: "2026-08-04T10:0\(index):09Z",
+              level: ParameterLevel(tempoBpm: 80, clickLevel: level))
+          ])
+      }, wanders: [], updatedAt: Self.updatedAt)
+
+    let read = try store.loadCoachRecords()
+    #expect(
+      read.compactMap { $0.attempts.first?.level.clickLevel } == levels,
+      "a decoder that drifts from its encoder relocates evidence silently")
+  }
+
+  @Test("a row written before the per-attempt level falls back to the block's")
+  func readBackLegacyAttemptWithoutLevel() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      // A level no suite helper uses, so a hardcoded fallback would fail.
+      try db.execute(
+        sql: """
+          UPDATE block_record SET attempts = ?,
+            level_tempo_bpm = 77, level_click_level = 'bar_downbeat'
+          WHERE id = 'b1'
+          """,
+        arguments: [
+          """
+          [{"at":"2026-08-04T10:00:09Z","verdict":"clean","source":"tap_verdict","cold":false}]
+          """
+        ])
+    }
+
+    let read = try #require(try store.loadCoachRecords().first)
+    #expect(
+      read.attempts.first?.level == ParameterLevel(tempoBpm: 77, clickLevel: .barDownbeat),
+      "the block's level is all a pre-#1214 row ever knew; it must not be dropped")
+  }
+
+  @Test("an attempts blob that will not decode fails the read rather than emptying it")
+  func readBackCorruptAttemptsThrows() throws {
+    // Returning [] would replay as a block nobody played (invariant 5).
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [block(attempts: [attempt(clean: true)])], wanders: [], updatedAt: Self.updatedAt)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE block_record SET attempts = 'not json' WHERE id = 'b1'")
+    }
+
+    #expect(throws: (any Error).self) { try store.loadCoachRecords() }
   }
 
   // ── Upgrade path (CLAUDE.md "Local data migrations") ───────────────────

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -130,7 +130,7 @@ final class StoreEffectLoopTests: XCTestCase {
     attempts: [
       AttemptSummary(
         at: "2026-08-04T10:00:09Z", verdict: .clean, source: .tapVerdict, cold: true,
-        selfPredicted: nil)
+        selfPredicted: nil, level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour))
     ],
     attemptsToPass: 3, gateOpenedAtAttempt: 3, repsAfterGate: 0, activeMs: 30_000,
     escalationFired: [], exit: .gatePassed)
@@ -166,6 +166,35 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(
       bridge.persistenceResolved.first?.output, .failed,
       "a lost block must surface as .failed, never a phantom .ack (#816)")
+  }
+
+  func testCoachRecordsReadResolvesWhatWasWritten() throws {
+    let libraryStore = try LibraryStore.inMemory()
+    try libraryStore.saveCoachRecords(
+      blocks: [Self.coachBlock], wanders: [], updatedAt: "2026-08-04T10:00:30Z")
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [Request(id: 22, effect: .persistence(.loadCoachRecords))]
+    }
+    let store = Store(bridge: bridge, session: mockSession(), store: libraryStore)
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.first?.output, .coachRecords([Self.coachBlock]),
+      "the launch read hands the core back the evidence it wrote (#1214)")
+  }
+
+  func testCoachRecordsReadFailureResolvesFailed() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in [Request(id: 23, effect: .persistence(.loadCoachRecords))] }
+    let store = Store(bridge: bridge, session: mockSession(), store: FailingStore())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.first?.output, .failed,
+      "a failed read surfaces, so the core never rebuilds mastery from a lie (#816)")
   }
 
   /// The session the core just snapshotted for crash recovery — also the only
@@ -812,36 +841,53 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().error)
   }
 
-  /// Real-bridge rebuild round-trip (#846, #1214): the launch's
-  /// `LoadCoachRecords` request decodes in Swift, and a full `BlockRecord`
-  /// batch rides back across the bincode wire into the core's replay. A wire
-  /// break here would silently reset mastery on every restart.
-  func testRealBridgeLaunchLoadsCoachRecordsAndDecodesOnTheRealWire() throws {
+  /// Real-bridge evidence read-back (#846, #1214): a wire break would leave the
+  /// mastery track silently unrebuilt, so drive the resolve through LiveBridge
+  /// and read the outcome off the plan, the only ViewModel surface it reaches.
+  func testRealBridgeCoachRecordsRebuildMasteryOnTheWire() throws {
     let bridge = LiveBridge()
-    let requests = try bridge.update(
+    let launch = try bridge.update(
       .startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
-    let request = try XCTUnwrap(
-      requests.first {
-        if case .persistence(.loadCoachRecords) = $0.effect { return true }
+    let id = try XCTUnwrap(
+      launch.first { request in
+        if case .persistence(.loadCoachRecords) = request.effect { return true }
         return false
-      }, "a local-first launch asks the store for the coach records")
+      }?.id, "a local-first launch must ask for the coach records")
 
-    let block = BlockRecord(
-      id: "b1", node: "rootless-a-b", drill: "rootless-under-melody",
-      gate: "rootless-under-melody",
-      level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour),
-      circle: .hands, mode: .keys,
-      startedAt: "2026-08-04T10:00:00Z", endedAt: "2026-08-04T10:00:30Z",
-      attempts: [
-        AttemptSummary(
-          at: "2026-08-04T10:00:09Z", verdict: .clean, source: .tapVerdict, cold: true,
-          selfPredicted: nil)
-      ],
-      attemptsToPass: 1, gateOpenedAtAttempt: 1, repsAfterGate: 0, activeMs: 30_000,
-      escalationFired: [], exit: .gatePassed)
+    _ = try bridge.resolve(id, persistenceOutput: .coachRecords(Self.overdueEvidence))
+    _ = try bridge.update(
+      .coach(.planSession(now: "2026-09-20T10:00:00Z", availableMinutes: 30)))
 
-    _ = try bridge.resolve(request.id, persistenceOutput: .coachRecords([block]))
-    XCTAssertNil(try bridge.view().error, "a decoded batch is not a storage error")
+    let plan = try XCTUnwrap(try bridge.view().coach.plan, "a planned session")
+    XCTAssertNil(try bridge.view().error, "a clean read leaves nothing to surface")
+    // "is due back" needs `overdue_pct >= 100`, unreachable without a replayed
+    // `last_attempt_at`: its appearance proves the records crossed the wire.
+    XCTAssertTrue(
+      plan.blocks.contains { $0.why.contains("is due back") },
+      "the plan must say what fell due while the app was closed: "
+        + "\(plan.blocks.map(\.why))")
+  }
+
+  /// A fortnight of clean passes on the last node of the authored route, far
+  /// enough back to be overdue by the time the plan is asked for.
+  private static var overdueEvidence: [BlockRecord] {
+    (0..<12).map { day in
+      BlockRecord(
+        id: "b\(day)", node: "phrase-transposition", drill: "phrase-home-key",
+        gate: "phrase-home-key",
+        level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour),
+        circle: .head, mode: .keys,
+        startedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:00Z",
+        endedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:30Z",
+        attempts: [
+          AttemptSummary(
+            at: "2026-08-\(String(format: "%02d", day + 1))T10:00:09Z", verdict: .clean,
+            source: .tapVerdict, cold: false, selfPredicted: nil,
+            level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour))
+        ],
+        attemptsToPass: nil, gateOpenedAtAttempt: nil, repsAfterGate: 0, activeMs: 30_000,
+        escalationFired: [], exit: .ceilingHit)
+    }
   }
 
   /// Real-bridge escalation (#846, #1176): "I'm stuck" is the core's decision —

--- a/specs/coach-2a-slice-contract.md
+++ b/specs/coach-2a-slice-contract.md
@@ -231,8 +231,105 @@ pub struct PlanContext {
   `gates.toml`: the file authors none of them yet (#1188 permits this
   explicitly). `MasteryConstants` is the single place they live, and moving
   them into the file is a follow-up.
-- **The mastery store is not persisted.** It lives on `CoachState` for the app's
-  lifetime and is re-seeded from content at launch, so "returning material" and
-  `overdue` are within-run facts for now. Rebuilding it from the persisted
-  `BlockRecord`s needs a read side the persistence layer does not have. Tracked
-  as a follow-up.
+- **The mastery store is still not persisted, and never will be.** It is rebuilt
+  at launch from the persisted `BlockRecord`s instead (§7, #1214): the records
+  already hold every fact the store derives, so storing the store as well would
+  be a second source of truth for the same evidence.
+
+## 7. The read half of the evidence: rebuilding mastery at launch (#1214)
+
+`SaveCoachRecords` (§4 of the engine spec) has written every attempt with its
+verdict, level and timestamp since #1181, and nothing read them back. So
+`last_attempt_at` only existed for attempts made since launch, which made
+planner stage 3's overdue pull and the cold test dead paths for a real user.
+
+The store itself is **not** persisted. It is a projection of the records, and
+the records are the log:
+
+```rust
+pub enum PersistenceOperation {
+    // … unchanged …
+    /// Every closed block, tombstones excluded. Read once at a local-first
+    /// launch; the core replays the attempts through the mastery track.
+    LoadCoachRecords,
+}
+
+pub enum PersistenceOutput {
+    // … unchanged …
+    CoachRecords(Vec<BlockRecord>),
+}
+
+pub enum Event {
+    // … unchanged …
+    CoachRecordsLoaded(PersistenceOutput),
+}
+```
+
+Blocks only. A `WanderRecord` has no node and no level (§4), so it carries
+nothing the mastery track is keyed by and nothing to replay.
+
+`AttemptSummary` gains the level it was played at, which is a change to a
+persisted shape as well as a bridged one:
+
+```rust
+pub struct AttemptSummary {
+    // … unchanged …
+    /// Not always the block's: `Rung::TempoDown` drops the tempo mid-block, so
+    /// a block that escalated holds attempts belonging to two rungs.
+    pub level: ParameterLevel,
+}
+```
+
+`BlockRecord::level` is the level the block *closed* on, so without this a
+rebuild puts the pre-drop attempts on the post-drop rung, and the rung the user
+was actually stuck at comes back looking untouched (`overdue == 0`,
+`is_cold == false`), which is the dead path this was meant to close. The ladder's
+first rung is a tempo drop at three consecutive misses, so that is the common
+case, not a corner. `escalation_fired` carries no timestamp, so the row cannot be
+repaired after the fact: the level has to travel with the attempt.
+
+The stored `attempts` blob is JSON, so the two new keys are additive and no table
+migration follows. Rows written before this read back with the block's level,
+which is all they ever knew. The level-up replay still uses `BlockRecord::level`:
+the gate was passed at the level the block closed on, whatever the ladder did on
+the way there.
+
+`Event::StartApp { local_first: true }` requests it alongside `LoadItems` and
+`LoadSessions`. `CoachRecordsLoaded(CoachRecords(blocks))` calls:
+
+```rust
+impl CoachState {
+    /// Re-seed from content, then replay every attempt in timestamp order.
+    /// Idempotent by construction: the seed is the starting point each time,
+    /// so calling it twice cannot double-count evidence.
+    pub fn rebuild_mastery(&mut self, records: Vec<BlockRecord>)
+}
+```
+
+Replay is a projection, in one ordered pass:
+
+- Every attempt of every block becomes `mastery.record(node, level, verdict, at)`.
+- A block whose `exit` is `GatePassed` becomes a `level_up` at its `ended_at`.
+- The whole stream sorts by timestamp before it runs, stably. Order matters
+  (`level_up` declines to overwrite a rung that already has evidence), so a
+  store that read the rows back in a different order would hold different
+  priors.
+
+Reconciliation stays in the core (offline-first invariant 4): the shell runs the
+typed read and nothing else. `CoachRecordsLoaded(Failed)` surfaces an error and
+reloads nothing, like `StoreLoaded(Failed)`: a retry against a store that just
+failed a read is a loop.
+
+In Swift, the read is a decoder for rows the codec has only ever written:
+
+```swift
+protocol ItemStore {
+  // … unchanged …
+  func loadCoachRecords() throws -> [BlockRecord]
+}
+```
+
+`SELECT … WHERE deleted_at IS NULL`. The stored enum spellings (`"clean"`,
+`"two_and_four"`, `"gate_passed"`, …) that #1181 pinned as the format contract
+are now read by production code, and an unrecognised one is reported through
+`report(_:)` rather than silently defaulting (#949).

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -243,6 +243,12 @@ pre-play prediction against a tap-verdict — considered and cut, design doc v6.
 > `CoachEvent::RecoverSession` re-anchors the clock, so a recovered block keeps
 > the minutes already spent against its ceiling and a wander banks none of the
 > outage.
+>
+> **Read back 7 Aug 2026 (#1214).** `PersistenceOperation::LoadCoachRecords`
+> returns every closed `BlockRecord`, and a local-first launch replays their
+> attempts through the mastery track in timestamp order. The records are the log
+> and the mastery store is a projection of them, so the store is never persisted
+> itself. Contract: `specs/coach-2a-slice-contract.md` §7.
 
 > **Rebuilt 6 Aug 2026 (#1223), from a fortnight of playing it.** Three
 > transitions changed and one state was added; the table below reads through
@@ -427,6 +433,13 @@ non-empty why citing the destination whenever one is declared (principle 7).
 > until the session-end narrative. A stub target and a rung with no click both
 > land in `Plan::deferred` rather than vanishing, and the session length comes
 > from `[defaults]` until press-start (#1182) can ask for it.
+
+> **Stage 3 fires for a real user from 7 Aug 2026 (#1214).** The live mastery
+> store arrived with #1188, but nothing read the persisted evidence back, so
+> `last_attempt_at` existed only for attempts made since launch: the `overdue`
+> pull above and the cold test were covered by tests and dead in production. The
+> store is now rebuilt at launch by replaying the persisted `BlockRecord`s (§4's
+> read-back note).
 
 ## 6. The FFI contract
 


### PR DESCRIPTION
Follow-up to #1247, salvaging the review-hardening deltas from the closed duplicate #1243 (both implemented #1214 independently; #1247 merged first but never had a self-review pass).

## The bug this fixes, live on main until now

`Rung::TempoDown` drops the tempo mid-block, but `BlockRecord::level` is only the level the block *closed* on. The rebuild therefore put every pre-drop attempt on the post-drop rung, and the rung the user was actually stuck at came back looking untouched: `overdue == 0`, `is_cold == false`. That is the dead path #1214 exists to close, still dead for exactly the blocks a struggling user produces, since the ladder's first rung fires at three consecutive misses.

`escalation_fired` carries no timestamp, so the row could not be repaired after the fact. `AttemptSummary` gains `level: ParameterLevel` instead, which is where it belonged: the mastery track is keyed by `(node, level)`, so the level is a property of the attempt, not of the block. The stored `attempts` blob is JSON, so the two new keys are additive and no table migration follows; rows written before this read back with the block's level, which is all they ever knew (covered by an upgrade-path test against raw legacy JSON).

The rebuild now replays a flat stream sorted by attempt timestamp (stable sort; level-ups at their block's `ended_at`), so cross-block interleavings order correctly too. The headline test is the strongest statement the replay can make and catches the class rather than the instance: run a block through the live path to escalation, rebuild from the record it wrote, assert the two mastery stores are equal.

## Also salvaged from #1243's review

- **Invariant 5 on the read side**: a block whose attempts blob will not decode now fails the read (`PersistenceOutput::Failed`, surfaced by the core) instead of reading back as a block nobody played, which the mastery track would have taken for material never practised. Matches what the writer already does with the same data.
- **`CoachRecordsLoaded` no longer renders on success**: nothing in `ViewModel` derives from the mastery track; it reaches a screen only through the plan, computed later on `PlanSession`.
- **A real-bridge test that can actually fail**: reads the outcome off the plan ("is due back", unreachable without a replayed `last_attempt_at`) rather than asserting an error that was already nil; plus FakeBridge read-path coverage (store round-trip and `.failed` resolution).
- **Every click level round-trip tested**: it is half the mastery key, and a decoder that drifted from its encoder would relocate evidence silently.
- **The read-side contract documented**: `specs/coach-2a-slice-contract.md` §7 and the engine spec's dated notes, which #1247 never wrote.

## Notes

- The ported comments were condensed to pass the comment-density gate: each keeps its issue citation, with the full rationale living in spec §7 rather than repeated at every site.
- Pre-existing follow-up #1242 (an authored tempo edit orphans that node's mastery history) is newly load-bearing now the key survives a launch; already tracked.

Coverage: full on the Rust side — the replay fix ships with the live-vs-rebuilt escalation equality test plus the existing rebuild suite (809 core tests). `ios/` is excluded from Codecov by config; the Swift codec paths are covered by the new unit tests (`just ios-test-full` green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
