### PR TITLE
feat(core): upgrade crux to 0.20.0 and surface the API's rejection message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,8 @@ specs/                   # Spec docs for major features (Tier 3 only)
 
 ## Tech Stack
 
-- **Rust** stable (1.90.0 CI; MSRV 1.75+, intrada-api 1.78+)
-- **Core**: crux_core 0.19.0, serde, ulid, chrono, thiserror
+- **Rust** stable (1.90.0 CI; MSRV 1.90 via crux_core 0.20, intrada-api 1.78+)
+- **Core**: crux_core 0.20.0, serde, ulid, chrono, thiserror
 - **API**: axum 0.8, tokio, libsql 0.9 (Turso), tower-http (CORS), jsonwebtoken 10
 - **Native iOS**: SwiftUI, iOS 17.0+, UniFFI + facet typegen, GRDB (on-device)
 - **Auth**: Clerk (Google OAuth) exchanged for a long-lived PAT on iOS; JWT RS256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.5.0",
  "log",
  "native-tls",
  "serde",
@@ -235,7 +235,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -267,7 +267,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -677,9 +677,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crux_core"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159720bb44c1a09e0089459217c8ea6c71a78d868c5bf55d5b41f8781e92af7a"
+checksum = "488100da60c1b29000fb4de03b8da5318cfd51a9f15021823c034f97074276ba"
 dependencies = [
  "anyhow",
  "bincode",
@@ -697,11 +697,10 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5aec17a4618dc5834f201aaa28f0ea4cad5a5f593714e74a43ff95cf171313"
+checksum = "a6a077c2252d0f866476d3dc27bae40e3bed2f776f3c42075c181b4cdb9c7e2f"
 dependencies = [
- "anyhow",
  "async-trait",
  "crux_core",
  "derive_builder",
@@ -709,9 +708,8 @@ dependencies = [
  "facet",
  "facet-generate-attrs",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "mime",
- "pin-project-lite",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -723,16 +721,16 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952c0b238735c79e917b908c140c7c5f6f6921924ebee21171203fe5fb5fc3f3"
+checksum = "98e4708c9175417f5b89fdd200e1b7da19d1f732de2c8d6a87f6fe3bbb8872b6"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -805,12 +803,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -829,15 +827,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -853,13 +851,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.0",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -1092,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.5"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78066af2cc259674a54fef24323f6081ae54a5f3a3fb53b995af7a867041c81"
+checksum = "df488bcda61dde160301ee6bce43d42397db599ffc689381a1873b5f035135f9"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -1103,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04625a816bc27bb757b5f62ec17a228b90c08631f579ee0b36eccd6c426df207"
+checksum = "c33cf9d80307e9a29f93e5a65ddb65b227b5fa082d649c65d4083345f5d398d0"
 dependencies = [
  "autocfg",
  "chrono",
@@ -1116,18 +1114,18 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
+checksum = "8759a95863bc332c2cdbdacdbe2595573aa3431ce42609b66a1eccf62f1ee1bb"
 dependencies = [
  "facet",
 ]
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a288cd230608b4d7e89b307f85be2029f265e27dcdc565a2ae5358d0c4e53f57"
+checksum = "c5ab349bd1823fbfa129e595a826ef7fb4d1b9c7215428b28de18044d009dbc1"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -1136,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c805b7f1ad4bba14e1dba5c67ef810bf9eef2373364fe3916af1d08a5411296"
+checksum = "79622a74665b47d1744998dd0d15b73eb0eecdfeb16630b436c5f03365b02e55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1147,18 +1145,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cc46a94a2725e82f2c0095bac16665057c24d7f4f11169a7a879dbcba81d8f"
+checksum = "a6656fc7457975f5e1c86791b7a810c40ba53993823ae655f7c331e808c4b5ff"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af13fd5dfa728cc48418cf33cbcfc0d5cfdbaaf22a3d0f5229da4b1e5669fa5"
+checksum = "f462bad2b5a574b2c94e9ad54162704ceacf3200741b4f0fb88020936b9003ec"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -1170,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
 dependencies = [
  "derive_builder",
  "facet",
@@ -1473,7 +1471,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1498,18 +1496,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1580,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1606,7 +1598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1617,7 +1609,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1684,7 +1676,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1719,7 +1711,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.5.0",
  "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.40",
@@ -1754,7 +1746,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
  "ipnet",
@@ -1881,15 +1873,14 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "iddqd"
-version = "0.3.18"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616230c7d641ef971a3a5bfcc654c6b7524ab9c9fb665693c6a397dba9a14aca"
+checksum = "8450e1521a7518a32addf0b805ffcfbc8f9c558d2ad5769f068f2aeef5a81126"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "rustc-hash 2.1.2",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2348,7 +2339,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "httparse",
  "memchr",
  "mime",
@@ -3195,7 +3186,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -3236,7 +3227,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
@@ -3333,7 +3324,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac",
- "http 1.4.0",
+ "http 1.5.0",
  "log",
  "maybe-async",
  "md5",
@@ -3667,7 +3658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a8a0a33239c65f95ff719fcb56655f398f4e4e74a01af8daca725cf7c2b5f"
 dependencies = [
  "axum",
- "http 1.4.0",
+ "http 1.5.0",
  "pin-project",
  "sentry-core",
  "tower-layer",
@@ -4324,7 +4315,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower 0.5.3",
@@ -4341,7 +4332,7 @@ checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags",
  "bytes",
- "http 1.4.0",
+ "http 1.5.0",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -4655,7 +4646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.5.0",
  "httparse",
  "log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,17 @@ members = [
   "crates/intrada-api",
 ]
 resolver = "2"
-package.rust-version = "1.75"
+# Set by crux_core 0.20, which declares rust-version 1.90 (rust-toolchain.toml
+# already pins it). intrada-api keeps its own lower floor: it has no crux.
+package.rust-version = "1.90"
 
 [workspace.dependencies]
-crux_core = "0.19.0"
-crux_http = "0.19.0" # tracks crux_core: crux_http 0.18 requires crux_core ^0.19
-# Must track the facet version crux_core 0.19 pulls in (0.44.x) so the
-# gated `derive(facet::Facet)` impls match crux's typegen reflection.
-facet = "0.44"
+crux_core = "0.20.0"
+crux_http = "0.20.0" # tracks crux_core: a capability on 0.19 pulls in a second, incompatible crux_core
+# Pinned exactly because crux_core 0.20's facet_generate 0.19 pins it too —
+# two facet versions in one tree surface as `Facet<'_> is not satisfied`
+# rather than a version conflict.
+facet = "=0.46.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ulid = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ package.rust-version = "1.90"
 [workspace.dependencies]
 crux_core = "0.20.0"
 crux_http = "0.20.0" # tracks crux_core: a capability on 0.19 pulls in a second, incompatible crux_core
-# Pinned exactly because crux_core 0.20's facet_generate 0.19 pins it too —
-# two facet versions in one tree surface as `Facet<'_> is not satisfied`
+# Pinned exactly because crux_core 0.20's facet_generate 0.19 pins it too.
+# Two facet versions in one tree surface as `Facet<'_> is not satisfied`
 # rather than a version conflict.
 facet = "=0.46.5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -854,7 +854,7 @@ pub(crate) fn build_practice_summaries(
             record.0 += 1;
             record.1 += entry.duration_secs;
             // Keep the latest date (RFC3339 strings compare chronologically).
-            if record.4.as_ref().map_or(true, |cur| session_date > *cur) {
+            if record.4.as_ref().is_none_or(|cur| session_date > *cur) {
                 record.4 = Some(session_date.clone());
             }
 
@@ -966,16 +966,12 @@ fn build_exercise_contexts(
             if record
                 .last_practiced_at
                 .as_ref()
-                .map_or(true, |cur| date > *cur)
+                .is_none_or(|cur| date > *cur)
             {
                 record.last_practiced_at = Some(date.clone());
             }
             if let Some(score) = entry.score {
-                if record
-                    .latest_scored
-                    .as_ref()
-                    .map_or(true, |(d, _)| date > *d)
-                {
+                if record.latest_scored.as_ref().is_none_or(|(d, _)| date > *d) {
                     record.latest_scored = Some((date.clone(), score));
                 }
             }

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -274,7 +274,7 @@ pub fn format_duration_display(secs: u64) -> String {
 /// The builder's planned-duration dialect ("12 min" for whole minutes) —
 /// shared by block rows, per-entry planned labels, and the builder total.
 pub fn format_planned_duration(secs: u64) -> String {
-    if secs % 60 == 0 {
+    if secs.is_multiple_of(60) {
         format!("{} min", secs / 60)
     } else {
         format_duration_display(secs)

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -52,16 +52,22 @@ fn json_response<T: Clone>(
             Some(body) => on_body(body),
             None => Event::LoadFailed(empty_msg.to_string()),
         },
-        Err(e) => {
-            let detail = rejection_reason(&e).unwrap_or_else(|| e.to_string());
-            Event::LoadFailed(format!("{error_context}: {detail}"))
-        }
+        Err(e) => Event::LoadFailed(format!("{error_context}: {}", rejection_detail(&e))),
     }
 }
 
-/// Reads `intrada-api`'s `{"error": …}` envelope. `Display` on `HttpError`
-/// reports the status alone, so without this a 409 reaches the user as
-/// "HTTP error 409: 409 Conflict" and the API's explanation is dropped (#1272).
+/// The only way an `HttpError` becomes user-facing text in this module: every
+/// builder's error arm goes through it, so a new one can't reintroduce a bare
+/// `{e}` by copy-paste (#1272).
+///
+/// `Display` reports the status alone, so a bare `{e}` reaches the user as
+/// "HTTP error 409: 409 Conflict" and the API's own explanation is dropped.
+fn rejection_detail(error: &crux_http::HttpError) -> String {
+    rejection_reason(error).unwrap_or_else(|| error.to_string())
+}
+
+/// The sentence `intrada-api` sent in its `{"error": …}` envelope
+/// (`ApiError::into_response`), if it sent a non-blank one.
 fn rejection_reason(error: &crux_http::HttpError) -> Option<String> {
     #[derive(serde::Deserialize)]
     struct Envelope {
@@ -200,7 +206,7 @@ pub fn delete_item(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         .build()
         .then_send(|result| match result {
             Ok(_) => Event::DeleteConfirmed,
-            Err(e) => Event::LoadFailed(format!("Failed to delete item: {e}")),
+            Err(e) => Event::LoadFailed(format!("Failed to delete item: {}", rejection_detail(&e))),
         })
 }
 
@@ -221,7 +227,9 @@ pub fn create_session(api_base_url: &str, session: &PracticeSession) -> Command<
             // before the write is visible, causing #247 (practice data not
             // updating after session save).
             Ok(_) => Event::SessionSaved,
-            Err(e) => Event::LoadFailed(format!("Failed to save session: {e}")),
+            Err(e) => {
+                Event::LoadFailed(format!("Failed to save session: {}", rejection_detail(&e)))
+            }
         })
 }
 
@@ -233,7 +241,10 @@ pub fn delete_session(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         .build()
         .then_send(|result| match result {
             Ok(_) => Event::DeleteConfirmed,
-            Err(e) => Event::LoadFailed(format!("Failed to delete session: {e}")),
+            Err(e) => Event::LoadFailed(format!(
+                "Failed to delete session: {}",
+                rejection_detail(&e)
+            )),
         })
 }
 
@@ -254,7 +265,7 @@ pub fn create_set(
         .build()
         .then_send(move |result| match result {
             Ok(_) => Event::SetSaveSucceeded { request_id },
-            Err(e) => Event::LoadFailed(format!("Failed to save set: {e}")),
+            Err(e) => Event::LoadFailed(format!("Failed to save set: {}", rejection_detail(&e))),
         })
 }
 
@@ -288,7 +299,7 @@ pub fn delete_set(api_base_url: &str, id: &str) -> Command<Effect, Event> {
         .build()
         .then_send(|result| match result {
             Ok(_) => Event::DeleteConfirmed,
-            Err(e) => Event::LoadFailed(format!("Failed to delete set: {e}")),
+            Err(e) => Event::LoadFailed(format!("Failed to delete set: {}", rejection_detail(&e))),
         })
 }
 
@@ -334,7 +345,7 @@ pub fn save_account_preferences(
             },
             Err(e) => Event::Account(AccountEvent::SavePreferencesFailed {
                 previous: previous.clone(),
-                message: format!("Failed to save preferences: {e}"),
+                message: format!("Failed to save preferences: {}", rejection_detail(&e)),
             }),
         })
 }
@@ -348,7 +359,8 @@ pub fn delete_account(api_base_url: &str) -> Command<Effect, Event> {
         .then_send(|result| match result {
             Ok(_) => Event::Account(AccountEvent::AccountDeleted),
             Err(e) => Event::Account(AccountEvent::DeleteAccountFailed(format!(
-                "Failed to delete account: {e}"
+                "Failed to delete account: {}",
+                rejection_detail(&e)
             ))),
         })
 }
@@ -370,7 +382,8 @@ pub fn list_mcp_tokens(api_base_url: &str) -> Command<Effect, Event> {
                 )),
             },
             Err(e) => Event::McpToken(McpTokenEvent::LoadTokensFailed(format!(
-                "Failed to load tokens: {e}"
+                "Failed to load tokens: {}",
+                rejection_detail(&e)
             ))),
         })
 }
@@ -397,7 +410,8 @@ pub fn create_mcp_token(api_base_url: &str, name: &str) -> Command<Effect, Event
                 )),
             },
             Err(e) => Event::McpToken(McpTokenEvent::CreateTokenFailed(format!(
-                "Failed to create token: {e}"
+                "Failed to create token: {}",
+                rejection_detail(&e)
             ))),
         })
 }
