### PR TITLE
ci(ios): fan out the native-ios full tier — build once, test in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,16 +164,21 @@ jobs:
           category: clippy-native
           wait-for-processing: true
 
-  native-ios:
-    # Native SwiftUI app — regenerate bindings (facet typegen + cargo-swift),
-    # build, and run the snapshot test. Pinned to macos-26 + Xcode 26.5 so the
-    # toolchain matches local dev (and the spec's iOS 26 SDK): SwiftUI snapshots
-    # are renderer-specific, so dev and CI MUST share Xcode/iOS.
+  native-ios-build:
+    # Native SwiftUI app, build half — regenerate bindings (facet typegen +
+    # cargo-swift), build the test products once. Pinned to macos-26 + Xcode
+    # 26.5 so the toolchain matches local dev (and the spec's iOS 26 SDK):
+    # SwiftUI snapshots are renderer-specific, so dev and CI MUST share
+    # Xcode/iOS.
     #
-    # PR optimisations (vs main): the launch+screenshot smoke is skipped (the
-    # snapshot test is the regression gate) and DerivedData is restore-only.
-    # Main runs the full launch+screenshot and writes the cache.
-    name: Native iOS (build + test)
+    # Fanned out (#1207): this job builds once and uploads the built test
+    # products (app + .xctest bundles, not all of DerivedData) as an
+    # artifact; `native-ios-test-unit` and `native-ios-test-ui` consume it in
+    # parallel instead of each rebuilding. Parked since 2026-08-05 (doubles
+    # macOS runner minutes to save ~2min wall time, plus artifact transfer
+    # cost) until merges regularly wait on this job or the full tier's wall
+    # time grows past ~10 minutes — see #1207 for the full trade-off writeup.
+    name: "Native iOS: build"
     runs-on: macos-26
     timeout-minutes: 40
     needs: changes
@@ -298,15 +303,64 @@ jobs:
           # swift-snapshot-testing) — and skip the write. The exact-key on main
           # tracks `main`'s own source, so PR incremental builds stay warm.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # Full gate = unit + snapshot + XCUITests, via the same `just
-      # ios-test-full` recipe local dev runs (#1198) — one recipe shared
-      # between CI and local, instead of a hand-copied xcodebuild invocation
-      # that can drift from it. The reference is recorded on iOS 26.5 / Xcode
-      # 26.5 (= local dev); SwiftUI snapshots are renderer-specific — bump the
-      # pin in the justfile + the reference together when local dev moves to
-      # a newer Xcode/iOS.
-      - name: Run tests (just ios-test-full)
-        run: just ios-test-full
+      # Build only, via the same `_ios-build-for-testing` recipe local dev's
+      # `_ios-test-run` calls (#1198, split further in #1207) — the
+      # xcodebuild invocation lives in exactly one place shared between CI and
+      # local, instead of a hand-copied one that can drift from it. The
+      # reference is recorded on iOS 26.5 / Xcode 26.5 (= local dev); SwiftUI
+      # snapshots are renderer-specific — bump the pin in the justfile + the
+      # reference together when local dev moves to a newer Xcode/iOS.
+      - name: Build for testing (just _ios-build-for-testing)
+        run: just _ios-build-for-testing
+      # Not all of DerivedData — just the built app + .xctest bundles (and the
+      # .xctestrun that points at them) the test-without-building jobs need.
+      # ios/build/dd is a relative derivedDataPath under the same checkout
+      # layout in every job, so the .xctestrun's embedded __TESTROOT__
+      # resolves the same way there as it did here (#1207).
+      - name: Upload built test products
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-ios-test-products
+          path: ios/build/dd/Build/Products
+          retention-days: 1
+
+  native-ios-test-unit:
+    # Test half 1/2 (#1207): IntradaTests (unit + snapshot) against the
+    # products `native-ios-build` already built — no rebuild here. Also owns
+    # the main-only launch+screenshot smoke, since it already has the built
+    # app on disk via the downloaded artifact.
+    name: "Native iOS: unit + snapshot"
+    runs-on: macos-26
+    timeout-minutes: 20
+    needs: [changes, native-ios-build]
+    if: github.event_name == 'push' || needs.changes.outputs.native == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.5"
+      - uses: taiki-e/install-action@v2.85.5
+        with:
+          tool: just
+      - name: Cache Homebrew packages
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+      - name: Install xcodegen
+        run: brew install xcodegen
+      # project.yml is checked in; regenerating the .xcodeproj from it needs
+      # no Rust/bindings step here (that already happened in native-ios-build).
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+      - name: Download built test products
+        uses: actions/download-artifact@v7
+        with:
+          name: native-ios-test-products
+          path: ios/build/dd/Build/Products
+      - name: Test (just _ios-test-without-building IntradaTests)
+        run: just _ios-test-without-building IntradaTests 0
       - name: Upload snapshot failures
         if: failure()
         uses: actions/upload-artifact@v7
