### PR TITLE
just worktree-new: warm-start bootstrap for fresh worktrees

### DIFF
--- a/docs/ios-testing.md
+++ b/docs/ios-testing.md
@@ -114,7 +114,9 @@ trees, DerivedData (keyed by project *path*), `ios/generated` bindings, cargo
 other's files.
 
 **`just worktree-new <name>`** creates a worktree at
-`.claude/worktrees/<name>` off fresh `origin/main` and seeds it from the main
+`.claude/worktrees/<name>` (also `<name>`'s branch — no slashes, so
+`.claude/worktrees/` stays flat and the sim-name collision check below
+actually sees every worktree) off fresh `origin/main` and seeds it from the main
 checkout's warm caches (`target/`, `ios/build/spm`, `ios/build/dd`,
 `ios/generated`) via APFS clonefile (`cp -Rc`, copy-on-write — near-instant,
 no duplicated disk until the copies diverge). Cuts the first `just check` /

--- a/docs/ios-testing.md
+++ b/docs/ios-testing.md
@@ -113,6 +113,19 @@ trees, DerivedData (keyed by project *path*), `ios/generated` bindings, cargo
 `target/`, and snapshot PNG files. Building or recording in one never overwrites the
 other's files.
 
+**`just worktree-new <name>`** creates a worktree at
+`.claude/worktrees/<name>` off fresh `origin/main` and seeds it from the main
+checkout's warm caches (`target/`, `ios/build/spm`, `ios/build/dd`,
+`ios/generated`) via APFS clonefile (`cp -Rc`, copy-on-write — near-instant,
+no duplicated disk until the copies diverge). Cuts the first `just check` /
+`just ios-test` in a fresh worktree from ~5-10 minutes cold to close to what
+the main checkout pays warm. `ios/generated` seeds only when the new
+worktree's own core source hash matches the main checkout's binding stamp
+(same rule `_ios-sync` enforces) — otherwise it's left to regenerate.
+Refuses a `<name>` that sanitises to the same simulator name as an existing
+worktree (the `foo`/`foo.1` collision below). `just worktree-rm <name>`
+cleans up the worktree's sim, then removes the worktree.
+
 **The simulator is the exception.** The iOS Simulator and
 `CoreSimulatorService` are **one per macOS login, shared across every checkout**.
 That's the only real clash surface, and the recovery commands above are global

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,6 +26,8 @@ just ios-snapshots-check   # fail orphaned / oversized snapshot references
 just ios-snapshots-optimize # drop Xcode's opaque alpha channel (~75% smaller)
 just check-all             # check + the fast ios-test tier
 just testflight            # signed Release .ipa → TestFlight (needs setup)