@@ -416,7 +430,7 @@ pub fn revoke_mcp_token(api_base_url: &str, id: &str) -> Command<Effect, Event> 
             }),
             Err(e) => Event::McpToken(McpTokenEvent::RevokeTokenFailed {
                 id: id_for_callback.clone(),
-                message: format!("Failed to revoke token: {e}"),
+                message: format!("Failed to revoke token: {}", rejection_detail(&e)),
             }),
         })
 }
@@ -438,7 +452,8 @@ pub fn list_mcp_audit(api_base_url: &str) -> Command<Effect, Event> {
                 )),
             },
             Err(e) => Event::McpAudit(McpAuditEvent::LoadAuditFailed(format!(
-                "Failed to load audit log: {e}"
+                "Failed to load audit log: {}",
+                rejection_detail(&e)
             ))),
         })
 }
@@ -469,7 +484,8 @@ pub fn oauth_finalize(api_base_url: &str, params: &OAuthFinalizeParams) -> Comma
                 )),
             },
             Err(e) => Event::OAuth(OAuthEvent::ConsentFailed(format!(
-                "Failed to finalize OAuth consent: {e}"
+                "Failed to finalize OAuth consent: {}",
+                rejection_detail(&e)
             ))),
         })
 }
@@ -837,37 +853,59 @@ mod tests {
 
     // ── rejections ───────────────────────────────────────────────────
 
-    fn rejection_event(status: u16, body: &str) -> Event {
-        json_response::<Vec<u8>>(
-            crux_http::testing::rejection(status, body),
-            |_| panic!("on_body must not run on a rejection"),
-            "empty body",
-            "Failed to save set",
-        )
+    /// Every builder's error arm reaches `rejection_detail`, so testing it
+    /// directly covers all 19 rather than whichever one a context string names.
+    fn detail(status: u16, body: &str) -> String {
+        let error = crux_http::testing::rejection::<Vec<u8>>(status, body)
+            .expect_err("a 4xx/5xx is never Ok");
+        rejection_detail(&error)
     }
 
     #[test]
     fn rejection_surfaces_the_message_the_api_wrote() {
-        let event = rejection_event(409, r#"{"error":"A set with that name already exists"}"#);
-        assert!(matches!(event, Event::LoadFailed(m)
-                if m == "Failed to save set: A set with that name already exists"));
+        assert_eq!(
+            detail(409, r#"{"error":"A set with that name already exists"}"#),
+            "A set with that name already exists"
+        );
+    }
+
+    #[test]
+    fn rejection_message_is_trimmed_before_it_reaches_a_banner() {
+        assert_eq!(
+            detail(400, "{\"error\":\"  Name is required\\n\"}"),
+            "Name is required"
+        );
     }
 
     #[test]
     fn rejection_falls_back_to_the_status_when_the_body_is_not_our_envelope() {
-        let event = rejection_event(502, "<html>Bad Gateway</html>");
-        assert!(matches!(event, Event::LoadFailed(m) if m.contains("502")));
+        assert!(detail(502, "<html>Bad Gateway</html>").contains("502"));
+    }
+
+    #[test]
+    fn rejection_falls_back_to_the_status_when_the_error_key_is_not_a_string() {
+        assert!(detail(400, r#"{"error":{"code":42}}"#).contains("400"));
     }
 
     #[test]
     fn rejection_falls_back_to_the_status_when_there_is_no_body() {
-        let event = rejection_event(404, "");
-        assert!(matches!(event, Event::LoadFailed(m) if m.contains("404")));
+        assert!(detail(404, "").contains("404"));
     }
 
     #[test]
     fn rejection_falls_back_to_the_status_when_the_message_is_blank() {
-        let event = rejection_event(422, r#"{"error":"   "}"#);
-        assert!(matches!(event, Event::LoadFailed(m) if m.contains("422")));
+        assert!(detail(422, r#"{"error":"   "}"#).contains("422"));
+    }
+
+    #[test]
+    fn a_rejection_reaching_a_builder_carries_the_api_message_through() {
+        let event = json_response::<Vec<u8>>(
+            crux_http::testing::rejection(409, r#"{"error":"Already exists"}"#),
+            |_| panic!("on_body must not run on a rejection"),
+            "empty body",
+            "Failed to update set",
+        );
+        assert!(matches!(event, Event::LoadFailed(m)
+                if m == "Failed to update set: Already exists"));
     }
 }

--- a/crates/intrada-core/src/http.rs
+++ b/crates/intrada-core/src/http.rs
@@ -52,8 +52,25 @@ fn json_response<T: Clone>(
             Some(body) => on_body(body),
             None => Event::LoadFailed(empty_msg.to_string()),
         },
-        Err(e) => Event::LoadFailed(format!("{error_context}: {e}")),
+        Err(e) => {
+            let detail = rejection_reason(&e).unwrap_or_else(|| e.to_string());
+            Event::LoadFailed(format!("{error_context}: {detail}"))
+        }
     }
+}
+
+/// Reads `intrada-api`'s `{"error": …}` envelope. `Display` on `HttpError`
+/// reports the status alone, so without this a 409 reaches the user as
+/// "HTTP error 409: 409 Conflict" and the API's explanation is dropped (#1272).
+fn rejection_reason(error: &crux_http::HttpError) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct Envelope {
+        error: String,
+    }
+
+    let envelope = error.body_json::<Envelope>().ok()?;
+    let reason = envelope.error.trim();
+    (!reason.is_empty()).then(|| reason.to_string())
 }
 
 // ── Fetch operations ────────────────────────────────────────────────────
@@ -816,5 +833,41 @@ mod tests {
             "Failed to load items",
         );
         assert!(matches!(event, Event::LoadFailed(m) if m == "Failed to load items: Timeout"));
+    }
+
+    // ── rejections ───────────────────────────────────────────────────
+
+    fn rejection_event(status: u16, body: &str) -> Event {
+        json_response::<Vec<u8>>(
+            crux_http::testing::rejection(status, body),
+            |_| panic!("on_body must not run on a rejection"),
+            "empty body",
+            "Failed to save set",
+        )
+    }
+
+    #[test]
+    fn rejection_surfaces_the_message_the_api_wrote() {
+        let event = rejection_event(409, r#"{"error":"A set with that name already exists"}"#);
+        assert!(matches!(event, Event::LoadFailed(m)
+                if m == "Failed to save set: A set with that name already exists"));
+    }
+
+    #[test]
+    fn rejection_falls_back_to_the_status_when_the_body_is_not_our_envelope() {
+        let event = rejection_event(502, "<html>Bad Gateway</html>");
+        assert!(matches!(event, Event::LoadFailed(m) if m.contains("502")));
+    }
+
+    #[test]
+    fn rejection_falls_back_to_the_status_when_there_is_no_body() {
+        let event = rejection_event(404, "");
+        assert!(matches!(event, Event::LoadFailed(m) if m.contains("404")));
+    }
+
+    #[test]
+    fn rejection_falls_back_to_the_status_when_the_message_is_blank() {
+        let event = rejection_event(422, r#"{"error":"   "}"#);
+        assert!(matches!(event, Event::LoadFailed(m) if m.contains("422")));
     }
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -35,6 +35,21 @@ countable criteria.
   `[A-Za-z0-9_-]` — no slashes — so `.claude/worktrees/` stays flat and the
   sim-name collision check can see every worktree. Companion
   `just worktree-rm <name>` cleans up the sim then removes the worktree
+- #1272 — crux upgraded to 0.20.0 (`crux_core`, `crux_http`; `crux_macros`
+  0.10.1, `facet` pinned `=0.46.5`). The reason to take it: fire-and-forget
+  effects no longer leak the bridge registry. Every `Render` and `AppEffect`
+  took a slot that was never freed, because only a resolve removed one, so a
+  long practice session grew it for the life of the process. It also stops a
+  resolved `EffectId` being reissued to a later request, which could deliver
+  one request's response to another and succeed silently (our `Store` resolves
+  each request once, so we were not hit). No breaking change in 0.20 touched
+  us and the generated Swift is byte-for-byte unchanged. Riding along:
+  `json_response` now reads the API's `{"error": …}` envelope via
+  `HttpError::body_json`, so a rejection surfaces the sentence the server
+  wrote instead of "HTTP error 409: 409 Conflict" — `Display` on `HttpError`
+  carries the status alone. Pinned end-to-end through the live bridge, not
+  just in the core. `Retry-After` back-off on a 429 is now reachable too, and
+  deferred to #1273
 - #1260 — the l0 drill screen: `DrillScreen` branches on `tempoBpm == nil`
   throughout. During `.playing` the tempo/click pill/beat position give way to
   `GateDots` alone, and the tap-verdict footer (`TapVerdict` + escapes) —

--- a/docs/status.md
+++ b/docs/status.md
@@ -42,14 +42,16 @@ countable criteria.
   long practice session grew it for the life of the process. It also stops a
   resolved `EffectId` being reissued to a later request, which could deliver
   one request's response to another and succeed silently (our `Store` resolves
-  each request once, so we were not hit). No breaking change in 0.20 touched
-  us and the generated Swift is byte-for-byte unchanged. Riding along:
-  `json_response` now reads the API's `{"error": …}` envelope via
-  `HttpError::body_json`, so a rejection surfaces the sentence the server
-  wrote instead of "HTTP error 409: 409 Conflict" — `Display` on `HttpError`
-  carries the status alone. Pinned end-to-end through the live bridge, not
-  just in the core. `Retry-After` back-off on a 429 is now reachable too, and
-  deferred to #1273
+  each request once, so we were not hit). No breaking change in 0.20 touches
+  us; the generated Swift moves only in doc comments and a redundant explicit
+  `Equatable` on 114 types (Swift's `Hashable` already refines it), with no
+  type, field, variant or wire change. Riding along: every one of the 19 HTTP
+  builders now routes its error arm through one `rejection_detail`, which
+  reads the API's `{"error": …}` envelope via `HttpError::body_json`. A
+  rejection surfaces the sentence the server wrote rather than
+  "HTTP error 409: 409 Conflict", since `Display` carries the status alone.
+  Pinned end-to-end through the live bridge, not just in the core.
+  `Retry-After` back-off on a 429 is now reachable too, and deferred to #1273
 - #1260 — the l0 drill screen: `DrillScreen` branches on `tempoBpm == nil`
   throughout. During `.playing` the tempo/click pill/beat position give way to
   `GateDots` alone, and the tap-verdict footer (`TapVerdict` + escapes) —

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -1405,8 +1405,7 @@ final class StoreEffectLoopTests: XCTestCase {
       "the API's sentence must reach the banner, not the bare status")
   }
 
-  /// The fallback half of the pair above: a body that is not our envelope must
-  /// leave the status showing rather than blank the banner.
+  /// Guards the banner going blank rather than showing the status.
   func testRealBridgeFallsBackToTheStatusWhenARejectionIsNotOurEnvelope() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -1383,6 +1383,47 @@ final class StoreEffectLoopTests: XCTestCase {
       "clearing the attribution round-trips")
   }
 
+  /// A stub bridge can't catch a regression here (#1272): the message is
+  /// assembled in the core, so only the real wire carries a 4xx body in and the
+  /// finished string back out.
+  func testRealBridgeSurfacesTheMessageTheServerSentWithARejection() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+
+    let requests = try bridge.update(.account(.loadPreferences))
+    let http = try XCTUnwrap(
+      requests.first { if case .http = $0.effect { return true } else { return false } },
+      "preferences are server-backed, so loading them emits an Http effect")
+
+    let body = Array(#"{"error":"Your session has expired. Sign in again."}"#.utf8)
+    _ = try bridge.resolve(
+      http.id, httpResult: .ok(HttpResponse(status: 401, headers: [], body: body)))
+
+    XCTAssertEqual(
+      try bridge.view().error,
+      "Failed to load preferences: Your session has expired. Sign in again.",
+      "the API's sentence must reach the banner, not the bare status")
+  }
+
+  /// The fallback half of the pair above: a body that is not our envelope must
+  /// leave the status showing rather than blank the banner.
+  func testRealBridgeFallsBackToTheStatusWhenARejectionIsNotOurEnvelope() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+
+    let requests = try bridge.update(.account(.loadPreferences))
+    let http = try XCTUnwrap(
+      requests.first { if case .http = $0.effect { return true } else { return false } })
+
+    _ = try bridge.resolve(
+      http.id,
+      httpResult: .ok(
+        HttpResponse(status: 502, headers: [], body: Array("<html>Bad Gateway</html>".utf8))))
+
+    let error = try XCTUnwrap(try bridge.view().error, "a rejection must surface something")
+    XCTAssertTrue(error.contains("502"), "got \(error)")
+  }
+
   /// App effects come from `notify_shell` — fire-and-forget notifications the
   /// live bridge rejects resolving, so the Store must not resolve `.app`. The
   /// stub bridge can't enforce this; pinned here against the real bridge (#882).


### PR DESCRIPTION
Closes #1272.

## Why take 0.20

Two bug fixes, one of which we are actually hitting.

**Fire-and-forget effects leaked the bridge registry.** Every `Render` and every `AppEffect` took a registry slot that was never freed, because only a resolve removed one. We render on every event and never resolve `.render` or `.app` ([`Store.swift`](ios/Intrada/Core/Store.swift)), so a long practice session grew the registry for the life of the process. Upstream measured roughly a megabyte a day for an app rendering ten times a second.

**A resolved `EffectId` could be reissued to a later request.** Ids were slab indices recycled on completion, so a double-resolve landed on whichever unrelated request inherited the slot, and for two HTTP requests it generally deserialized fine and succeeded silently. Ids are now monotonic. Our `Store` resolves each request exactly once, so we were not hit, but it is the silent-corruption class the CLAUDE.md bridge rules exist for.

## Blast radius: nothing breaking touches us

Verified before starting, and each one grepped:

| Breaking change in 0.20 | Us |
|---|---|
| `effects::EffectId` renamed `ParkedEffectId` | no usage |
| `HttpError::Http` gains `headers`; `body` no longer `Option` | never constructed or destructured |
| Two new `HttpError` variants (enum is not `non_exhaustive`) | no exhaustive match |
| `ResponseBuilder::with_status` panics on 4xx/5xx | no call sites |
| `From<http_types::Error>` removed | feature not enabled |

Neither `crux_kv` nor `crux_time` is a dependency, so no companion bumps.

**Generated Swift.** `ios/generated/` is gitignored, so a clean `git status` there proves nothing. Regenerating on 0.19 and diffing against 0.20 gives the honest answer: doc comments, plus a redundant explicit `Equatable` on 114 types (Swift's `Hashable` already refines `Equatable`, so this is a no-op). **Zero** type, field, variant, or wire changes. The `native-ios` CI job is the real gate, since it builds against freshly generated bindings.

## Riding along: the API's own error message

`json_response` formatted a rejection with `Display`, which reports the status alone:

```rust
Err(e) => Event::LoadFailed(format!("{error_context}: {e}")),
```

So a 409 carrying a written explanation reached the user as "Failed to save set: HTTP error 409: 409 Conflict" and the sentence the API wrote was dropped. That is "surface, don't swallow" failing at the last layer, and until 0.20 there was no way to test it either.

All **19** builders now route their error arm through a single `rejection_detail`, which reads `intrada-api`'s `{"error": …}` envelope via `HttpError::body_json` and falls back to the status when the body is absent, is not ours (a proxy's HTML page), has a non-string `error` key, or carries a blank message. One chokepoint means a new builder cannot reintroduce a bare `{e}` by copy-paste.

Live for the server-backed screens: account preferences and deletion, OAuth finalize, MCP tokens and audit, plus the legacy online branches. The local-first library and coach paths never touch HTTP and are unaffected.

This is in the same PR rather than a follow-up because the accessor it needs only exists in 0.20.

## Two knock-ons from the bump

- `package.rust-version` moves 1.75 to 1.90, which `crux_core` 0.20 requires and `rust-toolchain.toml` already pinned. `rust-version` gates MSRV-sensitive clippy lints, so this ungated four of them (`is_none_or` x3, `is_multiple_of`), fixed here via `clippy --fix`. `intrada-api` keeps its own 1.78 floor: it has no crux.
- `facet` is pinned exactly to `=0.46.5`, because `crux_core` 0.20's `facet_generate` 0.19 pins it. Two facet versions in one tree surface as a confusing `Facet<'_> is not satisfied` rather than a version conflict, so the pin is worth its inflexibility.

## Testing

Written test-first, then mutation-tested, because three of the new tests pass against the *old* code too (they assert the status appears, which `Display` also satisfied). Rather than trust them:

- Removing the blank-message guard turns exactly `…when_the_message_is_blank` red.
- Replacing the status fallback with `unwrap_or_default` turns the other three red.
- Reverting the core fix entirely turns the live-bridge test `testRealBridgeSurfacesTheMessageTheServerSentWithARejection` red. Re-confirmed after the refactor below.

That last one is the end-to-end verification. The message is assembled inside the core, so only the real bincode wire carries a 4xx body in and the finished string back out to `viewModel.error`; a stub bridge would pass regardless. I did not drive the simulator by hand for this, because staging a real 409 against a live API would verify less than the live-bridge test already does, and would not stay verified.

Gates re-run after rebasing onto current `main`: `just check` green (965 tests), `just ios-fmt-check` green, `just ios-test-full` green.

**Coverage:** expected high on the diff. The new core logic (`rejection_detail` / `rejection_reason` and the builder error arms) is covered by seven direct unit tests plus two live-bridge tests. `Cargo.toml` / `Cargo.lock` / docs carry no coverage. The clippy autofixes in `app.rs` and `session.rs` are semantics-preserving rewrites of already-covered lines.

## Tier

Tier 2. Dependency bump plus a core error-handling change. The domain-sensitivity override for "FFI bridge contract" does not apply: no type, field, variant or wire shape moves.
