### PR TITLE
chore(git): union-merge docs/status.md so parallel PRs stop colliding on it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,10 @@
 # (See CLAUDE.md → "Snapshot test hygiene" for how we keep these from bloating
 # git history — they're re-recorded on every intentional UI change.)
 ios/IntradaTests/__Snapshots__/**/*.png binary
+
+# status.md takes one prepended bullet from every PR that lands, so two
+# in-flight branches always collide on the same lines. Union keeps both
+# sides' bullets instead of conflicting (ordering may vary; harmless in a
+# list of unique entries). The "Last updated" line was removed for this:
+# a line every PR rewrites would duplicate under union.
+docs/status.md merge=union

--- a/docs/status.md
+++ b/docs/status.md
@@ -5,9 +5,8 @@ Updated in every PR that changes scope or state (see CLAUDE.md → After
 completing work). Direction and phases live in [`roadmap.md`](roadmap.md);
 scope and timing detail on the
 [project board](https://github.com/users/jonyardley/projects/2). When this
-doc and the issues disagree, the issues are right.*
-
-> Last updated: 2026-08-07 (#1214 follow-up: an attempt carries its rung)
+doc and the issues disagree, the issues are right. For the last-updated date,
+ask git: `git log -1 --format=%cs docs/status.md`.*
 
 ## Where we are
 


### PR DESCRIPTION
status.md conflicted twice today (#1250 and #1251) because every landing PR prepends a bullet to Recently landed and rewrites the same `Last updated` line. Two changes:

1. `docs/status.md merge=union` in `.gitattributes`: git keeps both sides' lines instead of conflicting. Right for this file because each PR's edit is a unique prepended bullet. Trade-off: bullet order after a union merge can vary, which is harmless in a list of unique entries.
2. The `> Last updated:` line is removed. It was the guaranteed collision (every PR edits it) and would duplicate under union. The header now points at `git log -1 --format=%cs docs/status.md`, which carries the same fact without the contention.

Note: #1251 branched before this and re-adds its own `Last updated` line; whoever merges second should delete it (one line, no conflict).

Coverage: n/a — config and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)