### PR TITLE
feat(core,ios): built session — spec, design assets and the Phase A scaffold (#1256)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -16,8 +16,10 @@ extend-ignore-re = [
 
 [files]
 extend-exclude = [
-    # Generated / minified design-system exports (covers *.dc.html too)
+    # Generated / minified design-system exports (covers *.dc.html too), both
+    # where they live and where a spec pulls a copy of them (#1256)
     "design/*.html",
+    "specs/*/design/",
     # Retired docs, reference only (mirrors .graphifyignore)
     "specs/_archive/",
     ".specify/",

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::analytics::compute_analytics;
 use crate::domain::account::{handle_account_event, AccountEvent};
+use crate::domain::built_session::{handle_built_session_event, BuiltSessionEvent};
 use crate::domain::item::{handle_item_event, Item, ItemEvent, ItemKind};
 use crate::domain::mcp_audit::{handle_mcp_audit_event, McpAuditEvent};
 use crate::domain::mcp_tokens::{handle_mcp_token_event, McpTokenEvent};
@@ -68,6 +69,7 @@ pub enum Event {
     McpAudit(McpAuditEvent),
     OAuth(OAuthEvent),
     Coach(CoachEvent),
+    BuiltSession(BuiltSessionEvent),
 
     // ── Data loaded callbacks ───────────────────────────────────────
     DataLoaded {
@@ -124,6 +126,11 @@ pub enum Event {
     /// stored, so a reload cannot recover it: the batch is offered again once
     /// instead, and only a second failure surfaces (#1181).
     CoachStoreWritten(PersistenceOutput),
+    /// Built-session hydration back at launch (#1256).
+    BuiltStoreLoaded(PersistenceOutput),
+    /// Built-session write result: a failure surfaces and rehydrates, so the
+    /// model never keeps an optimistic row the store refused (invariant 5).
+    BuiltStoreWritten(PersistenceOutput),
 }
 
 /// Side effects the core requests from shells.
@@ -200,6 +207,7 @@ impl Intrada {
                         persistence::load_items(),
                         persistence::load_sessions(),
                         persistence::load_coach_records(),
+                        persistence::load_built_session_data(),
                     ])
                 } else {
                     Command::all([
@@ -249,6 +257,7 @@ impl Intrada {
             Event::McpToken(token_event) => handle_mcp_token_event(token_event, model),
             Event::McpAudit(audit_event) => handle_mcp_audit_event(audit_event, model),
             Event::OAuth(oauth_event) => handle_oauth_event(oauth_event, model),
+            Event::BuiltSession(event) => handle_built_session_event(event, model),
             Event::Coach(coach_event) => {
                 // Render coalescing (engine spec §6): the click reports several
                 // beats a second, and every render rebuilds the whole
@@ -380,7 +389,8 @@ impl Intrada {
                 }
                 PersistenceOutput::Ack
                 | PersistenceOutput::Sessions(_)
-                | PersistenceOutput::CoachRecords(_) => Command::done(),
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
                 // Failed read: surface only — no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -391,7 +401,8 @@ impl Intrada {
                 PersistenceOutput::Ack => Command::done(),
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)
-                | PersistenceOutput::CoachRecords(_) => Command::done(),
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
                 // Failed write → reload to roll back the un-persisted change (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -406,7 +417,8 @@ impl Intrada {
                 }
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Ack
-                | PersistenceOutput::CoachRecords(_) => Command::done(),
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
                     crux_core::render::render()
@@ -416,7 +428,8 @@ impl Intrada {
                 PersistenceOutput::Ack => Command::done(),
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)
-                | PersistenceOutput::CoachRecords(_) => Command::done(),
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
                 // Failed save → reload sessions to roll back the optimistic push (#825).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't access local storage.");
@@ -432,7 +445,8 @@ impl Intrada {
                 }
                 PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)
-                | PersistenceOutput::Ack => Command::done(),
+                | PersistenceOutput::Ack
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
                 // Failed read: surface only, no reload (would loop a broken store).
                 PersistenceOutput::Failed => {
                     model.surface_error("Couldn't read back what you've practised.");
@@ -443,7 +457,8 @@ impl Intrada {
                 PersistenceOutput::Ack
                 | PersistenceOutput::Items(_)
                 | PersistenceOutput::Sessions(_)
-                | PersistenceOutput::CoachRecords(_) => {
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => {
                     model.coach_write_in_flight = None;
                     Command::done()
                 }
@@ -458,6 +473,39 @@ impl Intrada {
                         crux_core::render::render()
                     }
                 },
+            },
+            Event::BuiltStoreLoaded(output) => match output {
+                PersistenceOutput::BuiltSessionData(data) => {
+                    model.user_drills = data.user_drills;
+                    model.journal_items = data.journal_items;
+                    model.built_sessions = data.built_sessions;
+                    model.play_throughs = data.play_throughs;
+                    model.reflections = data.reflections;
+                    model.feel_entries = data.feel_entries;
+                    crux_core::render::render()
+                }
+                PersistenceOutput::Ack
+                | PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_) => Command::done(),
+                // Failed read: surface only — no reload (would loop a broken store).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    crux_core::render::render()
+                }
+            },
+            Event::BuiltStoreWritten(output) => match output {
+                PersistenceOutput::Ack
+                | PersistenceOutput::Items(_)
+                | PersistenceOutput::Sessions(_)
+                | PersistenceOutput::CoachRecords(_)
+                | PersistenceOutput::BuiltSessionData(_) => Command::done(),
+                // Failed write → surface + reload to roll back the optimistic
+                // push (#825 shape, invariant 5).
+                PersistenceOutput::Failed => {
+                    model.surface_error("Couldn't access local storage.");
+                    persistence::load_built_session_data()
+                }
             },
         }
     }

--- a/crates/intrada-core/src/domain/built_session.rs
+++ b/crates/intrada-core/src/domain/built_session.rs
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn built_session_round_trips_with_every_target_kind() {
         assert_round_trips(BuiltSession {
-            id: "01J0000000000000000000BULT".into(),
+            id: "01J000000000000000000BSESH".into(),
             source: Some("From Friday's lesson".into()),
             blocks: vec![
                 BuiltBlock {
@@ -494,7 +494,7 @@ mod tests {
             assert_round_trips(Reflection {
                 id: "01J0000000000000000000REFL".into(),
                 kind,
-                session_ref: Some("01J0000000000000000000BULT".into()),
+                session_ref: Some("01J000000000000000000BSESH".into()),
                 transcript: Some("The bridge still rushes from memory".into()),
                 audio_path: Some("reflections/01J.m4a".into()),
                 duration_s: Some(24),
@@ -684,7 +684,7 @@ mod tests {
 
     fn sample_built_session() -> BuiltSession {
         BuiltSession {
-            id: "01J0000000000000000000BULT".into(),
+            id: "01J000000000000000000BSESH".into(),
             source: None,
             blocks: vec![],
             created_at: at(),

--- a/crates/intrada-core/src/domain/built_session.rs
+++ b/crates/intrada-core/src/domain/built_session.rs
@@ -3,9 +3,13 @@
 //! Phase A; the compose/resolution flows arrive with their screens.
 
 use chrono::{DateTime, Utc};
+use crux_core::command::Command;
 use serde::{Deserialize, Serialize};
 
+use crate::app::{Effect, Event};
 use crate::engine::Circle;
+use crate::model::Model;
+use crate::persistence;
 
 /// Decision 19b: a countable target with no authored node. The dictated
 /// sentence *is* the gate; the parsed parameters are read back, never asked
@@ -227,10 +231,7 @@ pub enum BuiltSessionEvent {
     },
 }
 
-use crate::app::{Effect, Event};
-use crate::model::Model;
-use crate::persistence;
-use crux_core::command::Command;
+// ── Handlers ─────────────────────────────────────────────────────────
 
 fn mint_id() -> String {
     ulid::Ulid::generate().to_string()

--- a/crates/intrada-core/src/domain/built_session.rs
+++ b/crates/intrada-core/src/domain/built_session.rs
@@ -1,0 +1,915 @@
+//! Self-directed practice — the built session, play-through altitudes and
+//! qualitative capture (#1256, `specs/built-session.md`). Entities only in
+//! Phase A; the compose/resolution flows arrive with their screens.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::engine::Circle;
+
+/// Decision 19b: a countable target with no authored node. The dictated
+/// sentence *is* the gate; the parsed parameters are read back, never asked
+/// for. Low-band prior, cold-testable, own mastery — enforced where evidence
+/// lands (Phase B), not stored here.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct UserDrill {
+    pub id: String,
+    pub name: String,
+    /// The criterion sentence, verbatim — editable in place (A4).
+    pub criterion: String,
+    pub tempo_bpm: Option<u16>,
+    pub keys: Vec<String>,
+    pub passes_to_open: u8,
+    pub serves: Option<Serves>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// Where a user drill's evidence shows in the ability picture (decision 19):
+/// a fluency circle or a named node (an authored node or a piece's).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum Serves {
+    Circle(Circle),
+    Node(String),
+}
+
+/// Decision 19c: the genuinely unmeasurable target — time and notes on the
+/// judgement track, no gate, no mastery.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct JournalItem {
+    pub id: String,
+    pub name: String,
+    pub notes: Option<String>,
+    /// The piece it is kept with (A5), where there is one.
+    pub linked_item_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// Decision 19: today's composed session — the strongest form of a steer,
+/// never a mode. Blocks are ordered; each keeps its own gate semantics via
+/// its target kind.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct BuiltSession {
+    pub id: String,
+    /// Provenance, in the user's words — "From Friday's lesson" (A6).
+    pub source: Option<String>,
+    pub blocks: Vec<BuiltBlock>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct BuiltBlock {
+    pub id: String,
+    pub target: BuiltTarget,
+    pub minutes: Option<u16>,
+}
+
+/// The three-way resolution's outcome, plus the tune pipeline entry a piece
+/// gets by nature (decision 19 / the brief's journey A).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum BuiltTarget {
+    /// (a) matched an authored node — evidence at full weight.
+    Node { node: String },
+    /// (b) user drill — own node, own gate.
+    UserDrill { drill_id: String },
+    /// (c) journal — judgement track only.
+    Journal { journal_id: String },
+    /// A piece headed for the tune pipeline.
+    Piece { item_id: String },
+}
+
+/// One gated run-through (Journey B's run-through altitude): section-level
+/// verdicts only, never note-level. Off-piste and unmonitored play are
+/// already the engine's `WanderRecord` and `unmonitored_seconds`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct PlayThroughRecord {
+    pub id: String,
+    pub item_id: String,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
+    /// False when the user chose "Don't count this run" (B1).
+    pub counted: bool,
+    pub sections: Vec<SectionVerdict>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// "Did it hold?" — one tap per section (B1).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct SectionVerdict {
+    pub section: String,
+    pub held: bool,
+    pub at: DateTime<Utc>,
+}
+
+/// Voice-first qualitative capture (decision 17): audio is kept,
+/// transcription is opportunistic, and none of it ever feeds mastery.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct Reflection {
+    pub id: String,
+    pub kind: ReflectionKind,
+    /// The session or wander it was said in, where there was one.
+    pub session_ref: Option<String>,
+    pub transcript: Option<String>,
+    /// Shell-relative path to the kept audio; the core never reads the bytes.
+    pub audio_path: Option<String>,
+    pub duration_s: Option<u32>,
+    pub at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum ReflectionKind {
+    /// Off-piste's "Found something? Say it" (B2).
+    VoiceNote,
+    /// The session-close reflection (C2).
+    SessionClose,
+}
+
+/// At most one per block, and only where feel is the point (C1).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct FeelEntry {
+    pub id: String,
+    pub block_id: String,
+    pub feel: Feel,
+    pub at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum Feel {
+    FoughtIt,
+    GettingThere,
+    ItSang,
+}
+
+// ── Events ───────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct CreateUserDrill {
+    pub name: String,
+    pub criterion: String,
+    pub tempo_bpm: Option<u16>,
+    pub keys: Vec<String>,
+    pub passes_to_open: u8,
+    pub serves: Option<Serves>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct CreateJournalItem {
+    pub name: String,
+    pub notes: Option<String>,
+    pub linked_item_id: Option<String>,
+}
+
+/// Local-first only (invariant 6: new engine/domain code targets local-first
+/// exclusively) — no handler here may emit `Http`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum BuiltSessionEvent {
+    CreateUserDrill(CreateUserDrill),
+    UpdateUserDrill {
+        drill: UserDrill,
+    },
+    DeleteUserDrill {
+        id: String,
+    },
+    CreateJournalItem(CreateJournalItem),
+    UpdateJournalItem {
+        journal: JournalItem,
+    },
+    DeleteJournalItem {
+        id: String,
+    },
+    /// Upsert by id — the compose flow (Phase B) edits in place.
+    SaveBuiltSession {
+        session: BuiltSession,
+    },
+    RecordPlayThrough {
+        record: PlayThroughRecord,
+    },
+    RecordReflection {
+        kind: ReflectionKind,
+        session_ref: Option<String>,
+        transcript: Option<String>,
+        audio_path: Option<String>,
+        duration_s: Option<u32>,
+    },
+    RecordFeel {
+        block_id: String,
+        feel: Feel,
+    },
+}
+
+use crate::app::{Effect, Event};
+use crate::model::Model;
+use crate::persistence;
+use crux_core::command::Command;
+
+fn mint_id() -> String {
+    ulid::Ulid::generate().to_string()
+}
+
+pub fn handle_built_session_event(
+    event: BuiltSessionEvent,
+    model: &mut Model,
+) -> Command<Effect, Event> {
+    let now = chrono::Utc::now();
+    match event {
+        BuiltSessionEvent::CreateUserDrill(input) => {
+            let drill = UserDrill {
+                id: mint_id(),
+                name: input.name,
+                criterion: input.criterion,
+                tempo_bpm: input.tempo_bpm,
+                keys: input.keys,
+                passes_to_open: input.passes_to_open,
+                serves: input.serves,
+                created_at: now,
+                updated_at: now,
+                deleted_at: None,
+            };
+            model.user_drills.push(drill.clone());
+            save_and_render(persistence::save_user_drill(drill))
+        }
+        BuiltSessionEvent::UpdateUserDrill { mut drill } => {
+            let Some(stored) = model.user_drills.iter_mut().find(|d| d.id == drill.id) else {
+                model.surface_error("That drill no longer exists.");
+                return crux_core::render::render();
+            };
+            drill.updated_at = now;
+            *stored = drill.clone();
+            save_and_render(persistence::save_user_drill(drill))
+        }
+        BuiltSessionEvent::DeleteUserDrill { id } => {
+            let Some(index) = model.user_drills.iter().position(|d| d.id == id) else {
+                model.surface_error("That drill no longer exists.");
+                return crux_core::render::render();
+            };
+            let mut tombstone = model.user_drills.remove(index);
+            tombstone.deleted_at = Some(now);
+            tombstone.updated_at = now;
+            save_and_render(persistence::save_user_drill(tombstone))
+        }
+        BuiltSessionEvent::CreateJournalItem(input) => {
+            let journal = JournalItem {
+                id: mint_id(),
+                name: input.name,
+                notes: input.notes,
+                linked_item_id: input.linked_item_id,
+                created_at: now,
+                updated_at: now,
+                deleted_at: None,
+            };
+            model.journal_items.push(journal.clone());
+            save_and_render(persistence::save_journal_item(journal))
+        }
+        BuiltSessionEvent::UpdateJournalItem { mut journal } => {
+            let Some(stored) = model.journal_items.iter_mut().find(|j| j.id == journal.id) else {
+                model.surface_error("That journal item no longer exists.");
+                return crux_core::render::render();
+            };
+            journal.updated_at = now;
+            *stored = journal.clone();
+            save_and_render(persistence::save_journal_item(journal))
+        }
+        BuiltSessionEvent::DeleteJournalItem { id } => {
+            let Some(index) = model.journal_items.iter().position(|j| j.id == id) else {
+                model.surface_error("That journal item no longer exists.");
+                return crux_core::render::render();
+            };
+            let mut tombstone = model.journal_items.remove(index);
+            tombstone.deleted_at = Some(now);
+            tombstone.updated_at = now;
+            save_and_render(persistence::save_journal_item(tombstone))
+        }
+        BuiltSessionEvent::SaveBuiltSession { mut session } => {
+            session.updated_at = now;
+            match model.built_sessions.iter_mut().find(|s| s.id == session.id) {
+                Some(stored) => *stored = session.clone(),
+                None => model.built_sessions.push(session.clone()),
+            }
+            save_and_render(persistence::save_built_session(session))
+        }
+        BuiltSessionEvent::RecordPlayThrough { mut record } => {
+            record.updated_at = now;
+            model.play_throughs.push(record.clone());
+            save_and_render(persistence::save_play_through(record))
+        }
+        BuiltSessionEvent::RecordReflection {
+            kind,
+            session_ref,
+            transcript,
+            audio_path,
+            duration_s,
+        } => {
+            let reflection = Reflection {
+                id: mint_id(),
+                kind,
+                session_ref,
+                transcript,
+                audio_path,
+                duration_s,
+                at: now,
+                updated_at: now,
+                deleted_at: None,
+            };
+            model.reflections.push(reflection.clone());
+            save_and_render(persistence::save_reflection(reflection))
+        }
+        BuiltSessionEvent::RecordFeel { block_id, feel } => {
+            let entry = FeelEntry {
+                id: mint_id(),
+                block_id,
+                feel,
+                at: now,
+                updated_at: now,
+                deleted_at: None,
+            };
+            model.feel_entries.push(entry.clone());
+            save_and_render(persistence::save_feel_entry(entry))
+        }
+    }
+}
+
+fn save_and_render(save: Command<Effect, Event>) -> Command<Effect, Event> {
+    Command::all([save, crux_core::render::render()])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::types::assert_round_trips;
+    use crate::engine::Circle;
+    use chrono::{TimeZone, Utc};
+
+    fn at() -> chrono::DateTime<chrono::Utc> {
+        Utc.with_ymd_and_hms(2020, 1, 1, 10, 0, 0).unwrap()
+    }
+
+    fn sample_drill() -> UserDrill {
+        UserDrill {
+            id: "01J0000000000000000000DRIL".into(),
+            name: "Descending run into the bridge".into(),
+            criterion: "Three clean passes at 72, left hand alone".into(),
+            tempo_bpm: Some(72),
+            keys: vec!["F".into()],
+            passes_to_open: 3,
+            serves: Some(Serves::Node("alice-bridge".into())),
+            created_at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn user_drill_round_trips_on_the_wire() {
+        assert_round_trips(sample_drill());
+    }
+
+    #[test]
+    fn user_drill_with_no_optionals_round_trips() {
+        assert_round_trips(UserDrill {
+            tempo_bpm: None,
+            keys: vec![],
+            serves: None,
+            deleted_at: Some(at()),
+            ..sample_drill()
+        });
+    }
+
+    #[test]
+    fn serves_circle_round_trips() {
+        assert_round_trips(Serves::Circle(Circle::Hands));
+    }
+
+    #[test]
+    fn journal_item_round_trips_on_the_wire() {
+        assert_round_trips(JournalItem {
+            id: "01J0000000000000000000JRNL".into(),
+            name: "Rubato feel in the intro".into(),
+            notes: Some("Time and notes, kept with the piece".into()),
+            linked_item_id: Some("01J0000000000000000000PIEC".into()),
+            created_at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        });
+    }
+
+    #[test]
+    fn built_session_round_trips_with_every_target_kind() {
+        assert_round_trips(BuiltSession {
+            id: "01J0000000000000000000BULT".into(),
+            source: Some("From Friday's lesson".into()),
+            blocks: vec![
+                BuiltBlock {
+                    id: "b1".into(),
+                    target: BuiltTarget::Node {
+                        node: "shell-voicings".into(),
+                    },
+                    minutes: Some(5),
+                },
+                BuiltBlock {
+                    id: "b2".into(),
+                    target: BuiltTarget::UserDrill {
+                        drill_id: "01J0000000000000000000DRIL".into(),
+                    },
+                    minutes: None,
+                },
+                BuiltBlock {
+                    id: "b3".into(),
+                    target: BuiltTarget::Journal {
+                        journal_id: "01J0000000000000000000JRNL".into(),
+                    },
+                    minutes: Some(8),
+                },
+                BuiltBlock {
+                    id: "b4".into(),
+                    target: BuiltTarget::Piece {
+                        item_id: "01J0000000000000000000PIEC".into(),
+                    },
+                    minutes: Some(10),
+                },
+            ],
+            created_at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        });
+    }
+
+    #[test]
+    fn play_through_record_round_trips_on_the_wire() {
+        assert_round_trips(PlayThroughRecord {
+            id: "01J0000000000000000000PLAY".into(),
+            item_id: "01J0000000000000000000PIEC".into(),
+            started_at: at(),
+            ended_at: at(),
+            counted: true,
+            sections: vec![
+                SectionVerdict {
+                    section: "The bridge, from memory".into(),
+                    held: true,
+                    at: at(),
+                },
+                SectionVerdict {
+                    section: "Out head".into(),
+                    held: false,
+                    at: at(),
+                },
+            ],
+            updated_at: at(),
+            deleted_at: None,
+        });
+    }
+
+    #[test]
+    fn reflection_round_trips_on_the_wire() {
+        for kind in [ReflectionKind::VoiceNote, ReflectionKind::SessionClose] {
+            assert_round_trips(Reflection {
+                id: "01J0000000000000000000REFL".into(),
+                kind,
+                session_ref: Some("01J0000000000000000000BULT".into()),
+                transcript: Some("The bridge still rushes from memory".into()),
+                audio_path: Some("reflections/01J.m4a".into()),
+                duration_s: Some(24),
+                at: at(),
+                updated_at: at(),
+                deleted_at: None,
+            });
+        }
+    }
+
+    #[test]
+    fn feel_entry_round_trips_for_every_feel() {
+        for feel in [Feel::FoughtIt, Feel::GettingThere, Feel::ItSang] {
+            assert_round_trips(FeelEntry {
+                id: "01J0000000000000000000FEEL".into(),
+                block_id: "b1".into(),
+                feel,
+                at: at(),
+                updated_at: at(),
+                deleted_at: None,
+            });
+        }
+    }
+
+    // ── Events, model and persistence (Phase A handlers) ──────────────
+
+    use crate::app::{Effect, Event, Intrada};
+    use crate::model::Model;
+    use crate::persistence::{BuiltSessionData, PersistenceOperation, PersistenceOutput};
+    use crux_core::App;
+
+    fn update(model: &mut Model, event: BuiltSessionEvent) -> Vec<Effect> {
+        let app = Intrada;
+        let mut cmd = app.update(Event::BuiltSession(event), model);
+        cmd.effects().collect()
+    }
+
+    fn persistence_ops(effects: &[Effect]) -> Vec<PersistenceOperation> {
+        effects
+            .iter()
+            .filter_map(|e| match e {
+                Effect::Persistence(req) => Some(req.operation.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn assert_no_http(effects: &[Effect]) {
+        assert!(
+            !effects.iter().any(|e| matches!(e, Effect::Http(_))),
+            "local-first path must never emit Http (invariant 1)"
+        );
+    }
+
+    fn sample_create_drill() -> CreateUserDrill {
+        CreateUserDrill {
+            name: "Descending run".into(),
+            criterion: "Three clean passes at 72".into(),
+            tempo_bpm: Some(72),
+            keys: vec![],
+            passes_to_open: 3,
+            serves: None,
+        }
+    }
+
+    #[test]
+    fn create_user_drill_mints_a_ulid_and_persists() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(sample_create_drill()),
+        );
+        assert_eq!(model.user_drills.len(), 1);
+        let drill = &model.user_drills[0];
+        assert_eq!(drill.id.len(), 26, "client-minted ulid (invariant 3)");
+        assert_eq!(drill.created_at, drill.updated_at);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveUserDrill(drill.clone())]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn update_user_drill_stamps_updated_at_and_persists() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(sample_create_drill()),
+        );
+        let mut edited = model.user_drills[0].clone();
+        edited.criterion = "Five clean passes".into();
+        edited.updated_at = at();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::UpdateUserDrill {
+                drill: edited.clone(),
+            },
+        );
+        let stored = &model.user_drills[0];
+        assert_eq!(stored.criterion, "Five clean passes");
+        assert!(
+            stored.updated_at > at(),
+            "core stamps updated_at, never trusts the caller's"
+        );
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveUserDrill(stored.clone())]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn delete_user_drill_tombstones_never_hard_deletes() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(sample_create_drill()),
+        );
+        let id = model.user_drills[0].id.clone();
+        let effects = update(&mut model, BuiltSessionEvent::DeleteUserDrill { id });
+        assert!(model.user_drills.is_empty(), "model holds live rows only");
+        match persistence_ops(&effects).as_slice() {
+            [PersistenceOperation::SaveUserDrill(saved)] => {
+                assert!(saved.deleted_at.is_some())
+            }
+            other => panic!("expected one tombstone save, got {other:?}"),
+        }
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn unknown_user_drill_update_surfaces_an_error() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::UpdateUserDrill {
+                drill: sample_drill(),
+            },
+        );
+        assert!(model.last_error.is_some());
+        assert!(persistence_ops(&effects).is_empty(), "nothing to persist");
+    }
+
+    #[test]
+    fn create_journal_item_mints_and_persists() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::CreateJournalItem(CreateJournalItem {
+                name: "Rubato feel".into(),
+                notes: None,
+                linked_item_id: None,
+            }),
+        );
+        assert_eq!(model.journal_items.len(), 1);
+        let journal = &model.journal_items[0];
+        assert_eq!(journal.id.len(), 26);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveJournalItem(journal.clone())]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn delete_journal_item_tombstones() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateJournalItem(CreateJournalItem {
+                name: "Rubato feel".into(),
+                notes: None,
+                linked_item_id: None,
+            }),
+        );
+        let id = model.journal_items[0].id.clone();
+        let effects = update(&mut model, BuiltSessionEvent::DeleteJournalItem { id });
+        assert!(model.journal_items.is_empty(), "model holds live rows only");
+        match persistence_ops(&effects).as_slice() {
+            [PersistenceOperation::SaveJournalItem(saved)] => {
+                assert!(saved.deleted_at.is_some())
+            }
+            other => panic!("expected one tombstone save, got {other:?}"),
+        }
+    }
+
+    fn sample_built_session() -> BuiltSession {
+        BuiltSession {
+            id: "01J0000000000000000000BULT".into(),
+            source: None,
+            blocks: vec![],
+            created_at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn save_built_session_upserts_and_persists() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::SaveBuiltSession {
+                session: sample_built_session(),
+            },
+        );
+        assert_eq!(model.built_sessions.len(), 1);
+        assert!(model.built_sessions[0].updated_at > at());
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveBuiltSession(
+                model.built_sessions[0].clone()
+            )]
+        );
+        assert_no_http(&effects);
+
+        // Saving the same id again replaces, never duplicates.
+        update(
+            &mut model,
+            BuiltSessionEvent::SaveBuiltSession {
+                session: sample_built_session(),
+            },
+        );
+        assert_eq!(model.built_sessions.len(), 1);
+    }
+
+    #[test]
+    fn record_play_through_persists() {
+        let mut model = Model::test_default();
+        let record = PlayThroughRecord {
+            id: "01J0000000000000000000PLAY".into(),
+            item_id: "piece".into(),
+            started_at: at(),
+            ended_at: at(),
+            counted: true,
+            sections: vec![],
+            updated_at: at(),
+            deleted_at: None,
+        };
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordPlayThrough {
+                record: record.clone(),
+            },
+        );
+        assert_eq!(model.play_throughs.len(), 1);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SavePlayThrough(
+                model.play_throughs[0].clone()
+            )]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn record_reflection_mints_and_persists() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordReflection {
+                kind: ReflectionKind::SessionClose,
+                session_ref: None,
+                transcript: Some("The bridge still rushes".into()),
+                audio_path: Some("reflections/x.m4a".into()),
+                duration_s: Some(24),
+            },
+        );
+        assert_eq!(model.reflections.len(), 1);
+        assert_eq!(model.reflections[0].id.len(), 26);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveReflection(
+                model.reflections[0].clone()
+            )]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn record_feel_mints_and_persists() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordFeel {
+                block_id: "b1".into(),
+                feel: Feel::ItSang,
+            },
+        );
+        assert_eq!(model.feel_entries.len(), 1);
+        assert_eq!(model.feel_entries[0].id.len(), 26);
+        assert_eq!(model.feel_entries[0].feel, Feel::ItSang);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveFeelEntry(
+                model.feel_entries[0].clone()
+            )]
+        );
+        assert_no_http(&effects);
+    }
+
+    // ── Hydration and write results ────────────────────────────────────
+
+    fn app_update(model: &mut Model, event: Event) -> Vec<Effect> {
+        let app = Intrada;
+        let mut cmd = app.update(event, model);
+        cmd.effects().collect()
+    }
+
+    #[test]
+    fn local_first_start_loads_built_session_data() {
+        let mut model = Model::test_default();
+        let effects = app_update(
+            &mut model,
+            Event::StartApp {
+                api_base_url: "http://localhost".into(),
+                local_first: true,
+            },
+        );
+        assert!(persistence_ops(&effects).contains(&PersistenceOperation::LoadBuiltSessionData));
+    }
+
+    #[test]
+    fn online_start_never_touches_the_built_session_store() {
+        let mut model = Model::test_default();
+        let effects = app_update(
+            &mut model,
+            Event::StartApp {
+                api_base_url: "http://localhost".into(),
+                local_first: false,
+            },
+        );
+        assert!(!persistence_ops(&effects).contains(&PersistenceOperation::LoadBuiltSessionData));
+    }
+
+    #[test]
+    fn built_store_loaded_populates_the_model() {
+        let mut model = Model::test_default();
+        let data = BuiltSessionData {
+            user_drills: vec![sample_drill()],
+            journal_items: vec![],
+            built_sessions: vec![sample_built_session()],
+            play_throughs: vec![],
+            reflections: vec![],
+            feel_entries: vec![],
+        };
+        app_update(
+            &mut model,
+            Event::BuiltStoreLoaded(PersistenceOutput::BuiltSessionData(data)),
+        );
+        assert_eq!(model.user_drills.len(), 1);
+        assert_eq!(model.built_sessions.len(), 1);
+    }
+
+    #[test]
+    fn built_store_loaded_failed_surfaces_without_reloading() {
+        let mut model = Model::test_default();
+        let effects = app_update(
+            &mut model,
+            Event::BuiltStoreLoaded(PersistenceOutput::Failed),
+        );
+        assert!(model.last_error.is_some());
+        assert!(persistence_ops(&effects).is_empty(), "no reload loop");
+    }
+
+    #[test]
+    fn built_store_written_failed_surfaces_and_rehydrates() {
+        let mut model = Model::test_default();
+        let effects = app_update(
+            &mut model,
+            Event::BuiltStoreWritten(PersistenceOutput::Failed),
+        );
+        assert!(model.last_error.is_some(), "invariant 5: never silent");
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::LoadBuiltSessionData]
+        );
+    }
+
+    #[test]
+    fn built_store_written_ack_is_a_noop() {
+        let mut model = Model::test_default();
+        let effects = app_update(&mut model, Event::BuiltStoreWritten(PersistenceOutput::Ack));
+        assert!(model.last_error.is_none());
+        assert!(persistence_ops(&effects).is_empty());
+    }
+
+    // ── Bridge payloads (#846) ──────────────────────────────────────────
+
+    #[test]
+    fn built_session_events_round_trip_on_the_wire() {
+        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::CreateUserDrill(
+            sample_create_drill(),
+        )));
+        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::RecordFeel {
+            block_id: "b1".into(),
+            feel: Feel::GettingThere,
+        }));
+        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::SaveBuiltSession {
+            session: sample_built_session(),
+        }));
+    }
+
+    #[test]
+    fn built_session_persistence_payloads_round_trip_on_the_wire() {
+        assert_round_trips(PersistenceOperation::SaveUserDrill(sample_drill()));
+        assert_round_trips(PersistenceOperation::LoadBuiltSessionData);
+        assert_round_trips(PersistenceOutput::BuiltSessionData(BuiltSessionData {
+            user_drills: vec![sample_drill()],
+            journal_items: vec![],
+            built_sessions: vec![sample_built_session()],
+            play_throughs: vec![],
+            reflections: vec![],
+            feel_entries: vec![],
+        }));
+    }
+}

