### PR TITLE
chore: close the loops #1256 Phase B leaked time through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,12 @@ wastes a ~3-minute roundtrip. Keep the justfile recipes and `ci.yml` in lockstep
 when either changes. Changes under `ios/` additionally need `just ios-fmt-check`
 (fix with `just ios-fmt`).
 
+**Read every compile error before fixing the first.** `cargo check --all-targets`
+(not `cargo build`) surfaces test-code breakage in the same pass as the lib —
+adding a field to a widely-constructed type otherwise costs one build per call
+site, discovered one at a time. Same for Swift: read the whole `just ios-test`
+error list, then fix.
+
 **Simulator safety.** The iOS Simulator and `CoreSimulatorService` are
 machine-global. Before any global reset (`simctl shutdown all`,
 `killall CoreSimulatorService`) or a fresh test run, check for another live
@@ -239,9 +245,20 @@ the only UI quality gate, so keep the suite but keep it lean:
 - **Snapshot load-bearing states, not the cross-product.** Prefer
   component-level (`sizeThatFits`) or structural/text snapshots where the
   assertion isn't pixel-perfect.
-- **Optimize before committing.** Run `just ios-snapshots-optimize` after
-  recording. CI's **Snapshot Hygiene** job enforces a per-file size ceiling and
-  fails on un-optimized references.
+- **Re-record with `just ios-snapshots-record <filter>`**, not by hand. It
+  deletes the matching references, runs only those tests (recording is
+  fail-then-pass by design), optimises what it wrote and re-checks hygiene —
+  one command instead of five, and scoped, so it is seconds rather than the
+  whole suite.
+- **Optimize before committing.** `ios-snapshots-record` does it; if you record
+  another way, run `just ios-snapshots-optimize`. CI's **Snapshot Hygiene** job
+  enforces a per-file size ceiling and fails on un-optimized references.
+- **Over the ceiling? Read `scripts/check-snapshots.sh` before reacting.** It
+  carries an allowlist for references that stay large as lossless PNG — the
+  smooth gradients (practice hero, player radial) and dense-control screens.
+  **Cropping does not help those**: flat paper costs almost nothing and the
+  gradient is the whole bill. Add to the allowlist with the reason, and keep the
+  list tight.
 - **No orphans.** Delete a test → delete its PNG. The same job fails any
   reference with no matching `func test…`. Check locally with
   `just ios-snapshots-check`.
@@ -507,6 +524,23 @@ fails) before hardening. If nothing can distinguish the behaviour being present
 from absent, the honest fix is to **delete** the test, not to bulk it out with
 assertions about something else while keeping the name.
 