+just worktree-new <name>   # new worktree, seeded from the main checkout's warm caches
+just worktree-rm <name>    # clean up a worktree's sim, then remove it
 ```
 
 Test tiering, worktree simulator isolation, and the green-stamp skip (which lets

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,13 @@ countable criteria.
 
 ## Recently landed
 
+- #1205 — `just worktree-new <name>` warm-start bootstrap: creates a worktree
+  off fresh `origin/main` and seeds `target/`, `ios/build/{spm,dd}` and
+  `ios/generated` from the main checkout via APFS clonefile (`cp -Rc`),
+  builds on the sccache work (#1206). Names are restricted to
+  `[A-Za-z0-9_-]` — no slashes — so `.claude/worktrees/` stays flat and the
+  sim-name collision check can see every worktree. Companion
+  `just worktree-rm <name>` cleans up the sim then removes the worktree
 - #1260 — the l0 drill screen: `DrillScreen` branches on `tempoBpm == nil`
   throughout. During `.playing` the tempo/click pill/beat position give way to
   `GateDots` alone, and the tap-verdict footer (`TapVerdict` + escapes) —

--- a/justfile
+++ b/justfile
@@ -81,6 +81,102 @@ seed:
     bash scripts/seed-dev-data.sh
 
 # ─────────────────────────────────────────────
+# Worktrees — warm-start bootstrap (#1205)
+# ─────────────────────────────────────────────
+
+# New worktree branched from fresh origin/main, seeded from the main
+# checkout's warm caches (target/, ios/build/{spm,dd}, ios/generated) via
+# APFS clonefile (`cp -Rc`: copy-on-write, near-instant, no duplicated disk
+# until files diverge). Cuts the first `just check` / `just ios-test` in a
+# fresh worktree from ~5-10 min cold to close to what the main checkout pays
+# warm. Refuses a name that sanitises to the same simulator name as an
+# existing worktree (the foo/foo.1 collision documented in ios-testing.md).
+[group('Worktrees')]
+worktree-new name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    main_root="$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)"
+    # Always alongside the main checkout's own worktrees, even when this
+    # recipe is invoked from inside another worktree — otherwise it nests
+    # the new worktree under the current one instead of beside it.
+    target="$main_root/.claude/worktrees/{{name}}"
+
+    slug="$(printf '%s' "{{name}}" | tr -c 'A-Za-z0-9_-' '-' | sed 's/-*$//')"
+    for dir in "$main_root"/.claude/worktrees/*/; do
+        [ -d "$dir" ] || continue
+        other="$(basename "$dir" | tr -c 'A-Za-z0-9_-' '-' | sed 's/-*$//')"
+        if [ "$other" = "$slug" ]; then
+            echo "✗ $(basename "$dir") already sanitises to sim name '$slug' — pick a different name (see docs/ios-testing.md § worktrees)." >&2
+            exit 1
+        fi
+    done
+
+    echo "→ fetching origin and creating worktree at $target…"
+    git fetch origin
+    git worktree add "$target" -b "{{name}}" origin/main
+
+    echo "→ seeding warm caches from $main_root…"
+    seeded=()
+    for rel in target ios/build/spm ios/build/dd; do
+        src="$main_root/$rel"
+        dst="$target/$rel"
+        if [ -d "$src" ]; then
+            mkdir -p "$(dirname "$dst")"
+            cp -Rc "$src" "$dst"
+            seeded+=("$rel")
+        fi
+    done
+    # A new branch must earn its own green (#1204) — strip the check-stamp
+    # that came along with the target/ clone rather than exclude it up front.
+    rm -f "$target/target/.check-stamp"
+
+    # ios/generated only seeds when this worktree's own core source hash
+    # matches the stamp being copied — same rule _ios-sync enforces, so a
+    # binding for a different core revision never gets treated as fresh.
+    stamp="$main_root/ios/generated/.gen-stamp"
+    if [ -f "$stamp" ] && [ -d "$main_root/ios/generated" ]; then
+        current="$(cd "$target" && just _ios-src-hash)"
+        if [ "$(cat "$stamp")" = "$current" ]; then
+            mkdir -p "$target/ios"
+            cp -Rc "$main_root/ios/generated" "$target/ios/generated"
+            seeded+=("ios/generated")
+        else
+            echo "  ios/generated skipped — main checkout's bindings don't match this branch's core source"
+        fi
+    fi
+
+    echo
+    echo "✓ worktree ready: $target"
+    if [ "${#seeded[@]}" -gt 0 ]; then
+        echo "  seeded (warm): ${seeded[*]}"
+    else
+        echo "  nothing to seed — main checkout has no warm caches yet"
+    fi
+    stale=()
+    for rel in target ios/build/spm ios/build/dd ios/generated; do
+        found=0
+        for s in "${seeded[@]:-}"; do [ "$s" = "$rel" ] && found=1; done
+        [ "$found" = 1 ] || stale+=("$rel")
+    done
+    [ "${#stale[@]}" -eq 0 ] || echo "  will rebuild cold: ${stale[*]}"
+    echo "  cd $target && just check"
+
+# Companion to worktree-new: cleans the worktree's throwaway sim (if any),
+# then removes the worktree via git. Run from any checkout; leaves the
+# branch itself intact (delete separately once merged).
+[group('Worktrees')]
+worktree-rm name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    main_root="$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)"
+    target="$main_root/.claude/worktrees/{{name}}"
+    if [ -d "$target" ]; then
+        (cd "$target" && just ios-test-sim-clean) || true
+    fi
+    git worktree remove "$target"
+    echo "✓ removed worktree $target"
+
+# ─────────────────────────────────────────────
 # Diagnostics & cleanup
 # ─────────────────────────────────────────────
 

--- a/justfile
+++ b/justfile
@@ -95,6 +95,15 @@ seed:
 worktree-new name:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Directory and sim-name slug both derive from the raw name (matching
+    # _ios-test-sim-name's basename-of-checkout basis), so a slash or shell
+    # metacharacter would either nest the worktree under a subdirectory the
+    # collision scan below can't see, or break out of the surrounding quotes.
+    if ! printf '%s' "{{name}}" | grep -qE '^[A-Za-z0-9][A-Za-z0-9_-]*$'; then
+        echo "✗ '{{name}}' must be alphanumeric plus '_'/'-' (no slashes) — .claude/worktrees/ stays flat." >&2
+        exit 1
+    fi
+
     main_root="$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)"
     # Always alongside the main checkout's own worktrees, even when this
     # recipe is invoked from inside another worktree — otherwise it nests
@@ -122,8 +131,12 @@ worktree-new name:
         dst="$target/$rel"
         if [ -d "$src" ]; then
             mkdir -p "$(dirname "$dst")"
-            cp -Rc "$src" "$dst"
-            seeded+=("$rel")
+            if cp -Rc "$src" "$dst" 2>/dev/null; then
+                seeded+=("$rel")
+            else
+                echo "  ⚠ $rel: clonefile copy failed (non-APFS volume?) — worktree still created, will build cold" >&2
+                rm -rf "$dst"
+            fi
         fi
     done
     # A new branch must earn its own green (#1204) — strip the check-stamp
@@ -138,8 +151,12 @@ worktree-new name:
         current="$(cd "$target" && just _ios-src-hash)"
         if [ "$(cat "$stamp")" = "$current" ]; then
             mkdir -p "$target/ios"
-            cp -Rc "$main_root/ios/generated" "$target/ios/generated"
-            seeded+=("ios/generated")
+            if cp -Rc "$main_root/ios/generated" "$target/ios/generated" 2>/dev/null; then
+                seeded+=("ios/generated")
+            else
+                echo "  ⚠ ios/generated: clonefile copy failed (non-APFS volume?) — will build cold" >&2
+                rm -rf "$target/ios/generated"
+            fi
         else
             echo "  ios/generated skipped — main checkout's bindings don't match this branch's core source"
         fi


### PR DESCRIPTION
## Summary
- Adds `just worktree-new <name>`: creates a worktree off fresh `origin/main` and seeds `target/`, `ios/build/{spm,dd}` and `ios/generated` from the main checkout via APFS clonefile (`cp -Rc`, copy-on-write, near-instant), cutting the first `just check`/`just ios-test` in a fresh worktree from ~5-10 min cold to close to what the main checkout pays warm.
- Adds companion `just worktree-rm <name>`: cleans the worktree's throwaway sim then removes it.
- `ios/generated` only seeds when the new worktree's own core source hash matches the main checkout's `.gen-stamp` (same rule `_ios-sync` already enforces); `target/.check-stamp` is always stripped so a new branch earns its own green (#1204).
- Names are restricted to `[A-Za-z0-9_-]` (no slashes) so `.claude/worktrees/` stays flat and the sim-name collision check (mirrors `_ios-test-sim-name`) can actually see every existing worktree.

Closes #1205.

**Coverage:** N/A — tooling-only justfile + docs change, no Rust/Swift source under Codecov's scope.

## Test plan
- [x] `just check` green locally (926/926 tests, fmt/clippy/hygiene clean)
- [x] Manually exercised `just worktree-new`/`worktree-rm` end-to-end against this repo (created, seeded, verified `.check-stamp` stripped, verified collision rejection for duplicate/sanitised-duplicate names and slash-containing names, cleaned up)
- [x] Self-review via `requesting-code-review` — two Important findings fixed (slash-name collision-check gap, ungraceful `cp -Rc` failure); see PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)