@@ -315,11 +369,12 @@ jobs:
           path: ios/IntradaTests/__Snapshots__/
           retention-days: 7
           if-no-files-found: ignore
-      # REUSE_BUILD: the snapshot-test step above already built the app into
-      # build/dd — install + launch it for the screenshot without rebuilding.
-      # Main only (~105s): the snapshot test is the per-PR UI regression gate;
-      # the launch+screenshot is a "does the real app boot through its FFI
-      # entry point" smoke + visual artifact, which only main needs.
+      # REUSE_BUILD: the test step above's downloaded artifact already has
+      # build/dd/Build/Products/Intrada.app — install + launch it for the
+      # screenshot without rebuilding. Main only (~105s): the unit/snapshot
+      # run is the per-PR UI regression gate; the launch+screenshot is a "does
+      # the real app boot through its FFI entry point" smoke + visual
+      # artifact, which only main needs.
       - name: Launch on simulator + screenshot
         if: github.event_name == 'push'
         run: REUSE_BUILD=1 bash scripts/ios-run-sim.sh "$GITHUB_WORKSPACE/ios-screenshots/native.png"
@@ -331,6 +386,63 @@ jobs:
           path: ios-screenshots/
           retention-days: 7
           if-no-files-found: ignore
+
+  native-ios-test-ui:
+    # Test half 2/2 (#1207): IntradaUITests against the products
+    # `native-ios-build` already built — no rebuild here. Keeps the
+    # relaunch-on-crash retry flags (#1203) scoped to this job only, so a UI
+    # flake's retry can't also re-run (and re-cost) the unit/snapshot suite.
+    name: "Native iOS: UI"
+    runs-on: macos-26
+    timeout-minutes: 20
+    needs: [changes, native-ios-build]
+    if: github.event_name == 'push' || needs.changes.outputs.native == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.5"
+      - uses: taiki-e/install-action@v2.85.5
+        with:
+          tool: just
+      - name: Cache Homebrew packages
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Caches/Homebrew/downloads
+          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+      - name: Install xcodegen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+      - name: Download built test products
+        uses: actions/download-artifact@v7
+        with:
+          name: native-ios-test-products
+          path: ios/build/dd/Build/Products
+      - name: Test (just _ios-test-without-building IntradaUITests)
+        run: just _ios-test-without-building IntradaUITests 1
+
+  # Fan-in gate (#1207): branch protection's required status check is this
+  # job's `name:`, unchanged from before the fan-out, so splitting the build
+  # and test jobs above needs no required-checks reconfiguration on GitHub.
+  # Skips in lockstep with the fanned-out jobs (same `if:`) — a skip is a pass
+  # for a required check, same as the single job's skip was before #1207.
+  native-ios:
+    name: Native iOS (build + test)
+    runs-on: ubuntu-latest
+    needs: [changes, native-ios-build, native-ios-test-unit, native-ios-test-ui]
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.native == 'true')
+    steps:
+      - name: Check fan-out results
+        run: |
+          echo "build=${{ needs.native-ios-build.result }} unit=${{ needs.native-ios-test-unit.result }} ui=${{ needs.native-ios-test-ui.result }}"
+          for r in "${{ needs.native-ios-build.result }}" "${{ needs.native-ios-test-unit.result }}" "${{ needs.native-ios-test-ui.result }}"; do
+            if [ "$r" != "success" ]; then
+              echo "✗ native-ios fan-out did not all succeed" >&2
+              exit 1
+            fi
+          done
 
   # Cheap (<5s, no macOS) guard that keeps the snapshot-reference suite from
   # bloating git history: every PNG must map to a current test (no orphans) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,20 @@ jobs:
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
+      # `_ios-test-without-building` still passes `-clonedSourcePackagesDirPath
+      # build/spm` (it resolves the package graph even without compiling) —
+      # without restoring this cache here too, a fresh runner re-clones Sentry
+      # + swift-syntax + swift-snapshot-testing + GRDB over the network, which
+      # is exactly the #813 flake this cache exists to prevent. `native-ios-
+      # build` always writes this key, and it always finishes first (`needs:`
+      # below), so this is a guaranteed hit — not an extra build.
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v6
+        with:
+          path: ios/build/spm
+          key: ios-spm-v1-${{ runner.os }}-${{ hashFiles('ios/project.yml') }}
+          restore-keys: |
+            ios-spm-v1-${{ runner.os }}-
       - name: Download built test products
         uses: actions/download-artifact@v7
         with:
