### PR TITLE
feat(core,ios): l0 — the clickless acquisition block (decision 20, #1244)

### DIFF
--- a/content/gates.toml
+++ b/content/gates.toml
@@ -42,7 +42,7 @@ count_in_beats = 4
 
 # Sparse-click ladder: gate levels *within* click-always (decision 2), plus the
 # rung beneath them where the clock has not arrived yet (decision 20, #1244).
-# An l0 gate names no `tempo_bpm` — a tempo at l0 is a contradiction, and fails
+# An l0 gate names no `tempo_bpm`: a tempo at l0 is a contradiction, and fails
 # the parse. The know-it/own-it gate pairs that use it are #1245.
 [click_levels]
 l0 = "no click at all"
@@ -74,6 +74,10 @@ name_the_wall_max_times = 1      # the second encouragement is a nag
 tempo_down_pct = 20              # what the first rung drops the tempo by
 tempo_floor_bpm = 40             # below this a drop is not practice
 gate_open_hold_s = 2             # how long the open gate is left on screen
+# How long the tap's glance is left on screen where no beat ends it, which is
+# only l0 (#1244). At a clicked level the next beat turns the page, about half
+# a second at 120.
+glance_hold_s = 1
 
 [planner]
 # A node at or above this seeded estimate is maintenance rather than

--- a/content/gates.toml
+++ b/content/gates.toml
@@ -40,11 +40,12 @@ bars = 8
 beats_per_bar = 4
 count_in_beats = 4
 
-# Sparse-click ladder: gate levels *within* click-always (decision 2).
-# l0 (no click: the acquisition rung, decision 20) is deliberately absent:
-# no gate can reference it (the click enum is l1-l4, and an l0 gate fails
-# startup), so an entry here would be dead content. Lands with #1244.
+# Sparse-click ladder: gate levels *within* click-always (decision 2), plus the
+# rung beneath them where the clock has not arrived yet (decision 20, #1244).
+# An l0 gate names no `tempo_bpm` — a tempo at l0 is a contradiction, and fails
+# the parse. The know-it/own-it gate pairs that use it are #1245.
 [click_levels]
+l0 = "no click at all"
 l1 = "click on every beat"
 l2 = "click on 2 and 4"
 l3 = "click on beat 1 of each bar"

--- a/content/tunes.md
+++ b/content/tunes.md
@@ -14,8 +14,9 @@ with each join its own rung, then the full form. The size is never asked or
 authored; only the boundaries are (sections here, phrase marks per stage,
 TODO(jon) with the seeds). The
 know-it gate is a default, never a wall: Skip jumps it, and passing the
-clocked gate retires it. The engine can't run l0 yet (#1244, #1245), so until
-then the know-it column is practised by hand, Phase 0 style.
+clocked gate retires it. The engine runs an l0 block from #1244; no gate here
+authors one until #1245 pairs them, so until then the know-it column is
+practised by hand, Phase 0 style.
 
 Seeds marked `TODO(jon)` — fill from where the tune actually is (README,
 day-one checklist).

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -241,8 +241,8 @@ fn next_rung(record: &BlockRecord) -> Option<ParameterLevel> {
         .find_map(|drill| drill.level)
 }
 
-/// " at 120", where there is a tempo to be at. An l0 rung has none to claim
-/// (decision 20), and a gate must not ask for one it cannot name.
+/// " at 120", where there is a tempo to be at: a gate must not ask for one
+/// the rung cannot name (decision 20).
 fn at_tempo(tempo_bpm: Option<u16>) -> String {
     tempo_bpm
         .map(|bpm| format!(" at {bpm}"))
@@ -474,6 +474,29 @@ mod tests {
     }
 
     #[test]
+    fn the_glance_at_l0_is_ended_by_the_clock_rather_than_by_a_beat() {
+        let mut coach = playing_untimed();
+        coach.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+        assert_eq!(
+            coach.view().drill.unwrap().phase,
+            DrillPhase::Acknowledged { clean: true },
+            "the tap is still acknowledged"
+        );
+
+        coach.apply(&CoachEvent::Tick { now: at(22) });
+
+        assert_eq!(
+            coach.view().drill.unwrap().phase,
+            DrillPhase::Playing,
+            "no beat turns the page at l0, so a glance left to a beat would \
+             hold the screen on a phase with nothing to tap"
+        );
+    }
+
+    #[test]
     fn the_gate_question_at_l0_makes_no_claim_about_tempo() {
         let drill = playing_untimed().view().drill.expect("a running drill");
 
@@ -488,10 +511,20 @@ mod tests {
             tempo_bpm: 120,
             click_level: ClickLevel::TwoAndFour,
         };
+        // Real evidence at the tempo, so "unchanged" is a claim about this
+        // tap rather than about a rung nothing has ever touched.
+        for second in [1, 2, 3] {
+            coach
+                .mastery
+                .record("rootless-a-b", clocked, Verdict::Clean, at(second));
+        }
+        // Read at the same instant as the assertion below: decay is a read,
+        // so two clocks would differ by elapsed time, not by the tap.
         let before = coach
             .mastery
-            .reading("rootless-a-b", clocked, at(0))
+            .reading("rootless-a-b", clocked, at(20))
             .evidence;
+        assert!(before > 0.0);
 
         coach.apply(&CoachEvent::Tap {
             clean: true,

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -165,6 +165,7 @@ impl CoachState {
         };
         let block = self.session.block()?;
         let spec = self.session.spec()?;
+        let tempo_bpm = (!block.level.is_untimed()).then_some(block.level.tempo_bpm);
 
         Some(DrillView {
             phase: match block.phase {
@@ -188,7 +189,7 @@ impl CoachState {
             section: spec.section.clone(),
             destination: spec.destination.clone(),
             kind: spec.kind.clone(),
-            tempo_bpm: block.level.tempo_bpm,
+            tempo_bpm,
             click_level: block.level.click_level.spoken().to_string(),
             beat: block.beat(),
             beats_per_bar: block.beats_per_bar,
@@ -197,7 +198,9 @@ impl CoachState {
             count_in_beats: block.count_in_beats,
             phrase_beats: block.body_beats(),
             pulse_seq: block.pulse_seq,
-            pulse_running: block.phase != Phase::BlockEntry,
+            // Never at l0: the metronome there is absent, not silenced, so the
+            // shell has no pulse to schedule and no key to hold.
+            pulse_running: block.phase != Phase::BlockEntry && !block.level.is_untimed(),
             click_pattern: block.level.click_level.pattern(block.beats_per_bar),
             elapsed_seconds: block.elapsed_seconds(),
             minutes: spec.minutes,
@@ -213,8 +216,8 @@ impl CoachState {
                 .map(|block| block.spec.kind.clone())
                 .collect(),
             block_index: block.spec_index,
-            gate_question: gate_question(&spec.gate.requirement, block.level.tempo_bpm),
-            gate_summary: gate_summary(&spec.gate.requirement, block.level.tempo_bpm),
+            gate_question: gate_question(&spec.gate.requirement, tempo_bpm),
+            gate_summary: gate_summary(&spec.gate.requirement, tempo_bpm),
             gate_filled: block.gate_progress.filled(),
             gate_target: block.gate_progress.target(),
         })
@@ -238,19 +241,29 @@ fn next_rung(record: &BlockRecord) -> Option<ParameterLevel> {
         .find_map(|drill| drill.level)
 }
 
-fn gate_question(requirement: &Requirement, tempo_bpm: u16) -> String {
+/// " at 120", where there is a tempo to be at. An l0 rung has none to claim
+/// (decision 20), and a gate must not ask for one it cannot name.
+fn at_tempo(tempo_bpm: Option<u16>) -> String {
+    tempo_bpm
+        .map(|bpm| format!(" at {bpm}"))
+        .unwrap_or_default()
+}
+
+fn gate_question(requirement: &Requirement, tempo_bpm: Option<u16>) -> String {
+    let at = at_tempo(tempo_bpm);
     match requirement {
         Requirement::CleanPasses { .. } | Requirement::KeyCoverage { .. } => {
-            format!("Clean at {tempo_bpm}?")
+            format!("Clean{at}?")
         }
-        Requirement::Chained { .. } => format!("Clean at {tempo_bpm}, no stops?"),
+        Requirement::Chained { .. } => format!("Clean{at}, no stops?"),
         Requirement::SelfConfirmed { .. } => "Did that match?".to_string(),
     }
 }
 
-fn gate_summary(requirement: &Requirement, tempo_bpm: u16) -> String {
+fn gate_summary(requirement: &Requirement, tempo_bpm: Option<u16>) -> String {
+    let at = at_tempo(tempo_bpm);
     match requirement {
-        Requirement::CleanPasses { count, .. } => format!("{count} clean at {tempo_bpm}"),
+        Requirement::CleanPasses { count, .. } => format!("{count} clean{at}"),
         Requirement::KeyCoverage {
             keys_required,
             per_key_passes,
@@ -259,7 +272,7 @@ fn gate_summary(requirement: &Requirement, tempo_bpm: u16) -> String {
             if *first_attempt {
                 format!("clean first time, in {keys_required} keys")
             } else {
-                format!("{per_key_passes} clean at {tempo_bpm}, in {keys_required} keys")
+                format!("{per_key_passes} clean{at}, in {keys_required} keys")
             }
         }
         Requirement::Chained { min_keys } => format!("{min_keys} keys chained, no stops"),
@@ -333,7 +346,10 @@ pub struct DrillView {
     pub section: Option<String>,
     pub destination: Option<String>,
     pub kind: ItemKind,
-    pub tempo_bpm: u16,
+    /// `None` at l0, where the rung has no tempo to state (decision 20). It is
+    /// the same fact as having no beat to count, so a view with no tempo draws
+    /// no beat position either.
+    pub tempo_bpm: Option<u16>,
     /// The running click level in the musician's words — "beats 2 & 4".
     pub click_level: String,
     pub beat: u8,
@@ -401,7 +417,7 @@ mod tests {
         assert_eq!(drill.drill_title, "Rootless voicings");
         assert_eq!(drill.section.as_deref(), Some("A section"));
         assert_eq!(drill.destination.as_deref(), Some("Strasbourg / St. Denis"));
-        assert_eq!(drill.tempo_bpm, 120);
+        assert_eq!(drill.tempo_bpm, Some(120));
         assert_eq!(drill.click_level, "beats 2 & 4");
         assert_eq!(
             (drill.bar, drill.beat),
@@ -423,6 +439,87 @@ mod tests {
         assert!(
             !drill.why.is_empty(),
             "the card's why line is the core's sentence, not the shell's"
+        );
+    }
+
+    // ── l0: the clickless acquisition block (decision 20) ──
+
+    fn playing_untimed() -> CoachState {
+        let mut coach = CoachState::default();
+        coach.session.start_untimed_fixture(at(0));
+        coach.apply(&CoachEvent::StartBlock { now: at(0) });
+        coach
+    }
+
+    #[test]
+    fn the_drill_view_claims_no_tempo_at_l0() {
+        let drill = playing_untimed().view().drill.expect("a running drill");
+
+        assert_eq!(
+            drill.tempo_bpm, None,
+            "the shell cannot draw a tempo the rung does not have, and a beat \
+             position is the same fact"
+        );
+        assert_eq!(drill.click_level, "no click");
+        assert!(
+            !drill.pulse_running,
+            "the metronome at l0 is absent, not silenced"
+        );
+        assert_eq!(drill.count_in_beats, 0);
+        assert_eq!(
+            drill.elapsed_seconds, 0,
+            "the ceiling and the elapsed clock stay (decision 15)"
+        );
+        assert_eq!(drill.ceiling_seconds, Some(360));
+    }
+
+    #[test]
+    fn the_gate_question_at_l0_makes_no_claim_about_tempo() {
+        let drill = playing_untimed().view().drill.expect("a running drill");
+
+        assert_eq!(drill.gate_question, "Clean?");
+        assert_eq!(drill.gate_summary, "3 clean");
+    }
+
+    #[test]
+    fn l0_evidence_never_lands_on_the_clocked_rung() {
+        let mut coach = playing_untimed();
+        let clocked = ParameterLevel {
+            tempo_bpm: 120,
+            click_level: ClickLevel::TwoAndFour,
+        };
+        let before = coach
+            .mastery
+            .reading("rootless-a-b", clocked, at(0))
+            .evidence;
+
+        coach.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+
+        assert_eq!(
+            coach
+                .mastery
+                .reading("rootless-a-b", clocked, at(20))
+                .evidence,
+            before,
+            "l0 is a level, so knowing it out of time cannot vouch for the tempo"
+        );
+        assert!(
+            coach
+                .mastery
+                .reading(
+                    "rootless-a-b",
+                    ParameterLevel {
+                        tempo_bpm: 0,
+                        click_level: ClickLevel::NoClick,
+                    },
+                    at(20),
+                )
+                .evidence
+                > 0.0,
+            "and it lands on the rung that was actually played"
         );
     }
 
@@ -513,7 +610,7 @@ mod tests {
         coach.apply(&CoachEvent::Stuck { now: at(5) });
 
         let drill = coach.view().drill.unwrap();
-        assert_eq!(drill.tempo_bpm, 96);
+        assert_eq!(drill.tempo_bpm, Some(96));
         assert_eq!(drill.gate_question, "Clean at 96?");
         assert_eq!(drill.gate_summary, "3 clean at 96");
         assert_eq!(
@@ -1160,5 +1257,29 @@ mod tests {
         }
         assert_eq!(open.view().drill.unwrap().phase, DrillPhase::GateOpen);
         assert_round_trips(open.view());
+
+        // A view with no tempo: the one shape a bincode wire has no "absent"
+        // for, and the one the shell would otherwise draw a 0 from.
+        let mut untimed = playing_untimed();
+        assert_round_trips(untimed.view());
+        untimed.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+        assert_round_trips(untimed.view());
+    }
+
+    #[test]
+    fn an_l0_session_survives_the_ffi_wire() {
+        let mut coach = playing_untimed();
+        coach.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+
+        assert_round_trips(crate::app::Event::Coach(CoachEvent::RecoverSession {
+            session: coach.session.clone(),
+            now: at(30),
+        }));
     }
 }

--- a/crates/intrada-core/src/engine/content.rs
+++ b/crates/intrada-core/src/engine/content.rs
@@ -116,6 +116,7 @@ pub struct Escalation {
     pub tempo_down_pct: u16,
     pub tempo_floor_bpm: u16,
     pub gate_open_hold_s: u32,
+    pub glance_hold_s: u32,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -233,6 +234,7 @@ struct RawEscalation {
     tempo_down_pct: u16,
     tempo_floor_bpm: u16,
     gate_open_hold_s: u32,
+    glance_hold_s: u32,
 }
 
 #[derive(Deserialize, Debug)]
@@ -616,6 +618,7 @@ impl RawContent {
                 tempo_down_pct: self.escalation.tempo_down_pct,
                 tempo_floor_bpm: self.escalation.tempo_floor_bpm,
                 gate_open_hold_s: self.escalation.gate_open_hold_s,
+                glance_hold_s: self.escalation.glance_hold_s,
             },
             planner: PlannerLimits {
                 maintenance_estimate: self.planner.maintenance_estimate,
@@ -651,8 +654,7 @@ impl RawGate {
                 tempo_bpm,
                 click_level: click_level.into(),
             })),
-            // A rung the loop cannot run: the planner defers it rather than
-            // prescribing a block with nothing to play against.
+            // A rung the loop cannot run, which the planner defers.
             (Some(_), None) | (None, _) => Ok(None),
         }
     }
@@ -787,8 +789,7 @@ mod tests {
 
     // ── l0, the acquisition rung (decision 20) ──
 
-    /// The shells cycle gate, rewritten as the clickless rung it would be while
-    /// the hands are still finding the shapes.
+    /// The shells cycle gate, rewritten as the clickless rung it would be.
     fn shells_cycle_at_l0(tempo: &str) -> String {
         SHIPPED.replace(
             "criterion = \"ii-V-I shells through the full cycle of fourths, no stops\"\n\
@@ -819,13 +820,13 @@ mod tests {
 
     #[test]
     fn an_l0_gate_that_names_a_tempo_fails_to_parse() {
-        let error = error_of(ContentIndex::parse(&shells_cycle_at_l0(
-            "tempo_bpm = 100\n",
-        )));
-        assert!(
-            error.contains("shells-cycle"),
+        assert_eq!(
+            ContentIndex::parse(&shells_cycle_at_l0("tempo_bpm = 100\n")),
+            Err(ContentError::TimedAcquisitionGate(
+                "shells-cycle".to_string()
+            )),
             "a tempo at l0 states two contradictory things, and a gate that \
-             cannot be represented fails rather than losing one of them: {error}"
+             cannot be represented fails rather than losing one of them"
         );
     }
 
@@ -893,6 +894,7 @@ mod tests {
         assert_eq!(content.escalation.tempo_down_pct, 20);
         assert_eq!(content.escalation.tempo_floor_bpm, 40);
         assert_eq!(content.escalation.gate_open_hold_s, 2);
+        assert_eq!(content.escalation.glance_hold_s, 1);
     }
 
     // ── Validation: what must fail to parse (spec §8) ──

--- a/crates/intrada-core/src/engine/content.rs
+++ b/crates/intrada-core/src/engine/content.rs
@@ -54,6 +54,8 @@ pub enum ContentError {
     NodeMismatch(String, String, String),
     #[error("gate \"{0}\" is unreachable: no drill runs it")]
     UnreachableGate(String),
+    #[error("gate \"{0}\" is l0 and names a tempo; acquisition happens out of time")]
+    TimedAcquisitionGate(String),
     #[error("gate \"{0}\" states no requirement anything can count")]
     UncountableGate(String),
     #[error("node \"{0}\" is a stub and a stub has no drills")]
@@ -379,6 +381,7 @@ enum JudgeToken {
 #[derive(Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 enum ClickLevelToken {
+    L0,
     L1,
     L2,
     L3,
@@ -427,6 +430,7 @@ impl From<JudgeToken> for Judge {
 impl ClickLevelToken {
     fn key(self) -> &'static str {
         match self {
+            ClickLevelToken::L0 => "l0",
             ClickLevelToken::L1 => "l1",
             ClickLevelToken::L2 => "l2",
             ClickLevelToken::L3 => "l3",
@@ -438,6 +442,7 @@ impl ClickLevelToken {
 impl From<ClickLevelToken> for ClickLevel {
     fn from(token: ClickLevelToken) -> Self {
         match token {
+            ClickLevelToken::L0 => ClickLevel::NoClick,
             ClickLevelToken::L1 => ClickLevel::EveryBeat,
             ClickLevelToken::L2 => ClickLevel::TwoAndFour,
             ClickLevelToken::L3 => ClickLevel::BarDownbeat,
@@ -531,12 +536,7 @@ impl RawContent {
                         applied: raw_drill.applied,
                         bars: raw_drill.bars.unwrap_or(self.defaults.bars),
                         minutes: raw_drill.minutes,
-                        level: raw_gate.tempo_bpm.zip(raw_gate.click_level).map(
-                            |(tempo_bpm, click_level)| ParameterLevel {
-                                tempo_bpm,
-                                click_level: click_level.into(),
-                            },
-                        ),
+                        level: raw_gate.level(&raw_drill.gate)?,
                     },
                 );
             }
@@ -634,6 +634,29 @@ impl RawContent {
 }
 
 impl RawGate {
+    /// The rung this gate is played at, where the file states a runnable one.
+    /// An l0 gate carries no `tempo_bpm` by construction (decision 20), so one
+    /// that names a tempo states two contradictory things and fails rather than
+    /// having one of them quietly win.
+    fn level(&self, id: &str) -> Result<Option<ParameterLevel>, ContentError> {
+        match (self.click_level, self.tempo_bpm) {
+            (Some(ClickLevelToken::L0), Some(_)) => {
+                Err(ContentError::TimedAcquisitionGate(id.to_string()))
+            }
+            (Some(ClickLevelToken::L0), None) => Ok(Some(ParameterLevel {
+                tempo_bpm: 0,
+                click_level: ClickLevel::NoClick,
+            })),
+            (Some(click_level), Some(tempo_bpm)) => Ok(Some(ParameterLevel {
+                tempo_bpm,
+                click_level: click_level.into(),
+            })),
+            // A rung the loop cannot run: the planner defers it rather than
+            // prescribing a block with nothing to play against.
+            (Some(_), None) | (None, _) => Ok(None),
+        }
+    }
+
     /// One resolution order, so an unrepresentable gate fails to parse rather
     /// than silently losing the field that made it what it is (spec §8).
     fn requirement(&self, id: &str) -> Result<Requirement, ContentError> {
@@ -759,6 +782,50 @@ mod tests {
                 .unwrap()
                 .requirement,
             Requirement::Chained { min_keys: 4 }
+        );
+    }
+
+    // ── l0, the acquisition rung (decision 20) ──
+
+    /// The shells cycle gate, rewritten as the clickless rung it would be while
+    /// the hands are still finding the shapes.
+    fn shells_cycle_at_l0(tempo: &str) -> String {
+        SHIPPED.replace(
+            "criterion = \"ii-V-I shells through the full cycle of fourths, no stops\"\n\
+             clean_passes = 1\n\
+             tempo_bpm = 100\n\
+             click_level = \"l2\"",
+            &format!(
+                "criterion = \"ii-V-I shells through the full cycle of fourths, no stops\"\n\
+                 clean_passes = 1\n{tempo}click_level = \"l0\""
+            ),
+        )
+    }
+
+    #[test]
+    fn an_l0_gate_is_runnable_without_a_tempo() {
+        let content = ContentIndex::parse(&shells_cycle_at_l0("")).expect("an l0 gate parses");
+
+        assert_eq!(
+            content.drill("shells-cycle").expect("the drill").level,
+            Some(ParameterLevel {
+                tempo_bpm: 0,
+                click_level: ClickLevel::NoClick,
+            }),
+            "no click and no tempo is a rung the loop can run, not a rung it \
+             has to skip for want of a click"
+        );
+    }
+
+    #[test]
+    fn an_l0_gate_that_names_a_tempo_fails_to_parse() {
+        let error = error_of(ContentIndex::parse(&shells_cycle_at_l0(
+            "tempo_bpm = 100\n",
+        )));
+        assert!(
+            error.contains("shells-cycle"),
+            "a tempo at l0 states two contradictory things, and a gate that \
+             cannot be represented fails rather than losing one of them: {error}"
         );
     }
 

--- a/crates/intrada-core/src/engine/gate.rs
+++ b/crates/intrada-core/src/engine/gate.rs
@@ -45,14 +45,14 @@ pub enum Judge {
     SelfConfirmed,
 }
 
-/// The sparse-click ladder — gate levels *within* click-always (decision 2),
-/// below which sits the rung where the clock has not arrived yet (decision 20).
-/// Declared in ladder order: `NoClick` is the bottom.
+/// The sparse-click ladder: gate levels *within* click-always (decision 2),
+/// plus the rung below them where the clock has not arrived yet (decision 20).
+/// Declared in ladder order, so `NoClick` sorts bottom.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 #[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum ClickLevel {
-    /// l0: no click, no tempo, no count-in. Acquisition happens out of time.
+    /// l0: no click, no tempo, no count-in.
     NoClick,
     EveryBeat,
     TwoAndFour,

--- a/crates/intrada-core/src/engine/gate.rs
+++ b/crates/intrada-core/src/engine/gate.rs
@@ -26,6 +26,10 @@ pub enum Verdict {
 #[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum EvidenceSource {
     TapVerdict,
+    /// A tap at l0, where nothing bounds the pass but the tap itself
+    /// (decision 20). Its own class, so acquisition evidence and evidence
+    /// earned against a click never read as the same thing.
+    TapVerdictUntimed,
     Midi,
     Audio,
 }
@@ -41,11 +45,15 @@ pub enum Judge {
     SelfConfirmed,
 }
 
-/// The sparse-click ladder — gate levels *within* click-always (decision 2).
+/// The sparse-click ladder — gate levels *within* click-always (decision 2),
+/// below which sits the rung where the clock has not arrived yet (decision 20).
+/// Declared in ladder order: `NoClick` is the bottom.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 #[cfg_attr(feature = "facet_typegen", repr(C))]
 pub enum ClickLevel {
+    /// l0: no click, no tempo, no count-in. Acquisition happens out of time.
+    NoClick,
     EveryBeat,
     TwoAndFour,
     BarDownbeat,
@@ -55,6 +63,7 @@ pub enum ClickLevel {
 impl ClickLevel {
     pub fn spoken(&self) -> &'static str {
         match self {
+            ClickLevel::NoClick => "no click",
             ClickLevel::EveryBeat => "every beat",
             ClickLevel::TwoAndFour => "beats 2 & 4",
             ClickLevel::BarDownbeat => "beat 1 of each bar",
@@ -67,6 +76,9 @@ impl ClickLevel {
     pub fn pattern(&self, beats_per_bar: u8) -> Vec<bool> {
         let bar = usize::from(beats_per_bar.max(1));
         let mut pattern = match self {
+            // Nothing sounds at l0, and a one-beat cycle rather than an empty
+            // one leaves the shell's `beat_index % len` something to divide by.
+            ClickLevel::NoClick => return vec![false],
             ClickLevel::EveryBeat => vec![true; bar],
             ClickLevel::TwoAndFour => (0..bar).map(|beat| beat == 1 || beat == 3).collect(),
             ClickLevel::BarDownbeat => (0..bar).map(|beat| beat == 0).collect(),
@@ -345,6 +357,27 @@ mod tests {
     fn click_levels_read_as_a_musician_says_them() {
         assert_eq!(ClickLevel::TwoAndFour.spoken(), "beats 2 & 4");
         assert_eq!(ClickLevel::EveryBeat.spoken(), "every beat");
+        assert_eq!(ClickLevel::NoClick.spoken(), "no click");
+    }
+
+    // ── l0, the acquisition rung (decision 20) ──
+
+    #[test]
+    fn l0_sits_below_every_clicked_level() {
+        assert!(
+            ClickLevel::NoClick < ClickLevel::EveryBeat,
+            "l0 is the bottom rung of the ladder, not a level beside it"
+        );
+    }
+
+    #[test]
+    fn l0_sounds_nothing_and_still_leaves_the_shell_a_cycle_to_divide_by() {
+        assert_eq!(
+            ClickLevel::NoClick.pattern(4),
+            vec![false],
+            "the metronome at l0 is absent, not silenced, and an empty cycle \
+             would divide by zero in the shell"
+        );
     }
 
     // ── Click placement ──

--- a/crates/intrada-core/src/engine/plan.rs
+++ b/crates/intrada-core/src/engine/plan.rs
@@ -49,8 +49,18 @@ pub enum Mode {
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct ParameterLevel {
+    /// Meaningless at l0, where there is no clock to state one against: read it
+    /// through [`ParameterLevel::is_untimed`] rather than on its own.
     pub tempo_bpm: u16,
     pub click_level: ClickLevel,
+}
+
+impl ParameterLevel {
+    /// The acquisition rung (decision 20): no click, so no tempo, no count-in
+    /// and no phrase boundary to bound an attempt on.
+    pub fn is_untimed(&self) -> bool {
+        self.click_level == ClickLevel::NoClick
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -733,6 +743,17 @@ impl Plan {
             rng_seed: 0,
             deferred: Vec::new(),
         }
+    }
+
+    /// The same block at l0 (decision 20). Only the rung changes: everything
+    /// the clock implied — the count-in included — falls out of it.
+    pub(crate) fn fixture_untimed() -> Self {
+        let mut plan = Self::fixture();
+        plan.blocks[0].spec.level = ParameterLevel {
+            tempo_bpm: 0,
+            click_level: ClickLevel::NoClick,
+        };
+        plan
     }
 }
 

--- a/crates/intrada-core/src/engine/plan.rs
+++ b/crates/intrada-core/src/engine/plan.rs
@@ -57,7 +57,7 @@ pub struct ParameterLevel {
 
 impl ParameterLevel {
     /// The acquisition rung (decision 20): no click, so no tempo, no count-in
-    /// and no phrase boundary to bound an attempt on.
+    /// and no boundary to bound an attempt on.
     pub fn is_untimed(&self) -> bool {
         self.click_level == ClickLevel::NoClick
     }
@@ -745,8 +745,8 @@ impl Plan {
         }
     }
 
-    /// The same block at l0 (decision 20). Only the rung changes: everything
-    /// the clock implied — the count-in included — falls out of it.
+    /// The same block at l0. Only the rung changes: what the clock implied,
+    /// the count-in included, falls out of it.
     pub(crate) fn fixture_untimed() -> Self {
         let mut plan = Self::fixture();
         plan.blocks[0].spec.level = ParameterLevel {

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -261,6 +261,8 @@ pub struct EngineConfig {
     pub consecutive_fail_trigger: u8,
     pub ladder: Vec<Rung>,
     pub gate_open_hold_s: u32,
+    /// How long the tap's glance holds where no beat ends it, which is only l0.
+    pub glance_hold_s: u32,
     pub tempo_down_pct: u16,
     pub tempo_floor_bpm: u16,
 }
@@ -272,6 +274,7 @@ impl Default for EngineConfig {
             consecutive_fail_trigger: escalation.consecutive_fail_trigger,
             ladder: escalation.ladder.clone(),
             gate_open_hold_s: escalation.gate_open_hold_s,
+            glance_hold_s: escalation.glance_hold_s,
             tempo_down_pct: escalation.tempo_down_pct,
             tempo_floor_bpm: escalation.tempo_floor_bpm,
         }
@@ -361,6 +364,22 @@ impl BlockState {
             Phase::CountIn {
                 beats_remaining: self.count_in_beats,
             }
+        }
+    }
+
+    /// At a clicked level the next beat turns the page on the tap's glance
+    /// (T11). At l0 no beat ever arrives, so the clock ends it instead: left
+    /// to a beat, the screen would hold on a phase with nothing to tap.
+    fn end_untimed_glance(&mut self, now: DateTime<Utc>, hold_s: u32) {
+        if !self.level.is_untimed() || self.phase != Phase::Listening {
+            return;
+        }
+        let held = self
+            .attempts
+            .last()
+            .is_some_and(|attempt| (now - attempt.at).num_seconds() >= i64::from(hold_s));
+        if held {
+            self.last_verdict = None;
         }
     }
 
@@ -675,10 +694,6 @@ impl EngineSession {
         let Some(block) = self.block_mut() else {
             return;
         };
-        // Nothing sounds at l0, so nothing can be reported from it.
-        if block.level.is_untimed() {
-            return;
-        }
         if matches!(
             block.phase,
             Phase::CountIn { .. } | Phase::Escalating { .. }
@@ -787,9 +802,6 @@ impl EngineSession {
         // With a window open this voids the pass it asks about, not the one in
         // flight. Voiding the pass in flight reads as well: open, see #1237.
         match block.phase {
-            // At l0 nothing is pending: the tap is the only thing that records,
-            // so the discarded pass is simply the one not tapped for.
-            Phase::Listening if block.level.is_untimed() => {}
             Phase::Listening => block.discarded = true,
             Phase::AwaitingVerdict => block.phase = Phase::Listening,
             _ => return,
@@ -1035,10 +1047,12 @@ impl EngineSession {
     fn tick(&mut self, now: DateTime<Utc>) {
         let ceiling = self.spec().map(|spec| u32::from(spec.minutes) * 60);
         let hold = self.config.gate_open_hold_s;
+        let glance = self.config.glance_hold_s;
         let Some(block) = self.block_mut() else {
             return;
         };
         block.now = now;
+        block.end_untimed_glance(now, glance);
 
         let held = block.phase == Phase::GateOpen
             && block
@@ -1162,7 +1176,6 @@ impl EngineSession {
         self.start(Plan::fixture(), now);
     }
 
-    /// The same fixture at l0, for the clickless half of the machine.
     #[cfg(test)]
     pub(crate) fn start_untimed_fixture(&mut self, now: DateTime<Utc>) {
         self.start(Plan::fixture_untimed(), now);
@@ -2796,8 +2809,8 @@ mod tests {
 
     // ── l0: the clickless acquisition block (decision 20) ──
 
-    /// An l0 block, started. There is no count-in to sit through, so the hands
-    /// are already on the material.
+    /// An l0 block, started: no count-in to sit through, so the hands are
+    /// already on the material.
     fn untimed() -> EngineSession {
         let mut session = EngineSession::default();
         session.start_untimed_fixture(at(0));
@@ -2888,8 +2901,8 @@ mod tests {
         assert_eq!(
             session.block().unwrap().attempts.len(),
             1,
-            "nothing was pending when the user discarded, so the pass they went \
-             on to play still counts"
+            "the tap is the only thing that records at l0, so a discard voids \
+             nothing and the pass the user goes on to play still counts"
         );
     }
 

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -329,7 +329,13 @@ impl BlockState {
             level: spec.level,
             bars: spec.bars,
             beats_per_bar: spec.beats_per_bar,
-            count_in_beats: spec.count_in_beats,
+            // An l0 rung has nothing to count in, whatever the content's
+            // default says: the count-in belongs to the click, not the block.
+            count_in_beats: if spec.level.is_untimed() {
+                0
+            } else {
+                spec.count_in_beats
+            },
             beat_index: 0,
             attempts: Vec::new(),
             consecutive_fails: 0,
@@ -343,6 +349,18 @@ impl BlockState {
             reps_after_gate: 0,
             cold: false,
             gate_open_since: None,
+        }
+    }
+
+    /// Where the hands come back in: at l0 there is no count-in to sit through,
+    /// and one nothing clicks through would never end (decision 20).
+    fn opening_phase(&self) -> Phase {
+        if self.level.is_untimed() {
+            Phase::Listening
+        } else {
+            Phase::CountIn {
+                beats_remaining: self.count_in_beats,
+            }
         }
     }
 
@@ -633,9 +651,7 @@ impl EngineSession {
                     block.phase = Phase::GateOpen;
                 } else {
                     block.gate_open_since = None;
-                    block.phase = Phase::CountIn {
-                        beats_remaining: block.count_in_beats,
-                    };
+                    block.phase = block.opening_phase();
                 }
             }
             SessionState::OffPiste { started_at } | SessionState::Unmonitored { started_at } => {
@@ -659,6 +675,10 @@ impl EngineSession {
         let Some(block) = self.block_mut() else {
             return;
         };
+        // Nothing sounds at l0, so nothing can be reported from it.
+        if block.level.is_untimed() {
+            return;
+        }
         if matches!(
             block.phase,
             Phase::CountIn { .. } | Phase::Escalating { .. }
@@ -673,6 +693,11 @@ impl EngineSession {
         let Some(block) = self.block_mut() else {
             return;
         };
+        // There is no grid at l0, so nothing can finish a phrase on one: the
+        // tap is what bounds an attempt there.
+        if block.level.is_untimed() {
+            return;
+        }
         let phrase = block.body_beats();
         match block.phase {
             // A pulse reports its first body beat as 0, so anything else here
@@ -719,9 +744,7 @@ impl EngineSession {
         }
         block.started_at = now;
         block.now = now;
-        block.phase = Phase::CountIn {
-            beats_remaining: block.count_in_beats,
-        };
+        block.phase = block.opening_phase();
     }
 
     fn skip_block(&mut self, now: DateTime<Utc>) {
@@ -764,6 +787,9 @@ impl EngineSession {
         // With a window open this voids the pass it asks about, not the one in
         // flight. Voiding the pass in flight reads as well: open, see #1237.
         match block.phase {
+            // At l0 nothing is pending: the tap is the only thing that records,
+            // so the discarded pass is simply the one not tapped for.
+            Phase::Listening if block.level.is_untimed() => {}
             Phase::Listening => block.discarded = true,
             Phase::AwaitingVerdict => block.phase = Phase::Listening,
             _ => return,
@@ -776,7 +802,15 @@ impl EngineSession {
         let trigger = self.config.consecutive_fail_trigger;
         let node = self.spec()?.node.clone();
         let block = self.block_mut()?;
-        if block.phase != Phase::AwaitingVerdict {
+        // At l0 the tap is what bounds the attempt (decision 20), so it is
+        // taken from the pass in flight rather than from an open window.
+        let untimed = block.level.is_untimed();
+        let bounded = if untimed {
+            Phase::Listening
+        } else {
+            Phase::AwaitingVerdict
+        };
+        if block.phase != bounded {
             return None;
         }
 
@@ -789,7 +823,11 @@ impl EngineSession {
         block.attempts.push(AttemptSummary {
             at: now,
             verdict,
-            source: EvidenceSource::TapVerdict,
+            source: if untimed {
+                EvidenceSource::TapVerdictUntimed
+            } else {
+                EvidenceSource::TapVerdict
+            },
             cold: block.cold && block.attempts.is_empty(),
             self_predicted: None,
             level: block.level,
@@ -870,7 +908,13 @@ impl EngineSession {
                         };
                         block.consecutive_fails = 0;
                         block.restart_pulse();
-                        block.phase = Phase::Escalating { rung };
+                        // Nothing counts an l0 block back in, so a hold for the
+                        // count-in would freeze the loop.
+                        block.phase = if block.level.is_untimed() {
+                            Phase::Listening
+                        } else {
+                            Phase::Escalating { rung }
+                        };
                         return true;
                     }
                 }
@@ -918,6 +962,9 @@ impl EngineSession {
             return false;
         };
         match rung {
+            // There is no tempo to drop at l0, and handing the block the floor
+            // tempo would move it onto a rung it has never practised at.
+            Rung::TempoDown if block.level.is_untimed() => false,
             Rung::TempoDown => {
                 let dropped = block
                     .level
@@ -1115,6 +1162,12 @@ impl EngineSession {
         self.start(Plan::fixture(), now);
     }
 
+    /// The same fixture at l0, for the clickless half of the machine.
+    #[cfg(test)]
+    pub(crate) fn start_untimed_fixture(&mut self, now: DateTime<Utc>) {
+        self.start(Plan::fixture_untimed(), now);
+    }
+
     fn block_mut(&mut self) -> Option<&mut BlockState> {
         match &mut self.state {
             SessionState::Running { block, .. } => Some(block),
@@ -1126,7 +1179,7 @@ impl EngineSession {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::engine::gate::Requirement;
+    use crate::engine::gate::{ClickLevel, Requirement};
     use chrono::TimeZone;
 
     fn at(second: i64) -> DateTime<Utc> {
@@ -2739,5 +2792,181 @@ mod tests {
         assert_eq!(session.unmonitored_seconds, 600);
         assert!(session.closed_blocks.is_empty());
         assert!(session.wanders.is_empty(), "decision 16: nothing inferred");
+    }
+
+    // ── l0: the clickless acquisition block (decision 20) ──
+
+    /// An l0 block, started. There is no count-in to sit through, so the hands
+    /// are already on the material.
+    fn untimed() -> EngineSession {
+        let mut session = EngineSession::default();
+        session.start_untimed_fixture(at(0));
+        session.apply(&CoachEvent::StartBlock { now: at(0) });
+        session
+    }
+
+    #[test]
+    fn an_l0_block_starts_playing_rather_than_counting_in() {
+        let mut session = EngineSession::default();
+        session.start_untimed_fixture(at(0));
+
+        session.apply(&CoachEvent::StartBlock { now: at(0) });
+
+        assert_eq!(
+            session.phase(),
+            Some(&Phase::Listening),
+            "with no click there is nothing to count in, and a count-in nothing \
+             clicks through would never end"
+        );
+    }
+
+    #[test]
+    fn the_tap_bounds_the_attempt_at_l0() {
+        let mut session = untimed();
+
+        let writes = session.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+
+        assert_eq!(
+            writes.evidence.len(),
+            1,
+            "with no phrase boundary to open a window on, the tap is what says \
+             that pass is judged (Jon's ruling, 7 Aug 2026)"
+        );
+        assert_eq!(session.block().unwrap().attempts.len(), 1);
+        assert_eq!(
+            session.phase(),
+            Some(&Phase::Listening),
+            "and the next pass is already the one being played"
+        );
+    }
+
+    #[test]
+    fn an_l0_attempt_is_tagged_as_untimed_evidence() {
+        let mut session = untimed();
+        session.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+
+        assert_eq!(
+            session.block().unwrap().attempts[0].source,
+            EvidenceSource::TapVerdictUntimed,
+            "knowing it out of time and owning it at tempo must never silently \
+             share a number"
+        );
+    }
+
+    #[test]
+    fn a_stray_beat_at_l0_opens_no_verdict_window() {
+        let mut session = untimed();
+        let phrase = session.block().unwrap().body_beats();
+
+        session.apply(&CoachEvent::Beat { beat_index: phrase });
+
+        assert_eq!(
+            session.phase(),
+            Some(&Phase::Listening),
+            "there is no grid at l0, so nothing can finish a phrase on one"
+        );
+    }
+
+    #[test]
+    fn a_discard_at_l0_writes_nothing_off_that_has_not_been_played() {
+        let mut session = untimed();
+
+        let writes = session.apply(&CoachEvent::DiscardAttempt { now: at(10) });
+        assert!(writes.evidence.is_empty());
+        assert!(session.block().unwrap().attempts.is_empty());
+
+        session.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+        assert_eq!(
+            session.block().unwrap().attempts.len(),
+            1,
+            "nothing was pending when the user discarded, so the pass they went \
+             on to play still counts"
+        );
+    }
+
+    #[test]
+    fn the_gate_opens_at_l0_on_the_taps_alone() {
+        let mut session = untimed();
+        for second in [10, 20, 30] {
+            session.apply(&CoachEvent::Tap {
+                clean: true,
+                now: at(second),
+            });
+        }
+
+        assert_eq!(session.phase(), Some(&Phase::GateOpen));
+        assert_eq!(session.block().unwrap().gate_opened_at_attempt, Some(3));
+    }
+
+    #[test]
+    fn the_tempo_rung_cannot_hand_a_tempo_to_a_block_that_has_none() {
+        let mut session = untimed();
+
+        session.apply(&CoachEvent::Stuck { now: at(10) });
+
+        let block = session.block().expect("the ladder acted, it did not close");
+        assert_eq!(
+            block.level,
+            ParameterLevel {
+                tempo_bpm: 0,
+                click_level: ClickLevel::NoClick,
+            },
+            "dropping a tempo that does not exist would move the block onto a \
+             mastery key it never practised at"
+        );
+    }
+
+    #[test]
+    fn an_acting_rung_at_l0_returns_to_playing_rather_than_waiting_to_be_counted_in() {
+        let mut session = untimed();
+
+        session.apply(&CoachEvent::Stuck { now: at(10) });
+
+        assert_eq!(
+            session.block().unwrap().bars,
+            4,
+            "the scope rung is the one that can act without a tempo"
+        );
+        assert_eq!(
+            session.phase(),
+            Some(&Phase::Listening),
+            "nothing counts an l0 block back in, so waiting for it would freeze \
+             the loop"
+        );
+    }
+
+    #[test]
+    fn a_recovered_l0_block_comes_back_playing() {
+        let mut crashed = untimed();
+        crashed.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(20),
+        });
+
+        let mut restored = EngineSession::default();
+        restored.apply(&CoachEvent::RecoverSession {
+            session: crashed,
+            now: at(3600),
+        });
+
+        assert_eq!(
+            restored.phase(),
+            Some(&Phase::Listening),
+            "there is no count-in to come back to"
+        );
+        assert_eq!(
+            restored.block().unwrap().attempts.len(),
+            1,
+            "and the evidence banked before the crash survives it"
+        );
     }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,15 @@ countable criteria.
 
 ## Recently landed
 
+- #1244 — the coach engine runs a clickless block (decision 20's engine half):
+  `ClickLevel` gains l0 at the bottom of the ladder, a block at it starts
+  playing rather than counting in, and the tap bounds the attempt (Jon's ruling
+  on the issue, 7 Aug) since there is no phrase boundary to open a window on.
+  Evidence is tagged `TapVerdictUntimed` and lands on l0's own mastery key, so
+  knowing it out of time never vouches for the tempo; a tempo-down rung cannot
+  act where there is no tempo. `DrillView::tempo_bpm` is now `Option<u16>`.
+  The l0 drill screen is #1260 and the gates that use l0 are #1245, so nothing
+  reaches it in the app yet
 - #1190 — the session-builder machinery deleted (2a close-out): the Building
   phase and its screens (`SessionBuilderScreen`, `AddToSessionSheet`,
   `EntrySettingsSheet`, `AddRelatedExerciseSheet`) are gone from both
@@ -91,5 +100,6 @@ countable criteria.
 ## Next (once 2a closes)
 
 - Phase 2b — steer and guard: declaration surfaces, back-chaining, gap read,
-  circling check, grind trade, acquisition before the clock (#1244, #1245;
-  see the phase plan in `roadmap.md`)
+  circling check, grind trade, the rest of acquisition before the clock
+  (#1245's gates and ramp, #1260's l0 screen; see the phase plan in
+  `roadmap.md`)

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -863,16 +863,18 @@ final class LibraryStore: ItemStore {
   private static func evidenceSource(from raw: String) -> EvidenceSource {
     switch raw {
     case "tap_verdict": return .tapVerdict
+    case "tap_verdict_untimed": return .tapVerdictUntimed
     case "midi": return .midi
     case "audio": return .audio
     default:
       report(UnknownStoredEnum(kind: "EvidenceSource", raw: raw), decodeContext)
-      return .tapVerdict  // conservative: the lowest-weight evidence class
+      return .tapVerdictUntimed  // conservative: the lowest-weight evidence class
     }
   }
 
   private static func clickLevel(from raw: String) -> ClickLevel {
     switch raw {
+    case "no_click": return .noClick
     case "every_beat": return .everyBeat
     case "two_and_four": return .twoAndFour
     case "bar_downbeat": return .barDownbeat
@@ -933,6 +935,7 @@ final class LibraryStore: ItemStore {
   private static func evidenceSourceString(_ source: EvidenceSource) -> String {
     switch source {
     case .tapVerdict: "tap_verdict"
+    case .tapVerdictUntimed: "tap_verdict_untimed"
     case .midi: "midi"
     case .audio: "audio"
     }
@@ -940,6 +943,7 @@ final class LibraryStore: ItemStore {
 
   private static func clickLevelString(_ level: ClickLevel) -> String {
     switch level {
+    case .noClick: "no_click"
     case .everyBeat: "every_beat"
     case .twoAndFour: "two_and_four"
     case .barDownbeat: "bar_downbeat"

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -868,7 +868,9 @@ final class LibraryStore: ItemStore {
     case "audio": return .audio
     default:
       report(UnknownStoredEnum(kind: "EvidenceSource", raw: raw), decodeContext)
-      return .tapVerdictUntimed  // conservative: the lowest-weight evidence class
+      // Not `.tapVerdictUntimed`: an untimed source on a clocked rung is a row
+      // the engine can never write, and a fallback must not invent one.
+      return .tapVerdict
     }
   }
 

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -23,10 +23,16 @@ final class Store {
   /// change and the upgrade ignores the stale blob instead of misreading it.
   /// v2 (#1223): `Phase::BlockEntry` renumbered every variant and `discarded`
   /// added a byte mid-struct, so a v1 blob no longer decodes.
-  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v2"
+  /// v3 (#1244): `ClickLevel::NoClick` and `EvidenceSource::TapVerdictUntimed`
+  /// went in at the bottom of their enums, renumbering the variants below them.
+  /// A v2 blob still *decodes*, into a clocked block read back as an l0 one,
+  /// with its evidence on a rung nothing practised.
+  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v3"
   /// Retired keys, cleared on the next write so a dead blob doesn't sit in
   /// UserDefaults for the life of the install.
-  static let retiredCoachSessionKeys = ["intrada.coach-session-in-progress.v1"]
+  static let retiredCoachSessionKeys = [
+    "intrada.coach-session-in-progress.v1", "intrada.coach-session-in-progress.v2",
+  ]
 
   private let bridge: CoreBridge
   private let session: URLSession

--- a/ios/Intrada/Views/Screens/DrillLoopHost.swift
+++ b/ios/Intrada/Views/Screens/DrillLoopHost.swift
@@ -207,9 +207,13 @@ private final class Click {
     engine.onBeat = { index, _ in
       store.send(.coach(.beat(beatIndex: UInt32(max(0, index)))))
     }
+    // A pulse needs a tempo. The core sends none at l0, where it also holds
+    // `pulseRunning` false, so this is unreachable rather than a state to
+    // invent a bpm for.
+    guard let bpm = drill.tempoBpm else { return false }
     do {
       try engine.start(
-        bpm: Double(drill.tempoBpm), beatsPerBar: Int(drill.beatsPerBar),
+        bpm: Double(bpm), beatsPerBar: Int(drill.beatsPerBar),
         countInBeats: Int(drill.countInBeats), clickPattern: drill.clickPattern)
       return true
     } catch {

--- a/ios/Intrada/Views/Screens/DrillLoopHost.swift
+++ b/ios/Intrada/Views/Screens/DrillLoopHost.swift
@@ -207,9 +207,8 @@ private final class Click {
     engine.onBeat = { index, _ in
       store.send(.coach(.beat(beatIndex: UInt32(max(0, index)))))
     }
-    // A pulse needs a tempo. The core sends none at l0, where it also holds
-    // `pulseRunning` false, so this is unreachable rather than a state to
-    // invent a bpm for.
+    // The core sends no tempo at l0, and holds `pulseRunning` false there, so
+    // this is unreachable rather than a state to invent a bpm for.
     guard let bpm = drill.tempoBpm else { return false }
     do {
       try engine.start(

--- a/ios/Intrada/Views/Screens/DrillScreen.swift
+++ b/ios/Intrada/Views/Screens/DrillScreen.swift
@@ -130,11 +130,15 @@ struct DrillScreen: View {
       VStack(spacing: IntradaSpacing.row + 2) {
         tempo
         clickPill
-        BeatPosition(
-          beat: Int(state.beat), beatsPerBar: Int(state.beatsPerBar), bar: Int(state.bar),
-          bars: Int(state.bars)
-        )
-        .padding(.top, IntradaSpacing.cardCompact)
+        // No tempo means no beat to count either (l0): a position frozen at
+        // bar 1 beat 1 would claim a pulse that never runs. Centre is #1260.
+        if state.tempoBpm != nil {
+          BeatPosition(
+            beat: Int(state.beat), beatsPerBar: Int(state.beatsPerBar), bar: Int(state.bar),
+            bars: Int(state.bars)
+          )
+          .padding(.top, IntradaSpacing.cardCompact)
+        }
       }
     case .awaitingVerdict:
       VStack(spacing: IntradaSpacing.section) {
@@ -192,8 +196,8 @@ struct DrillScreen: View {
     [state.section, "about \(state.minutes) min"].compactMap { $0 }.joined(separator: " · ")
   }
 
-  /// Nothing at all where the rung has no tempo (l0): the core says so by
-  /// sending none, and a marking the music does not carry is worse than a gap.
+  /// Nothing at all where the rung has no tempo (l0), which the core says by
+  /// sending none.
   @ViewBuilder private var tempo: some View {
     if let bpm = state.tempoBpm {
       HStack(alignment: .firstTextBaseline, spacing: scale == .compact ? 9 : 12) {

--- a/ios/Intrada/Views/Screens/DrillScreen.swift
+++ b/ios/Intrada/Views/Screens/DrillScreen.swift
@@ -192,17 +192,21 @@ struct DrillScreen: View {
     [state.section, "about \(state.minutes) min"].compactMap { $0 }.joined(separator: " · ")
   }
 
-  private var tempo: some View {
-    HStack(alignment: .firstTextBaseline, spacing: scale == .compact ? 9 : 12) {
-      Text("♩")
-        .font(IntradaFont.drillTitle(scale.tempo * 0.88))
-      Text("= \(state.tempoBpm)")
-        .font(IntradaFont.drillTitle(scale.tempo))
-        .monospacedDigit()
+  /// Nothing at all where the rung has no tempo (l0): the core says so by
+  /// sending none, and a marking the music does not carry is worse than a gap.
+  @ViewBuilder private var tempo: some View {
+    if let bpm = state.tempoBpm {
+      HStack(alignment: .firstTextBaseline, spacing: scale == .compact ? 9 : 12) {
+        Text("♩")
+          .font(IntradaFont.drillTitle(scale.tempo * 0.88))
+        Text("= \(bpm)")
+          .font(IntradaFont.drillTitle(scale.tempo))
+          .monospacedDigit()
+      }
+      .foregroundStyle(IntradaColor.ink)
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel("\(bpm) beats per minute")
     }
-    .foregroundStyle(IntradaColor.ink)
-    .accessibilityElement(children: .ignore)
-    .accessibilityLabel("\(state.tempoBpm) beats per minute")
   }
 
   private var clickPill: some View {

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -233,6 +233,9 @@ struct CoachRecordStoreTests {
       attempts: [
         attempt(clean: false, cold: true, at: "2026-08-04T10:00:09Z"),
         attempt(clean: true, at: "2026-08-04T10:00:18Z", source: .midi, selfPredicted: .clean),
+        // An l0 tap: its own evidence class, and one a decoder that drifts
+        // would quietly demote to a clocked one (#1244).
+        attempt(clean: true, at: "2026-08-04T10:00:27Z", source: .tapVerdictUntimed),
       ],
       escalations: [.tempoDown, .changeMode], exit: .ceilingHit)
     try store.saveCoachRecords(blocks: [written], wanders: [], updatedAt: Self.updatedAt)
@@ -309,7 +312,7 @@ struct CoachRecordStoreTests {
   @Test("every click level survives the round trip, since it is half the mastery key")
   func readBackEveryClickLevel() throws {
     let (store, _) = try makeStore()
-    let levels: [ClickLevel] = [.everyBeat, .twoAndFour, .barDownbeat, .everyOtherBar]
+    let levels: [ClickLevel] = [.noClick, .everyBeat, .twoAndFour, .barDownbeat, .everyOtherBar]
     try store.saveCoachRecords(
       blocks: levels.enumerated().map { index, level in
         block(

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -724,9 +724,10 @@ final class StoreEffectLoopTests: XCTestCase {
 
     _ = try bridge.update(.coach(.startBlock(now: SessionClock.nowRFC3339())))
     let opening = try XCTUnwrap(try bridge.view().coach.drill)
+    let openingTempo = try XCTUnwrap(opening.tempoBpm, "a clocked rung crosses with its tempo")
     XCTAssertFalse(opening.drillTitle.isEmpty, "the block crossed the wire with its title")
     XCTAssertEqual(
-      opening.gateQuestion, "Clean at \(opening.tempoBpm)?",
+      opening.gateQuestion, "Clean at \(openingTempo)?",
       "the criterion names the tempo it is asked at")
     XCTAssertGreaterThanOrEqual(opening.gateTarget, 1, "a gate needs at least one clean pass")
     XCTAssertEqual(opening.gateFilled, 0)
@@ -918,15 +919,17 @@ final class StoreEffectLoopTests: XCTestCase {
     _ = try bridge.update(.coach(.stuck(now: SessionClock.nowRFC3339())))
     let after = try XCTUnwrap(try bridge.view().coach.drill)
 
-    let opened = UInt32(opening.tempoBpm)
+    let openingTempo = try XCTUnwrap(opening.tempoBpm, "a clocked rung has a tempo to drop")
+    let afterTempo = try XCTUnwrap(after.tempoBpm, "and still has one after the drop")
+    let opened = UInt32(openingTempo)
     let dropped = opened - opened * UInt32(min(config.tempoDownPct, 100)) / 100
     XCTAssertEqual(
-      after.tempoBpm, UInt16(max(dropped, UInt32(config.tempoFloorBpm))),
+      afterTempo, UInt16(max(dropped, UInt32(config.tempoFloorBpm))),
       "the first rung takes the configured percentage off, floored")
     XCTAssertLessThan(
-      after.tempoBpm, opening.tempoBpm, "a rung that moves nothing is not an escalation")
+      afterTempo, openingTempo, "a rung that moves nothing is not an escalation")
     XCTAssertEqual(
-      after.gateQuestion, "Clean at \(after.tempoBpm)?",
+      after.gateQuestion, "Clean at \(afterTempo)?",
       "the criterion follows the tempo down")
     XCTAssertEqual(after.phase, .playing, "escalation acts rather than narrates")
     XCTAssertGreaterThan(

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -57,6 +57,12 @@ of attempts, and its pass is a derived event triggering a level-up. State is per
 > tag — a flag on the attempt, not an `EvidenceSource` variant, since a cold
 > MIDI-scored attempt must be expressible later. Nothing else in
 > this section changes: the Beta update is source-agnostic.
+>
+> **Extended 7 Aug 2026 (decision 20, #1244):** a fourth tag,
+> `TapVerdictUntimed`, for a tap at l0, where nothing bounds the pass but the
+> tap itself (§4). The Beta update is still source-agnostic — l0 is a
+> `parameter_level`, so acquisition evidence is held apart by the key it lands
+> under rather than by a weight.
 
 ```rust
 struct Mastery { alpha: f32, beta: f32, prior: (f32, f32), last_attempt_at: Timestamp }
@@ -310,6 +316,38 @@ pre-play prediction against a tap-verdict — considered and cut, design doc v6.
 >   phase, closes the block and advances to the next card (or `Closing` on the
 >   last). A block skipped from its card still writes a `BlockRecord` with no
 >   attempts: a skip is a fact worth keeping, not an absence.
+
+> **Clickless from 7 Aug 2026 (#1244), decision 20.** `ClickLevel` gains `l0`
+> at the bottom of the ladder, and a block at it has no click, no tempo and no
+> count-in. Three rows of the table read differently there, all for the same
+> reason — there is no grid:
+>
+> - **`StartBlock` lands in `Listening`.** There is no count-in to sit through,
+>   and one nothing clicks through would never end. `RecoverSession` and an
+>   acting escalation rung come back the same way, rather than to `CountIn` or
+>   `Escalating`.
+> - **The tap bounds the attempt** (Jon's ruling on #1244, 7 Aug 2026). With no
+>   phrase boundary to open a verdict window on, `AwaitingVerdict` never opens
+>   and the tap is taken from the pass in flight: tap = "that pass is judged".
+>   Squared with decision 17 by the evidence class below — the bound is looser,
+>   and the record says so. `CountInBeat` and `Beat` are inert.
+> - **`DiscardAttempt` has nothing pending to void**, since the tap is the only
+>   thing that records, so it clears the glance and writes nothing off. The pass
+>   the user goes on to play still counts.
+>
+> Evidence is tagged `EvidenceSource::TapVerdictUntimed`, its own class so
+> acquisition evidence never reads as evidence earned against a click. The Beta
+> update stays source-agnostic (§2 as amended): the separation that matters is
+> already structural, because mastery is per `(node, parameter_level)` and l0 is
+> a level. `Rung::TempoDown` cannot act at l0 — dropping a tempo that does not
+> exist would move the block onto a rung it never practised at — so the ladder
+> spends it and moves on to `ShrinkScope`.
+>
+> **The bridge says so rather than implying it.** `DrillView::tempo_bpm` is
+> `Option<u16>`, `None` at l0, and `pulse_running` is false throughout: the
+> shell cannot draw a tempo or schedule a click that the rung does not have.
+> The l0 drill screen itself is unbuilt (#1260) and no content authors an l0
+> gate until #1245, so nothing reaches it yet.
 
 New machine in `engine/`, beside the legacy `SessionStatus` that Phase 2a
 deletes. Off-piste and unmonitored are **peers** of `Running`, not sub-states,

--- a/specs/intrada-coach-engine.md
+++ b/specs/intrada-coach-engine.md
@@ -60,9 +60,17 @@ of attempts, and its pass is a derived event triggering a level-up. State is per
 >
 > **Extended 7 Aug 2026 (decision 20, #1244):** a fourth tag,
 > `TapVerdictUntimed`, for a tap at l0, where nothing bounds the pass but the
-> tap itself (§4). The Beta update is still source-agnostic — l0 is a
+> tap itself (§4). The Beta update is still source-agnostic: l0 is a
 > `parameter_level`, so acquisition evidence is held apart by the key it lands
 > under rather than by a weight.
+>
+> **With one door the key does not close.** `level_up` crosses keys by
+> construction, and an l0 gate pass seeds the clocked rung above it at the same
+> `transfer` a clocked promotion gets. So the separation is complete for
+> `record` and incomplete for `level_up`, and the tag is recorded but read by
+> nothing. Whether the crossing wants its own constant, and whether
+> `EvidenceSource` should carry a weight at all, are calibration questions for
+> Phase 0's log: **#1261**.
 
 ```rust
 struct Mastery { alpha: f32, beta: f32, prior: (f32, f32), last_attempt_at: Timestamp }
@@ -319,8 +327,8 @@ pre-play prediction against a tap-verdict — considered and cut, design doc v6.
 
 > **Clickless from 7 Aug 2026 (#1244), decision 20.** `ClickLevel` gains `l0`
 > at the bottom of the ladder, and a block at it has no click, no tempo and no
-> count-in. Three rows of the table read differently there, all for the same
-> reason — there is no grid:
+> count-in. Four rows of the table read differently there, all for the same
+> reason: there is no grid.
 >
 > - **`StartBlock` lands in `Listening`.** There is no count-in to sit through,
 >   and one nothing clicks through would never end. `RecoverSession` and an
@@ -329,25 +337,33 @@ pre-play prediction against a tap-verdict — considered and cut, design doc v6.
 > - **The tap bounds the attempt** (Jon's ruling on #1244, 7 Aug 2026). With no
 >   phrase boundary to open a verdict window on, `AwaitingVerdict` never opens
 >   and the tap is taken from the pass in flight: tap = "that pass is judged".
->   Squared with decision 17 by the evidence class below — the bound is looser,
->   and the record says so. `CountInBeat` and `Beat` are inert.
+>   Squared with decision 17 by the evidence class below, since the bound is
+>   looser and the record says so. `CountInBeat` and `Beat` are inert.
 > - **`DiscardAttempt` has nothing pending to void**, since the tap is the only
 >   thing that records, so it clears the glance and writes nothing off. The pass
 >   the user goes on to play still counts.
+> - **`Tick` ends the tap's glance**, after `escalation.glance_hold_s`. At a
+>   clicked level the next beat turns the page (T11); left to a beat at l0 the
+>   screen would hold on a phase with nothing to tap, which is the frozen-loop
+>   bug one layer up.
 >
 > Evidence is tagged `EvidenceSource::TapVerdictUntimed`, its own class so
-> acquisition evidence never reads as evidence earned against a click. The Beta
-> update stays source-agnostic (§2 as amended): the separation that matters is
-> already structural, because mastery is per `(node, parameter_level)` and l0 is
-> a level. `Rung::TempoDown` cannot act at l0 — dropping a tempo that does not
-> exist would move the block onto a rung it never practised at — so the ladder
-> spends it and moves on to `ShrinkScope`.
+> acquisition evidence never reads as evidence earned against a click, and the
+> Beta update stays source-agnostic (§2 as amended, including what `level_up`
+> still crosses). `Rung::TempoDown` cannot act at l0, since dropping a tempo
+> that does not exist would move the block onto a rung it never practised at,
+> so the ladder spends it and moves on to `ShrinkScope`.
 >
 > **The bridge says so rather than implying it.** `DrillView::tempo_bpm` is
 > `Option<u16>`, `None` at l0, and `pulse_running` is false throughout: the
 > shell cannot draw a tempo or schedule a click that the rung does not have.
+> Adding both variants renumbered their enums, so the crash-recovery blob's key
+> went to v3 — a v2 blob still *decodes*, into a clocked block read back as an
+> l0 one, which is the #846 class rather than a lost session.
+>
 > The l0 drill screen itself is unbuilt (#1260) and no content authors an l0
-> gate until #1245, so nothing reaches it yet.
+> gate until #1245, so nothing reaches it yet. **#1245 should not land before
+> #1260**, or the first authored l0 gate is a screen with nothing to tap.
 
 New machine in `engine/`, beside the legacy `SessionStatus` that Phase 2a
 deletes. Off-piste and unmonitored are **peers** of `Running`, not sub-states,


### PR DESCRIPTION
Closes #1244. Decision 20's engine half: new material is learnt out of time before it is owned in time, so the sparse-click ladder gains a bottom rung with no click, no tempo and no count-in.

Contract: `specs/intrada-coach-engine.md` §2 and §4, amended here.

## What the engine does now

- **`ClickLevel::NoClick`** at the bottom of the ladder, `l0` in `gates.toml`. An l0 gate names no `tempo_bpm`: a tempo at l0 is a contradiction, and `RawGate::level()` fails the parse rather than letting one of the two quietly win.
- **A block at l0 starts playing rather than counting in**, and comes back the same way from a recovery or an acting escalation rung. A count-in nothing clicks through would never end.
- **The tap bounds the attempt** (Jon's ruling on the issue, 7 Aug). With no phrase boundary to open a verdict window on, the tap is taken from the pass in flight. `Beat` and `CountInBeat` are inert; a discard has nothing pending to void, so the pass the user goes on to play still counts; `Tick` ends the tap's glance after `escalation.glance_hold_s`, because no beat is coming to turn the page.
- **Evidence is tagged `EvidenceSource::TapVerdictUntimed`** and lands on l0's own mastery key, so knowing it out of time never vouches for the tempo.
- **`Rung::TempoDown` cannot act at l0.** Without the guard it would have set the block's tempo to the floor while reporting that it moved nothing, relocating the block to a mastery key it never practised at.

The bridge says all of this rather than implying it: `DrillView::tempo_bpm` is `Option<u16>`, `None` at l0, and `pulse_running` is false throughout, so the shell cannot draw a tempo or schedule a click that the rung does not have.

## The one deliberate reading

The issue calls l0 evidence "a distinct, lower-weight class". The tag ships; the Beta update stays source-agnostic, exactly as spec §2's decision-18 amendment has it, because the separation is structural: mastery is per `(node, parameter_level)` and l0 is a level.

The self-review found the door that reading leaves open — `level_up` crosses keys and seeds the clocked rung above an l0 pass at the same `transfer` a clocked promotion gets. The spec now says so rather than claiming the separation is complete, and the calibration question is **#1261**.

## iOS

Core-only in intent; the Swift here is what the bridge change forces plus one blocker the review caught.

- The crash-recovery blob key goes to **v3**: both new variants went in at the bottom of their enums, so a v2 blob still *decodes*, into a clocked block read back as an l0 one with its evidence on a rung nothing practised. That is the #846 class, not a lost session.
- Persistence codec cases for both variants; the `EvidenceSource` decode fallback stays `.tapVerdict`, since an untimed source on a clocked rung is a row the engine can never write.
- The tempo pill and `BeatPosition` draw nothing where there is no tempo.

**The l0 drill screen is not built (#1260)** — at l0 the verdict control has to be reachable from `.playing`, and that is a design pass. No content authors an l0 gate until #1245, so nothing reaches it in the app today. **#1245 should not land before #1260.**

## Testing

TDD throughout: tests first, red confirmed, then the implementation. Twelve new core tests across the ladder, the parser, the machine and the view, plus the l0 shapes added to the bincode round-trips and the Swift store codec sweep. Three of the load-bearing ones were mutation-tested (delete the guard, watch the named test fail) — the tempo-rung guard, the escalation phase and the count-in rule.

`just check` green (925 tests), `just ios-fmt-check` and `just ios-test-full` green.

Coverage: expect a high patch figure — this is core logic with tests shipped alongside. The Swift lines (the codec cases, the two view conditionals, the blob key) sit under `ios/`, which Codecov ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)