### PR TITLE
ci(ios): add a Release compile-only build alongside Debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,12 @@ jobs:
       # reference together when local dev moves to a newer Xcode/iOS.
       - name: Build for testing (just _ios-build-for-testing)
         run: just _ios-build-for-testing
+      # Debug and Release can diverge on `#if DEBUG`-gated code (#1177) — the
+      # Debug build above wouldn't catch a non-DEBUG-gated file referencing a
+      # DEBUG-only symbol. Compile-only, no signing, no tests; a separate
+      # derivedDataPath (ios-build-release) keeps it out of the artifact below.
+      - name: Build Release (just ios-build-release)
+        run: just ios-build-release
       # Not all of DerivedData — just the built app + .xctest bundles (and the
       # .xctestrun that points at them) the test-without-building jobs need.
       # ios/build/dd is a relative derivedDataPath under the same checkout

--- a/justfile
+++ b/justfile
@@ -200,6 +200,22 @@ ios-test: _ios-sync (_ios-test-run "fast")
 [group('iOS')]
 ios-test-full: _ios-sync (_ios-test-run "full")
 
+# Compile-only Release build (no signing, no tests) — catches `#if DEBUG`-only
+# code referenced from a file that itself compiles in Release, which passes
+# every Debug-only PR gate and then fails `just testflight` / the release lane
+# nobody runs per-PR (#1177). Separate derivedDataPath from the Debug test
+# build so it can't disturb the products `_ios-build-for-testing` uploads.
+[group('iOS')]
+ios-build-release: _ios-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd ios
+    xcodegen generate --use-cache
+    xcodebuild build -project Intrada.xcodeproj -scheme Intrada -sdk iphonesimulator \
+        -configuration Release -destination "generic/platform=iOS Simulator" \
+        -derivedDataPath build/dd-release -clonedSourcePackagesDirPath build/spm -quiet \
+        COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGNING_ALLOWED=NO
+
 # Shared build+test body for both tiers. Splits `build-for-testing` from
 # `test-without-building` (#1198) so a flake retry or test-only change reruns
 # in seconds instead of rebuilding the whole app. Skips the run entirely when


### PR DESCRIPTION
## Summary
- The per-PR `native-ios` job only builds Debug (`just ios-test`). A `#if DEBUG`-only reference from a file that itself compiles in Release passes every PR gate and then only fails `just testflight` / the release-testflight lane, which nobody runs per-PR.
- Adds a compile-only Release build (no signing, no tests) to the `native-ios-build` job, right after the existing Debug `_ios-build-for-testing` step, using its own `derivedDataPath` (`build/dd-release`) so it can't disturb the Debug test products the job uploads for the fanned-out test jobs.
- Adds a matching `just ios-build-release` recipe so the same check can be run locally before pushing.

## Test plan
- [x] `just ios-build-release` — green on current HEAD
- [x] Verified it actually catches the failure mode: added a `#if DEBUG`-only symbol referenced from a non-gated file, confirmed `just ios-build-release` fails with `cannot find 'X' in scope`, then reverted the probe
- [x] `just check` — 926 tests pass
- [x] No files under `ios/` changed, so `just ios-fmt-check` / `just ios-test-full` don't apply

Fixes #1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)