@@ -415,6 +429,16 @@ jobs:
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
+      # See the identical step + comment in native-ios-test-unit: without
+      # restoring this, `test-without-building`'s package-graph resolution
+      # re-clones SwiftPM deps over the network here too (#813 flake class).
+      - name: Cache SwiftPM packages
+        uses: actions/cache@v6
+        with:
+          path: ios/build/spm
+          key: ios-spm-v1-${{ runner.os }}-${{ hashFiles('ios/project.yml') }}
+          restore-keys: |
+            ios-spm-v1-${{ runner.os }}-
       - name: Download built test products
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,8 +349,17 @@ jobs:
           key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
       - name: Install xcodegen
         run: brew install xcodegen
-      # project.yml is checked in; regenerating the .xcodeproj from it needs
-      # no Rust/bindings step here (that already happened in native-ios-build).
+      # project.yml declares IntradaCoreFFI/SharedTypes as local Swift
+      # packages under ios/generated — xcodegen fails ("Invalid local
+      # package") if that directory is missing, even though this job runs no
+      # Rust toolchain and regenerates nothing. native-ios-build always
+      # populates this cache first (restore or regenerate-then-save), so
+      # restoring it here is a guaranteed hit.
+      - name: Restore generated Swift bindings
+        uses: actions/cache@v6
+        with:
+          path: ios/generated
+          key: ios-bindings-cargoswift-0.9.0-${{ runner.os }}-${{ hashFiles('crates/intrada-core/src/**', 'crates/intrada-ffi/src/**', 'crates/intrada-core/Cargo.toml', 'crates/intrada-ffi/Cargo.toml', 'Cargo.lock') }}
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
@@ -426,6 +435,14 @@ jobs:
           key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
       - name: Install xcodegen
         run: brew install xcodegen
+      # See the identical step + comment in native-ios-test-unit: xcodegen
+      # fails without ios/generated present, even though this job regenerates
+      # nothing itself.
+      - name: Restore generated Swift bindings
+        uses: actions/cache@v6
+        with:
+          path: ios/generated
+          key: ios-bindings-cargoswift-0.9.0-${{ runner.os }}-${{ hashFiles('crates/intrada-core/src/**', 'crates/intrada-ffi/src/**', 'crates/intrada-core/Cargo.toml', 'crates/intrada-ffi/Cargo.toml', 'Cargo.lock') }}
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,17 @@ countable criteria.
 
 ## Recently landed
 
+- #1207 — the native-ios full-tier CI job fanned out: `native-ios-build`
+  builds the test products once and uploads them as an artifact,
+  `native-ios-test-unit` (IntradaTests) and `native-ios-test-ui`
+  (IntradaUITests) consume it in parallel instead of each rebuilding, with the
+  #1203 retry flags scoped to the UI job only. A thin `native-ios` fan-in job
+  keeps branch protection's required-check name unchanged. `justfile`'s
+  `_ios-test-run` was split into `_ios-build-for-testing` /
+  `_ios-test-without-building` so CI and local dev share the same xcodebuild
+  invocations. Deliberately parked since 2026-08-05 (doubles macOS runner
+  minutes to save ~2min); picked up on request. xcodegen version-pin
+  follow-up tracked in #1263
 - #1206 — sccache adopted for cross-checkout Rust build caching: ~30% faster
   `just check` in a fresh worktree with `target/` cold and the sccache cache
   warm (58s → 40s, measured on the issue). Opt-in per developer via a