--- a/crates/intrada-core/src/domain/built_session.rs
+++ b/crates/intrada-core/src/domain/built_session.rs
@@ -10,6 +10,7 @@ use crate::app::{Effect, Event};
 use crate::engine::Circle;
 use crate::model::Model;
 use crate::persistence;
+use crate::validation;
 
 /// Decision 19b: a countable target with no authored node. The dictated
 /// sentence *is* the gate; the parsed parameters are read back, never asked
@@ -149,7 +150,8 @@ pub enum ReflectionKind {
     SessionClose,
 }
 
-/// At most one per block, and only where feel is the point (C1).
+/// One feel, asked at most once per block and only where feel is the point
+/// (C1) — the budget is the asking surface's, enforced in Phase D, not here.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct FeelEntry {
@@ -185,6 +187,16 @@ pub struct CreateUserDrill {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct RecordPlayThrough {
+    pub item_id: String,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
+    pub counted: bool,
+    pub sections: Vec<SectionVerdict>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreateJournalItem {
     pub name: String,
     pub notes: Option<String>,
@@ -215,9 +227,7 @@ pub enum BuiltSessionEvent {
     SaveBuiltSession {
         session: BuiltSession,
     },
-    RecordPlayThrough {
-        record: PlayThroughRecord,
-    },
+    RecordPlayThrough(RecordPlayThrough),
     RecordReflection {
         kind: ReflectionKind,
         session_ref: Option<String>,
@@ -244,6 +254,11 @@ pub fn handle_built_session_event(
     let now = chrono::Utc::now();
     match event {
         BuiltSessionEvent::CreateUserDrill(input) => {
+            let input = validation::normalize_create_user_drill(input);
+            if let Err(e) = validation::validate_create_user_drill(&input) {
+                model.surface_error(e.to_string());
+                return crux_core::render::render();
+            }
             let drill = UserDrill {
                 id: mint_id(),
                 name: input.name,
@@ -264,6 +279,10 @@ pub fn handle_built_session_event(
                 model.surface_error("That drill no longer exists.");
                 return crux_core::render::render();
             };
+            // Provenance and tombstone are the core's to set: an update must
+            // not be able to resurrect a deleted drill or delete a live one.
+            drill.created_at = stored.created_at;
+            drill.deleted_at = stored.deleted_at;
             drill.updated_at = now;
             *stored = drill.clone();
             save_and_render(persistence::save_user_drill(drill))
@@ -279,6 +298,11 @@ pub fn handle_built_session_event(
             save_and_render(persistence::save_user_drill(tombstone))
         }
         BuiltSessionEvent::CreateJournalItem(input) => {
+            let input = validation::normalize_create_journal_item(input);
+            if let Err(e) = validation::validate_create_journal_item(&input) {
+                model.surface_error(e.to_string());
+                return crux_core::render::render();
+            }
             let journal = JournalItem {
                 id: mint_id(),
                 name: input.name,
@@ -296,6 +320,8 @@ pub fn handle_built_session_event(
                 model.surface_error("That journal item no longer exists.");
                 return crux_core::render::render();
             };
+            journal.created_at = stored.created_at;
+            journal.deleted_at = stored.deleted_at;
             journal.updated_at = now;
             *stored = journal.clone();
             save_and_render(persistence::save_journal_item(journal))
@@ -318,8 +344,17 @@ pub fn handle_built_session_event(
             }
             save_and_render(persistence::save_built_session(session))
         }
-        BuiltSessionEvent::RecordPlayThrough { mut record } => {
-            record.updated_at = now;
+        BuiltSessionEvent::RecordPlayThrough(input) => {
+            let record = PlayThroughRecord {
+                id: mint_id(),
+                item_id: input.item_id,
+                started_at: input.started_at,
+                ended_at: input.ended_at,
+                counted: input.counted,
+                sections: input.sections,
+                updated_at: now,
+                deleted_at: None,
+            };
             model.play_throughs.push(record.clone());
             save_and_render(persistence::save_play_through(record))
         }
@@ -580,6 +615,66 @@ mod tests {
     }
 
     #[test]
+    fn a_whitespace_only_criterion_is_refused_not_stored() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(CreateUserDrill {
+                criterion: "   ".into(),
+                ..sample_create_drill()
+            }),
+        );
+        assert!(model.user_drills.is_empty(), "nothing persisted");
+        assert!(persistence_ops(&effects).is_empty());
+        assert!(model.last_error.is_some(), "the refusal reaches the user");
+    }
+
+    #[test]
+    fn an_ungateable_drill_is_refused() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(CreateUserDrill {
+                passes_to_open: 0,
+                ..sample_create_drill()
+            }),
+        );
+        assert!(
+            model.user_drills.is_empty(),
+            "zero passes is a gate nothing can open"
+        );
+    }
+
+    #[test]
+    fn drill_free_text_is_trimmed_before_it_is_stored() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(CreateUserDrill {
+                name: "  Descending run  ".into(),
+                ..sample_create_drill()
+            }),
+        );
+        assert_eq!(model.user_drills[0].name, "Descending run");
+    }
+
+    #[test]
+    fn a_nameless_journal_item_is_refused() {
+        let mut model = Model::test_default();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::CreateJournalItem(CreateJournalItem {
+                name: "  ".into(),
+                notes: None,
+                linked_item_id: None,
+            }),
+        );
+        assert!(model.journal_items.is_empty());
+        assert!(persistence_ops(&effects).is_empty());
+        assert!(model.last_error.is_some());
+    }
+
+    #[test]
     fn update_user_drill_stamps_updated_at_and_persists() {
         let mut model = Model::test_default();
         update(
@@ -606,6 +701,25 @@ mod tests {
             vec![PersistenceOperation::SaveUserDrill(stored.clone())]
         );
         assert_no_http(&effects);
+    }
+
+    #[test]
+    fn an_update_cannot_resurrect_a_tombstoned_drill() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::CreateUserDrill(sample_create_drill()),
+        );
+        let mut revived = model.user_drills[0].clone();
+        revived.deleted_at = Some(at());
+        update(
+            &mut model,
+            BuiltSessionEvent::UpdateUserDrill { drill: revived },
+        );
+        assert_eq!(
+            model.user_drills[0].deleted_at, None,
+            "only Delete* sets a tombstone"
+        );
     }
 
     #[test]
@@ -724,25 +838,26 @@ mod tests {
     }
 
     #[test]
-    fn record_play_through_persists() {
+    fn record_play_through_mints_a_ulid_and_persists() {
         let mut model = Model::test_default();
-        let record = PlayThroughRecord {
-            id: "01J0000000000000000000PLAY".into(),
-            item_id: "piece".into(),
-            started_at: at(),
-            ended_at: at(),
-            counted: true,
-            sections: vec![],
-            updated_at: at(),
-            deleted_at: None,
-        };
         let effects = update(
             &mut model,
-            BuiltSessionEvent::RecordPlayThrough {
-                record: record.clone(),
-            },
+            BuiltSessionEvent::RecordPlayThrough(RecordPlayThrough {
+                item_id: "piece".into(),
+                started_at: at(),
+                ended_at: at(),
+                counted: true,
+                sections: vec![SectionVerdict {
+                    section: "The bridge".into(),
+                    held: false,
+                    at: at(),
+                }],
+            }),
         );
         assert_eq!(model.play_throughs.len(), 1);
+        assert_eq!(model.play_throughs[0].id.len(), 26);
+        assert_eq!(model.play_throughs[0].deleted_at, None);
+        assert_eq!(model.play_throughs[0].sections.len(), 1);
         assert_eq!(
             persistence_ops(&effects),
             vec![PersistenceOperation::SavePlayThrough(
@@ -750,6 +865,25 @@ mod tests {
             )]
         );
         assert_no_http(&effects);
+    }
+
+    #[test]
+    fn two_play_throughs_are_two_records() {
+        let mut model = Model::test_default();
+        let input = RecordPlayThrough {
+            item_id: "piece".into(),
+            started_at: at(),
+            ended_at: at(),
+            counted: true,
+            sections: vec![],
+        };
+        update(
+            &mut model,
+            BuiltSessionEvent::RecordPlayThrough(input.clone()),
+        );
+        update(&mut model, BuiltSessionEvent::RecordPlayThrough(input));
+        assert_eq!(model.play_throughs.len(), 2);
+        assert_ne!(model.play_throughs[0].id, model.play_throughs[1].id);
     }
 
     #[test]
@@ -886,31 +1020,127 @@ mod tests {
 
     // ── Bridge payloads (#846) ──────────────────────────────────────────
 
-    #[test]
-    fn built_session_events_round_trip_on_the_wire() {
-        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::CreateUserDrill(
-            sample_create_drill(),
-        )));
-        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::RecordFeel {
+    fn sample_journal_item() -> JournalItem {
+        JournalItem {
+            id: "01J000000000000000000JOUR".into(),
+            name: "Rubato feel".into(),
+            notes: Some("Time and notes".into()),
+            linked_item_id: Some("piece".into()),
+            created_at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    fn sample_play_through() -> PlayThroughRecord {
+        PlayThroughRecord {
+            id: "01J0000000000000000000PLAY".into(),
+            item_id: "piece".into(),
+            started_at: at(),
+            ended_at: at(),
+            counted: true,
+            sections: vec![SectionVerdict {
+                section: "The bridge".into(),
+                held: true,
+                at: at(),
+            }],
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    fn sample_reflection() -> Reflection {
+        Reflection {
+            id: "01J000000000000000000REFL".into(),
+            kind: ReflectionKind::SessionClose,
+            session_ref: Some("built".into()),
+            transcript: Some("The bridge still rushes".into()),
+            audio_path: Some("reflections/r1.m4a".into()),
+            duration_s: Some(24),
+            at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    fn sample_feel_entry() -> FeelEntry {
+        FeelEntry {
+            id: "01J000000000000000000FEEL".into(),
             block_id: "b1".into(),
-            feel: Feel::GettingThere,
-        }));
-        assert_round_trips(Event::BuiltSession(BuiltSessionEvent::SaveBuiltSession {
-            session: sample_built_session(),
-        }));
+            feel: Feel::ItSang,
+            at: at(),
+            updated_at: at(),
+            deleted_at: None,
+        }
+    }
+
+    /// Every variant, not a sample: a positional bincode wire has no "absent",
+    /// so an untested variant is an untested field order (#846).
+    #[test]
+    fn every_built_session_event_round_trips_on_the_wire() {
+        for event in [
+            BuiltSessionEvent::CreateUserDrill(sample_create_drill()),
+            BuiltSessionEvent::UpdateUserDrill {
+                drill: sample_drill(),
+            },
+            BuiltSessionEvent::DeleteUserDrill { id: "d1".into() },
+            BuiltSessionEvent::CreateJournalItem(CreateJournalItem {
+                name: "Rubato feel".into(),
+                notes: Some("Time and notes".into()),
+                linked_item_id: Some("piece".into()),
+            }),
+            BuiltSessionEvent::UpdateJournalItem {
+                journal: sample_journal_item(),
+            },
+            BuiltSessionEvent::DeleteJournalItem { id: "j1".into() },
+            BuiltSessionEvent::SaveBuiltSession {
+                session: sample_built_session(),
+            },
+            BuiltSessionEvent::RecordPlayThrough(RecordPlayThrough {
+                item_id: "piece".into(),
+                started_at: at(),
+                ended_at: at(),
+                counted: false,
+                sections: vec![SectionVerdict {
+                    section: "Out head".into(),
+                    held: false,
+                    at: at(),
+                }],
+            }),
+            BuiltSessionEvent::RecordReflection {
+                kind: ReflectionKind::VoiceNote,
+                session_ref: Some("built".into()),
+                transcript: Some("The bridge still rushes".into()),
+                audio_path: Some("reflections/r1.m4a".into()),
+                duration_s: Some(24),
+            },
+            BuiltSessionEvent::RecordFeel {
+                block_id: "b1".into(),
+                feel: Feel::GettingThere,
+            },
+        ] {
+            assert_round_trips(Event::BuiltSession(event));
+        }
     }
 
     #[test]
     fn built_session_persistence_payloads_round_trip_on_the_wire() {
         assert_round_trips(PersistenceOperation::SaveUserDrill(sample_drill()));
+        assert_round_trips(PersistenceOperation::SaveJournalItem(sample_journal_item()));
+        assert_round_trips(PersistenceOperation::SaveBuiltSession(
+            sample_built_session(),
+        ));
+        assert_round_trips(PersistenceOperation::SavePlayThrough(sample_play_through()));
+        assert_round_trips(PersistenceOperation::SaveReflection(sample_reflection()));
+        assert_round_trips(PersistenceOperation::SaveFeelEntry(sample_feel_entry()));
         assert_round_trips(PersistenceOperation::LoadBuiltSessionData);
         assert_round_trips(PersistenceOutput::BuiltSessionData(BuiltSessionData {
             user_drills: vec![sample_drill()],
-            journal_items: vec![],
+            journal_items: vec![sample_journal_item()],
             built_sessions: vec![sample_built_session()],
-            play_throughs: vec![],
-            reflections: vec![],
-            feel_entries: vec![],
+            play_throughs: vec![sample_play_through()],
+            reflections: vec![sample_reflection()],
+            feel_entries: vec![sample_feel_entry()],
         }));
     }
 }

--- a/crates/intrada-core/src/domain/mod.rs
+++ b/crates/intrada-core/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod built_session;
 pub mod chart;
 pub mod item;
 pub mod mcp_audit;

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::analytics::AnalyticsView;
 use crate::domain::account::AccountPreferences;
+use crate::domain::built_session::{
+    BuiltSession, FeelEntry, JournalItem, PlayThroughRecord, Reflection, UserDrill,
+};
 use crate::domain::chart::{ChordChart, ScaffoldKind};
 use crate::domain::item::{Item, ItemKind, Modality};
 use crate::domain::mcp_audit::McpAuditEntry;
@@ -88,6 +91,14 @@ pub struct Model {
     /// One slot, because the shell resolves persistence synchronously
     /// (`Store.process`), so only one coach write is ever in flight.
     pub coach_write_in_flight: Option<PersistenceOperation>,
+    // Built-session entities (#1256, `specs/built-session.md`). Tombstoned
+    // rows stay out of these: the shell loads live rows only.
+    pub user_drills: Vec<UserDrill>,
+    pub journal_items: Vec<JournalItem>,
+    pub built_sessions: Vec<BuiltSession>,
+    pub play_throughs: Vec<PlayThroughRecord>,
+    pub reflections: Vec<Reflection>,
+    pub feel_entries: Vec<FeelEntry>,
 }
 
 impl Model {

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -8,6 +8,9 @@ use crux_core::command::Command;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{Effect, Event};
+use crate::domain::built_session::{
+    BuiltSession, FeelEntry, JournalItem, PlayThroughRecord, Reflection, UserDrill,
+};
 use crate::domain::item::Item;
 use crate::domain::session::PracticeSession;
 use crate::engine::{BlockRecord, WanderRecord};
@@ -42,6 +45,28 @@ pub enum PersistenceOperation {
     /// The closed blocks back, so the mastery track can rebuild at launch
     /// (#1214). Wanders stay unread: they carry no `(node, level)` to score.
     LoadCoachRecords,
+    // Built-session entities (#1256). Saves are upserts by id; deletes are
+    // tombstoned saves (invariant 2) — no hard-delete op exists on purpose.
+    SaveUserDrill(UserDrill),
+    SaveJournalItem(JournalItem),
+    SaveBuiltSession(BuiltSession),
+    SavePlayThrough(PlayThroughRecord),
+    SaveReflection(Reflection),
+    SaveFeelEntry(FeelEntry),
+    /// One read for the whole surface at launch, like `LoadItems`.
+    LoadBuiltSessionData,
+}
+
+/// Everything the built-session surface hydrates from, in one output.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct BuiltSessionData {
+    pub user_drills: Vec<UserDrill>,
+    pub journal_items: Vec<JournalItem>,
+    pub built_sessions: Vec<BuiltSession>,
+    pub play_throughs: Vec<PlayThroughRecord>,
+    pub reflections: Vec<Reflection>,
+    pub feel_entries: Vec<FeelEntry>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -51,6 +76,7 @@ pub enum PersistenceOutput {
     Items(Vec<Item>),
     Sessions(Vec<PracticeSession>),
     CoachRecords(Vec<BlockRecord>),
+    BuiltSessionData(BuiltSessionData),
     Ack,
     /// Local store failed the op — surfaced, not trusted as success (#816).
     Failed,
@@ -97,6 +123,39 @@ pub fn load_sessions() -> Command<Effect, Event> {
 pub fn save_session(session: PracticeSession) -> Command<Effect, Event> {
     Command::request_from_shell(PersistenceOperation::SaveSession(session))
         .then_send(Event::SessionStoreWritten)
+}
+
+fn save_built(op: PersistenceOperation) -> Command<Effect, Event> {
+    Command::request_from_shell(op).then_send(Event::BuiltStoreWritten)
+}
+
+pub fn save_user_drill(drill: UserDrill) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SaveUserDrill(drill))
+}
+
+pub fn save_journal_item(journal: JournalItem) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SaveJournalItem(journal))
+}
+
+pub fn save_built_session(session: BuiltSession) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SaveBuiltSession(session))
+}
+
+pub fn save_play_through(record: PlayThroughRecord) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SavePlayThrough(record))
+}
+
+pub fn save_reflection(reflection: Reflection) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SaveReflection(reflection))
+}
+
+pub fn save_feel_entry(entry: FeelEntry) -> Command<Effect, Event> {
+    save_built(PersistenceOperation::SaveFeelEntry(entry))
+}
+
+pub fn load_built_session_data() -> Command<Effect, Event> {
+    Command::request_from_shell(PersistenceOperation::LoadBuiltSessionData)
+        .then_send(Event::BuiltStoreLoaded)
 }
 
 #[cfg(test)]

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -1,3 +1,4 @@
+use crate::domain::built_session::{CreateJournalItem, CreateUserDrill};
 use crate::domain::item::ItemKind;
 use crate::domain::types::{CreateItem, Tempo, UpdateItem};
 use crate::error::LibraryError;
@@ -29,6 +30,12 @@ pub const MIN_SESSION_TARGET_MINS: u32 = 5;
 pub const MAX_SESSION_TARGET_MINS: u32 = 120;
 pub const MIN_ACHIEVED_TEMPO: u16 = 1;
 pub const MAX_ACHIEVED_TEMPO: u16 = 500;
+pub const MAX_DRILL_NAME: usize = 200;
+pub const MAX_CRITERION: usize = 500;
+pub const MAX_DRILL_KEYS: usize = 12;
+pub const MIN_PASSES_TO_OPEN: u8 = 1;
+pub const MAX_PASSES_TO_OPEN: u8 = 20;
+pub const MAX_JOURNAL_NAME: usize = 200;
 
 // ── Normalisation ──
 // Trim free-text on input and collapse a now-blank value to absent, so a
@@ -76,6 +83,73 @@ pub fn normalize_update_item(mut input: UpdateItem) -> UpdateItem {
     input.tempo = input.tempo.map(normalize_tempo);
     input.tags = input.tags.map(normalize_tags);
     input
+}
+
+pub fn normalize_create_user_drill(mut input: CreateUserDrill) -> CreateUserDrill {
+    input.name = input.name.trim().to_string();
+    input.criterion = input.criterion.trim().to_string();
+    input.keys = normalize_tags(input.keys);
+    input
+}
+
+pub fn normalize_create_journal_item(mut input: CreateJournalItem) -> CreateJournalItem {
+    input.name = input.name.trim().to_string();
+    input.notes = trimmed_nonempty(input.notes);
+    input.linked_item_id = trimmed_nonempty(input.linked_item_id);
+    input
+}
+
+fn validate_bounded(field: &str, label: &str, value: &str, max: usize) -> Result<(), LibraryError> {
+    if value.is_empty() || value.len() > max {
+        return Err(LibraryError::Validation {
+            field: field.to_string(),
+            message: format!("{label} must be between 1 and {max} characters"),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_create_user_drill(input: &CreateUserDrill) -> Result<(), LibraryError> {
+    validate_bounded("name", "Name", &input.name, MAX_DRILL_NAME)?;
+    // The dictated sentence *is* the gate (decision 19b), so an empty one
+    // leaves a block with nothing to pass.
+    validate_bounded("criterion", "Criterion", &input.criterion, MAX_CRITERION)?;
+    if let Some(bpm) = input.tempo_bpm {
+        if !(MIN_BPM..=MAX_BPM).contains(&bpm) {
+            return Err(LibraryError::Validation {
+                field: "tempo_bpm".to_string(),
+                message: format!("BPM must be between {MIN_BPM} and {MAX_BPM}"),
+            });
+        }
+    }
+    if input.keys.len() > MAX_DRILL_KEYS {
+        return Err(LibraryError::Validation {
+            field: "keys".to_string(),
+            message: format!("A drill can name at most {MAX_DRILL_KEYS} keys"),
+        });
+    }
+    if !(MIN_PASSES_TO_OPEN..=MAX_PASSES_TO_OPEN).contains(&input.passes_to_open) {
+        return Err(LibraryError::Validation {
+            field: "passes_to_open".to_string(),
+            message: format!(
+                "Passes must be between {MIN_PASSES_TO_OPEN} and {MAX_PASSES_TO_OPEN}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn validate_create_journal_item(input: &CreateJournalItem) -> Result<(), LibraryError> {
+    validate_bounded("name", "Name", &input.name, MAX_JOURNAL_NAME)?;
+    if let Some(ref notes) = input.notes {
+        if notes.len() > MAX_NOTES {
+            return Err(LibraryError::Validation {
+                field: "notes".to_string(),
+                message: format!("Notes must be {MAX_NOTES} characters or fewer"),
+            });
+        }
+    }
+    Ok(())
 }
 
 pub fn validate_title(title: &str) -> Result<(), LibraryError> {

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -330,3 +330,50 @@ admin friction at the piano, T1, and self-assessed familiarity is exactly what
 decision 17 quarantines); keeping acquisition outside the app as unmonitored
 prose (rejected: the plan would skip the first week of any new material, and
 the evidence from that week would be lost to the mastery track).
+
+### T13 — Voice splits by surface, and the engine never speaks on screen
+
+**Status:** DECIDED 2026-08-07 (graduated from
+`design/briefs/2026-08-copy-language.md` v2, decided with Jon while reviewing
+the Built Session A/B/C mockups; lands with jonyardley/intrada#1256).
+
+The first copy pass fixed vocabulary but kept the stance: the app narrated its
+own data model in nicer words. The fix is not better sentences; it is fewer,
+and different rules per surface class.
+
+- **In-session — the silent tool** (drill loop, run-throughs, feel moments,
+  off-piste, unmonitored play): prose is budgeted like taps, at most eight
+  words beyond labels and buttons. No captions explaining mechanics: what is
+  and isn't being recorded is carried by the interface itself (the altitude
+  chip; the presence or absence of instrumentation). Buttons and chips are the
+  vocabulary: "Held / Broke down", "Fought it / Getting there / It sang".
+- **Set-up and composition — the plain peer** (steer sheet, resolution
+  questions, composed-session view, altitude choice): one short sentence per
+  card, maximum. Explain a thing once, at the decision point, then never
+  again; repeat visits get labels only. Questions are fine when they are the
+  actual decision.
+- **Reflective and narrative — warmth allowed** (session summary, reflection,
+  the morning proposal, the weekly thread): the user's own words do the
+  emotional work, quoted in serif; the app's words stay brief and concrete
+  around them. The only surface class where the app may have a personality.
+
+Universal: engine vocabulary never appears on screen: gate, verdict,
+evidence, mastery, prerequisite, node, steer, prescribed, judgement track,
+countable, cold test (as a noun). Screen translations: target / the buttons
+themselves / history / progress / "you added this" / "today's plan" / "by
+ear" / "from cold" (as lived experience). Never explain the data model inline
+(if a screen seems to need that paragraph, the design is wrong, not the copy);
+no philosophy headlines; buttons name the action, not the mechanism ("Keep it
+as a drill", never "write the gate").
+
+The full spec, with worked per-frame examples, is
+`design/briefs/2026-08-copy-language.md`; the design system gains a Voice
+section beside the tokens so future frames are written against it.
+
+Options considered: one app-wide voice with a softer register (rejected: what
+reads warm at session close is chatter mid-drill; the surfaces have opposite
+jobs); keeping the consent explanation as on-screen captions (rejected: the
+deleted three-bullet consent list on A5 is the type specimen; the interface
+carries it, or an ⓘ does); letting spec vocabulary through where it is
+"technically accurate" (rejected: core says `variant`, the screen says
+**Steps**, and the precedent holds everywhere).

--- a/docs/status.md
+++ b/docs/status.md
@@ -18,6 +18,13 @@ countable criteria.
 ## In flight
 
 - #1143 — Phase 0 fortnight practising from `content/`
+- #1256 — built session, play-through altitudes, qualitative capture (2b).
+  Phase A landed the spec (`specs/built-session.md`), the pulled A/B/C mockups
+  (`specs/built-session/design/`), the voice spec graduated as T13, and the
+  core scaffold: entities (`UserDrill`, `JournalItem`, `BuiltSession`,
+  `PlayThroughRecord`, `Reflection`, `FeelEntry`), `BuiltSessionEvent`
+  handlers (local-first only), GRDB v11 with an upgrade-path test, and
+  real-bridge round-trips. Next: Phase B, Journey A end-to-end
 
 ## Recently landed
 

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -17,6 +17,15 @@ protocol ItemStore {
   /// The closed blocks back, so the core can rebuild the mastery track at
   /// launch (#1214). Wanders stay write-only: no `(node, level)` to score.
   func loadCoachRecords() throws -> [BlockRecord]
+  // Built-session entities (#1256): upserts by id; deletes arrive as
+  // tombstoned saves, so no delete methods exist.
+  func saveUserDrill(_ drill: UserDrill) throws
+  func saveJournalItem(_ journal: JournalItem) throws
+  func saveBuiltSession(_ session: BuiltSession) throws
+  func savePlayThrough(_ record: PlayThroughRecord) throws
+  func saveReflection(_ reflection: Reflection) throws
+  func saveFeelEntry(_ entry: FeelEntry) throws
+  func loadBuiltSessionData() throws -> BuiltSessionData
 }
 
 /// On-device SQLite store (GRDB) — the B2 local-first persistence layer the
@@ -336,6 +345,88 @@ final class LibraryStore: ItemStore {
             ended_at TEXT NOT NULL,
             attempts TEXT NOT NULL DEFAULT '[]',
             keep_as_drill INTEGER,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+    }
+    migrator.registerMigration("v11_built_session") { db in
+      // Self-directed practice (#1256, specs/built-session.md). `blocks` and
+      // `sections` are JSON blobs for the same reason `session.entries` is:
+      // ordered child docs edited as one document, not independently synced rows.
+      try db.execute(
+        sql: """
+          CREATE TABLE user_drill (
+            id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
+            criterion TEXT NOT NULL,
+            tempo_bpm INTEGER,
+            keys TEXT NOT NULL DEFAULT '[]',
+            passes_to_open INTEGER NOT NULL,
+            serves_kind TEXT,
+            serves_value TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+      try db.execute(
+        sql: """
+          CREATE TABLE journal_item (
+            id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
+            notes TEXT,
+            linked_item_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+      try db.execute(
+        sql: """
+          CREATE TABLE built_session (
+            id TEXT PRIMARY KEY NOT NULL,
+            source TEXT,
+            blocks TEXT NOT NULL DEFAULT '[]',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+      try db.execute(
+        sql: """
+          CREATE TABLE play_through (
+            id TEXT PRIMARY KEY NOT NULL,
+            item_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            ended_at TEXT NOT NULL,
+            counted INTEGER NOT NULL,
+            sections TEXT NOT NULL DEFAULT '[]',
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+      try db.execute(
+        sql: """
+          CREATE TABLE reflection (
+            id TEXT PRIMARY KEY NOT NULL,
+            kind TEXT NOT NULL,
+            session_ref TEXT,
+            transcript TEXT,
+            audio_path TEXT,
+            duration_s INTEGER,
+            at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
+      try db.execute(
+        sql: """
+          CREATE TABLE feel_entry (
+            id TEXT PRIMARY KEY NOT NULL,
+            block_id TEXT NOT NULL,
+            feel TEXT NOT NULL,
+            at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             deleted_at TEXT
           )
@@ -985,6 +1076,355 @@ final class LibraryStore: ItemStore {
     case .shrinkScope: "shrink_scope"
     case .changeMode: "change_mode"
     case .swapDrill: "swap_drill"
+    }
+  }
+
+  // ── Built-session entities (#1256) ───────────────────────────────────
+
+  func saveUserDrill(_ drill: UserDrill) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO user_drill
+            (id, name, criterion, tempo_bpm, keys, passes_to_open, serves_kind, serves_value,
+             created_at, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name, criterion = excluded.criterion,
+            tempo_bpm = excluded.tempo_bpm, keys = excluded.keys,
+            passes_to_open = excluded.passes_to_open,
+            serves_kind = excluded.serves_kind, serves_value = excluded.serves_value,
+            created_at = excluded.created_at, updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          drill.id, drill.name, drill.criterion, drill.tempoBpm.map { Int($0) },
+          try Self.encodeJSON(drill.keys, field: "keys"), Int(drill.passesToOpen),
+          Self.servesKind(drill.serves), Self.servesValue(drill.serves),
+          drill.createdAt, drill.updatedAt, drill.deletedAt,
+        ])
+    }
+  }
+
+  func saveJournalItem(_ journal: JournalItem) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO journal_item
+            (id, name, notes, linked_item_id, created_at, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name, notes = excluded.notes,
+            linked_item_id = excluded.linked_item_id,
+            created_at = excluded.created_at, updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          journal.id, journal.name, journal.notes, journal.linkedItemId,
+          journal.createdAt, journal.updatedAt, journal.deletedAt,
+        ])
+    }
+  }
+
+  func saveBuiltSession(_ session: BuiltSession) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO built_session
+            (id, source, blocks, created_at, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            source = excluded.source, blocks = excluded.blocks,
+            created_at = excluded.created_at, updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          session.id, session.source, try Self.encodeBlocks(session.blocks),
+          session.createdAt, session.updatedAt, session.deletedAt,
+        ])
+    }
+  }
+
+  func savePlayThrough(_ record: PlayThroughRecord) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO play_through
+            (id, item_id, started_at, ended_at, counted, sections, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            item_id = excluded.item_id, started_at = excluded.started_at,
+            ended_at = excluded.ended_at, counted = excluded.counted,
+            sections = excluded.sections, updated_at = excluded.updated_at,
+            deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          record.id, record.itemId, record.startedAt, record.endedAt, record.counted,
+          try Self.encodeSections(record.sections), record.updatedAt, record.deletedAt,
+        ])
+    }
+  }
+
+  func saveReflection(_ reflection: Reflection) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO reflection
+            (id, kind, session_ref, transcript, audio_path, duration_s, at, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            kind = excluded.kind, session_ref = excluded.session_ref,
+            transcript = excluded.transcript, audio_path = excluded.audio_path,
+            duration_s = excluded.duration_s, at = excluded.at,
+            updated_at = excluded.updated_at, deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          reflection.id, Self.reflectionKindString(reflection.kind), reflection.sessionRef,
+          reflection.transcript, reflection.audioPath, reflection.durationS.map { Int($0) },
+          reflection.at, reflection.updatedAt, reflection.deletedAt,
+        ])
+    }
+  }
+
+  func saveFeelEntry(_ entry: FeelEntry) throws {
+    try dbQueue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO feel_entry
+            (id, block_id, feel, at, updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            block_id = excluded.block_id, feel = excluded.feel, at = excluded.at,
+            updated_at = excluded.updated_at, deleted_at = excluded.deleted_at
+          """,
+        arguments: [
+          entry.id, entry.blockId, Self.feelString(entry.feel), entry.at,
+          entry.updatedAt, entry.deletedAt,
+        ])
+    }
+  }
+
+  func loadBuiltSessionData() throws -> BuiltSessionData {
+    try dbQueue.read { db in
+      BuiltSessionData(
+        userDrills: try Row.fetchAll(
+          db, sql: "SELECT * FROM user_drill WHERE deleted_at IS NULL ORDER BY created_at, id"
+        ).map(Self.userDrill(from:)),
+        journalItems: try Row.fetchAll(
+          db, sql: "SELECT * FROM journal_item WHERE deleted_at IS NULL ORDER BY created_at, id"
+        ).map(Self.journalItem(from:)),
+        builtSessions: try Row.fetchAll(
+          db, sql: "SELECT * FROM built_session WHERE deleted_at IS NULL ORDER BY created_at, id"
+        ).map(Self.builtSession(from:)),
+        playThroughs: try Row.fetchAll(
+          db, sql: "SELECT * FROM play_through WHERE deleted_at IS NULL ORDER BY started_at, id"
+        ).map(Self.playThrough(from:)),
+        reflections: try Row.fetchAll(
+          db, sql: "SELECT * FROM reflection WHERE deleted_at IS NULL ORDER BY at, id"
+        ).map(Self.reflection(from:)),
+        feelEntries: try Row.fetchAll(
+          db, sql: "SELECT * FROM feel_entry WHERE deleted_at IS NULL ORDER BY at, id"
+        ).map(Self.feelEntry(from:)))
+    }
+  }
+
+  // ── Row ↔ built-session codecs ───────────────────────────────────────
+
+  private struct StoredBuiltBlock: Codable {
+    var id: String
+    var targetKind: String
+    var targetValue: String
+    var minutes: UInt16?
+  }
+
+  private struct StoredSectionVerdict: Codable {
+    var section: String
+    var held: Bool
+    var at: String
+  }
+
+  private static func userDrill(from row: Row) throws -> UserDrill {
+    UserDrill(
+      id: row["id"], name: row["name"], criterion: row["criterion"],
+      tempoBpm: (row["tempo_bpm"] as Int?).map { UInt16(clamping: $0) },
+      keys: try decodeKeys(row["keys"]),
+      passesToOpen: UInt8(clamping: row["passes_to_open"] as Int),
+      serves: serves(kind: row["serves_kind"], value: row["serves_value"]),
+      createdAt: row["created_at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func decodeKeys(_ json: String) throws -> [String] {
+    do { return try JSONDecoder().decode([String].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "keys", phase: "decode")
+    }
+  }
+
+  private static func journalItem(from row: Row) -> JournalItem {
+    JournalItem(
+      id: row["id"], name: row["name"], notes: row["notes"],
+      linkedItemId: row["linked_item_id"],
+      createdAt: row["created_at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func builtSession(from row: Row) throws -> BuiltSession {
+    BuiltSession(
+      id: row["id"], source: row["source"], blocks: try decodeBlocks(row["blocks"]),
+      createdAt: row["created_at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func playThrough(from row: Row) throws -> PlayThroughRecord {
+    PlayThroughRecord(
+      id: row["id"], itemId: row["item_id"],
+      startedAt: row["started_at"], endedAt: row["ended_at"], counted: row["counted"],
+      sections: try decodeSections(row["sections"]),
+      updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func reflection(from row: Row) -> Reflection {
+    Reflection(
+      id: row["id"], kind: reflectionKind(from: row["kind"]), sessionRef: row["session_ref"],
+      transcript: row["transcript"], audioPath: row["audio_path"],
+      durationS: (row["duration_s"] as Int?).map { UInt32(clamping: $0) },
+      at: row["at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func feelEntry(from row: Row) -> FeelEntry {
+    FeelEntry(
+      id: row["id"], blockId: row["block_id"], feel: feel(from: row["feel"]),
+      at: row["at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+  }
+
+  private static func encodeBlocks(_ blocks: [BuiltBlock]) throws -> String {
+    try encodeJSON(
+      blocks.map { block in
+        StoredBuiltBlock(
+          id: block.id, targetKind: targetKind(block.target),
+          targetValue: targetValue(block.target), minutes: block.minutes)
+      }, field: "blocks")
+  }
+
+  /// Throws on a broken blob (a lost block is invariant-5 territory); an
+  /// unrecognised target kind reports and drops that block only (#949) —
+  /// the rest of the composition stays readable.
+  private static func decodeBlocks(_ json: String) throws -> [BuiltBlock] {
+    let stored: [StoredBuiltBlock]
+    do { stored = try JSONDecoder().decode([StoredBuiltBlock].self, from: Data(json.utf8)) } catch {
+      throw CoachCodecError(field: "blocks", phase: "decode")
+    }
+    return stored.compactMap { block in
+      guard let target = target(kind: block.targetKind, value: block.targetValue) else {
+        return nil
+      }
+      return BuiltBlock(id: block.id, target: target, minutes: block.minutes)
+    }
+  }
+
+  private static func encodeSections(_ sections: [SectionVerdict]) throws -> String {
+    try encodeJSON(
+      sections.map { StoredSectionVerdict(section: $0.section, held: $0.held, at: $0.at) },
+      field: "sections")
+  }
+
+  private static func decodeSections(_ json: String) throws -> [SectionVerdict] {
+    let stored: [StoredSectionVerdict]
+    do {
+      stored = try JSONDecoder().decode([StoredSectionVerdict].self, from: Data(json.utf8))
+    } catch {
+      throw CoachCodecError(field: "sections", phase: "decode")
+    }
+    return stored.map { SectionVerdict(section: $0.section, held: $0.held, at: $0.at) }
+  }
+
+  private static func targetKind(_ target: BuiltTarget) -> String {
+    switch target {
+    case .node: "node"
+    case .userDrill: "user_drill"
+    case .journal: "journal"
+    case .piece: "piece"
+    }
+  }
+
+  private static func targetValue(_ target: BuiltTarget) -> String {
+    switch target {
+    case .node(let node): node
+    case .userDrill(let drillId): drillId
+    case .journal(let journalId): journalId
+    case .piece(let itemId): itemId
+    }
+  }
+
+  private static func target(kind: String, value: String) -> BuiltTarget? {
+    switch kind {
+    case "node": return .node(node: value)
+    case "user_drill": return .userDrill(drillId: value)
+    case "journal": return .journal(journalId: value)
+    case "piece": return .piece(itemId: value)
+    default:
+      report(UnknownStoredEnum(kind: "BuiltTarget", raw: kind), decodeContext)
+      return nil
+    }
+  }
+
+  private static func servesKind(_ serves: Serves?) -> String? {
+    switch serves {
+    case .circle: "circle"
+    case .node: "node"
+    case nil: nil
+    }
+  }
+
+  private static func servesValue(_ serves: Serves?) -> String? {
+    switch serves {
+    case .circle(let circle): circleString(circle)
+    case .node(let node): node
+    case nil: nil
+    }
+  }
+
+  private static func serves(kind: String?, value: String?) -> Serves? {
+    switch (kind, value) {
+    case (nil, _), (_, nil): return nil
+    case ("circle", .some(let value)): return .circle(circle(from: value))
+    case ("node", .some(let value)): return .node(value)
+    case (.some(let other), _):
+      report(UnknownStoredEnum(kind: "Serves", raw: other), decodeContext)
+      return nil
+    }
+  }
+
+  private static func reflectionKindString(_ kind: ReflectionKind) -> String {
+    switch kind {
+    case .voiceNote: "voice_note"
+    case .sessionClose: "session_close"
+    }
+  }
+
+  private static func reflectionKind(from raw: String) -> ReflectionKind {
+    switch raw {
+    case "voice_note": return .voiceNote
+    case "session_close": return .sessionClose
+    default:
+      report(UnknownStoredEnum(kind: "ReflectionKind", raw: raw), decodeContext)
+      return .voiceNote
+    }
+  }
+
+  private static func feelString(_ feel: Feel) -> String {
+    switch feel {
+    case .foughtIt: "fought_it"
+    case .gettingThere: "getting_there"
+    case .itSang: "it_sang"
+    }
+  }
+
+  private static func feel(from raw: String) -> Feel {
+    switch raw {
+    case "fought_it": return .foughtIt
+    case "getting_there": return .gettingThere
+    case "it_sang": return .itSang
+    default:
+      report(UnknownStoredEnum(kind: "Feel", raw: raw), decodeContext)
+      return .gettingThere  // conservative: the neutral middle, never the success tint
     }
   }
 

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -184,6 +184,26 @@ final class Store {
         try store.saveCoachRecords(blocks: blocks, wanders: wanders, updatedAt: updatedAt)
         return .ack
       case .loadCoachRecords: return .coachRecords(try store.loadCoachRecords())
+      case .saveUserDrill(let drill):
+        try store.saveUserDrill(drill)
+        return .ack
+      case .saveJournalItem(let journal):
+        try store.saveJournalItem(journal)
+        return .ack
+      case .saveBuiltSession(let session):
+        try store.saveBuiltSession(session)
+        return .ack
+      case .savePlayThrough(let record):
+        try store.savePlayThrough(record)
+        return .ack
+      case .saveReflection(let reflection):
+        try store.saveReflection(reflection)
+        return .ack
+      case .saveFeelEntry(let entry):
+        try store.saveFeelEntry(entry)
+        return .ack
+      case .loadBuiltSessionData:
+        return .builtSessionData(try store.loadBuiltSessionData())
       }
     } catch {
       report(error, "persistence")

--- a/ios/IntradaTests/BuiltSessionStoreTests.swift
+++ b/ios/IntradaTests/BuiltSessionStoreTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SharedTypes
+import Testing
+
+@testable import Intrada
+
+/// Row↔type codecs for the built-session entities (#1256 Phase A). Every
+/// entity must survive save → loadBuiltSessionData unchanged, tombstones
+/// must stay out of loads, and saves must upsert by id.
+struct BuiltSessionStoreTests {
+  private func sampleDrill(id: String = "01USERDRILL0000000000000001") -> UserDrill {
+    UserDrill(
+      id: id, name: "Descending run", criterion: "Three clean passes at 72",
+      tempoBpm: 72, keys: ["F", "Bb"], passesToOpen: 3,
+      serves: .node("alice-bridge"),
+      createdAt: "2026-08-07T10:00:00Z", updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
+  }
+
+  @Test func userDrillRoundTrips() throws {
+    let store = try LibraryStore.inMemory()
+    let drill = sampleDrill()
+    try store.saveUserDrill(drill)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.userDrills == [drill])
+  }
+
+  @Test func userDrillServesCircleRoundTrips() throws {
+    let store = try LibraryStore.inMemory()
+    var drill = sampleDrill()
+    drill.serves = .circle(.hands)
+    try store.saveUserDrill(drill)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.userDrills.first?.serves == .circle(.hands))
+  }
+
+  @Test func userDrillUpsertsById() throws {
+    let store = try LibraryStore.inMemory()
+    try store.saveUserDrill(sampleDrill())
+    var edited = sampleDrill()
+    edited.criterion = "Five clean passes"
+    edited.updatedAt = "2026-08-07T11:00:00Z"
+    try store.saveUserDrill(edited)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.userDrills == [edited])
+  }
+
+  @Test func tombstonedUserDrillStaysOutOfLoads() throws {
+    let store = try LibraryStore.inMemory()
+    var drill = sampleDrill()
+    drill.deletedAt = "2026-08-07T11:00:00Z"
+    try store.saveUserDrill(drill)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.userDrills.isEmpty)
+  }
+
+  @Test func journalItemRoundTrips() throws {
+    let store = try LibraryStore.inMemory()
+    let journal = JournalItem(
+      id: "01JOURNAL000000000000000001", name: "Rubato feel",
+      notes: "Time and notes", linkedItemId: "01PIECE0000000000000000001",
+      createdAt: "2026-08-07T10:00:00Z", updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
+    try store.saveJournalItem(journal)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.journalItems == [journal])
+  }
+
+  @Test func builtSessionRoundTripsWithEveryTargetKind() throws {
+    let store = try LibraryStore.inMemory()
+    let session = BuiltSession(
+      id: "01BUILT0000000000000000001", source: "From Friday's lesson",
+      blocks: [
+        BuiltBlock(id: "b1", target: .node(node: "shell-voicings"), minutes: 5),
+        BuiltBlock(id: "b2", target: .userDrill(drillId: "d1"), minutes: nil),
+        BuiltBlock(id: "b3", target: .journal(journalId: "j1"), minutes: 8),
+        BuiltBlock(id: "b4", target: .piece(itemId: "p1"), minutes: 10),
+      ],
+      createdAt: "2026-08-07T10:00:00Z", updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
+    try store.saveBuiltSession(session)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.builtSessions == [session])
+  }
+
+  @Test func playThroughRoundTripsWithSections() throws {
+    let store = try LibraryStore.inMemory()
+    let record = PlayThroughRecord(
+      id: "01PLAY00000000000000000001", itemId: "p1",
+      startedAt: "2026-08-07T10:00:00Z", endedAt: "2026-08-07T10:04:00Z",
+      counted: true,
+      sections: [
+        SectionVerdict(section: "The bridge, from memory", held: true, at: "2026-08-07T10:01:00Z"),
+        SectionVerdict(section: "Out head", held: false, at: "2026-08-07T10:03:00Z"),
+      ],
+      updatedAt: "2026-08-07T10:04:00Z", deletedAt: nil)
+    try store.savePlayThrough(record)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.playThroughs == [record])
+  }
+
+  @Test func reflectionRoundTripsForBothKinds() throws {
+    let store = try LibraryStore.inMemory()
+    let kinds: [(String, ReflectionKind)] = [("r1", .voiceNote), ("r2", .sessionClose)]
+    for (id, kind) in kinds {
+      try store.saveReflection(
+        Reflection(
+          id: id, kind: kind, sessionRef: "01BUILT0000000000000000001",
+          transcript: "The bridge still rushes", audioPath: "reflections/\(id).m4a",
+          durationS: 24, at: "2026-08-07T10:30:00Z",
+          updatedAt: "2026-08-07T10:30:00Z", deletedAt: nil))
+    }
+    let data = try store.loadBuiltSessionData()
+    #expect(data.reflections.count == 2)
+    #expect(data.reflections.map(\.kind) == [.voiceNote, .sessionClose])
+  }
+
+  @Test func feelEntryRoundTripsForEveryFeel() throws {
+    let store = try LibraryStore.inMemory()
+    let feels: [(String, Feel)] = [("f1", .foughtIt), ("f2", .gettingThere), ("f3", .itSang)]
+    for (id, feel) in feels {
+      try store.saveFeelEntry(
+        FeelEntry(
+          id: id, blockId: "b1", feel: feel, at: "2026-08-07T10:15:00Z",
+          updatedAt: "2026-08-07T10:15:00Z", deletedAt: nil))
+    }
+    let data = try store.loadBuiltSessionData()
+    #expect(data.feelEntries.map(\.feel) == [.foughtIt, .gettingThere, .itSang])
+  }
+}

--- a/ios/IntradaTests/LibraryStoreMigrationTests.swift
+++ b/ios/IntradaTests/LibraryStoreMigrationTests.swift
@@ -257,6 +257,49 @@ final class LibraryStoreMigrationTests: XCTestCase {
       "chord_chart must round-trip through JSON storage intact")
   }
 
+  func testV11BuiltSessionTablesArriveWithV10DataIntact() throws {
+    let queue = try DatabaseQueue()  // in-memory
+
+    // A device that stopped at v10, with real rows in the tables that exist there.
+    try LibraryStore.migrator.migrate(queue, upTo: "v10_coach_records")
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO item (id, title, kind, tags, created_at, updated_at)
+          VALUES ('i1', 'Alice in Wonderland', 'piece', '[]',
+                  '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+          """)
+      try db.execute(
+        sql: """
+          INSERT INTO block_record (id, node, drill, gate, level_tempo_bpm, level_click_level,
+            circle, mode, started_at, ended_at, attempts, reps_after_gate, active_ms,
+            escalation_fired, exit, updated_at)
+          VALUES ('b1', 'n', 'd', 'g', 72, 'every_beat', 'hands', 'keys',
+                  '2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', '[]', 0, 60000, '[]',
+                  'gate_passed', '2026-01-01T00:01:00Z')
+          """)
+    }
+
+    // The remaining chain must run cleanly from v10.
+    try LibraryStore.migrator.migrate(queue)
+
+    try queue.read { db in
+      XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM item"), 1)
+      XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM block_record"), 1)
+      for table in [
+        "user_drill", "journal_item", "built_session", "play_through", "reflection", "feel_entry",
+      ] {
+        XCTAssertTrue(try db.tableExists(table), "\(table) must exist after v11")
+        XCTAssertEqual(
+          try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), 0,
+          "\(table) starts empty on upgrade")
+        let columns = try db.columns(in: table).map(\.name)
+        XCTAssertTrue(columns.contains("updated_at"), "\(table) is sync-ready (invariant 2)")
+        XCTAssertTrue(columns.contains("deleted_at"), "\(table) carries a tombstone (invariant 2)")
+      }
+    }
+  }
+
   func testV6LinkedExerciseIdsRoundTrip() throws {
     let store = try LibraryStore.inMemory()
     let item = Item(

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -702,7 +702,12 @@ final class StoreEffectLoopTests: XCTestCase {
           serves: .circle(.hands), createdAt: "2026-08-07T10:00:00Z",
           updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
       ],
-      journalItems: [],
+      journalItems: [
+        JournalItem(
+          id: "01JOURNAL000000000000000001", name: "Rubato feel", notes: "Time and notes",
+          linkedItemId: "p1", createdAt: "2026-08-07T10:00:00Z",
+          updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
+      ],
       builtSessions: [],
       playThroughs: [
         PlayThroughRecord(
@@ -717,6 +722,46 @@ final class StoreEffectLoopTests: XCTestCase {
     _ = try bridge.resolve(load.id, persistenceOutput: .builtSessionData(data))
     let view = try bridge.view()
     XCTAssertNil(view.error, "hydration must not surface an error")
+  }
+
+  /// Real-bridge journal + play-through writes (#846, #1256): the two write
+  /// legs the other bridge tests don't reach. `CreateJournalItem` carries two
+  /// optional Strings; `RecordPlayThrough` carries a nested struct array.
+  func testRealBridgeJournalAndPlayThroughWritesDecodeOnWire() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+
+    let journalRequests = try bridge.update(
+      .builtSession(
+        .createJournalItem(
+          CreateJournalItem(name: "Rubato feel", notes: nil, linkedItemId: "p1"))))
+    let journal = try XCTUnwrap(
+      journalRequests.compactMap { request -> JournalItem? in
+        if case .persistence(.saveJournalItem(let journal)) = request.effect { return journal }
+        return nil
+      }.first, "CreateJournalItem must emit a SaveJournalItem persistence op")
+    XCTAssertEqual(journal.id.count, 26, "core-minted ulid")
+    XCTAssertNil(journal.notes, "an absent optional stays absent across the wire")
+    XCTAssertEqual(journal.linkedItemId, "p1")
+
+    let playRequests = try bridge.update(
+      .builtSession(
+        .recordPlayThrough(
+          RecordPlayThrough(
+            itemId: "p1", startedAt: "2026-08-07T10:00:00Z", endedAt: "2026-08-07T10:04:00Z",
+            counted: false,
+            sections: [
+              SectionVerdict(section: "The bridge", held: true, at: "2026-08-07T10:01:00Z"),
+              SectionVerdict(section: "Out head", held: false, at: "2026-08-07T10:03:00Z"),
+            ]))))
+    let record = try XCTUnwrap(
+      playRequests.compactMap { request -> PlayThroughRecord? in
+        if case .persistence(.savePlayThrough(let record)) = request.effect { return record }
+        return nil
+      }.first, "RecordPlayThrough must emit a SavePlayThrough persistence op")
+    XCTAssertEqual(record.id.count, 26, "core-minted ulid")
+    XCTAssertEqual(record.counted, false)
+    XCTAssertEqual(record.sections.map(\.held), [true, false], "verdict order survives the wire")
   }
 
   /// Real-bridge rung tag (#846, #1083): `SetEntryVariant` carries an optional

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -595,6 +595,130 @@ final class StoreEffectLoopTests: XCTestCase {
       "current step is the first not-yet-solid step")
   }
 
+  /// Real-bridge built-session write (#846, #1256): `CreateUserDrill` crosses
+  /// the wire, the core mints the entity, and the matching `SaveUserDrill`
+  /// operation comes back across the same wire. A stub bridge can't catch a
+  /// bincode break on either leg.
+  func testRealBridgeCreateUserDrillEmitsMatchingSaveOp() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let requests = try bridge.update(
+      .builtSession(
+        .createUserDrill(
+          CreateUserDrill(
+            name: "Descending run", criterion: "Three clean passes at 72",
+            tempoBpm: 72, keys: ["F"], passesToOpen: 3, serves: .node("alice-bridge")))))
+
+    let drill = try XCTUnwrap(
+      requests.compactMap { request -> UserDrill? in
+        if case .persistence(.saveUserDrill(let drill)) = request.effect { return drill }
+        return nil
+      }.first, "CreateUserDrill must emit a SaveUserDrill persistence op")
+    XCTAssertEqual(drill.id.count, 26, "core-minted ulid")
+    XCTAssertEqual(drill.criterion, "Three clean passes at 72")
+    XCTAssertEqual(drill.tempoBpm, 72)
+    XCTAssertEqual(drill.serves, .node("alice-bridge"))
+    XCTAssertNil(drill.deletedAt)
+  }
+
+  /// Real-bridge built-session composition (#846, #1256): every `BuiltTarget`
+  /// kind rides one `BuiltSession` across the wire and back out in the
+  /// `SaveBuiltSession` op — the enum-variant shape a stub can't exercise.
+  func testRealBridgeSaveBuiltSessionRoundTripsEveryTargetKind() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let blocks = [
+      BuiltBlock(id: "b1", target: .node(node: "shell-voicings"), minutes: 5),
+      BuiltBlock(id: "b2", target: .userDrill(drillId: "d1"), minutes: nil),
+      BuiltBlock(id: "b3", target: .journal(journalId: "j1"), minutes: 8),
+      BuiltBlock(id: "b4", target: .piece(itemId: "p1"), minutes: 10),
+    ]
+    let requests = try bridge.update(
+      .builtSession(
+        .saveBuiltSession(
+          session: BuiltSession(
+            id: "01BUILT0000000000000000001", source: "From Friday's lesson", blocks: blocks,
+            createdAt: "2026-08-07T10:00:00Z", updatedAt: "2026-08-07T10:00:00Z",
+            deletedAt: nil))))
+
+    let saved = try XCTUnwrap(
+      requests.compactMap { request -> BuiltSession? in
+        if case .persistence(.saveBuiltSession(let session)) = request.effect { return session }
+        return nil
+      }.first, "SaveBuiltSession must emit its persistence op")
+    XCTAssertEqual(saved.blocks, blocks, "all four target kinds survive the wire")
+    XCTAssertEqual(saved.source, "From Friday's lesson")
+  }
+
+  /// Real-bridge reflection + feel (#846, #1256): `RecordReflection` carries
+  /// three optional Strings (the absent-vs-present hazard) and `RecordFeel` a
+  /// fieldless enum; both must decode on the wire and emit their ops.
+  func testRealBridgeReflectionAndFeelDecodeOnWire() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let reflectionRequests = try bridge.update(
+      .builtSession(
+        .recordReflection(
+          kind: .sessionClose, sessionRef: nil,
+          transcript: "The bridge still rushes", audioPath: nil, durationS: 24)))
+    let reflection = try XCTUnwrap(
+      reflectionRequests.compactMap { request -> Reflection? in
+        if case .persistence(.saveReflection(let reflection)) = request.effect {
+          return reflection
+        }
+        return nil
+      }.first)
+    XCTAssertEqual(reflection.transcript, "The bridge still rushes")
+    XCTAssertNil(reflection.audioPath)
+
+    let feelRequests = try bridge.update(
+      .builtSession(.recordFeel(blockId: "b1", feel: .itSang)))
+    let entry = try XCTUnwrap(
+      feelRequests.compactMap { request -> FeelEntry? in
+        if case .persistence(.saveFeelEntry(let entry)) = request.effect { return entry }
+        return nil
+      }.first)
+    XCTAssertEqual(entry.feel, .itSang)
+  }
+
+  /// Real-bridge hydration (#846, #1256): the launch `LoadBuiltSessionData`
+  /// request resolves with a fully-populated `BuiltSessionData` — the read
+  /// leg of the wire, which must decode in Rust without error.
+  func testRealBridgeLoadBuiltSessionDataResolvesPopulatedPayload() throws {
+    let bridge = LiveBridge()
+    let requests = try bridge.update(
+      .startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let load = try XCTUnwrap(
+      requests.first { request in
+        if case .persistence(.loadBuiltSessionData) = request.effect { return true }
+        return false
+      }, "local-first launch must hydrate the built-session store")
+
+    let data = BuiltSessionData(
+      userDrills: [
+        UserDrill(
+          id: "01USERDRILL0000000000000001", name: "Descending run",
+          criterion: "Three clean passes", tempoBpm: nil, keys: [], passesToOpen: 3,
+          serves: .circle(.hands), createdAt: "2026-08-07T10:00:00Z",
+          updatedAt: "2026-08-07T10:00:00Z", deletedAt: nil)
+      ],
+      journalItems: [],
+      builtSessions: [],
+      playThroughs: [
+        PlayThroughRecord(
+          id: "01PLAY00000000000000000001", itemId: "p1",
+          startedAt: "2026-08-07T10:00:00Z", endedAt: "2026-08-07T10:04:00Z", counted: false,
+          sections: [SectionVerdict(section: "The bridge", held: true, at: "2026-08-07T10:01:00Z")],
+          updatedAt: "2026-08-07T10:04:00Z", deletedAt: nil)
+      ],
+      reflections: [],
+      feelEntries: [])
+    // A wire break on the read leg throws here rather than landing data.
+    _ = try bridge.resolve(load.id, persistenceOutput: .builtSessionData(data))
+    let view = try bridge.view()
+    XCTAssertNil(view.error, "hydration must not surface an error")
+  }
+
   /// Real-bridge rung tag (#846, #1083): `SetEntryVariant` carries an optional
   /// String across the bincode wire (the absent-vs-present hazard). Drive it
   /// through the live bridge and assert it decodes without error.
@@ -1360,6 +1484,13 @@ private struct FailingStore: ItemStore {
     throw TestError()
   }
   func loadCoachRecords() throws -> [BlockRecord] { throw TestError() }
+  func saveUserDrill(_ drill: UserDrill) throws { throw TestError() }
+  func saveJournalItem(_ journal: JournalItem) throws { throw TestError() }
+  func saveBuiltSession(_ session: BuiltSession) throws { throw TestError() }
+  func savePlayThrough(_ record: PlayThroughRecord) throws { throw TestError() }
+  func saveReflection(_ reflection: Reflection) throws { throw TestError() }
+  func saveFeelEntry(_ entry: FeelEntry) throws { throw TestError() }
+  func loadBuiltSessionData() throws -> BuiltSessionData { throw TestError() }
 }
 
 final class MockURLProtocol: URLProtocol {

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -1,0 +1,127 @@
+# Built session, play-through altitudes, and qualitative capture
+
+**Status**: Phase A in progress · **Issue**: #1256 · **Tier**: 3
+**Design**: `specs/built-session/design/` (Built Session A/B/C mockups) ·
+briefs in `design/briefs/2026-08-built-session-journeys.md` (journeys) and
+`design/briefs/2026-08-copy-language.md` (voice, graduated as T13)
+
+## Problem
+
+The old `SessionBuilderScreen` (hand-assembled setlists, 1–5 self-ratings) was
+deleted in #1255 (close-out of #1190). Its replacement is decision 19's
+**built session**: the user composes today's blocks from their own items, each
+block keeps a gate, and evidence lands in the mastery model exactly as a
+prescribed block's does. Alongside it sit decision 16's two lower altitudes
+(off-piste, unmonitored play) and decision 17's qualitative capture. None of
+this exists yet; the journeys are designed and judged right (Built Session
+A/B/C, 2026-08-07).
+
+## The three journeys (what ships)
+
+**A — compose from a lesson.** A steer line under the untouched Practice hero
+("I know what I want to practise today") opens a sheet, not a mode (decision
+11). Each new item resolves one of three ways (decision 19):
+
+- (a) **matches an authored node** — proposal + one-tap confirm; "No, it's
+  different" falls through to (b) with the name pre-filled.
+- (b) **countable, no node → user drill** — one dictated/typed sentence is the
+  criterion; tempo, key and passes parse into read-back chips, not empty
+  fields. Low-band prior, cold-testable, own mastery, optional *serves* tag.
+- (c) **genuinely unmeasurable → journal item** — opaque target on the
+  judgement track; time and notes, kept with the piece.
+
+Resolution is paid once per item, ever: repeat visits are add-add-add-build.
+The composed session reuses the press-start scaffold; template shape (warm-up
+first, music at the ends) is a one-line declinable suggestion. Start enters
+the existing drill loop; a user drill's boundary card shows GateDots filling
+from tap-verdicts and the serves line.
+
+**B — play-through, three altitudes.** From a piece, the B0 sheet asks "Play
+it through — how should it count?" (headline settled, Jon 2026-08-07 on
+#1256): **run-through** (section-by-section gated run, "Held / Broke down",
+one tap each), **off-piste** (time logged + a 96pt "Found something? Say it"
+mic; exit offers "Keep this as a drill?" routing into A's form with the
+transcript as draft criterion), **just play** (minutes only, silent middle, no
+exit prompt ever). The AltitudeChip stays visible in the orientation strip for
+the whole run; absence of instrumentation is the consent signal.
+
+**C — qualitative capture.** At most one feel moment per block ("Fought it /
+Getting there / It sang"), only where feel is the point, skipped entirely
+after two misses in a block (the budget shrinks on a bad day). Voice-first
+reflection at session close (audio kept, transcription opportunistic). A kept
+reflection can resurface next morning as a proposed steer: quote back, one
+concrete offer, accept inserts one block marked "you added this" (decision 12:
+propose, confirm, never plan).
+
+## Approach
+
+Core owns everything (Crux, local-first, offline-first invariants apply in
+full). New domain surface, sketched for Phase A:
+
+- **Entities** (GRDB, client ulids, `updated_at`/`deleted_at`): `UserDrill`
+  (criterion text, parsed gate params, serves tag, low-band mastery state),
+  `JournalItem`, `BuiltSession` (ordered blocks + provenance), `PlayThrough`
+  (altitude, per-section verdicts for run-throughs, elapsed for the others),
+  `Reflection` / feel entries (judgement track: never feed mastery, may retire
+  a target, decision 17).
+- **Events/Effects**: compose/resolve/reorder events; existing drill-loop
+  events reused unchanged for gated blocks; a new audio-capture `AppEffect`
+  for voice notes (record + opportunistic transcription in the shell as a dumb
+  pipe; the core stores the marker, path and transcript).
+- **Evidence**: a user drill's tap-verdicts land at full weight on its own
+  node; a run-through's section verdicts land on the pipeline stage; per the
+  #1244 ruling, the tap bounds the attempt at l0 (`TapVerdictUntimed`, lower
+  weight, already covers the looser bound). Off-piste and unmonitored produce
+  time entries only, with zero inference (decision 16).
+- **Resolution matching (a)**: v1 matches typed/dictated names against library
+  and node names in core (normalised text match); LLM-proposed matching and
+  the C3 morning proposal's LLM narration are Phase 3 of the coach roadmap;
+  C3 ships rule-based (most recent kept reflection with a named target) or not
+  at all in v1. The criterion-sentence parsing (tempo/keys/passes) is a small
+  core parser over dictated text, not an LLM call.
+- **Voice/copy**: every screen is written against T13. Engine vocabulary never
+  appears on screen; in-session prose ≤ 8 words beyond labels.
+
+### New design-system components (promoted with the screen that ships them)
+
+`AltitudeChip` (always visible while playing), `FeelChips` (one-per-block rule
+in its DS entry), `ReflectionCard` + proposed-steer card, journal kind badge
+(third kind beside piece/exercise), read-back chips (A4), the inline
+shape-advice card (CoachNote-weight, two inline choices), GateDots at section
+granularity (one-line DS note). Each lands in `Theme.swift` + the design
+system together; no hand-rolled clones.
+
+### Phasing
+
+- **A (this branch)**: spec + design assets + core scaffold: entity types,
+  events, model fields, migrations, bridge round-trip tests for every new
+  payload (build precondition, #846), no UI.
+- **B**: Journey A end-to-end (steer line, sheet, resolution, composed
+  session, drill-loop integration, evidence landing).
+- **C**: Journey B (B0 sheet, run-through with section gates, off-piste,
+  unmonitored; AltitudeChip).
+- **D**: Journey C (feel moments, reflection at close, morning proposal).
+
+Each phase is its own PR; every screen ships with snapshots, VoiceOver labels,
+Dynamic Type and iPad SplitView per the per-screen quality rule.
+
+## Key decisions (settled; do not reopen)
+
+1. Never a mode (11): composition is a steer reached from the hero; altitudes
+   are reached from the piece.
+2. Three-way resolution (19), template shape is advice, resolution paid once.
+3. Qualitative data never feeds mastery (17); measurement budget: one tap per
+   rep, ≤ 1 feel per block, budget shrinks on a bad day.
+4. Tap bounds the l0 attempt (#1244 ruling); B0 headline stays "how should it
+   count?" (#1256 comment; record in the design file when next open).
+5. Voice is T13; serif is reserved for the user's own words.
+
+## Open questions
+
+1. How much pipeline does v1 need? B1's note argues: a piece + named section
+   gates only, degrading gracefully to off-piste + piece tag when sections
+   aren't authored. Resolve when Phase C is planned.
+2. Audio storage/retention for voice notes and reflections (files on device,
+   rows carry paths; size cap? cleanup?). Resolve in Phase A schema review.
+3. C3's v1 trigger (rule-based vs deferred to coach Phase 3): decide at
+   Phase D, informed by what reflections actually look like by then.

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -1,6 +1,6 @@
 # Built session, play-through altitudes, and qualitative capture
 
-**Status**: Phase A in progress · **Issue**: #1256 · **Tier**: 3
+**Status**: Phase A landed (core scaffold, no UI) · **Issue**: #1256 · **Tier**: 3
 **Design**: `specs/built-session/design/` (Built Session A/B/C mockups) ·
 briefs in `design/briefs/2026-08-built-session-journeys.md` (journeys) and
 `design/briefs/2026-08-copy-language.md` (voice, graduated as T13)
@@ -121,7 +121,11 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
 1. How much pipeline does v1 need? B1's note argues: a piece + named section
    gates only, degrading gracefully to off-piste + piece tag when sections
    aren't authored. Resolve when Phase C is planned.
-2. Audio storage/retention for voice notes and reflections (files on device,
-   rows carry paths; size cap? cleanup?). Resolve in Phase A schema review.
+2. ~~Audio storage/retention for voice notes and reflections.~~ **Settled in
+   the Phase A schema review**: `reflection` carries `audio_path` (a
+   shell-relative path) and `duration_s`; the bytes are the shell's, the core
+   never reads them, and a tombstoned row leaves its file for the shell to
+   reap. A size cap and the reaping pass are deferred to Phase D, when there
+   is recorded audio to cap (#1267).
 3. C3's v1 trigger (rule-based vs deferred to coach Phase 3): decide at
    Phase D, informed by what reflections actually look like by then.

--- a/specs/built-session/design/Built Session A - Compose From a Lesson.dc.html
+++ b/specs/built-session/design/Built Session A - Compose From a Lesson.dc.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  a { color: #4C3FA6; text-decoration: none; }
+  a:hover { color: #6346E5; text-decoration: underline; }
+  ::selection { background: #4C3FA633; }
+  [data-lucide] { stroke-width: 2; }
+  @keyframes fadeUp { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div style="min-height:100vh;background:linear-gradient(180deg,#F4F1E8 0%,#EBE7D9 100%);font-family:'Inter',system-ui,sans-serif;color:#2B2A26;padding:56px 48px 160px;">
+<template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#FBFAF3"/><g fill="none" stroke="#4C3FA6" stroke-width="5" stroke-linecap="round"><path d="M30 34h40M30 50h40M30 66h24"/><circle cx="72" cy="66" r="8" fill="#4C3FA6" stroke="none"/></g></svg></template>
+<div style="max-width:1340px;margin:0 auto;">
+
+  <section id="intro">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Feature design · built session · brief 2026-08</div>
+    <h1 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:56px;line-height:1.04;letter-spacing:-0.02em;margin:14px 0 0;">Journey A — compose from a lesson</h1>
+    <p style="font-size:16px;line-height:1.68;color:#6E6557;max-width:680px;margin:18px 0 0;">A lesson hands over a piece and three exercises; the user wants to practise exactly those today, and everything still counts. Decision 11 — <strong style="color:#2B2A26;font-weight:600;">never a mode</strong>: the app opens prescribed, hero intact, and composing is reached for. Decision 19 — each new item gets one <strong style="color:#2B2A26;font-weight:600;">resolution</strong>: authored-node match, user node, or opaque target. Worked example: <em>Alice in Wonderland</em> plus Hanon №4, a stride pattern, and rubato work.</p>
+    <p style="font-size:14px;line-height:1.68;color:#6E6557;max-width:680px;margin:12px 0 0;">Assembled from <strong style="color:#2B2A26;font-weight:600;">Design System · Coach primitives</strong> (PressStartHero, PlanBlockRow, BlockEntryCard, GateDots, CoachAction, CoachNote). The play loop between A6 and A7 is <em>not redrawn</em> — see <strong style="color:#2B2A26;font-weight:600;">Drill Loop.dc.html</strong>.</p>
+  </section>
+
+  <section style="margin-top:72px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">The frames</div>
+    <div style="display:flex;gap:44px;flex-wrap:wrap;margin-top:30px;">
+
+      <!-- A1 · Practice, hero intact, reachable composition -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A1 — Practice, reachable composition" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;min-height:0;padding:0 16px 96px;">
+              <div style="padding:4px 0 0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Practice</div><div style="font-size:12px;color:#6E6557;margin-top:5px;">Friday · ready when you are</div></div>
+              <div style="margin-top:14px;border-radius:22px;padding:20px 20px 16px;background:linear-gradient(165deg,#5648B2 0%,#43388F 60%,#392F7C 100%);box-shadow:0 20px 40px -16px rgba(76,63,166,0.7);">
+                <div style="font-size:11px;font-weight:600;letter-spacing:1.4px;color:rgba(242,239,232,0.65);">TODAY'S PLAN · 40 MIN</div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:23px;color:#F4F1E8;margin-top:5px;line-height:1.1;">A balanced session</div>
+                <div style="font-size:12.5px;color:rgba(242,239,232,0.7);margin-top:3px;">5 blocks · spaced for what's due</div>
+                <div style="display:flex;justify-content:center;margin:16px 0 2px;">
+                  <button style="width:80px;height:80px;border-radius:50%;border:none;background:#F7F4EC;display:flex;align-items:center;justify-content:center;box-shadow:0 12px 28px -8px rgba(0,0,0,0.45);cursor:pointer;" style-active="transform:scale(0.93)"><i data-lucide="play" width="34" height="34" style="color:#4C3FA6;fill:#4C3FA6;margin-left:4px;"></i></button>
+                </div>
+                <div style="text-align:center;font-size:12.5px;font-weight:500;color:rgba(242,239,232,0.85);margin-top:8px;">Tap to begin</div>
+              </div>
+              <button style="margin-top:10px;display:flex;align-items:center;justify-content:center;gap:7px;background:none;border:none;font-family:Inter;font-size:14px;font-weight:500;color:#4C3FA6;padding:12px;cursor:pointer;"><i data-lucide="list-plus" width="16" height="16"></i>I know what I want to practise today</button>
+              <div style="margin-top:8px;display:flex;align-items:center;justify-content:space-between;"><span style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's shape</span><span style="font-size:11px;color:#6E6557;">in order</span></div>
+              <div style="margin-top:9px;display:flex;flex-direction:column;gap:6px;">
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Shell voicings — hands apart</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">5 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Strasbourg — A section</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">8 min</span></div>
+                <button style="display:flex;align-items:center;justify-content:center;gap:6px;background:none;border:none;font-family:Inter;font-size:13px;font-weight:500;color:#6E6557;padding:8px;cursor:pointer;"><i data-lucide="chevron-down" width="15" height="15"></i>3 more blocks · 27 min</button>
+              </div>
+            </div>
+            <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;display:flex;align-items:flex-start;justify-content:space-around;padding:10px 4px 22px;background:rgba(247,243,233,0.8);backdrop-filter:blur(20px) saturate(180%);border-top:1px solid rgba(176,168,146,0.3);">
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="library" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Library</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="timer" width="25" height="25" style="color:#4C3FA6;"></i><span style="font-size:10px;font-weight:600;color:#4C3FA6;">Practice</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="list-music" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Routines</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="trending-up" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Progress</span></div>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A1 · where composition lives (open question 1)</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The app opens prescribed, hero intact — nothing asks. The steer line sits <strong style="color:#2B2A26;font-weight:600;">directly under the hero</strong>, quiet weight, accent-coloured: reachable in one tap, never a footer secret like the old builder's link, never a mode chooser.</li>
+            <li>It is phrased as the user's own thought — “I know what I want to practise today” — not “Custom session”, because the built session is a steer on today, not an alternative app.</li>
+            <li>Tapping it opens a sheet <em>over</em> this screen (A2); the plan stays visible behind. Declining costs nothing and the hero is untouched.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A2 · the steer sheet, first use -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A2 — Steer sheet, first use" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="position:absolute;inset:0;background:rgba(43,42,38,0.32);z-index:40;"></div>
+            <div style="position:absolute;left:0;right:0;bottom:0;top:120px;z-index:50;background:#F7F4EC;border-radius:24px 24px 0 0;box-shadow:0 -18px 44px -20px rgba(43,42,38,0.5);display:flex;flex-direction:column;padding:10px 20px 26px;">
+              <div style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;margin:0 auto;"></div>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:24px;color:#2B2A26;margin-top:16px;line-height:1.15;">What do you want to practise today?</div>
+              <div style="font-size:13px;color:#6E6557;margin-top:6px;line-height:1.55;">From your lesson, from your list — it all still counts.</div>
+              <div style="margin-top:14px;display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E0D9C8;border-radius:13px;padding:12px 14px;">
+                <i data-lucide="search" width="17" height="17" style="color:#9A927F;"></i>
+                <span style="flex:1;font-size:14.5px;color:#9A927F;">Add a piece, drill, or anything…</span>
+                <i data-lucide="mic" width="17" height="17" style="color:#4C3FA6;"></i>
+              </div>
+              <div style="margin-top:16px;font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's list · 4</div>
+              <div style="margin-top:9px;display:flex;flex-direction:column;gap:7px;">
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:13px;padding:12px 14px;">
+                  <div style="display:flex;align-items:center;gap:9px;"><span style="display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:7px;background:#E7E3F4;color:#4C3FA6;font-weight:600;font-size:10.5px;"><i data-lucide="music" width="11" height="11"></i>Piece</span><span style="flex:1;"></span><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#4C3FA6;"><i data-lucide="sparkles" width="12" height="12"></i>New tune</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;margin-top:7px;">Alice in Wonderland</div>
+                  <div style="font-size:12px;color:#6E6557;margin-top:3px;">Joins your tunes — learn, memorise, run cold</div>
+                </div>
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:13px;padding:12px 14px;">
+                  <div style="display:flex;align-items:center;gap:9px;"><span style="display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:7px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:10.5px;"><i data-lucide="dumbbell" width="11" height="11"></i>Exercise</span><span style="flex:1;"></span><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#6E6557;"><i data-lucide="help-circle" width="12" height="12"></i>1 question</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;margin-top:7px;">Hanon №4, hands together</div>
+                </div>
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:13px;padding:12px 14px;">
+                  <div style="display:flex;align-items:center;gap:9px;"><span style="display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:7px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:10.5px;"><i data-lucide="dumbbell" width="11" height="11"></i>Exercise</span><span style="flex:1;"></span><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#6E6557;"><i data-lucide="help-circle" width="12" height="12"></i>1 question</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;margin-top:7px;">Stride pattern — bars 1–8</div>
+                </div>
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:13px;padding:12px 14px;">
+                  <div style="display:flex;align-items:center;gap:9px;"><span style="display:inline-flex;align-items:center;gap:4px;padding:3px 9px;border-radius:7px;background:#F0E7D6;color:#6E6557;font-weight:600;font-size:10.5px;"><i data-lucide="feather" width="11" height="11"></i>Journal</span><span style="flex:1;"></span><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#6E6557;"><i data-lucide="help-circle" width="12" height="12"></i>1 question</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:16.5px;color:#2B2A26;margin-top:7px;">Freer rubato in the intro</div>
+                </div>
+              </div>
+              <div style="flex:1;"></div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:16.5px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Continue — three quick questions</button>
+              <button style="width:100%;height:48px;background:none;border:none;font-family:Inter;font-size:14px;font-weight:500;color:#6E6557;cursor:pointer;">Back to today's plan</button>
+            </div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A2 · the steer sheet, first use</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>A sheet over the prescribed screen, not a destination — dismissing it lands back on the intact hero. One field, voice-first; typed or dictated names are matched against the library as you go.</li>
+            <li>Resolution cost is stated honestly up front: the primary action names the price (“three quick questions”), never hides it. The piece costs nothing — pieces are user-added by nature and go straight to the tune pipeline.</li>
+            <li>The <strong style="color:#2B2A26;font-weight:600;">Journal</strong> kind chip (surfaceSunken + inkSecondary) is new — flagged below.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A2r · repeat use -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A2r — Steer sheet, repeat use" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="position:absolute;inset:0;background:rgba(43,42,38,0.32);z-index:40;"></div>
+            <div style="position:absolute;left:0;right:0;bottom:0;top:200px;z-index:50;background:#F7F4EC;border-radius:24px 24px 0 0;box-shadow:0 -18px 44px -20px rgba(43,42,38,0.5);display:flex;flex-direction:column;padding:10px 20px 26px;">
+              <div style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;margin:0 auto;"></div>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:24px;color:#2B2A26;margin-top:16px;line-height:1.15;">What do you want to practise today?</div>
+              <div style="margin-top:14px;display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E0D9C8;border-radius:13px;padding:12px 14px;">
+                <i data-lucide="search" width="17" height="17" style="color:#9A927F;"></i>
+                <span style="flex:1;font-size:14.5px;color:#9A927F;">Add a piece, drill, or anything…</span>
+                <i data-lucide="mic" width="17" height="17" style="color:#4C3FA6;"></i>
+              </div>
+              <div style="margin-top:16px;font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's list · 3 · all known</div>
+              <div style="margin-top:9px;display:flex;flex-direction:column;gap:7px;">
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Hanon №4, hands together</div><i data-lucide="check" width="15" height="15" style="color:#1F8A5B;"></i></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Stride pattern — bars 1–8</div><i data-lucide="check" width="15" height="15" style="color:#1F8A5B;"></i></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Alice in Wonderland — bridge</div><i data-lucide="check" width="15" height="15" style="color:#1F8A5B;"></i></div>
+              </div>
+              <div style="flex:1;"></div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:16.5px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Build session — no questions today</button>
+              <button style="width:100%;height:48px;background:none;border:none;font-family:Inter;font-size:14px;font-weight:500;color:#6E6557;cursor:pointer;">Back to today's plan</button>
+            </div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A2r · repeat use (open question 2)</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Resolution is paid <strong style="color:#2B2A26;font-weight:600;">once per item, ever</strong>. On a repeat visit every row lands already-known: kind tint, green tick, zero questions. Add, add, add, build — as drag-and-go as the old builder, with richer tracking underneath.</li>
+            <li>The section label says so out loud (“all known”), and the primary action confirms the price is zero.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A3 · resolution 1 — authored node match -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A3 — Resolution: proposed match" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="x" width="22" height="22" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">QUESTION 1 OF 3</span><span style="width:22px;"></span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Hanon №4, hands together</div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:26px;line-height:1.18;color:#2B2A26;margin-top:8px;">Is this the drill you already have?</div>
+                <div style="margin-top:16px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:22px;padding:20px;box-shadow:0 16px 36px -20px rgba(43,42,38,0.32);">
+                  <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+                    <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;"><i data-lucide="dumbbell" width="12" height="12"></i>Exercise</span>
+                    <span style="font-size:12px;color:#6E6557;">in your library</span>
+                  </div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:21px;line-height:1.16;color:#2B2A26;margin-top:12px;">Hanon №4 — hands together, crotchet = 96</div>
+                  <div style="display:flex;align-items:center;gap:10px;margin-top:12px;">
+                    <span style="width:15px;height:15px;border-radius:50%;background:#4C3FA6;"></span>
+                    <span style="width:15px;height:15px;border-radius:50%;background:#4C3FA6;"></span>
+                    <span style="width:15px;height:15px;border-radius:50%;box-shadow:inset 0 0 0 2px #DCD4C1;"></span>
+                    <span style="font-size:13px;font-weight:500;color:#6E6557;margin-left:4px;">Solid at 88 · 2 of 3 at 96</span>
+                  </div>
+                  <div style="height:1px;background:#E5DECD;margin:14px 0 12px;"></div>
+                  <div style="font-size:13px;line-height:1.55;color:#6E6557;">Same drill, same history.</div>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Yes — same drill</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">No, it's different</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A3 · resolution (a) — authored-node match</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The LLM proposes, the user confirms (decision 19a). One card, one yes — the match shows its own evidence (GateDots + mastery line) so the confirmation is informed, not blind.</li>
+            <li>“No, it's different” falls through to the user-node form (A4) with the name pre-filled — a wrong guess costs one tap, not a retype.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A4 · resolution 2 — user node -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A4 — Resolution: user node" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="x" width="22" height="22" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">QUESTION 2 OF 3</span><span style="width:22px;"></span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Stride pattern — bars 1–8 · new drill</div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:26px;line-height:1.18;color:#2B2A26;margin-top:8px;">What counts as a clean pass?</div>
+                <div style="margin-top:14px;background:#FCFAF3;border:1px solid #E0D9C8;border-radius:16px;padding:15px 16px;display:flex;align-items:flex-start;gap:11px;">
+                  <div style="flex:1;font-family:'Source Serif 4',serif;font-weight:500;font-size:16.5px;line-height:1.45;color:#2B2A26;">Both hands together, bars 1–8, no stalls, at crotchet = 72.</div>
+                  <i data-lucide="mic" width="19" height="19" style="color:#4C3FA6;flex:none;margin-top:2px;"></i>
+                </div>
+                <div style="display:flex;gap:8px;margin-top:10px;">
+                  <div style="flex:1;background:#F0E7D6;border:1px solid #E5DECD;border-radius:12px;padding:10px 12px;"><div style="font-size:10.5px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;color:#9A927F;">Tempo</div><div style="font-size:14.5px;font-weight:600;color:#2B2A26;margin-top:3px;font-variant-numeric:tabular-nums;">♩ = 72</div></div>
+                  <div style="flex:1;background:#F0E7D6;border:1px solid #E5DECD;border-radius:12px;padding:10px 12px;"><div style="font-size:10.5px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;color:#9A927F;">Key</div><div style="font-size:14.5px;font-weight:600;color:#2B2A26;margin-top:3px;">F</div></div>
+                  <div style="flex:1;background:#F0E7D6;border:1px solid #E5DECD;border-radius:12px;padding:10px 12px;"><div style="font-size:10.5px;font-weight:600;letter-spacing:.8px;text-transform:uppercase;color:#9A927F;">Done when</div><div style="font-size:14.5px;font-weight:600;color:#2B2A26;margin-top:3px;font-variant-numeric:tabular-nums;">3 clean</div></div>
+                </div>
+                <div style="margin-top:16px;font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Helps with · optional</div>
+                <div style="display:flex;gap:8px;margin-top:8px;flex-wrap:wrap;">
+                  <span style="display:inline-flex;align-items:center;gap:5px;padding:8px 13px;border-radius:999px;background:#E7E3F4;border:1px solid #D9D2EC;color:#4C3FA6;font-weight:600;font-size:12.5px;"><i data-lucide="check" width="13" height="13"></i>Alice in Wonderland</span>
+                  <span style="display:inline-flex;align-items:center;padding:8px 13px;border-radius:999px;background:#FCFAF3;border:1px solid #DCD4C1;color:#6E6557;font-weight:500;font-size:12.5px;">Left hand</span>
+                  <span style="display:inline-flex;align-items:center;padding:8px 13px;border-radius:999px;background:#FCFAF3;border:1px solid #DCD4C1;color:#6E6557;font-weight:500;font-size:12.5px;">Nothing yet</span>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Create drill</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Track time and notes instead</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A4 · resolution (b) — user node, the short form</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>One dictated sentence <em>is</em> the criterion — the serif line is the gate, editable in place, mic adjacent. Tempo, key and passes-to-open are parsed out of it and shown back as three read-back chips, not three empty fields.</li>
+            <li>The <strong style="color:#2B2A26;font-weight:600;">serves</strong> tag is one optional tap (the piece is pre-proposed since the lesson handed both over). New drill starts low-band, cold-testable, own mastery — stated in the library, not lectured here.</li>
+            <li>The quiet escape (“can't be counted”) is the honest exit to resolution (c) — the form never forces a fake gate.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A5 · resolution 3 — opaque target -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A5 — Resolution: opaque target" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="x" width="22" height="22" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">QUESTION 3 OF 3</span><span style="width:22px;"></span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Freer rubato in the intro</div>
+                
+                <div style="margin-top:16px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:22px;padding:20px;box-shadow:0 16px 36px -20px rgba(43,42,38,0.32);">
+                  <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E7D6;color:#6E6557;font-weight:600;font-size:11px;"><i data-lucide="feather" width="12" height="12"></i>Journal</span>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:500;font-size:17px;line-height:1.5;color:#2B2A26;margin-top:12px;">Time and notes, kept with the piece.</div>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Add</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Set a target instead</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A5 · resolution (c) — opaque target</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The judgement track, said plainly: three facts about what is and isn't recorded (decision 17). No fake gate, no guilt — “you decide when it's done”.</li>
+            <li>The reverse escape mirrors A4's: the two forms are one surface with two exits, so a misjudged kind costs one tap either way.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A6 · composed session -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A6 — Composed session, shape as advice" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;min-height:0;padding:0 16px 24px;">
+              <div style="padding:4px 0 0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Your session</div><div style="font-size:12px;color:#6E6557;margin-top:5px;">Built by you</div></div>
+              <div style="margin-top:14px;border-radius:22px;padding:16px 20px 14px;background:linear-gradient(165deg,#5648B2 0%,#43388F 60%,#392F7C 100%);box-shadow:0 20px 40px -16px rgba(76,63,166,0.7);display:flex;align-items:center;gap:16px;">
+                <div style="flex:1;min-width:0;">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.4px;color:rgba(242,239,232,0.65);">YOUR SESSION · 35 MIN</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:21px;color:#F4F1E8;margin-top:4px;line-height:1.12;">From Friday's lesson</div>
+                  <div style="font-size:12.5px;color:rgba(242,239,232,0.8);margin-top:4px;font-weight:500;">Tap to begin</div>
+                </div>
+                <button style="width:68px;height:68px;flex:none;border-radius:50%;border:none;background:#F7F4EC;display:flex;align-items:center;justify-content:center;box-shadow:0 12px 28px -8px rgba(0,0,0,0.45);cursor:pointer;" style-active="transform:scale(0.93)"><i data-lucide="play" width="30" height="30" style="color:#4C3FA6;fill:#4C3FA6;margin-left:3px;"></i></button>
+              </div>
+              <div style="margin-top:12px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:14px 16px;">
+                <div style="font-family:'Source Serif 4',serif;font-weight:500;font-size:15.5px;line-height:1.45;color:#2B2A26;">Warm-up first, the tune at the end — that's the shape I'd suggest.</div>
+                <div style="display:flex;gap:14px;margin-top:10px;">
+                  <span style="font-size:13px;font-weight:600;color:#4C3FA6;">Use this shape</span>
+                  <span style="font-size:13px;font-weight:500;color:#6E6557;">Keep my order</span>
+                </div>
+              </div>
+              <div style="margin-top:12px;display:flex;align-items:center;justify-content:space-between;"><span style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's shape</span><span style="font-size:11px;color:#6E6557;">5 blocks · in order</span></div>
+              <div style="margin-top:9px;display:flex;flex-direction:column;gap:6px;">
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Hanon №4, hands together</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">5 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Stride pattern — bars 1–8</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">8 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:#C9C0AC;"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Freer rubato in the intro</div><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#6E6557;"><i data-lucide="feather" width="11" height="11"></i>journal · 6 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Alice in Wonderland — learn A</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">10 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Alice in Wonderland — play it out</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">6 min</span></div>
+              </div>
+              
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A6 · the composed session — shape as advice</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Same press-start scaffold as the prescribed day — the built session is the strongest steer, not a different app. Hero copy names its source (“From Friday's lesson”) instead of pretending the plan wrote it.</li>
+            <li>The template shape is a CoachNote-weight suggestion with two inline choices — offered, declinable, one line. “A shape you can't decline isn't your session.”</li>
+            <li>PlanBlockRows unchanged; the journal row takes the flagged neutral tint and a feather mark instead of a false kind colour. Start leads into the canonical drill loop — <em>not redrawn here</em>, see Drill Loop.dc.html.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- A7 · evidence landing -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="A7 — Block boundary, evidence landing" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">BLOCK 2 OF 5 · DONE</span><span style="font-size:13px;font-weight:600;color:#6E6557;font-variant-numeric:tabular-nums;">13:42</span></div>
+              <div style="display:flex;gap:5px;margin-top:14px;"><span style="flex:1;height:4px;border-radius:999px;background:#4C3FA6;"></span><span style="flex:1;height:4px;border-radius:999px;background:#4C3FA6;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:22px;padding:22px;box-shadow:0 16px 36px -20px rgba(43,42,38,0.32);">
+                  <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;">
+                    <span style="display:inline-flex;align-items:center;gap:5px;padding:4px 11px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;"><i data-lucide="dumbbell" width="12" height="12"></i>Your drill</span>
+                    <span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">8 min</span>
+                  </div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:23px;line-height:1.14;color:#2B2A26;margin-top:12px;">Stride pattern — bars 1–8</div>
+                  <div style="display:flex;align-items:center;gap:10px;margin-top:14px;">
+                    <span style="width:15px;height:15px;border-radius:50%;background:#4C3FA6;"></span>
+                    <span style="width:15px;height:15px;border-radius:50%;background:#4C3FA6;"></span>
+                    <span style="width:15px;height:15px;border-radius:50%;box-shadow:inset 0 0 0 2px #DCD4C1;"></span>
+                    <span style="font-size:15px;font-weight:500;color:#6E6557;margin-left:6px;font-variant-numeric:tabular-nums;">2 of 3</span>
+                  </div>
+                  <div style="height:1px;background:#E5DECD;margin:16px 0 14px;"></div>
+                  <div style="display:flex;flex-direction:column;gap:8px;font-size:13px;color:#6E6557;">
+                    <div style="display:flex;align-items:center;gap:8px;"><i data-lucide="corner-down-right" width="14" height="14" style="color:#4C3FA6;"></i>Adds to <span style="font-weight:600;color:#2B2A26;">Alice in Wonderland</span></div>
+                    
+                  </div>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Next block</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">End session here</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">A7 · evidence landing at the block boundary</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The loop itself is the canonical drill loop (Drill Loop.dc.html); only the boundary card changes for a user drill: GateDots fill from tap-verdicts, the cold-test rule is stated in one clause, and the <strong style="color:#2B2A26;font-weight:600;">serves</strong> line shows where the evidence lands in the ability picture.</li>
+            <li>“Your drill” in the kind chip is the only mark distinguishing a user node — same weight, same dots, no second-class styling.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+    </div>
+  </section>
+
+  <section style="margin-top:88px;max-width:820px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Flagged — new, not yet tokens</div>
+    <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:22px 26px;margin-top:14px;">
+      <ul style="margin:0;padding-left:18px;font-size:13.5px;line-height:1.8;color:#6E6557;">
+        <li><strong style="color:#2B2A26;font-weight:600;">journalBadge</strong> — surfaceSunken <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">#F0E7D6</span> / inkSecondary <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">#6E6557</span> + feather glyph, and the matching neutral <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">#C9C0AC</span> PlanBlockRow bar. A third kind alongside piece/exercise. Needs <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">Theme.swift</span> + DS promotion if the journey wins.</li>
+        <li><strong style="color:#2B2A26;font-weight:600;">Read-back chips</strong> (A4) — sunken parameter chips echoing a parsed criterion. Composed entirely from existing tokens; the pattern (not the colours) is new.</li>
+        <li><strong style="color:#2B2A26;font-weight:600;">Inline shape-advice card</strong> (A6) — CoachNote surface with two inline text actions. Reuses CoachNote tokens; the two-action variant is new behaviour.</li>
+      </ul>
+    </div>
+  </section>
+
+</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;showNotes&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() { if (window.lucide) lucide.createIcons(); }
+  componentDidUpdate() { if (window.lucide) lucide.createIcons(); }
+  renderVals() {
+    return { showNotes: this.props.showNotes ?? true };
+  }
+}
+</script>
+</body>
+</html>
+

--- a/specs/built-session/design/Built Session B - Play-Through, Three Altitudes.dc.html
+++ b/specs/built-session/design/Built Session B - Play-Through, Three Altitudes.dc.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  a { color: #4C3FA6; text-decoration: none; }
+  a:hover { color: #6346E5; text-decoration: underline; }
+  ::selection { background: #4C3FA633; }
+  [data-lucide] { stroke-width: 2; }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div style="min-height:100vh;background:linear-gradient(180deg,#F4F1E8 0%,#EBE7D9 100%);font-family:'Inter',system-ui,sans-serif;color:#2B2A26;padding:56px 48px 160px;">
+<template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#FBFAF3"/><g fill="none" stroke="#4C3FA6" stroke-width="5" stroke-linecap="round"><path d="M38 30 L68 50 L38 70 Z" stroke-linejoin="round"/></g></svg></template>
+<div style="max-width:1340px;margin:0 auto;">
+
+  <section id="intro">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Feature design · built session · brief 2026-08</div>
+    <h1 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:56px;line-height:1.04;letter-spacing:-0.02em;margin:14px 0 0;">Journey B — the play-through, three altitudes</h1>
+    <p style="font-size:16px;line-height:1.68;color:#6E6557;max-width:680px;margin:18px 0 0;">The same piece, played three ways (decision 16): as a <strong style="color:#2B2A26;font-weight:600;">pipeline block</strong> (gated section run-through, everything counts), <strong style="color:#2B2A26;font-weight:600;">off-piste</strong> (time logged, a voice-note moment, a keep-as-drill exit), and <strong style="color:#2B2A26;font-weight:600;">unmonitored play</strong> (time only, nothing scored, nothing inferred). The consent distinction is a visible instrument: at every moment the user can read <em>which altitude they are at and what is being recorded</em>. Worked example: <em>Alice in Wonderland</em>.</p>
+  </section>
+
+  <section style="margin-top:72px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">The frames</div>
+    <div style="display:flex;gap:44px;flex-wrap:wrap;margin-top:30px;">
+
+      <!-- B0 · the altitude choice -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B0 — How should this count?" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="position:absolute;inset:0;background:rgba(43,42,38,0.32);z-index:40;"></div>
+            <div style="position:absolute;left:0;right:0;bottom:0;top:132px;z-index:50;background:#F7F4EC;border-radius:24px 24px 0 0;box-shadow:0 -18px 44px -20px rgba(43,42,38,0.5);display:flex;flex-direction:column;padding:10px 20px 26px;">
+              <div style="width:40px;height:5px;border-radius:3px;background:#D8D0BD;margin:0 auto;"></div>
+              <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;margin-top:16px;">Alice in Wonderland</div>
+              <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:24px;color:#2B2A26;margin-top:6px;line-height:1.15;">Play it through — how should it count?</div>
+              <div style="margin-top:16px;display:flex;flex-direction:column;gap:9px;">
+                <div style="background:#FCFAF3;border:1.5px solid #4C3FA6;border-radius:16px;padding:15px 16px;box-shadow:0 10px 26px -16px rgba(76,63,166,0.5);">
+                  <div style="display:flex;align-items:center;gap:8px;"><span style="display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;background:#E7E3F4;color:#4C3FA6;font-weight:600;font-size:11px;"><i data-lucide="circle-check" width="12" height="12"></i>Run-through</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;margin-top:9px;">A proper run — it counts</div>
+                  <div style="font-size:12.5px;color:#6E6557;margin-top:4px;line-height:1.5;">Section by section, one tap each.</div>
+                </div>
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:15px 16px;">
+                  <div style="display:flex;align-items:center;gap:8px;"><span style="display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;background:#F0E5CC;color:#8A6A2E;font-weight:600;font-size:11px;"><i data-lucide="compass" width="12" height="12"></i>Off-piste</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;margin-top:9px;">Just explore</div>
+                  <div style="font-size:12.5px;color:#6E6557;margin-top:4px;line-height:1.5;">Time logged. Say something if you find something.</div>
+                </div>
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:15px 16px;">
+                  <div style="display:flex;align-items:center;gap:8px;"><span style="display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:8px;background:#F0E7D6;color:#6E6557;font-weight:600;font-size:11px;"><i data-lucide="eye-off" width="12" height="12"></i>Just play</span></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:17px;color:#2B2A26;margin-top:9px;">Off the record</div>
+                  <div style="font-size:12.5px;color:#6E6557;margin-top:4px;line-height:1.5;">Minutes only. No questions.</div>
+                </div>
+              </div>
+              <div style="flex:1;"></div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Start the run</button>
+              <button style="width:100%;height:48px;background:none;border:none;font-family:Inter;font-size:14px;font-weight:500;color:#6E6557;cursor:pointer;">Cancel</button>
+            </div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B0 · the altitude choice — consent up front</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Reached from the piece (library or steer sheet), never from a mode menu (decision 11). Each card states in one clause <em>what will be recorded</em> — the consent contract is made before a note is played.</li>
+            <li>Recommended altitude is pre-selected (border, not fill); the primary button re-labels to match the selection. One primary, as ever.</li>
+            <li>The three altitude chips (Run-through / Off-piste / Just play) are new marks — flagged below. Open question 3 is answered at B1's note.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- B1 · pipeline block in play -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B1 — Gated run-through, section verdict" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;letter-spacing:1.2px;color:#4C3FA6;"><i data-lucide="circle-check" width="12" height="12"></i>RUN-THROUGH · COUNTS</span><span style="font-size:13px;font-weight:600;color:#6E6557;font-variant-numeric:tabular-nums;">4:12</span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="text-align:center;">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Alice in Wonderland</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:30px;line-height:1.14;color:#2B2A26;margin-top:8px;">The bridge, from memory</div>
+                  <div style="font-size:14px;color:#6E6557;margin-top:8px;">From cold</div>
+                </div>
+                <div style="margin-top:26px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:14px 16px;">
+                  <div style="display:flex;align-items:center;justify-content:space-between;font-size:13px;color:#6E6557;">
+                    <span>Section 3 of 4</span>
+                    <span style="display:inline-flex;align-items:center;gap:8px;"><span style="width:12px;height:12px;border-radius:50%;background:#4C3FA6;"></span><span style="width:12px;height:12px;border-radius:50%;background:#4C3FA6;"></span><span style="width:12px;height:12px;border-radius:50%;box-shadow:inset 0 0 0 2px #DCD4C1;"></span><span style="width:12px;height:12px;border-radius:50%;box-shadow:inset 0 0 0 2px #DCD4C1;"></span></span>
+                  </div>
+                </div>
+                <div style="font-size:13px;color:#6E6557;text-align:center;margin-top:22px;">Did it hold?</div>
+                <div style="display:flex;gap:10px;margin-top:10px;">
+                  <button style="flex:1.5;height:66px;border:1px solid #C9E2D3;background:#E7F1EB;color:#1F8A5B;border-radius:16px;font-family:Inter;font-weight:600;font-size:16px;display:flex;align-items:center;justify-content:center;gap:8px;cursor:pointer;" style-active="transform:scale(0.96)"><i data-lucide="check" width="19" height="19"></i>Yes — held</button>
+                  <button style="flex:1;height:66px;border:1px solid #DCD4C1;background:#EFEADC;color:#8A8170;border-radius:16px;font-family:Inter;font-weight:600;font-size:14px;white-space:nowrap;display:flex;align-items:center;justify-content:center;gap:7px;cursor:pointer;padding:0 8px;" style-active="transform:scale(0.96)"><i data-lucide="x" width="16" height="16"></i>Broke down</button>
+                </div>
+              </div>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Don't count this run</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B1 · pipeline block — the gated run (open question 3)</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>A pipeline-stage block with a <strong style="color:#2B2A26;font-weight:600;">section-level</strong> gate only (“bridge, from memory, cold”) — never a note-level target. The verdict is the standard TapVerdict pair, one per section, relabelled for a run (“held / broke down”).</li>
+            <li>The altitude chip lives <em>in</em> the orientation strip for the whole run — you can always read that this one counts.</li>
+            <li>On question 3: v1 needs only <em>this much</em> pipeline — a piece + a named section gate. Full pipeline authoring can wait; without it, off-piste + a piece tag (B2) is the honest fallback, and this card degrades to it gracefully.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- B2 · off-piste in play -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B2 — Off-piste, in play" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;letter-spacing:1.2px;color:#8A6A2E;"><i data-lucide="compass" width="12" height="12"></i>OFF-PISTE · TIME ONLY</span><span style="font-size:13px;font-weight:600;color:#6E6557;font-variant-numeric:tabular-nums;">11:38</span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;min-height:0;text-align:center;">
+                <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Alice in Wonderland</div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:52px;line-height:1;color:#2B2A26;margin-top:14px;font-variant-numeric:tabular-nums;">11:38</div>
+
+              </div>
+              <button style="width:100%;height:96px;border-radius:22px;border:1.5px solid #E0D9C8;background:#FCFAF3;font-family:Inter;font-size:20px;font-weight:600;color:#2B2A26;display:flex;align-items:center;justify-content:center;gap:11px;cursor:pointer;" style-active="transform:scale(0.97)"><i data-lucide="mic" width="24" height="24" style="color:#4C3FA6;"></i>Found something? Say it</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;margin-top:6px;">I'm done</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B2 · off-piste — the voice-note moment</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>One instrument on screen: the mic, drawn by StuckTarget's 96pt shape because it must be hittable mid-flow without a look. Elapsed time is the only number; the strip says <em>time only</em> in the altitude's own words.</li>
+            <li>No gate dots, no sections, no verdicts anywhere — absence of instrumentation is itself the consent signal, and it is total.</li>
+            <li>A voice note drops a timestamped marker; audio is kept, transcription is opportunistic. No prompt ever interrupts play.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- B2x · off-piste exit -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B2x — Off-piste exit, keep as drill" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:center;"><span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;letter-spacing:1.2px;color:#8A6A2E;"><i data-lucide="compass" width="12" height="12"></i>OFF-PISTE · 17 MIN LOGGED</span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:22px;padding:22px;box-shadow:0 16px 36px -20px rgba(43,42,38,0.32);">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">You said, at 11:38</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:500;font-size:18px;line-height:1.5;color:#2B2A26;margin-top:10px;">“That descending run into the bridge — left hand alone it actually swings.”</div>
+                  <div style="display:flex;align-items:center;gap:7px;font-size:12.5px;color:#6E6557;margin-top:12px;"><i data-lucide="audio-lines" width="14" height="14" style="color:#4C3FA6;"></i>0:19 · audio kept</div>
+                  <div style="height:1px;background:#E5DECD;margin:16px 0 14px;"></div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:21px;line-height:1.2;color:#2B2A26;">Keep this as a drill?</div>
+                  <div style="font-size:13px;color:#6E6557;margin-top:6px;line-height:1.55;">You'll set the target; it's tracked like your other drills.</div>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Keep it</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Just the note</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B2x · off-piste exit — “keep this as a drill?”</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The exit plays back what <em>you</em> found — your words, your audio — and asks the one question decision 16 allows. Keeping it routes into Journey A's user-node form (A4) with the transcript as the draft criterion.</li>
+            <li>Declining is equal-weight in consequence and quiet in style: the note still lives on the piece; nothing nags later.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- B3 · unmonitored middle -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B3 — Unmonitored, the silent middle" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:center;"><span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;letter-spacing:1.2px;color:#6E6557;"><i data-lucide="eye-off" width="12" height="12"></i>OFF THE RECORD</span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;align-items:center;min-height:0;text-align:center;">
+                <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:44px;line-height:1;color:#6E6557;font-variant-numeric:tabular-nums;">23 min</div>
+                <div style="font-size:14px;color:#6E6557;margin-top:12px;max-width:240px;line-height:1.6;">Just you and the piano.</div>
+              </div>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Done</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B3 · unmonitored — the deliberately silent middle</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>The emptiest screen in the app, on purpose. Elapsed minutes in inkSecondary — not ink, because even the number refuses to perform. No mic, no card, no piece title once running.</li>
+            <li>The only exit is a quiet “Done”; there is no primary here because there is nothing the app wants from you.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- B3x · unmonitored exit -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="B3x — Unmonitored exit, no prompt" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;min-height:0;padding:0 16px 96px;">
+              <div style="margin-top:6px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:13px 16px;display:flex;align-items:center;gap:11px;box-shadow:0 10px 24px -14px rgba(43,42,38,0.3);">
+                <i data-lucide="eye-off" width="17" height="17" style="color:#6E6557;flex:none;"></i>
+                <div style="flex:1;font-size:13.5px;color:#2B2A26;">23 min at the piano — logged, off the record.</div>
+              </div>
+              <div style="padding:14px 0 0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Practice</div><div style="font-size:12px;color:#6E6557;margin-top:5px;">Friday · ready when you are</div></div>
+              <div style="margin-top:14px;border-radius:22px;padding:16px 20px 14px;background:linear-gradient(165deg,#5648B2 0%,#43388F 60%,#392F7C 100%);box-shadow:0 20px 40px -16px rgba(76,63,166,0.7);display:flex;align-items:center;gap:16px;">
+                <div style="flex:1;min-width:0;">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.4px;color:rgba(242,239,232,0.65);">TODAY'S PLAN · 40 MIN</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:21px;color:#F4F1E8;margin-top:4px;line-height:1.12;">A balanced session</div>
+                  <div style="font-size:12.5px;color:rgba(242,239,232,0.8);margin-top:4px;font-weight:500;">Still here when you want it</div>
+                </div>
+                <button style="width:68px;height:68px;flex:none;border-radius:50%;border:none;background:#F7F4EC;display:flex;align-items:center;justify-content:center;box-shadow:0 12px 28px -8px rgba(0,0,0,0.45);cursor:pointer;" style-active="transform:scale(0.93)"><i data-lucide="play" width="30" height="30" style="color:#4C3FA6;fill:#4C3FA6;margin-left:3px;"></i></button>
+              </div>
+            </div>
+            <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;display:flex;align-items:flex-start;justify-content:space-around;padding:10px 4px 22px;background:rgba(247,243,233,0.8);backdrop-filter:blur(20px) saturate(180%);border-top:1px solid rgba(176,168,146,0.3);">
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="library" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Library</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="timer" width="25" height="25" style="color:#4C3FA6;"></i><span style="font-size:10px;font-weight:600;color:#4C3FA6;">Practice</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="list-music" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Routines</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="trending-up" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Progress</span></div>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">B3x · unmonitored exit — no prompt, ever</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Done drops you straight back on Practice. One dismissing toast confirms the contract was honoured — minutes logged, off the record — and nothing asks how it went. The absent end-of-session prompt <em>is</em> the design.</li>
+            <li>The hero is untouched and unresentful: “still here when you want it”.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+    </div>
+  </section>
+
+  <section style="margin-top:88px;max-width:820px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Flagged — new, not yet tokens</div>
+    <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:22px 26px;margin-top:14px;">
+      <ul style="margin:0;padding-left:18px;font-size:13.5px;line-height:1.8;color:#6E6557;">
+        <li><strong style="color:#2B2A26;font-weight:600;">AltitudeChip</strong> — the in-strip consent mark: run-through in accent, off-piste in exercise gold, off-the-record in inkSecondary, each with its glyph (circle-check / compass / eye-off). Colours are existing tokens; the component and the rule (<em>always visible while playing</em>) are new. Needs <span style="font-family:ui-monospace,Menlo,monospace;font-size:12px;">Theme.swift</span> naming + DS promotion if the journey wins.</li>
+        <li><strong style="color:#2B2A26;font-weight:600;">Section dots in a run</strong> (B1) — GateDots reused at section granularity with a position label. Same tokens, new context; the DS GateDots entry would need one line saying so.</li>
+      </ul>
+    </div>
+  </section>
+
+</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;showNotes&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() { if (window.lucide) lucide.createIcons(); }
+  componentDidUpdate() { if (window.lucide) lucide.createIcons(); }
+  renderVals() {
+    return { showNotes: this.props.showNotes ?? true };
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/built-session/design/Built Session C - Qualitative Capture.dc.html
+++ b/specs/built-session/design/Built Session C - Qualitative Capture.dc.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<style>
+  * { box-sizing: border-box; }
+  body { margin: 0; -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+  a { color: #4C3FA6; text-decoration: none; }
+  a:hover { color: #6346E5; text-decoration: underline; }
+  ::selection { background: #4C3FA633; }
+  [data-lucide] { stroke-width: 2; }
+  @media (prefers-reduced-motion: reduce) { * { animation-duration: .001ms !important; } }
+</style>
+</helmet>
+<div style="min-height:100vh;background:linear-gradient(180deg,#F4F1E8 0%,#EBE7D9 100%);font-family:'Inter',system-ui,sans-serif;color:#2B2A26;padding:56px 48px 160px;">
+<template id="__bundler_thumbnail"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="22" fill="#FBFAF3"/><g fill="none" stroke="#4C3FA6" stroke-width="5" stroke-linecap="round"><path d="M50 28v28"/><path d="M36 44a14 14 0 0 0 28 0"/><path d="M50 62v10M40 72h20"/></g></svg></template>
+<div style="max-width:1340px;margin:0 auto;">
+
+  <section id="intro">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Feature design · built session · brief 2026-08</div>
+    <h1 style="font-family:'Source Serif 4',serif;font-weight:600;font-size:56px;line-height:1.04;letter-spacing:-0.02em;margin:14px 0 0;">Journey C — qualitative capture</h1>
+    <p style="font-size:16px;line-height:1.68;color:#6E6557;max-width:680px;margin:18px 0 0;">Feel and reflection, woven through a self-directed session on the <strong style="color:#2B2A26;font-weight:600;">judgement track</strong> (decision 17): it can retire a target and show trends, never satisfy a prerequisite. The measurement budget holds — <strong style="color:#2B2A26;font-weight:600;">at most one feel rating per block</strong>, reflections always optional, everything voice-first. And it comes back: last week's words become tomorrow's proposed steer (decision 12 — the LLM proposes, the user confirms, never plans).</p>
+  </section>
+
+  <section style="margin-top:72px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">The frames</div>
+    <div style="display:flex;gap:44px;flex-wrap:wrap;margin-top:30px;">
+
+      <!-- C1 · feel rating at the block boundary -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="C1 — Feel rating, one per block" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:space-between;"><i data-lucide="chevron-down" width="24" height="24" style="color:#6E6557;"></i><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">BLOCK 3 OF 5 · DONE</span><span style="font-size:13px;font-weight:600;color:#6E6557;font-variant-numeric:tabular-nums;">21:06</span></div>
+              <div style="display:flex;gap:5px;margin-top:14px;"><span style="flex:1;height:4px;border-radius:999px;background:#4C3FA6;"></span><span style="flex:1;height:4px;border-radius:999px;background:#4C3FA6;"></span><span style="flex:1;height:4px;border-radius:999px;background:#4C3FA6;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span><span style="flex:1;height:4px;border-radius:999px;background:#E0D9C8;"></span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="text-align:center;">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Freer rubato in the intro</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;line-height:1.16;color:#2B2A26;margin-top:8px;">How did it feel?</div>
+                </div>
+                <div style="display:flex;gap:10px;margin-top:22px;">
+                  <button style="flex:1;height:66px;border:1px solid #DCD4C1;background:#FCFAF3;color:#2B2A26;border-radius:16px;font-family:Inter;font-weight:600;font-size:14.5px;cursor:pointer;" style-active="transform:scale(0.96)">Fought it</button>
+                  <button style="flex:1;height:66px;border:1px solid #DCD4C1;background:#FCFAF3;color:#2B2A26;border-radius:16px;font-family:Inter;font-weight:600;font-size:14.5px;cursor:pointer;" style-active="transform:scale(0.96)">Getting there</button>
+                  <button style="flex:1;height:66px;border:1px solid #C9E2D3;background:#E7F1EB;color:#1F8A5B;border-radius:16px;font-family:Inter;font-weight:600;font-size:14.5px;cursor:pointer;" style-active="transform:scale(0.96)">It sang</button>
+                </div>
+
+              </div>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Skip</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">C1 · the feel moment — at most one per block</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Asked only where feel is the point — a journal target here; a gated drill block ends with GateDots instead and never both. On a bad day the budget shrinks: two misses in the block and this screen doesn't appear at all.</li>
+            <li>Musician's words, not a 1–5 scale: <em>fought it / getting there / it sang</em>. Only “it sang” carries the success tint; the other two stay neutral because feel is not a verdict.</li>
+            <li>Lands on the judgement track — the caption says so in plain words. Skip is a first-class exit.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- C2 · session-close reflection -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="C2 — Voice-first reflection at close" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:radial-gradient(120% 80% at 50% 22%,#F7F4EC 0%,#EFEADC 55%,#E7E2D2 100%);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;padding:6px 22px 24px;min-height:0;">
+              <div style="display:flex;align-items:center;justify-content:center;"><span style="font-size:11px;font-weight:600;letter-spacing:1.5px;color:#6E6557;">SESSION DONE · 36 MIN</span></div>
+              <div style="flex:1;display:flex;flex-direction:column;justify-content:center;min-height:0;">
+                <div style="text-align:center;">
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;line-height:1.16;color:#2B2A26;">Anything worth keeping?</div>
+                  <div style="font-size:13.5px;color:#6E6557;margin-top:8px;line-height:1.6;max-width:280px;margin-left:auto;margin-right:auto;">What improved, what's still rough, what's next — say it however it comes.</div>
+                </div>
+                <div style="display:flex;justify-content:center;margin-top:24px;">
+                  <button style="width:96px;height:96px;border-radius:50%;border:1.5px solid #E0D9C8;background:#FCFAF3;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 36px -20px rgba(43,42,38,0.32);cursor:pointer;" style-active="transform:scale(0.95)"><i data-lucide="mic" width="38" height="38" style="color:#4C3FA6;"></i></button>
+                </div>
+                <div style="margin-top:22px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:16px 18px;">
+                  <div style="display:flex;align-items:center;gap:7px;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#9A927F;"><i data-lucide="audio-lines" width="13" height="13" style="color:#4C3FA6;"></i>Transcribing…</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:500;font-size:16.5px;line-height:1.55;color:#2B2A26;margin-top:9px;">“Stride's nearly there at 72. The bridge still rushes when I go from memory — that's the thing to hit next. And the rubato idea from the lesson actually works in bar four.”</div>
+                  <div style="font-size:12px;color:#6E6557;margin-top:10px;">0:24 · audio kept with the session</div>
+                </div>
+              </div>
+              <button style="width:100%;height:62px;border-radius:16px;border:none;background:linear-gradient(165deg,#5648B2,#43388F);color:#F7F4EC;font-family:Inter;font-size:17px;font-weight:600;box-shadow:0 12px 26px -14px rgba(76,63,166,0.85);cursor:pointer;" style-active="transform:scale(0.97)">Keep it</button>
+              <button style="width:100%;height:54px;background:none;border:none;font-family:Inter;font-size:14.5px;font-weight:500;color:#6E6557;cursor:pointer;">Not tonight</button>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">C2 · reflection at close — voice first</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>One mic, one gentle shape (<em>improved / still rough / next</em>) offered as a prompt, never as three fields. The transcript renders in serif — it is the user's thought, and the serif voice is reserved for thoughts.</li>
+            <li>Audio is kept; transcription is opportunistic and can finish later. “Not tonight” is respected without a follow-up nudge — reflections are always optional.</li>
+            <li>This sits <em>after</em> the session-summary celebration (see Session Summary.dc.html), not instead of it.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+      <!-- C3 · reflections become tomorrow's steer -->
+      <div style="width:392px;">
+        <div style="width:392px;border-radius:54px;padding:11px;background:linear-gradient(150deg,#3a3a3c,#1c1c1e);box-shadow:0 30px 60px -20px rgba(43,42,38,0.45),0 0 0 2px #0a0a0a;">
+          <div data-screen-label="C3 — Reflection surfaces as proposed steer" style="position:relative;width:370px;height:782px;border-radius:43px;overflow:hidden;background:linear-gradient(180deg,#F4F1E8,#EBE7D9);display:flex;flex-direction:column;">
+            <div style="position:absolute;top:11px;left:50%;transform:translateX(-50%);width:104px;height:30px;background:#000;border-radius:18px;z-index:60;"></div>
+            <div style="display:flex;justify-content:space-between;align-items:center;height:46px;padding:0 24px 0 28px;flex:none;"><span style="font-weight:600;font-size:14px;color:#2B2A26;">9:41</span><div style="display:flex;align-items:center;gap:6px;"><i data-lucide="signal" width="16" height="16" style="color:#2B2A26;"></i><i data-lucide="wifi" width="16" height="16" style="color:#2B2A26;"></i><div style="width:23px;height:12px;border:1.3px solid #2B2A26;border-radius:3px;display:flex;align-items:center;padding:1.5px;"><div style="width:72%;height:100%;background:#2B2A26;border-radius:1px;"></div></div></div></div>
+            <div style="flex:1;display:flex;flex-direction:column;min-height:0;padding:0 16px 96px;">
+              <div style="padding:4px 0 0;"><div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:28px;color:#2B2A26;line-height:1;">Practice</div><div style="font-size:12px;color:#6E6557;margin-top:5px;">Saturday · ready when you are</div></div>
+              <div style="margin-top:12px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:15px 16px;">
+                <div style="display:flex;align-items:center;gap:7px;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#9A927F;"><i data-lucide="quote" width="13" height="13" style="color:#4C3FA6;"></i>You said, last night</div>
+                <div style="font-family:'Source Serif 4',serif;font-weight:500;font-size:16px;line-height:1.5;color:#2B2A26;margin-top:8px;">“The bridge still rushes when I go from memory.” Work it today — eight minutes, from memory, with the click?</div>
+                <div style="display:flex;gap:14px;margin-top:11px;">
+                  <span style="font-size:13px;font-weight:600;color:#4C3FA6;">Add it to today</span>
+                  <span style="font-size:13px;font-weight:500;color:#6E6557;">Not today</span>
+                </div>
+              </div>
+              <div style="margin-top:12px;border-radius:22px;padding:16px 20px 14px;background:linear-gradient(165deg,#5648B2 0%,#43388F 60%,#392F7C 100%);box-shadow:0 20px 40px -16px rgba(76,63,166,0.7);display:flex;align-items:center;gap:16px;">
+                <div style="flex:1;min-width:0;">
+                  <div style="font-size:11px;font-weight:600;letter-spacing:1.4px;color:rgba(242,239,232,0.65);">TODAY'S PLAN · 40 MIN</div>
+                  <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:21px;color:#F4F1E8;margin-top:4px;line-height:1.12;">A balanced session</div>
+                  <div style="font-size:12.5px;color:rgba(242,239,232,0.8);margin-top:4px;font-weight:500;">Tap to begin</div>
+                </div>
+                <button style="width:68px;height:68px;flex:none;border-radius:50%;border:none;background:#F7F4EC;display:flex;align-items:center;justify-content:center;box-shadow:0 12px 28px -8px rgba(0,0,0,0.45);cursor:pointer;" style-active="transform:scale(0.93)"><i data-lucide="play" width="30" height="30" style="color:#4C3FA6;fill:#4C3FA6;margin-left:3px;"></i></button>
+              </div>
+              <div style="margin-top:14px;display:flex;align-items:center;justify-content:space-between;"><span style="font-size:11px;font-weight:600;letter-spacing:1.2px;text-transform:uppercase;color:#9A927F;">Today's shape</span><span style="font-size:11px;color:#6E6557;">in order</span></div>
+              <div style="margin-top:9px;display:flex;flex-direction:column;gap:6px;">
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#9E7B33,#8A6A2E);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Shell voicings — hands apart</div><span style="font-size:12.5px;color:#6E6557;font-variant-numeric:tabular-nums;">5 min</span></div>
+                <div style="display:flex;align-items:center;gap:10px;background:#FCFAF3;border:1px solid #E5DECD;border-radius:12px;padding:11px 14px 11px 15px;position:relative;overflow:hidden;"><div style="position:absolute;left:0;top:0;bottom:0;width:4px;background:linear-gradient(180deg,#6346E5,#4C3FA6);"></div><div style="flex:1;font-family:'Source Serif 4',serif;font-weight:600;font-size:14.5px;color:#2B2A26;">Alice in Wonderland — the bridge</div><span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:600;color:#4C3FA6;"><i data-lucide="quote" width="11" height="11"></i>you added this · 8 min</span></div>
+                <button style="display:flex;align-items:center;justify-content:center;gap:6px;background:none;border:none;font-family:Inter;font-size:13px;font-weight:500;color:#6E6557;padding:8px;cursor:pointer;"><i data-lucide="chevron-down" width="15" height="15"></i>3 more blocks · 27 min</button>
+              </div>
+            </div>
+            <div style="position:absolute;left:0;right:0;bottom:0;z-index:55;display:flex;align-items:flex-start;justify-content:space-around;padding:10px 4px 22px;background:rgba(247,243,233,0.8);backdrop-filter:blur(20px) saturate(180%);border-top:1px solid rgba(176,168,146,0.3);">
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="library" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Library</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="timer" width="25" height="25" style="color:#4C3FA6;"></i><span style="font-size:10px;font-weight:600;color:#4C3FA6;">Practice</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="list-music" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Routines</span></div>
+              <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding:4px;flex:1;"><i data-lucide="trending-up" width="25" height="25" style="color:#6E6557;"></i><span style="font-size:10px;font-weight:500;color:#6E6557;">Progress</span></div>
+            </div>
+            <div style="position:absolute;bottom:8px;left:50%;transform:translateX(-50%);width:128px;height:5px;border-radius:3px;background:#2B2A26;opacity:0.8;z-index:60;"></div>
+          </div>
+        </div>
+        <sc-if value="{{ showNotes }}" hint-placeholder-val="{{ true }}">
+        <div style="margin-top:22px;">
+          <div style="font-family:'Source Serif 4',serif;font-weight:600;font-size:19px;">C3 · the return — reflection becomes a proposed steer</div>
+          <ul style="margin:10px 0 0;padding-left:18px;font-size:13.5px;line-height:1.7;color:#6E6557;">
+            <li>Next morning, the reflection surfaces as a proposal above the untouched hero: <em>your words quoted back</em>, one concrete offer, accept or decline inline. The LLM proposes, the user confirms — it never silently rewrote the plan (decision 12).</li>
+            <li>Accepting inserts one block, marked with the quote glyph and “your steer” so its provenance stays legible in the shape. Declining leaves no trace and no repeat nag.</li>
+            <li>The frame shows the <em>accepted</em> state below the card so both halves of the contract are visible at once.</li>
+          </ul>
+        </div>
+        </sc-if>
+      </div>
+
+    </div>
+  </section>
+
+  <section style="margin-top:88px;max-width:820px;">
+    <div style="font-size:12px;font-weight:600;letter-spacing:1.8px;text-transform:uppercase;color:#9A927F;">Flagged — new, not yet tokens</div>
+    <div style="background:#FCFAF3;border:1px solid #E5DECD;border-radius:16px;padding:22px 26px;margin-top:14px;">
+      <ul style="margin:0;padding-left:18px;font-size:13.5px;line-height:1.8;color:#6E6557;">
+        <li><strong style="color:#2B2A26;font-weight:600;">FeelChips</strong> (C1) — three labelled 66pt buttons on the CoachAction key shape; only the top state takes the success tint. New component; colours all existing. Needs DS promotion + the one-per-block rule written into its entry.</li>
+        <li><strong style="color:#2B2A26;font-weight:600;">ReflectionCard</strong> (C2/C3) — transcript-in-serif with audio row; and its morning form, the <strong style="color:#2B2A26;font-weight:600;">proposed-steer card</strong> (quote glyph + two inline text actions, same pattern as Journey A's shape-advice card). Both compose CoachNote's tokens; the quote-back rule is new behaviour.</li>
+      </ul>
+    </div>
+  </section>
+
+</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;showNotes&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Display&quot;}}">
+class Component extends DCLogic {
+  componentDidMount() { if (window.lucide) lucide.createIcons(); }
+  componentDidUpdate() { if (window.lucide) lucide.createIcons(); }
+  renderVals() {
+    return { showNotes: this.props.showNotes ?? true };
+  }
+}
+</script>
+</body>
+</html>

--- a/specs/built-session/design/README.md
+++ b/specs/built-session/design/README.md
@@ -1,0 +1,22 @@
+# Built Session — pulled design mockups
+
+Pulled 2026-08-07 from the Claude Design project "Intrada"
+(0e60f6f5-1dcf-404f-afe6-6f5488a4e3bc), per `docs/design-workflow.md`. The
+design project stays the living original; these are the implementation
+reference for #1256 (spec: `specs/built-session.md`).
+
+- `Built Session A - Compose From a Lesson.dc.html` — steer line, steer sheet
+  (first + repeat use), three-way resolution, composed session, evidence
+  landing.
+- `Built Session B - Play-Through, Three Altitudes.dc.html` — altitude choice,
+  gated section run, off-piste, unmonitored play.
+- `Built Session C - Qualitative Capture.dc.html` — feel moment, reflection at
+  close, morning proposed steer.
+- `support.js` — copy of `design/support.js` so the frames render in place.
+
+The journey brief and the voice spec live in `design/briefs/`
+(`2026-08-built-session-journeys.md`, `2026-08-copy-language.md`); the voice
+spec is graduated as T13 in `docs/design-principles.md`.
+
+Copy rulings recorded on the issues: B0's headline stays "Play it through —
+how should it count?" (#1256); the tap bounds the l0 attempt (#1244).

--- a/specs/built-session/design/support.js
+++ b/specs/built-session/design/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
Closes #1256's Phase A.

Tier 3, so the spec rides with the first implementation phase rather than landing as its own PR: reviewers can sanity-check `specs/built-session.md` against working code instead of an abstract diagram.

## What this is

The replacement for the session builder deleted in #1255. Three designed journeys — compose from a lesson (A), play-through altitudes (B), qualitative capture (C). This PR is **scaffold only: no UI**. The screens land in Phases B, C and D, one PR each.

## What landed

- **Spec** — `specs/built-session.md`: problem, the three journeys, entities, phasing, settled decisions, open questions.
- **Design assets** — the A/B/C mockups pulled into `specs/built-session/design/` per `docs/design-workflow.md`.
- **Voice spec graduated as T13** in `docs/design-principles.md`: voice splits by surface, and engine vocabulary never appears on screen.
- **Core** — `crates/intrada-core/src/domain/built_session.rs`: `UserDrill`, `JournalItem`, `BuiltSession`/`BuiltBlock`/`BuiltTarget`, `PlayThroughRecord`/`SectionVerdict`, `Reflection`, `FeelEntry`, plus `BuiltSessionEvent` and its handlers. Local-first only.
- **iOS** — GRDB `v11_built_session` (six additive tables), row↔type codecs, store wiring. No view code.

## Offline-first checklist

- [x] New reads/writes go through the persistence `Effect`, not HTTP — `assert_no_http` runs on every handler test (1)
- [x] All six new tables carry `updated_at` + `deleted_at`; deletes tombstone, and the `ItemStore` protocol has no delete method at all (2)
- [x] Every entity mints a client-owned ulid in core (3)
- [x] No merge logic in the shell; the core stamps every timestamp (4)
- [x] A failed local write resolves `Failed` and surfaces — never a faked `Ack` (5)
- [x] New code is local-first only (6)
- [x] Migration appended, never edits a shipped one, additive throughout; ships `testV11BuiltSessionTablesArriveWithV10DataIntact`, which seeds real v10 rows and migrates forward

## Testing

`just check` green (958 tests, +6 on main). `just ios-fmt-check` and `just ios-test-full` green.

Every `BuiltSessionEvent` variant and every persistence payload has a bincode round-trip (#846 is a silent no-op, not a crash, so this is a build precondition). The live-bridge tests in `StoreEffectLoopTests` drive both legs through a real `LiveBridge`, not a stub: all four `BuiltTarget` kinds, `Serves::Circle`, the optional-String hazard on `RecordReflection`, and the journal and play-through write legs.

**Coverage**: expect high patch coverage on the core module; `ios/` is Codecov-ignored, so the Swift codecs and migration count as a gap by construction. No expected gaps in `crates/`.

## Not in this PR

No UI, no resolution matching, no criterion parser, no audio capture effect — all Phase B onward, per the spec's phasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)