### PR TITLE
docs(design): commit the built-session journey brief and the voice spec

### DIFF
--- a/design/briefs/2026-08-built-session-journeys.md
+++ b/design/briefs/2026-08-built-session-journeys.md
@@ -1,0 +1,129 @@
+# Design brief — self-directed practice: the built session, play-through, and qualitative capture
+
+*2026-08-07. Written to inform a live decision: whether PR #1255 (delete the
+old session builder, #1190) merges before or after its replacement journeys
+exist. **Outcome, same day**: the journeys were mocked (Built Session A/B/C in
+the Claude Design project), judged right for both scenarios, and #1255 merged
+— normal 2b sequencing, per Jon. Implementation is tracked in #1256; the
+voice rules that came out of reviewing these mockups are in
+`2026-08-copy-language.md`.*
+
+## The decision this informs
+
+The old `SessionBuilderScreen` let a user hand-assemble a setlist from library
+items (drag, group, per-entry rep targets and durations), then play it with
+time tracking and self-rated 1–5 scores. The coach pivot replaces that with
+**decision 19's built session**: compose today's blocks from pipelines, nodes
+and your own items — each block keeps its gate and its evidence lands in the
+mastery model exactly as a prescribed block's does. Strictly richer tracking,
+but it does not exist yet (Phase 2b), and its journeys have never been drawn.
+
+Jon's two scenarios to bring to life:
+
+1. **"A few disconnected things."** A lesson hands over a piece and three
+   exercises. The user wants to practise exactly those today — but everything
+   should still count towards the bigger picture (mastery, ability view,
+   future prescriptions).
+2. **"Just play through a piece and track that."** No drilling, no gates —
+   a run-through, with the session still recorded and informing the model as
+   much as the user wants it to.
+
+Plus a cross-cutting layer: **qualitative capture** — these self-directed
+sessions are exactly where feel and reflection data adds richness that
+tap-verdicts cannot, and it should inform future sessions (indirectly, per
+decision 17).
+
+## Spec grounding (specs/intrada-practice-coach-design.md)
+
+- **Decision 11 — never a mode.** The app opens prescribed and never asks.
+  Composing is reached for, never chosen from a menu of modes. The built
+  session is "the strongest form of today's steer".
+- **Decision 19 — three-way target resolution.** Each item the user brings:
+  (a) *matches an authored node* → user drill, LLM proposes the match, user
+  confirms, evidence feeds that node at full weight; (b) *countable but no
+  node* → **user node**: own gate criteria (written at creation, one short
+  form or one dictated sentence), own mastery, low-band prior, cold-testable,
+  optional *serves* tag (a circle or a named node) for the ability picture;
+  (c) *genuinely unmeasurable* → opaque target on the judgement track.
+- **Decision 19 — template shape is advice.** Warm-up first, music at the
+  ends: offered, declinable. "A shape you can't decline isn't your session."
+- **Decision 16 — not everything is data.** Three altitudes below prescribed:
+  **built session** (everything gates and counts) → **off-piste** (no plan;
+  time logged plus an optional voice note — "found something? say it"; ends
+  with "keep this as a drill?") → **unmonitored play** (time logged, nothing
+  scored, nothing inferred, no end-of-session prompt).
+- **Decision 17 — qualitative data never feeds mastery.** Feel ratings and
+  reflections live on the judgement track: they can *retire* a target and
+  show trends, never satisfy a prerequisite. They inform future sessions
+  indirectly: retirement, keep-as-drill, repeated built-session shapes
+  surfacing an undeclared campaign, and (Phase 3) the LLM reading reflections
+  to *propose* steers the user confirms.
+- **The measurement budget.** One tap per rep; **at most one feel rating per
+  block**; reflections always optional; the budget *shrinks* on a bad day.
+- **Voice first.** Every text moment has a mic; reflections keep the audio
+  and transcribe opportunistically.
+- **Tune pipeline.** Pieces are user-added by nature; a play-through is a
+  pipeline-stage block with a section-level gate ("bridge, from memory,
+  cold") — no note-level target ever.
+
+## What to mock (deliverables)
+
+Use the existing kit (`intrada-design-system.dc.html` — Paper & Score, the
+coach primitives: `BlockEntryCard`, `PlanBlockRow`, `TapVerdict`, `GateDots`,
+`CoachNote`, `CoachAction`, `PressStartHero`, `ScreenScaffold`). Mock as
+`.dc.html` frames saved under `mockups/built-session/`.
+
+1. **Journey A — compose from a lesson.** From the Practice screen (which
+   opens prescribed, hero intact): where does "I know what I want to practise
+   today" live? Then: adding the piece (→ tune pipeline), adding three
+   exercises — one matching an authored node (show the proposed match +
+   confirm), one countable-but-unmatched (show user-node creation: the short
+   form — criterion, tempo/keys/passes — and the serves tag), one
+   unmeasurable (opaque target). Then the composed session view (template
+   shape as declinable advice), into the existing drill loop, one block's
+   evidence landing.
+2. **Journey B — the play-through, three altitudes.** The same piece,
+   three ways: as a pipeline block (gated section run-through); as off-piste
+   (time + the voice-note moment + "keep as a drill?" exit); as unmonitored
+   (entry, the deliberately silent middle, exit). Make the consent
+   distinction *visible* — the user should always know which altitude they
+   are at and what is being recorded.
+3. **Journey C — qualitative capture woven through.** The one-per-block feel
+   rating moment; a voice-first reflection at session close (the kept
+   improved / still-rough / next-target shape); and one *future-facing*
+   frame: how last week's reflections surface when they become tomorrow's
+   proposed steer ("you said the bridge rushes — work it today?"), per
+   decision 12 (LLM proposes, user confirms, never plans).
+
+## Constraints
+
+- Reuse tokens and primitives; anything new is a signal for `Theme.swift` +
+  the design system together. No hand-rolled clones.
+- One primary action per screen; content over chrome; progressive disclosure
+  (docs/design-principles.md, T1–T12 log).
+- Friction is spent deliberately: composition may cost taps; *starting to
+  play* may not. Hands stay on the keys.
+- British English, musician's words ("crotchet", "bar", "Solid").
+
+## Open questions the mockups should answer
+
+1. Where does composition live so it is reachable-not-modal (decision 11)?
+   The old builder hid behind a footer link; the steer surface is 2b's answer
+   — what does its strongest form look like *before* the other steer surfaces
+   exist?
+2. How heavy is first-time item resolution really? The old builder was
+   drag-and-go; the new model asks one resolution per new item. Show the
+   cheapest honest version — and what repeat use (all items already resolved)
+   feels like.
+3. Does the play-through scenario need the pipeline at all in v1, or is
+   off-piste + a piece tag enough until pipelines are authored?
+4. What, concretely, must exist before the old builder can die? (The output
+   of this exploration is a keep/kill/sequence recommendation on #1255.)
+
+## Reference
+
+- Old builder frames remain in the design-system screen gallery for
+  comparison (they are *retired*, not aspirational — #1253 tracks removing
+  them once this is settled).
+- The deleted implementation is recoverable from `main` commit `9e92ab2`
+  (screens) if any interaction detail needs consulting.

--- a/design/briefs/2026-08-copy-language.md
+++ b/design/briefs/2026-08-copy-language.md
@@ -1,0 +1,87 @@
+# Voice — how Intrada speaks
+
+*2026-08-07, v2 — supersedes the earlier glossary-only version of this file.
+Decided with Jon: voice splits by surface. The first copy pass fixed
+vocabulary but kept the stance — the app kept narrating its own data model in
+nicer words. The fix is not better sentences; it is fewer. Applied to the
+Built Session A/B/C mockups the same day; graduates to
+`docs/design-principles.md` (T13) with #1256's first commit.*
+
+## The three surface classes
+
+### 1. In-session — the silent tool
+*Drill loop, run-throughs, feel moments, off-piste, unmonitored play —
+anywhere hands belong on the keys.*
+
+- **Prose budget: ≤ 8 words beyond labels and buttons.** Reading is friction;
+  the measurement budget already believes this about taps.
+- No captions explaining mechanics. What is and isn't being recorded is
+  carried by the interface: the altitude chip, the presence or absence of
+  instrumentation (B2's note is right: "absence of instrumentation is itself
+  the consent signal"). Genuinely needed detail goes behind an ⓘ.
+- Buttons and chips are the vocabulary: "Held / Broke down", "Got it / Not
+  yet", "Fought it / Getting there / It sang". These are the register — keep
+  making words like these.
+
+### 2. Set-up and composition — the plain peer
+*The steer sheet, resolution questions, the composed-session view, altitude
+choice.*
+
+- **One short sentence per card, maximum.** Declarative, concrete, no
+  metaphors, no stacked reassurances.
+- Explain a thing once, at the decision point, then never again. Repeat
+  visits get labels only (A2r already does this: "all known").
+- Questions are fine when they are the actual decision: "What counts as a
+  clean pass?" stays.
+
+### 3. Reflective and narrative — warmth allowed
+*Session summary, the reflection moment, the morning proposal (C3), the
+weekly thread.*
+
+- The user's own words do the emotional work, quoted in serif. The app's
+  words stay brief and concrete around them.
+- This is the only class where the app may have a personality, and it is
+  the LLM-narration home the spec already defines. Warmth here, nowhere else.
+
+## Universal rules
+
+- **Never explain the data model inline.** If a screen seems to need a
+  paragraph about what is or isn't recorded, the design is wrong, not the
+  copy. (The deleted three-bullet consent list on A5 is the type specimen.)
+- **No philosophy headlines.** "Some things can't be counted" — the player
+  already knows; it's their craft. Cut, don't soften.
+- **Buttons name the action, not the mechanism.** "Keep it as a drill",
+  never "write the gate".
+- **Engine vocabulary never appears on screen** — gate, verdict, evidence,
+  mastery, prerequisite, node, steer, prescribed, judgement track, countable,
+  cold test (as a noun). Screen translations: target / the buttons themselves
+  / history / progress / "you added this" / "today's plan" / "by ear" /
+  "from cold" (as lived experience). Precedent: core says `variant`, screen
+  says **Steps**.
+- "Counts" only in plain English ("it all still counts"), never in the model
+  sense ("counts at full weight").
+- British English, musician's words. Frame annotations under the phones are
+  design documentation and may use spec vocabulary freely.
+
+## Worked examples — the frames, redone under this voice
+
+| Frame | Class | Copy becomes |
+|---|---|---|
+| A5 journal exit | set-up | Item name · kind **Journal** · "Time and notes, kept with the piece." · button **Add**. The three-bullet consent list is deleted (ⓘ if anywhere). No headline. |
+| A4 new-drill form | set-up | Keep "What counts as a clean pass?" and the read-back chips ("Done when · 3 clean", "Helps with · optional"). Delete the low-band/cold-test footnote — the library states it, the form doesn't lecture. |
+| A6 composed session | set-up | "Built by you". Delete "Every block gates and counts — same as a prescribed day." — the identical scaffold to a planned day *shows* it. Shape advice stays one line: "Warm-up first, the tune at the end — that's the shape I'd suggest." |
+| A7 block boundary | in-session | Dots + "2 of 3". Delete "gate holds till it's cold-tested" and "Full weight — same as a prescribed block". "Adds to · Left hand" may stay — 4 words. |
+| B0 altitude choice | set-up | Card titles + one line each: "A proper run — section by section, one tap each." / "Time logged. Say something if you find something." / "Minutes only. No questions." |
+| B1 gated run | in-session | "The bridge, from memory" · "From cold" · "Did it hold?" · **Held / Broke down**. Delete "first attempt of the day counts". |
+| B2x keep-as-drill | set-up | "Keep this as a drill?" · "You'll set the target; it's tracked like your other drills." · **Keep it / Just the note**. |
+| B3 unmonitored | in-session | "23 min" · "Just you and the piano." Nothing else — the second sentence ("Minutes are kept; nothing else is") moves to the B0 card where the choice is made. |
+| C1 feel moment | in-session | "How did it feel?" · the three chips · **Skip**. No caption. The absent score UI says there is no score. |
+| C3 morning proposal | reflective | As mocked — quote back, one concrete offer, "Add it to today / Not today". Row badge "your steer" → "you added this". |
+
+## On landing
+
+When a journey wins and reaches the repo: this graduates to
+`docs/design-principles.md`'s decisions log (T13 candidate — voice splits by
+surface; the engine's vocabulary never appears on screen; in-session prose is
+budgeted like taps), and the design system gains a Voice section beside the
+tokens so every future frame is written against it.


### PR DESCRIPTION
Tier 1, docs only. The two briefs from the 2026-08-07 design exploration that confirmed the session-builder deletion (#1190, PR #1255), committed to the repo's `design/briefs/` convention with their outcome notes updated:

- `2026-08-built-session-journeys.md` — the exploration brief; outcome recorded (journeys mocked and judged, #1255 merged, implementation in #1256).
- `2026-08-copy-language.md` — the voice spec v2 (screen words are the player's words; voice splits by surface: silent tool in-session, plain peer in set-up, warmth only in reflective moments). Graduates to `docs/design-principles.md` T13 with #1256's first commit.

Both files also live in the Claude Design project; the repo copy is the durable record.

Gates: `just check` green (908 tests). Review skipped per Tier 1 trivia rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)