--- a/justfile
+++ b/justfile
@@ -220,35 +220,66 @@ _ios-test-run tier:
         fi
     fi
     just _ios-test-guard
+    just _ios-build-for-testing
+    if [ "{{tier}}" = "fast" ]; then
+        just _ios-test-without-building IntradaTests 0
+    else
+        # Relaunch-in-new-process, not in-process: the flake this recovers
+        # from kills the runner process (#1203). Fast tier (unit/snapshot,
+        # deterministic) stays strict. Full tier runs both targets in one
+        # `xcodebuild` call locally, so retry applies to both; CI's fanned-out
+        # jobs (#1207) call `_ios-test-without-building` once per target and
+        # scope retry to the UI job only.
+        just _ios-test-without-building "" 1
+    fi
+    # Same exact-tree guard as `check` above (#1204).
+    if [ -z "$(git status --porcelain)" ] && [ "$(git rev-parse HEAD)" = "$sha" ]; then
+        printf '%s %s\n' "$sha" "{{tier}}" > "$stamp"
+    fi
+
+# Regenerate the Xcode project and build the test products (app + .xctest
+# bundles) for THIS worktree's pinned iPhone 16 / iOS 26.5 sim, without
+# running anything. Shared by `_ios-test-run` (local) and CI's
+# `native-ios-build` job (#1207) — the xcodebuild invocation lives in exactly
+# one place so CI and local dev can't drift apart.
+[private]
+_ios-build-for-testing:
+    #!/usr/bin/env bash
+    set -euo pipefail
     cd ios
     xcodegen generate --use-cache
     name="$(just _ios-test-sim-name)"
     udid="$(just _ios-test-sim-udid)"
     [ -n "$udid" ] || udid=$(xcrun simctl create "$name" "iPhone 16" "iOS26.5")
-    only=""
-    retry=""
-    if [ "{{tier}}" = "fast" ]; then
-        only="-only-testing:IntradaTests"
-    else
-        # Relaunch-in-new-process, not in-process: the flake this recovers
-        # from kills the runner process (#1203). Fast tier (unit/snapshot,
-        # deterministic) stays strict.
-        retry="-retry-tests-on-failure -test-iterations 2 -test-repetition-relaunch-enabled YES"
-    fi
     xcodebuild build-for-testing -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
         -destination "id=$udid" -derivedDataPath build/dd \
         -clonedSourcePackagesDirPath build/spm -quiet \
         COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
+
+# Run already-built tests against THIS worktree's sim, without rebuilding.
+# `only` is an xcodebuild target name (IntradaTests / IntradaUITests) or ""
+# to run everything the built products contain; `retry` is "1" to add the
+# relaunch-on-crash flags (#1203), else "0". Shared by `_ios-test-run` (local,
+# both targets in one call) and CI's fanned-out `native-ios-test-unit` /
+# `native-ios-test-ui` jobs (#1207), which call this once per target so a
+# UI-suite crash can't take the unit suite down with it.
+[private]
+_ios-test-without-building only retry:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ios
+    name="$(just _ios-test-sim-name)"
+    udid="$(just _ios-test-sim-udid)"
+    [ -n "$udid" ] || udid=$(xcrun simctl create "$name" "iPhone 16" "iOS26.5")
+    onlyflag=""
+    [ -z "{{only}}" ] || onlyflag="-only-testing:{{only}}"
+    retryflags=""
+    [ "{{retry}}" != "1" ] || retryflags="-retry-tests-on-failure -test-iterations 2 -test-repetition-relaunch-enabled YES"
     xcodebuild test-without-building -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
         -destination "id=$udid" -derivedDataPath build/dd \
         -clonedSourcePackagesDirPath build/spm -quiet \
