### PR TITLE
chore(tooling): adopt sccache for cross-checkout build caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ buildServer.json
 # graph lives in the main checkout; scope is controlled by the committed
 # .graphifyignore. See CLAUDE.md "Knowledge graph (graphify)".
 graphify-out/
+# Per-developer mise overlay (e.g. RUSTC_WRAPPER=sccache) — see SETUP.md §6.
+# Never committed: mise.toml itself must stay identical for everyone.
+mise.local.toml

--- a/SETUP.md
+++ b/SETUP.md
@@ -317,6 +317,28 @@ brew install mise
 mise install
 ```
 
+### Optional: sccache for faster fresh-worktree builds
+
+`mise install` provisions the `sccache` binary, but it stays inactive until
+you opt in — it isn't wired into `mise.toml`'s committed config, so nobody
+gets it by surprise. Measured ~30% faster `just check` in a fresh worktree
+with `target/` cold and the cache warm (#1206); no measurable overhead when
+the cache is empty. Opt in per-machine:
+
+```bash
+cat > mise.local.toml <<'EOF'
+[env]
+RUSTC_WRAPPER = "sccache"
+EOF
+```
+
+`mise.local.toml` is gitignored and merges over `mise.toml` automatically —
+run `mise install` again if you added it after your first install. Default
+cache size is 10G at `~/Library/Caches/Mozilla.sccache`; check usage with
+`sccache --show-stats`. CI stays on Swatinem/rust-cache, not sccache — the
+target-dir cache it already runs beats a cold sccache cache without paying
+for remote storage.
+
 ### One-time git config
 
 ```bash

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,13 @@ countable criteria.
 
 ## Recently landed
 
+- #1206 — sccache adopted for cross-checkout Rust build caching: ~30% faster
+  `just check` in a fresh worktree with `target/` cold and the sccache cache
+  warm (58s → 40s, measured on the issue). Opt-in per developer via a
+  gitignored `mise.local.toml` (`RUSTC_WRAPPER=sccache`), not the committed
+  `mise.toml` — nobody's build behaviour changes by surprise. CI stays on
+  Swatinem/rust-cache. Follow-up spot-check for `cargo swift package` /
+  codegen builds tracked in #1258
 - #1190 — the session-builder machinery deleted (2a close-out): the Building
   phase and its screens (`SessionBuilderScreen`, `AddToSessionSheet`,
   `EntrySettingsSheet`, `AddRelatedExerciseSheet`) are gone from both

--- a/mise.toml
+++ b/mise.toml
@@ -14,3 +14,7 @@ typos = "1.48"
 # Pinned exactly: cargo-swift 0.9.0's bundled uniffi-bindgen matches our
 # uniffi 0.29.4 runtime contract (see justfile ios-package). Bump in lockstep.
 "cargo:cargo-swift" = "0.9.0"
+# Cross-checkout Rust build cache — measured ~30% faster `just check` in a
+# fresh worktree with a warm cache (#1206). Provisioned for everyone, but
+# only active if you opt in with RUSTC_WRAPPER=sccache — see SETUP.md §6.
+sccache = "0.17"


### PR DESCRIPTION
## Summary
- Measured `just check` cold/warm with and without sccache in a fresh worktree (numbers on #1206): 57.9s baseline, 52.3s sccache-cold (no overhead penalty), **40.3s sccache-warm — ~30% faster**.
- Adopted: `sccache = "0.17"` added to `mise.toml` (provisioned for everyone), activated per-developer via a gitignored `mise.local.toml` setting `RUSTC_WRAPPER=sccache` — nobody's build behaviour changes by surprise.
- CI untouched: stays on Swatinem/rust-cache as already scoped in the issue's plan.
- SETUP.md §6 documents the opt-in and the 10G default cache size.

Closes #1206.

## Test plan
- [x] `just check` green with the doc/tooling changes (no sccache active, same as everyone gets by default)
- [x] `mise install sccache` resolves and installs 0.17.0 cleanly
- [x] All three benchmark runs (baseline / sccache-cold / sccache-warm) passed 908/908 tests, fmt/clippy/hygiene clean — numbers and sccache stats posted on #1206
- Follow-up tracked in #1258: spot-check sccache against `cargo swift package` / codegen-feature builds (not exercised by `just check`)

Deferred items tracked: #1258