+**A parser or validator gets a table test against its consumer, not cases you
+invented.** Hand-picked inputs are picked to match the implementation you just
+wrote, so they agree with it by construction. Write the table as a list of
+inputs a *user* would actually produce, and assert the property the next stage
+needs — `every_parse_is_a_drill_validation_will_accept` is the shape.
+
+Why (2026-08-07, #1256): the criterion parser shipped with fourteen green unit
+tests and still read "three clean passes **in a row**" as the key of A, which at
+two keys silently doubled the gate. Every one of those tests used a sentence
+written to match the scanner.
+
+**Test fixtures for a type with many fields live in one place.** Rust:
+`BlockSpec::fixture()` / `BlockRecord::fixture()`, composed with struct update
+(`BlockRecord { exit: Exit::Skipped, ..fixture() }`). Swift: `CoachFixture`,
+whose default arguments do the same job for the generated types. Adding a field
+should cost one edit, not one per call site found a build at a time.
+
 When skipping tests, say so explicitly in the PR description with the reason.
 "All 157 tests pass" is not coverage — those are existing tests.
 
@@ -530,6 +564,16 @@ the diagnosis and the fix: [`docs/reference.md`](docs/reference.md).
   crash (#846).
 - **Stub-bridge tests can't catch a wire break.** Cover bridge-crossing types
   with a *real*-bridge round-trip (`LiveBridge` in `StoreEffectLoopTests`).
+- **Adding a field inside `EngineSession` invalidates every crash-recovery blob
+  on every device.** The blob is positional bincode in UserDefaults, written by
+  one build and read by the next, so a new field anywhere in its transitive
+  graph (`Plan` → `PlannedBlock` → `BlockSpec`, `BlockState`, `BlockRecord`,
+  `WanderRecord`, `EngineConfig`) makes an old blob decode into a valid-looking
+  wrong session. `#[serde(default)]` does nothing here — serde never reaches the
+  default on a non-self-describing wire. Missed three times (#1223, #1244,
+  #1256); now gated by
+  `the_crash_recovery_wire_is_pinned_to_the_shell_key_that_reads_it`, whose
+  failure prints the exact two-line fix.
 - **`option_env!` needs `cargo:rerun-if-env-changed`.** Without it cargo caches
   the macro expansion and your "I changed the env var" rebuild silently uses
   stale values. Hit on `CLERK_PUBLISHABLE_KEY` and `INTRADA_API_URL`.
@@ -559,6 +603,22 @@ questions), then Claude Design for UI, then Plan mode, then implement.
 is the first commit on the Phase A branch; Phase A scaffold is the rest, and the
 PR title and body reflect both. Reviewers sanity-check the spec against working
 code rather than abstract diagrams. Phases B/C/D still ship as their own PRs.
+
+**A phase spanning core *and* screens ships as two PRs: core first, screens
+second.** The core PR carries the domain types, the events, the migration and
+the tests; the screens PR carries the SwiftUI and its snapshots. Only split when
+the phase really does span both — a core-only or screens-only phase stays one PR.
+
+Why (2026-08-07, #1256 Phase B): one PR of 4,300 insertions covering seven
+designed frames, a bridge change and a migration. Both blockers the self-review
+found were in core code written in the first third, and finding them at the end
+meant re-running every gate and rebasing. Two PRs would each have been ~45
+minutes, each independently reviewable, and the bridge risk would have landed
+away from the UI churn.
+
+**Review the core PR before starting the screens.** `requesting-code-review`
+says "review early, review often"; on a multi-surface phase, once at the end is
+too late to be cheap.
 
 Do not run `/speckit-*` slash commands. Historical SpecKit folders under
 `specs/` are reference only.

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -1066,16 +1066,9 @@ mod tests {
 
     fn closed_block(id: &str, verdicts: &[(bool, i64)], exit: Exit) -> BlockRecord {
         use crate::engine::gate::EvidenceSource;
-        use crate::engine::plan::{BlockOrigin, Circle, Mode};
         use crate::engine::session::AttemptSummary;
         BlockRecord {
             id: id.to_string(),
-            node: "rootless-a-b".to_string(),
-            drill: "rootless-under-melody".to_string(),
-            gate: "rootless-under-melody".to_string(),
-            level: fixture_level(),
-            circle: Circle::Hands,
-            mode: Mode::Keys,
             started_at: at(0),
             ended_at: at(verdicts.last().map(|(_, second)| *second).unwrap_or(0)),
             attempts: verdicts
@@ -1095,11 +1088,8 @@ mod tests {
                 .collect(),
             attempts_to_pass: None,
             gate_opened_at_attempt: None,
-            reps_after_gate: 0,
-            active_ms: 0,
-            escalation_fired: vec![],
             exit,
-            origin: BlockOrigin::Authored,
+            ..BlockRecord::fixture()
         }
     }
 

--- a/crates/intrada-core/src/engine/plan.rs
+++ b/crates/intrada-core/src/engine/plan.rs
@@ -742,43 +742,52 @@ fn block_spec(content: &ContentIndex, candidate: &Candidate) -> BlockSpec {
 }
 
 #[cfg(test)]
+impl BlockSpec {
+    /// The one place a test `BlockSpec` is spelt out in full — compose with
+    /// `BlockSpec { minutes: 3, ..fixture() }` so a new field costs one edit.
+    pub(crate) fn fixture() -> Self {
+        Self {
+            node: "rootless-a-b".to_string(),
+            drill: "rootless-under-melody".to_string(),
+            drill_title: "Rootless voicings".to_string(),
+            section: Some("A section".to_string()),
+            destination: Some("Strasbourg / St. Denis".to_string()),
+            kind: ItemKind::Exercise,
+            circle: Circle::Hands,
+            mode: Mode::Keys,
+            gate: GateCriteria {
+                id: "rootless-under-melody".to_string(),
+                node: "rootless-a-b".to_string(),
+                criterion: "Strasbourg A section, melody over rootless LH".to_string(),
+                requirement: Requirement::CleanPasses {
+                    count: 3,
+                    consecutive: false,
+                },
+                judge: Judge::TapVerdict,
+                time_ceiling_s: Some(360),
+            },
+            level: ParameterLevel {
+                tempo_bpm: 120,
+                click_level: ClickLevel::TwoAndFour,
+            },
+            bars: 8,
+            beats_per_bar: 4,
+            count_in_beats: 4,
+            minutes: 6,
+            origin: BlockOrigin::Authored,
+            serves: None,
+        }
+    }
+}
+
+#[cfg(test)]
 impl Plan {
     /// A stable plan for the state-machine tests, so what they assert is the
     /// machine rather than whatever the authored content currently says.
     pub(crate) fn fixture() -> Self {
         Self {
             blocks: vec![PlannedBlock {
-                spec: BlockSpec {
-                    node: "rootless-a-b".to_string(),
-                    drill: "rootless-under-melody".to_string(),
-                    drill_title: "Rootless voicings".to_string(),
-                    section: Some("A section".to_string()),
-                    destination: Some("Strasbourg / St. Denis".to_string()),
-                    kind: ItemKind::Exercise,
-                    circle: Circle::Hands,
-                    mode: Mode::Keys,
-                    gate: GateCriteria {
-                        id: "rootless-under-melody".to_string(),
-                        node: "rootless-a-b".to_string(),
-                        criterion: "Strasbourg A section, melody over rootless LH".to_string(),
-                        requirement: Requirement::CleanPasses {
-                            count: 3,
-                            consecutive: false,
-                        },
-                        judge: Judge::TapVerdict,
-                        time_ceiling_s: Some(360),
-                    },
-                    level: ParameterLevel {
-                        tempo_bpm: 120,
-                        click_level: ClickLevel::TwoAndFour,
-                    },
-                    bars: 8,
-                    beats_per_bar: 4,
-                    count_in_beats: 4,
-                    minutes: 6,
-                    origin: BlockOrigin::Authored,
-                    serves: None,
-                },
+                spec: BlockSpec::fixture(),
                 why: Why {
                     destination: Some("Strasbourg / St. Denis".to_string()),
                     node_state: NodeState {

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -244,6 +244,34 @@ pub struct BlockRecord {
     pub origin: BlockOrigin,
 }
 
+#[cfg(test)]
+impl BlockRecord {
+    /// The one place a test `BlockRecord` is spelt out in full — compose with
+    /// `BlockRecord { exit: Exit::Skipped, ..fixture() }`.
+    pub(crate) fn fixture() -> Self {
+        let spec = crate::engine::plan::BlockSpec::fixture();
+        Self {
+            id: "01J000000000000000000BREC".to_string(),
+            node: spec.node,
+            drill: spec.drill,
+            gate: spec.gate.id,
+            level: spec.level,
+            circle: spec.circle,
+            mode: spec.mode,
+            started_at: DateTime::UNIX_EPOCH,
+            ended_at: DateTime::UNIX_EPOCH,
+            attempts: Vec::new(),
+            attempts_to_pass: None,
+            gate_opened_at_attempt: None,
+            reps_after_gate: 0,
+            active_ms: 0,
+            escalation_fired: Vec::new(),
+            exit: Exit::SessionEnded,
+            origin: BlockOrigin::Authored,
+        }
+    }
+}
+
 /// A wander has no node, drill, gate or level, so it gets its own type rather
 /// than turning every id on `BlockRecord` into an `Option` (spec §4).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -1204,10 +1232,129 @@ impl EngineSession {
 mod tests {
     use super::*;
     use crate::engine::gate::{ClickLevel, Requirement};
+    use crate::engine::plan::Alternative;
     use chrono::TimeZone;
 
     fn at(second: i64) -> DateTime<Utc> {
         Utc.timestamp_opt(1_754_300_000 + second, 0).unwrap()
+    }
+
+    // ── The crash-recovery blob's wire shape ────────────────────────────
+    //
+    // `EngineSession` goes to UserDefaults as positional bincode, written by one
+    // build and read by the next. A field added anywhere in its transitive graph
+    // makes an old blob decode into a valid-looking wrong session, and
+    // `#[serde(default)]` cannot help — serde never reaches the default on a
+    // wire with no field names. The shell must read the new shape under a new
+    // key. Missed three times (#1223, #1244, #1256), each caught by a person.
+
+    const SHELL_SNAPSHOT_KEY: &str = "intrada.coach-session-in-progress.v4";
+    const SNAPSHOT_WIRE_LEN: usize = 1390;
+    const SNAPSHOT_WIRE_HASH: u64 = 0x090a125921cf96fc;
+
+    /// FNV-1a rather than `DefaultHasher`, whose output is explicitly unstable
+    /// across Rust releases — this value is committed.
+    fn fingerprint(bytes: &[u8]) -> u64 {
+        bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x1000_0000_01b3)
+        })
+    }
+
+    /// Saturated: every `Vec` non-empty and every `Option` `Some`, or a new
+    /// field nested inside one would not reach the wire. `Plan::fixture` is
+    /// deliberately not this.
+    fn saturated_session() -> EngineSession {
+        let mut plan = Plan::fixture();
+        plan.deferred.push("nothing here can count it".to_string());
+        plan.blocks[0].new_keys = Some(2);
+        plan.blocks[0].spec.serves = Some("Adds to what your hands know".to_string());
+        let alternative = Alternative {
+            rung: Rung::TempoDown,
+            spec: plan.blocks[0].spec.clone(),
+            why: plan.blocks[0].why.clone(),
+        };
+        plan.blocks[0].alternatives.push(alternative);
+
+        let mut session = EngineSession::default();
+        session.start(plan, at(0));
+        session.apply(&CoachEvent::Beat { beat_index: 0 });
+        session.apply(&CoachEvent::Beat { beat_index: 32 });
+        session.apply(&CoachEvent::Tap {
+            clean: true,
+            now: at(9),
+        });
+        if let Some(block) = session.block_mut() {
+            // `BlockState::open` mints a ulid — the one random thing on this
+            // wire, and the fingerprint must move only when the shape does.
+            block.id = "01J00000000000000000LIVEB".to_string();
+            block.escalation_fired.push(Rung::ShrinkScope);
+            block.gate_open_since = Some(at(9));
+            block.gate_opened_at_attempt = Some(1);
+            if let Some(attempt) = block.attempts.first_mut() {
+                attempt.self_predicted = Some(Verdict::Clean);
+            }
+        }
+
+        let spec = BlockSpec::fixture();
+        session.closed_blocks.push(BlockRecord {
+            id: "b0".to_string(),
+            started_at: at(0),
+            ended_at: at(60),
+            attempts: vec![AttemptSummary {
+                at: at(30),
+                verdict: Verdict::Missed,
+                source: EvidenceSource::TapVerdict,
+                cold: true,
+                self_predicted: Some(Verdict::Clean),
+                level: spec.level,
+            }],
+            // `Some` against the fixture's `None`: see `saturated_session`.
+            attempts_to_pass: Some(3),
+            gate_opened_at_attempt: Some(3),
+            reps_after_gate: 1,
+            active_ms: 60_000,
+            escalation_fired: vec![Rung::SwapDrill],
+            exit: Exit::GatePassed,
+            origin: BlockOrigin::Judgement,
+            ..BlockRecord::fixture()
+        });
+        session.wanders.push(WanderRecord {
+            id: "w0".to_string(),
+            started_at: at(70),
+            ended_at: at(130),
+            attempts: vec![AttemptSummary {
+                at: at(80),
+                verdict: Verdict::Clean,
+                source: EvidenceSource::TapVerdictUntimed,
+                cold: false,
+                self_predicted: None,
+                level: spec.level,
+            }],
+            keep_as_drill: Some(true),
+        });
+        session.unmonitored_seconds = 90;
+        session
+    }
+
+    /// Never re-pin this on its own: bumping the shell key is the other half,
+    /// and skipping it is the bug this exists to catch. The failure says how.
+    #[test]
+    fn the_crash_recovery_wire_is_pinned_to_the_shell_key_that_reads_it() {
+        use crux_core::bridge::{BincodeFfiFormat, FfiFormat};
+        let mut bytes = Vec::new();
+        BincodeFfiFormat::serialize(&mut bytes, &saturated_session()).expect("serialize");
+
+        assert_eq!(
+            (bytes.len(), fingerprint(&bytes)),
+            (SNAPSHOT_WIRE_LEN, SNAPSHOT_WIRE_HASH),
+            "the crash-recovery wire changed, so a blob written by the last \
+             build no longer means what it says.\n\
+             Bump coachSessionInProgressKey past {SHELL_SNAPSHOT_KEY} in \
+             ios/Intrada/Core/Store.swift, retire the old key, then set \
+             SNAPSHOT_WIRE_LEN = {} and SNAPSHOT_WIRE_HASH = {:#018x} here.",
+            bytes.len(),
+            fingerprint(&bytes)
+        );
     }
 
     /// Started, count-in done, one body beat played — the state every rep runs in.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -214,6 +214,53 @@ contract, the split cost more than it bought. Measured on that PR:
 The rule that came out of it — one agent per vertical slice, fan out only on
 genuinely independent work — is in CLAUDE.md under *Parallel work streams*.
 
+## Where #1256 Phase B's time actually went (2026-08-07)
+
+A retrospective measured rather than estimated, after Phase B felt slow. It is
+the source of the split-the-phase rule, the wire-shape gate, the shared fixtures
+and `just ios-snapshots-record`.
+
+**The tooling was not the bottleneck.** Timed on the worktree that built it:
+
+| Loop | Wall clock |
+|------|-----------|
+| `just ios-test`, warm | 43s |
+| `just ios-test` after one Swift edit | 31s |
+| One scoped test via `_ios-test-without-building` | 24s |
+| Whole CI run | ~10 min |
+
+Roughly, across about two hours: writing code and tests ~55%, review-and-then-
+re-run-everything ~20%, local gates ~15%, flakes and dead ends ~10%.
+
+**What actually cost time, in order:**
+
+1. **One PR for a phase spanning core and screens.** 4,300 insertions, seven
+   designed frames, a bridge change and a migration. Both self-review blockers
+   were in core code written in the first third; finding them at the end meant
+   re-running every gate and rebasing onto a main that had moved.
+2. **Reviewing once, at the end.** `requesting-code-review` says "review early,
+   often". A review after the core landed would have caught both blockers before
+   any SwiftUI existed.
+3. **The field-addition tax.** Adding `origin` to `BlockSpec`/`BlockRecord` broke
+   six construction sites, each found by a separate build, because errors were
+   read one at a time rather than with `cargo check --all-targets`.
+4. **Snapshot recording by hand.** Delete, run, run, optimise, check — five
+   steps, done five times. `ios-snapshots-optimize` over the whole suite cost
+   more than the test run it followed (94s → 50s once scoped).
+5. **Fighting the size ceiling before reading it.** Four cycles trying crops on
+   gradient-heavy references, when `check-snapshots.sh`'s own comment says
+   cropping cannot help those.
+
+**Tests, judged honestly.** Duration is fine. One real flake —
+`ClickEngineTests` stands up an `AVAudioEngine` inside a merge gate (#1282).
+The simulator's own "Busy / preflight checks" cost four local cycles. And the
+criterion parser's fourteen green unit tests all used sentences written to match
+the scanner, which is why it shipped misreading the likeliest real one.
+
+**What was worth keeping**: the code-reviewer subagent (two blockers for
+fourteen minutes), driving the simulator rather than trusting green tests, TDD
+on the core, and reading the spec and mockups properly.
+
 ## Mutate-response variants, in full
 
 Writes reconcile with the server response directly, with no full-list refetch.

--- a/ios/IntradaTests/CoachFixtures.swift
+++ b/ios/IntradaTests/CoachFixtures.swift
@@ -1,0 +1,50 @@
+import SharedTypes
+
+/// The one place a test coach record is spelt out in full. The generated types
+/// have no memberwise default, so every field gets one here instead: a new Rust
+/// field costs one edit rather than one per call site (#1256's `origin` cost
+/// four, each found by a separate build).
+enum CoachFixture {
+  static func attempt(
+    at: String = "2026-08-04T10:00:09Z",
+    verdict: Verdict = .clean,
+    source: EvidenceSource = .tapVerdict,
+    cold: Bool = false,
+    selfPredicted: Verdict? = nil,
+    level: ParameterLevel = Self.level
+  ) -> AttemptSummary {
+    AttemptSummary(
+      at: at, verdict: verdict, source: source, cold: cold, selfPredicted: selfPredicted,
+      level: level)
+  }
+
+  /// Computed, not stored: the generated types are not `Sendable`.
+  static var level: ParameterLevel { ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour) }
+
+  static func blockRecord(
+    id: String = "b1",
+    node: String = "rootless-a-b",
+    drill: String = "shell-voicings",
+    gate: String = "rootless-under-melody",
+    level: ParameterLevel = Self.level,
+    circle: Circle = .hands,
+    mode: Mode = .keys,
+    startedAt: String = "2026-08-04T10:00:00Z",
+    endedAt: String = "2026-08-04T10:00:30Z",
+    attempts: [AttemptSummary] = [],
+    attemptsToPass: UInt16? = 3,
+    gateOpenedAtAttempt: UInt16? = 3,
+    repsAfterGate: UInt16 = 0,
+    activeMs: UInt64 = 30_000,
+    escalationFired: [Rung] = [],
+    exit: Exit = .gatePassed,
+    origin: BlockOrigin = .authored
+  ) -> BlockRecord {
+    BlockRecord(
+      id: id, node: node, drill: drill, gate: gate, level: level, circle: circle, mode: mode,
+      startedAt: startedAt, endedAt: endedAt, attempts: attempts,
+      attemptsToPass: attemptsToPass, gateOpenedAtAttempt: gateOpenedAtAttempt,
+      repsAfterGate: repsAfterGate, activeMs: activeMs, escalationFired: escalationFired,
+      exit: exit, origin: origin)
+  }
+}

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -37,12 +37,8 @@ struct CoachRecordStoreTests {
     repsAfterGate: UInt16 = 0, activeMs: UInt64 = 30_000,
     origin: BlockOrigin = .authored
   ) -> BlockRecord {
-    BlockRecord(
-      id: id, node: "rootless-a-b", drill: "shell-voicings", gate: "rootless-under-melody",
-      level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour),
-      circle: .hands, mode: .keys,
-      startedAt: "2026-08-04T10:00:00Z", endedAt: Self.updatedAt,
-      attempts: attempts, attemptsToPass: attemptsToPass,
+    CoachFixture.blockRecord(
+      id: id, endedAt: Self.updatedAt, attempts: attempts, attemptsToPass: attemptsToPass,
       gateOpenedAtAttempt: gateOpenedAtAttempt, repsAfterGate: repsAfterGate,
       activeMs: activeMs, escalationFired: escalations, exit: exit, origin: origin)
   }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -123,17 +123,8 @@ final class StoreEffectLoopTests: XCTestCase {
       "a failing local store must resolve .failed, not a phantom .ack")
   }
 
-  private static let coachBlock = BlockRecord(
-    id: "b1", node: "rootless-a-b", drill: "shell-voicings", gate: "rootless-under-melody",
-    level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour), circle: .hands, mode: .keys,
-    startedAt: "2026-08-04T10:00:00Z", endedAt: "2026-08-04T10:00:30Z",
-    attempts: [
-      AttemptSummary(
-        at: "2026-08-04T10:00:09Z", verdict: .clean, source: .tapVerdict, cold: true,
-        selfPredicted: nil, level: ParameterLevel(tempoBpm: 92, clickLevel: .twoAndFour))
-    ],
-    attemptsToPass: 3, gateOpenedAtAttempt: 3, repsAfterGate: 0, activeMs: 30_000,
-    escalationFired: [], exit: .gatePassed, origin: .authored)
+  private static let coachBlock = CoachFixture.blockRecord(
+    attempts: [CoachFixture.attempt(cold: true)])
 
   private static func saveCoachRecords(id: UInt32) -> Request {
     Request(
@@ -1104,21 +1095,14 @@ final class StoreEffectLoopTests: XCTestCase {
   /// enough back to be overdue by the time the plan is asked for.
   private static var overdueEvidence: [BlockRecord] {
     (0..<12).map { day in
-      BlockRecord(
+      let level = ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour)
+      let date = String(format: "%02d", day + 1)
+      return CoachFixture.blockRecord(
         id: "b\(day)", node: "phrase-transposition", drill: "phrase-home-key",
-        gate: "phrase-home-key",
-        level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour),
-        circle: .head, mode: .keys,
-        startedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:00Z",
-        endedAt: "2026-08-\(String(format: "%02d", day + 1))T10:00:30Z",
-        attempts: [
-          AttemptSummary(
-            at: "2026-08-\(String(format: "%02d", day + 1))T10:00:09Z", verdict: .clean,
-            source: .tapVerdict, cold: false, selfPredicted: nil,
-            level: ParameterLevel(tempoBpm: 120, clickLevel: .twoAndFour))
-        ],
-        attemptsToPass: nil, gateOpenedAtAttempt: nil, repsAfterGate: 0, activeMs: 30_000,
-        escalationFired: [], exit: .ceilingHit, origin: .authored)
+        gate: "phrase-home-key", level: level, circle: .head,
+        startedAt: "2026-08-\(date)T10:00:00Z", endedAt: "2026-08-\(date)T10:00:30Z",
+        attempts: [CoachFixture.attempt(at: "2026-08-\(date)T10:00:09Z", level: level)],
+        attemptsToPass: nil, gateOpenedAtAttempt: nil, exit: .ceilingHit)
     }
   }
 

--- a/justfile
+++ b/justfile
@@ -280,6 +280,41 @@ ios-snapshots-optimize:
     find ios/IntradaTests/__Snapshots__ -name '*.png' -exec oxipng -o max --quiet {} +
     @echo "✓ snapshots optimized — review the git diff and commit"
 
+# Re-record snapshot references for the tests matching `filter`, then optimise
+# and re-check in one pass.
+#
+# Recording is delete-then-run-twice by nature: swift-snapshot-testing writes a
+# missing reference and *fails* that run, so the second run is what proves the
+# new image. Doing that by hand over the whole suite is the slow part of any UI
+# change — five rounds of it is most of what made #1256 Phase B feel long.
+#
+# `filter` is anything `-only-testing:` accepts, minus the target prefix:
+#   just ios-snapshots-record ScreenSnapshotTests/testComposeSheetFirstUse
+#   just ios-snapshots-record ScreenSnapshotTests   # the whole class
+[group('iOS')]
+ios-snapshots-record filter: _ios-sync
+    #!/usr/bin/env bash
+    set -euo pipefail
+    snaps=ios/IntradaTests/__Snapshots__
+    # A method filter names one reference; a class filter names all of its own.
+    # Newline-delimited rather than an array: macOS ships bash 3.2, no mapfile.
+    method="$(basename "{{filter}}")"
+    if [ "$method" != "{{filter}}" ]; then
+        refs="$(find "$snaps" -name "$method.*.png")"
+    else
+        refs="$(find "$snaps/$method" -name '*.png' 2>/dev/null || true)"
+    fi
+    [ -z "$refs" ] || printf '%s\n' "$refs" | tr '\n' '\0' | xargs -0 rm -v
+    just _ios-build-for-testing
+    # First run writes the references and fails by design; the second is the
+    # one whose result means anything.
+    just _ios-test-without-building "IntradaTests/{{filter}}" 0 || true
+    just _ios-test-without-building "IntradaTests/{{filter}}" 0
+    # Only what was just written: `oxipng -o max` over the whole suite costs
+    # more than the test run it follows.
+    [ -z "$refs" ] || printf '%s\n' "$refs" | tr '\n' '\0' | xargs -0 oxipng -o max --quiet
+    just ios-snapshots-check
+
 # Orphan + size-ceiling check on snapshot references (same as CI).
 [group('iOS')]
 ios-snapshots-check:


### PR DESCRIPTION
Phase B felt slow, so I measured where it actually went before changing anything. The write-up is in `docs/reference.md`; this PR is the fixes that fall out of it.

**The finding that reframed it: the tooling was never the bottleneck.** Timed on the worktree that built Phase B:

| Loop | Wall clock |
|------|-----------|
| `just ios-test`, warm | 43s |
| `just ios-test` after one Swift edit | 31s |
| One scoped test | 24s |

Roughly, across two hours: writing code and tests ~55%, review-then-re-run-everything ~20%, local gates ~15%, flakes and dead ends ~10%. So the wins are in **process and gates**, not in making builds faster.

## The crash-recovery wire now has a gate

Adding a field anywhere inside `EngineSession` invalidates every crash-recovery blob on every device — it is positional bincode, written by one build and read by the next, and `#[serde(default)]` cannot help because serde never reaches the default on a wire with no field names. The shell has to read the new shape under a new key.

That has been missed **three times** — #1223, #1244 and #1256 — each caught by a person reading a diff. `the_crash_recovery_wire_is_pinned_to_the_shell_key_that_reads_it` serialises a saturated session and pins its byte length and FNV-1a hash. FNV rather than `DefaultHasher`, whose output is explicitly unstable across Rust releases.

Mutation-tested rather than assumed: adding a throwaway field to `BlockSpec` makes it fail with

```
Bump coachSessionInProgressKey past intrada.coach-session-in-progress.v4 in
ios/Intrada/Core/Store.swift, retire the old key, then set
SNAPSHOT_WIRE_LEN = 1392 and SNAPSHOT_WIRE_HASH = 0x42c8f5936e9093ce here.
```

Two notes on the fixture, both found by the test itself: the live block's id had to be pinned because `BlockState::open` mints a ulid, and the record's `Option`s must stay `Some`, since inheriting `None` from a default hides the payload's width.

## Canonical fixtures

`BlockSpec::fixture()`, `BlockRecord::fixture()` and Swift's new `CoachFixture` replace six hand-spelt literals. Adding `origin` in #1256 cost four separate builds to find every site; it now costs one edit. Production construction sites stay explicit — those *should* break loudly.

## `just ios-snapshots-record <filter>`

Delete, run, run, optimise, check — the five manual steps behind every re-record, as one scoped command. 94s → 50s, mostly by not running `oxipng -o max` over all fifty references in order to re-record one. Verified idempotent: re-recording a committed reference reproduces it byte for byte.

```bash
just ios-snapshots-record ScreenSnapshotTests/testComposeSheetFirstUse
```

## Process (CLAUDE.md)

- **A Tier 3 phase spanning core *and* screens ships as two PRs**, core reviewed before the screens start. Phase B was 4,300 insertions in one; both self-review blockers were in core code written in the first third, so finding them at the end meant re-running every gate and rebasing.
- **Parsers get a table test against their consumer**, not cases you invented — Phase B's parser had fourteen green tests written to match the scanner and still read "three clean passes in a row" as the key of A.
- **Read every compile error before fixing the first** (`cargo check --all-targets`).
- **Read `check-snapshots.sh` before fighting the size ceiling** — it has an allowlist, and cropping cannot help a gradient. Four cycles went into learning that the hard way.

## Not fixed

`ClickEngineTests` stands up a real `AVAudioEngine` inside a merge gate and flaked once on #1279 — tracked in #1282 rather than fixed here, since one observation is thin and the fix is a refactor of code this PR does not touch.

**Coverage**: the new Rust is one test plus two test-only fixture constructors, so patch coverage should be at or near 100% for `session.rs`; `ios/` is a Codecov-ignored path. Note Codecov has posted no comment on the last three PRs — worth checking the app is still installed.

`just check`, `just ios-fmt-check`, `just ios-test-full` and `just ios-snapshots-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)