-        $only $retry \
+        $onlyflag $retryflags \
         COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
-    cd ..
-    # Same exact-tree guard as `check` above (#1204).
-    if [ -z "$(git status --porcelain)" ] && [ "$(git rev-parse HEAD)" = "$sha" ]; then
-        printf '%s %s\n' "$sha" "{{tier}}" > "$stamp"
-    fi
 
 # Refuse to start while another xcodebuild/XCTestAgent is already running
 # against THIS checkout — two overlapping full-suite runs in one checkout


### PR DESCRIPTION
## Summary

Closes #1207 (deliberately parked 2026-08-05, picked up now on explicit request).

Splits the monolithic `native-ios` CI job into:
- **`native-ios-build`** — regenerates Swift bindings, `xcodebuild build-for-testing` once, uploads the built test products (`ios/build/dd/Build/Products` only, not all of DerivedData) as an artifact.
- **`native-ios-test-unit`** — downloads the artifact, runs `IntradaTests` (unit + snapshot) via `-only-testing:IntradaTests`. Owns the snapshot-failure artifact upload and the main-only launch+screenshot smoke.
- **`native-ios-test-ui`** — downloads the same artifact, runs `IntradaUITests` via `-only-testing:IntradaUITests` with the #1203 relaunch-on-crash retry flags — scoped to this job only, so a UI flake's retry can't also re-cost the unit suite.
- **`native-ios`** — a thin fan-in gate job. Its `name:` is kept as the exact string `Native iOS (build + test)`, which is branch protection's required status check (no branch-protection config is tracked in git, so renaming would leave PRs permanently blocked until someone manually reconfigures it on GitHub). Fails if any of the three didn't succeed; skips in lockstep with them (skip = pass for a required check, same as before the split).

**`justfile`**: extracted `_ios-build-for-testing` and `_ios-test-without-building <only> <retry>` out of `_ios-test-run`'s inline shell, so the exact xcodebuild invocations are shared between local dev (`just ios-test` / `just ios-test-full`) and every CI job — CLAUDE.md's "keep the justfile recipes and ci.yml in lockstep" applied literally rather than by hand-copying.

## Review fix applied

Code review (general-purpose subagent) caught a Critical issue before this went up: `test-without-building` still passes `-clonedSourcePackagesDirPath build/spm` and resolves the package graph even without compiling, but only `native-ios-build` restored that cache. Without it, both new test jobs would re-clone Sentry/swift-syntax/swift-snapshot-testing/GRDB over the network every run — reintroducing the #813 flake class inside a 20-minute timeout. Fixed by restoring the identical SwiftPM cache in both test jobs (guaranteed hit — `native-ios-build` always writes that key and always finishes first).

## Verification

- `just check` (fmt, clippy, 908 Rust tests, hygiene) green.
- No files under `ios/` changed (justfile + `.github/workflows/ci.yml` only), so `just ios-fmt-check` / `just ios-test-full` don't apply per the ship checklist — but the refactored justfile recipes were verified for real anyway, against a live simulator:
  - `just ios-test` (fast tier, via the new `_ios-build-for-testing` + `_ios-test-without-building IntradaTests 0`): 245 tests passed, 0 failed.
  - `just _ios-test-without-building IntradaUITests 1` — the exact invocation `native-ios-test-ui` now uses — run directly against already-built products: first attempt hit a transient simulator "Busy/failed preflight checks" launch flake (known iOS Simulator class, unrelated to this change), second attempt passed clean.
- This is CI/tooling-only — the split itself can only be fully validated by a real GitHub Actions run, which this PR's own CI provides. Worth a look once checks report: confirm all three jobs run, the artifact download resolves correctly cross-job, and the `native-ios` fan-in check reports as the same required-check name it always has.

## Coverage

No new Rust/Swift code paths — CI workflow + justfile changes only, exercised by the real `just` runs above rather than unit tests.

## Deferred

- xcodegen is now resolved independently by three concurrent jobs instead of one (`brew install xcodegen`, unpinned). Low-probability, fails loud if it ever bites, but deserves the same lockstep-pin discipline this file already gives `cargo-swift`. Tracked in #1263.

Deferred items tracked: #1263