### PR TITLE
feat(core): built session Phase C core — Journey B's three altitudes (#1256)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -197,11 +197,21 @@ impl App for Intrada {
 /// the crash-recovery blob. Shared, because a built session enters the same
 /// state machine by a different door (#1256) and its writes must not go
 /// missing on the way.
+/// Replay every kind of evidence the store holds, from whichever load has
+/// landed. `rebuild_mastery` replaces rather than adds, so running it twice at
+/// launch costs a rebuild and can never double-count (#1214).
+fn rebuild_mastery(model: &mut Model) {
+    model
+        .coach
+        .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
+}
+
 pub(crate) fn coach_write_commands(
     model: &mut Model,
     writes: crate::engine::CoachWrites,
 ) -> Vec<Command<Effect, Event>> {
     let mut commands = Vec::new();
+    model.play_throughs.extend(writes.play_throughs.clone());
     // Append-only rows, so `updated_at` is the instant the record closed on the
     // engine's own clock — the shell never formats a timestamp of its own (the
     // `saveSession` convention).
@@ -209,11 +219,13 @@ pub(crate) fn coach_write_commands(
         .blocks
         .last()
         .map(|record| record.ended_at)
-        .or_else(|| writes.wanders.last().map(|record| record.ended_at));
+        .or_else(|| writes.wanders.last().map(|record| record.ended_at))
+        .or_else(|| writes.play_throughs.last().map(|record| record.ended_at));
     if let Some(recorded_at) = recorded_at {
         let batch = PersistenceOperation::SaveCoachRecords {
             blocks: writes.blocks,
             wanders: writes.wanders,
+            play_throughs: writes.play_throughs,
             updated_at: recorded_at,
         };
         model.coach_write_in_flight = Some(batch.clone());
@@ -459,7 +471,8 @@ impl Intrada {
                 // No render: nothing in `ViewModel` derives from the mastery
                 // track; it reaches a screen only through the plan, computed later.
                 PersistenceOutput::CoachRecords(blocks) => {
-                    model.coach.rebuild_mastery(blocks);
+                    model.coach_blocks = blocks;
+                    rebuild_mastery(model);
                     Command::done()
                 }
                 PersistenceOutput::Items(_)
@@ -501,6 +514,10 @@ impl Intrada {
                     model.play_throughs = data.play_throughs;
                     model.reflections = data.reflections;
                     model.feel_entries = data.feel_entries;
+                    // A run-through's section verdicts are mastery evidence, and
+                    // they arrive here rather than with the block records. The
+                    // two loads race, so both rebuild.
+                    rebuild_mastery(model);
                     crux_core::render::render()
                 }
                 PersistenceOutput::Ack

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -193,24 +193,31 @@ impl App for Intrada {
     }
 }
 
-/// What one applied coach event leaves for the shell: the evidence batch and
-/// the crash-recovery blob. Shared, because a built session enters the same
-/// state machine by a different door (#1256) and its writes must not go
-/// missing on the way.
 /// Replay every kind of evidence the store holds, from whichever load has
-/// landed. `rebuild_mastery` replaces rather than adds, so running it twice at
-/// launch costs a rebuild and can never double-count (#1214).
+/// landed. `rebuild_mastery` replaces rather than adds, so running it twice
+/// costs a rebuild and can never double-count (#1214) — but only while the
+/// model holds *everything* the live track was fed, which is why
+/// [`coach_write_commands`] banks each record as it closes.
 fn rebuild_mastery(model: &mut Model) {
     model
         .coach
         .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
 }
 
+/// What one applied coach event leaves for the shell: the evidence batch and
+/// the crash-recovery blob. Shared, because a built session enters the same
+/// state machine by a different door (#1256) and its writes must not go
+/// missing on the way.
 pub(crate) fn coach_write_commands(
     model: &mut Model,
     writes: crate::engine::CoachWrites,
 ) -> Vec<Command<Effect, Event>> {
     let mut commands = Vec::new();
+    // Banked as they close, not just handed to the store: a later reload — a
+    // failed built-session write reissues one — rebuilds the mastery track from
+    // the model, and a record the model dropped is evidence the rebuild would
+    // silently undo.
+    model.coach_blocks.extend(writes.blocks.clone());
     model.play_throughs.extend(writes.play_throughs.clone());
     // Append-only rows, so `updated_at` is the instant the record closed on the
     // engine's own clock — the shell never formats a timestamp of its own (the

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -11,6 +11,7 @@
 pub mod blocks;
 pub mod compose;
 pub mod criterion;
+pub mod playthrough;
 #[cfg(test)]
 pub(crate) mod tests_support;
 
@@ -19,7 +20,7 @@ use crux_core::command::Command;
 use serde::{Deserialize, Serialize};
 
 use crate::app::{Effect, Event};
-use crate::engine::Circle;
+use crate::engine::{Altitude, Circle, CoachEvent};
 use crate::model::Model;
 use crate::persistence;
 use crate::validation;
@@ -202,16 +203,6 @@ pub struct CreateUserDrill {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
-pub struct RecordPlayThrough {
-    pub item_id: String,
-    pub started_at: DateTime<Utc>,
-    pub ended_at: DateTime<Utc>,
-    pub counted: bool,
-    pub sections: Vec<SectionVerdict>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct CreateJournalItem {
     pub name: String,
     pub notes: Option<String>,
@@ -242,7 +233,6 @@ pub enum BuiltSessionEvent {
     SaveBuiltSession {
         session: BuiltSession,
     },
-    RecordPlayThrough(RecordPlayThrough),
     RecordReflection {
         kind: ReflectionKind,
         session_ref: Option<String>,
@@ -303,6 +293,16 @@ pub enum BuiltSessionEvent {
     /// Start the composed session in the canonical drill loop (A6 → A7).
     StartBuiltSession {
         session_id: String,
+        now: DateTime<Utc>,
+    },
+
+    // ── The altitudes (Journey B) ────────────────────────────────────
+    /// B0's answer to "Play it through — how should it count?". The piece is
+    /// resolved here, where the library lives; the engine is handed the named
+    /// sections and never does a lookup of its own.
+    StartPlayThrough {
+        item_id: String,
+        altitude: Altitude,
         now: DateTime<Utc>,
     },
 }
@@ -409,20 +409,6 @@ pub fn handle_built_session_event(
                 None => model.built_sessions.push(session.clone()),
             }
             save_and_render(persistence::save_built_session(session))
-        }
-        BuiltSessionEvent::RecordPlayThrough(input) => {
-            let record = PlayThroughRecord {
-                id: mint_id(),
-                item_id: input.item_id,
-                started_at: input.started_at,
-                ended_at: input.ended_at,
-                counted: input.counted,
-                sections: input.sections,
-                updated_at: now,
-                deleted_at: None,
-            };
-            model.play_throughs.push(record.clone());
-            save_and_render(persistence::save_play_through(record))
         }
         BuiltSessionEvent::RecordReflection {
             kind,
@@ -671,6 +657,41 @@ pub fn handle_built_session_event(
             }
             model.built_session_today = Some(session_id);
             let writes = model.coach.adopt_plan(plan, now);
+            let mut commands = crate::app::coach_write_commands(model, writes);
+            commands.push(crux_core::render::render());
+            Command::all(commands)
+        }
+
+        BuiltSessionEvent::StartPlayThrough {
+            item_id,
+            altitude,
+            now,
+        } => {
+            let Some(item) = model.items.iter().find(|item| item.id == item_id) else {
+                model.surface_error("That piece is no longer there.");
+                return crux_core::render::render();
+            };
+            if !playthrough::can_enter(item, altitude) {
+                model.surface_error("Add some section labels to the chart first.");
+                return crux_core::render::render();
+            }
+            let event = match altitude {
+                Altitude::RunThrough => CoachEvent::StartRunThrough {
+                    item_id: item.id.clone(),
+                    title: item.title.clone(),
+                    sections: playthrough::named_sections(item),
+                    now,
+                },
+                Altitude::OffPiste => CoachEvent::GoOffPiste {
+                    item_id: Some(item.id.clone()),
+                    now,
+                },
+                // The piece is dropped on purpose: this altitude captures
+                // nothing, so there is no record to tag and nothing that could
+                // later say what was played. See `SessionState::Unmonitored`.
+                Altitude::Unmonitored => CoachEvent::GoUnmonitored { now },
+            };
+            let writes = model.coach.apply(&event);
             let mut commands = crate::app::coach_write_commands(model, writes);
             commands.push(crux_core::render::render());
             Command::all(commands)
@@ -1119,55 +1140,6 @@ mod tests {
             },
         );
         assert_eq!(model.built_sessions.len(), 1);
-    }
-
-    #[test]
-    fn record_play_through_mints_a_ulid_and_persists() {
-        let mut model = Model::test_default();
-        let effects = update(
-            &mut model,
-            BuiltSessionEvent::RecordPlayThrough(RecordPlayThrough {
-                item_id: "piece".into(),
-                started_at: at(),
-                ended_at: at(),
-                counted: true,
-                sections: vec![SectionVerdict {
-                    section: "The bridge".into(),
-                    held: false,
-                    at: at(),
-                }],
-            }),
-        );
-        assert_eq!(model.play_throughs.len(), 1);
-        assert_eq!(model.play_throughs[0].id.len(), 26);
-        assert_eq!(model.play_throughs[0].deleted_at, None);
-        assert_eq!(model.play_throughs[0].sections.len(), 1);
-        assert_eq!(
-            persistence_ops(&effects),
-            vec![PersistenceOperation::SavePlayThrough(
-                model.play_throughs[0].clone()
-            )]
-        );
-        assert_no_http(&effects);
-    }
-
-    #[test]
-    fn two_play_throughs_are_two_records() {
-        let mut model = Model::test_default();
-        let input = RecordPlayThrough {
-            item_id: "piece".into(),
-            started_at: at(),
-            ended_at: at(),
-            counted: true,
-            sections: vec![],
-        };
-        update(
-            &mut model,
-            BuiltSessionEvent::RecordPlayThrough(input.clone()),
-        );
-        update(&mut model, BuiltSessionEvent::RecordPlayThrough(input));
-        assert_eq!(model.play_throughs.len(), 2);
-        assert_ne!(model.play_throughs[0].id, model.play_throughs[1].id);
     }
 
     #[test]
@@ -1823,6 +1795,204 @@ mod tests {
         assert_no_http(&effects);
     }
 
+    // ── The altitudes, end to end (Journey B) ───────────────────────────
+
+    fn charted_piece(id: &str) -> crate::domain::item::Item {
+        let mut item = sample_item(id, "Alice in Wonderland", ItemKind::Piece);
+        item.chord_chart = Some(
+            crate::domain::chart::parse_chart(
+                "[A]\n| Cmaj7 | Am7 |\n[Bridge]\n| Dm7 | G7 |",
+                "C",
+                crate::domain::item::Modality::Major,
+            )
+            .expect("a valid chart"),
+        );
+        item
+    }
+
+    fn start_altitude(model: &mut Model, item_id: &str, altitude: Altitude) -> Vec<Effect> {
+        update(
+            model,
+            BuiltSessionEvent::StartPlayThrough {
+                item_id: item_id.into(),
+                altitude,
+                now: at(),
+            },
+        )
+    }
+
+    #[test]
+    fn b0_runs_a_charted_piece_through_its_own_sections() {
+        let mut model = Model::test_default();
+        model.items.push(charted_piece("p1"));
+        let effects = start_altitude(&mut model, "p1", Altitude::RunThrough);
+
+        let run = view(&model)
+            .coach
+            .run_through
+            .expect("the run-through screen has something to draw");
+        assert_eq!(run.sections, vec!["A", "Bridge"]);
+        assert_eq!(run.current_section.as_deref(), Some("A"));
+        assert_eq!(run.title, "Alice in Wonderland");
+        assert_eq!(view(&model).coach.altitude, Some(Altitude::RunThrough));
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn a_piece_with_no_named_sections_is_refused_rather_than_run_on_nothing() {
+        let mut model = Model::test_default();
+        model
+            .items
+            .push(sample_item("p1", "Untitled", ItemKind::Piece));
+        start_altitude(&mut model, "p1", Altitude::RunThrough);
+
+        assert!(view(&model).coach.run_through.is_none());
+        assert!(
+            model.last_error.is_some(),
+            "a refusal with no surface is the silent-no-op bug (#846)"
+        );
+    }
+
+    #[test]
+    fn the_lower_altitudes_need_nothing_authored() {
+        let mut model = Model::test_default();
+        model
+            .items
+            .push(sample_item("p1", "Untitled", ItemKind::Piece));
+
+        start_altitude(&mut model, "p1", Altitude::OffPiste);
+        assert_eq!(view(&model).coach.altitude, Some(Altitude::OffPiste));
+        assert!(model.last_error.is_none());
+    }
+
+    #[test]
+    fn a_finished_run_lands_its_verdicts_and_its_record() {
+        let mut model = Model::test_default();
+        model.items.push(charted_piece("p1"));
+        start_altitude(&mut model, "p1", Altitude::RunThrough);
+
+        for held in [true, false] {
+            app_update(
+                &mut model,
+                Event::Coach(CoachEvent::JudgeSection { held, now: at() }),
+            );
+        }
+        let effects = app_update(
+            &mut model,
+            Event::Coach(CoachEvent::CloseSession { now: at() }),
+        );
+
+        assert_eq!(model.play_throughs.len(), 1, "the record is the user's");
+        assert_eq!(model.play_throughs[0].sections.len(), 2);
+        assert!(
+            matches!(
+                persistence_ops(&effects).first(),
+                Some(PersistenceOperation::SaveCoachRecords { play_throughs, .. })
+                    if play_throughs.len() == 1
+            ),
+            "a run rides the coach batch, so a failed write is offered again"
+        );
+        assert_no_http(&effects);
+
+        let held = model
+            .coach
+            .mastery
+            .get(
+                "piece:p1#A",
+                crate::engine::ParameterLevel {
+                    tempo_bpm: 0,
+                    click_level: crate::engine::ClickLevel::NoClick,
+                },
+            )
+            .expect("the section that held has evidence");
+        assert!(held.evidence() > 0.0);
+    }
+
+    #[test]
+    fn the_launch_replay_rebuilds_a_run_throughs_evidence_too() {
+        let mut model = Model::test_default();
+        model.items.push(charted_piece("p1"));
+        start_altitude(&mut model, "p1", Altitude::RunThrough);
+        for held in [true, true] {
+            app_update(
+                &mut model,
+                Event::Coach(CoachEvent::JudgeSection { held, now: at() }),
+            );
+        }
+        app_update(
+            &mut model,
+            Event::Coach(CoachEvent::CloseSession { now: at() }),
+        );
+        let live = model.coach.mastery.clone();
+
+        // Relaunch: the two loads race, and the run-throughs are on the second.
+        let mut relaunched = Model::test_default();
+        app_update(
+            &mut relaunched,
+            Event::CoachRecordsLoaded(PersistenceOutput::CoachRecords(vec![])),
+        );
+        app_update(
+            &mut relaunched,
+            Event::BuiltStoreLoaded(PersistenceOutput::BuiltSessionData(BuiltSessionData {
+                user_drills: vec![],
+                journal_items: vec![],
+                built_sessions: vec![],
+                play_throughs: model.play_throughs.clone(),
+                reflections: vec![],
+                feel_entries: vec![],
+            })),
+        );
+
+        assert_eq!(
+            relaunched.coach.mastery, live,
+            "a rule the live path enforces and the replay does not is not a rule (#1214)"
+        );
+    }
+
+    #[test]
+    fn an_uncounted_run_rebuilds_to_nothing() {
+        let mut model = Model::test_default();
+        model.items.push(charted_piece("p1"));
+        start_altitude(&mut model, "p1", Altitude::RunThrough);
+        app_update(
+            &mut model,
+            Event::Coach(CoachEvent::JudgeSection {
+                held: true,
+                now: at(),
+            }),
+        );
+        app_update(
+            &mut model,
+            Event::Coach(CoachEvent::DiscardRunThrough { now: at() }),
+        );
+
+        let mut relaunched = Model::test_default();
+        app_update(
+            &mut relaunched,
+            Event::BuiltStoreLoaded(PersistenceOutput::BuiltSessionData(BuiltSessionData {
+                user_drills: vec![],
+                journal_items: vec![],
+                built_sessions: vec![],
+                play_throughs: model.play_throughs.clone(),
+                reflections: vec![],
+                feel_entries: vec![],
+            })),
+        );
+        assert_eq!(
+            relaunched.coach.mastery,
+            Model::test_default().coach.mastery,
+            "\"don't count this run\" has to mean it at launch as well as live"
+        );
+    }
+
+    #[test]
+    fn starting_an_altitude_on_a_piece_that_has_gone_says_so() {
+        let mut model = Model::test_default();
+        start_altitude(&mut model, "gone", Altitude::RunThrough);
+        assert!(model.last_error.is_some());
+        assert!(view(&model).coach.altitude.is_none());
+    }
+
     // ── Bridge payloads (#846) ──────────────────────────────────────────
 
     fn sample_journal_item() -> JournalItem {
@@ -1901,17 +2071,6 @@ mod tests {
             BuiltSessionEvent::SaveBuiltSession {
                 session: sample_built_session(),
             },
-            BuiltSessionEvent::RecordPlayThrough(RecordPlayThrough {
-                item_id: "piece".into(),
-                started_at: at(),
-                ended_at: at(),
-                counted: false,
-                sections: vec![SectionVerdict {
-                    section: "Out head".into(),
-                    held: false,
-                    at: at(),
-                }],
-            }),
             BuiltSessionEvent::RecordReflection {
                 kind: ReflectionKind::VoiceNote,
                 session_ref: Some("built".into()),
@@ -1957,8 +2116,24 @@ mod tests {
                 session_id: "01J000000000000000000BSESH".into(),
                 now: at(),
             },
+            BuiltSessionEvent::StartPlayThrough {
+                item_id: "01J000000000000000000PIECE".into(),
+                altitude: Altitude::RunThrough,
+                now: at(),
+            },
         ] {
             assert_round_trips(Event::BuiltSession(event));
+        }
+    }
+
+    #[test]
+    fn every_altitude_crosses_the_wire() {
+        for altitude in [
+            Altitude::RunThrough,
+            Altitude::OffPiste,
+            Altitude::Unmonitored,
+        ] {
+            assert_round_trips(altitude);
         }
     }
 
@@ -1969,7 +2144,6 @@ mod tests {
         assert_round_trips(PersistenceOperation::SaveBuiltSession(
             sample_built_session(),
         ));
-        assert_round_trips(PersistenceOperation::SavePlayThrough(sample_play_through()));
         assert_round_trips(PersistenceOperation::SaveReflection(sample_reflection()));
         assert_round_trips(PersistenceOperation::SaveFeelEntry(sample_feel_entry()));
         assert_round_trips(PersistenceOperation::LoadBuiltSessionData);

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -667,23 +667,28 @@ pub fn handle_built_session_event(
             altitude,
             now,
         } => {
-            let Some(item) = model.items.iter().find(|item| item.id == item_id) else {
+            let offer = model
+                .items
+                .iter()
+                .find(|item| item.id == item_id)
+                .and_then(playthrough::altitude_offer);
+            let Some(offer) = offer else {
                 model.surface_error("That piece is no longer there.");
                 return crux_core::render::render();
             };
-            if !playthrough::can_enter(item, altitude) {
+            if !offer.allows(altitude) {
                 model.surface_error("Add some section labels to the chart first.");
                 return crux_core::render::render();
             }
             let event = match altitude {
                 Altitude::RunThrough => CoachEvent::StartRunThrough {
-                    item_id: item.id.clone(),
-                    title: item.title.clone(),
-                    sections: playthrough::named_sections(item),
+                    item_id: offer.item_id.clone(),
+                    title: offer.title.clone(),
+                    sections: offer.sections,
                     now,
                 },
                 Altitude::OffPiste => CoachEvent::GoOffPiste {
-                    item_id: Some(item.id.clone()),
+                    item_id: Some(offer.item_id.clone()),
                     now,
                 },
                 // The piece is dropped on purpose: this altitude captures
@@ -1982,6 +1987,61 @@ mod tests {
             relaunched.coach.mastery,
             Model::test_default().coach.mastery,
             "\"don't count this run\" has to mean it at launch as well as live"
+        );
+    }
+
+    #[test]
+    fn a_reload_mid_session_never_undoes_what_has_already_been_practised() {
+        // Both legs of the rebuild in one session — a closed block and a closed
+        // run-through — because a failed built-session write reissues the load,
+        // so `BuiltStoreLoaded` is reachable mid-session, not only at launch.
+        let mut model = Model::test_default();
+        let id = a_composed_day(&mut model);
+        // The shape puts the user drill first, which is the block whose taps
+        // are evidence — a judgement block's would prove nothing here.
+        update(&mut model, BuiltSessionEvent::UseSuggestedShape);
+        update(
+            &mut model,
+            BuiltSessionEvent::StartBuiltSession {
+                session_id: id,
+                now: at(),
+            },
+        );
+        let node = model.coach.session.spec().expect("a spec").node.clone();
+        let level = model.coach.session.block().expect("a block").level;
+        for _ in 0..3 {
+            play_one_pass(&mut model);
+        }
+        // The gate opens on the third pass; the hold is what closes the block.
+        app_update(
+            &mut model,
+            Event::Coach(CoachEvent::Tick {
+                now: at() + chrono::TimeDelta::seconds(600),
+            }),
+        );
+        assert!(
+            !model.coach_blocks.is_empty(),
+            "the gate opened and the block closed, so there is a record to lose"
+        );
+        let practised = model.coach.mastery.reading(&node, level, at()).evidence;
+        assert!(practised > 0.0, "it is in the live track before the reload");
+
+        let reloaded = BuiltSessionData {
+            user_drills: model.user_drills.clone(),
+            journal_items: model.journal_items.clone(),
+            built_sessions: model.built_sessions.clone(),
+            play_throughs: model.play_throughs.clone(),
+            reflections: vec![],
+            feel_entries: vec![],
+        };
+        app_update(
+            &mut model,
+            Event::BuiltStoreLoaded(PersistenceOutput::BuiltSessionData(reloaded)),
+        );
+        assert_eq!(
+            model.coach.mastery.reading(&node, level, at()).evidence,
+            practised,
+            "a rebuild replays everything the live track was fed, not the launch snapshot"
         );
     }
 

--- a/crates/intrada-core/src/domain/built_session/playthrough.rs
+++ b/crates/intrada-core/src/domain/built_session/playthrough.rs
@@ -1,0 +1,168 @@
+//! Journey B's three altitudes: what a piece can be played at, and where a
+//! gated run-through's verdicts land.
+//!
+//! **Open question 1, resolved (Phase C): v1 has no pipeline.** What a
+//! run-through gates on is the piece's own named chart sections — the `[A]`,
+//! `[Bridge]` labels the user already writes into their chart, in reading
+//! order. There is no stage graph, no authored pipeline entity and nothing
+//! between the piece and its sections. A piece with no chart, or a chart with
+//! no labelled section, cannot be run through: B0 offers the two lower
+//! altitudes instead, which is the graceful degradation B1's note asked for.
+//!
+//! Nothing lands on the piece as a whole. A section verdict is a bounded claim
+//! about a named stretch of music; "the piece held" is not a claim anything can
+//! currently make, so nothing here makes it (Phase B's interim, unchanged).
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::item::{Item, ItemKind};
+use crate::engine::Altitude;
+
+/// The sections a run-through would gate on, in reading order. Unlabelled
+/// sections are skipped rather than numbered: a verdict the user cannot name is
+/// a verdict they cannot give.
+pub fn named_sections(item: &Item) -> Vec<String> {
+    let Some(chart) = &item.chord_chart else {
+        return Vec::new();
+    };
+    chart
+        .sections
+        .iter()
+        .filter_map(|section| section.label.clone())
+        .filter(|label| !label.trim().is_empty())
+        .collect()
+}
+
+/// Where one section's verdicts land. Derived rather than stored, so the live
+/// path and the launch replay cannot name the same section two ways (the #1214
+/// class, and key decision 7's reason for putting the rule in one function).
+///
+/// Prefixed like [`super::blocks::node_id`], so a section can never collide
+/// with an authored node by name.
+pub fn section_node(item_id: &str, label: &str) -> String {
+    format!("piece:{item_id}#{label}")
+}
+
+/// What B0 may offer for this piece. The core decides, so the sheet never has
+/// to work out whether a run-through has anything to gate on.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct AltitudeOffer {
+    pub item_id: String,
+    pub title: String,
+    /// False where the piece has no named sections. The sheet still shows the
+    /// altitude and says why it is not available: a missing option with no
+    /// explanation reads as a bug.
+    pub run_through_available: bool,
+    pub sections: Vec<String>,
+}
+
+/// `None` for anything that is not a piece: an exercise is drilled, not played
+/// through.
+pub fn altitude_offer(item: &Item) -> Option<AltitudeOffer> {
+    if item.kind != ItemKind::Piece {
+        return None;
+    }
+    let sections = named_sections(item);
+    Some(AltitudeOffer {
+        item_id: item.id.clone(),
+        title: item.title.clone(),
+        run_through_available: !sections.is_empty(),
+        sections,
+    })
+}
+
+/// Whether this altitude can be entered for this piece at all. Only the
+/// run-through has a precondition; the two lower ones need nothing, which is
+/// the point of them.
+pub fn can_enter(item: &Item, altitude: Altitude) -> bool {
+    match altitude {
+        Altitude::RunThrough => !named_sections(item).is_empty(),
+        Altitude::OffPiste | Altitude::Unmonitored => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::built_session::tests_support::sample_item;
+    use crate::domain::chart::parse_chart;
+    use crate::domain::item::Modality;
+
+    fn charted(raw: &str) -> Item {
+        let mut item = sample_item("p1", "Alice in Wonderland", ItemKind::Piece);
+        item.chord_chart = Some(parse_chart(raw, "C", Modality::Major).expect("a valid chart"));
+        item
+    }
+
+    #[test]
+    fn a_pieces_named_sections_are_what_a_run_through_gates_on() {
+        let item = charted("[A]\n| Cmaj7 | Am7 |\n[Bridge]\n| Dm7 | G7 |");
+        assert_eq!(named_sections(&item), vec!["A", "Bridge"]);
+    }
+
+    #[test]
+    fn an_uncharted_piece_has_nothing_to_gate_on() {
+        let item = sample_item("p1", "Alice in Wonderland", ItemKind::Piece);
+        assert!(named_sections(&item).is_empty());
+        assert!(
+            !can_enter(&item, Altitude::RunThrough),
+            "a run-through with no sections would be a whole-piece verdict, which nothing can make"
+        );
+    }
+
+    #[test]
+    fn a_chart_with_no_labels_degrades_to_the_lower_altitudes() {
+        let item = charted("| Cmaj7 | Am7 |");
+        assert!(named_sections(&item).is_empty());
+        assert!(!can_enter(&item, Altitude::RunThrough));
+        assert!(can_enter(&item, Altitude::OffPiste));
+        assert!(
+            can_enter(&item, Altitude::Unmonitored),
+            "the two lower altitudes need nothing authored — that is the point of them"
+        );
+    }
+
+    #[test]
+    fn an_unlabelled_section_is_skipped_rather_than_numbered() {
+        let item = charted("| Cmaj7 |\n[B]\n| Dm7 |");
+        assert_eq!(
+            named_sections(&item),
+            vec!["B"],
+            "a verdict the user cannot name is a verdict they cannot give"
+        );
+    }
+
+    #[test]
+    fn a_section_node_can_never_collide_with_an_authored_one() {
+        let node = section_node("p1", "A");
+        assert_eq!(node, "piece:p1#A");
+        assert!(crate::engine::ContentIndex::shipped().node(&node).is_none());
+    }
+
+    #[test]
+    fn two_pieces_with_the_same_section_name_keep_separate_evidence() {
+        assert_ne!(section_node("p1", "A"), section_node("p2", "A"));
+    }
+
+    #[test]
+    fn the_offer_tells_the_sheet_whether_a_run_through_is_available() {
+        let offer = altitude_offer(&charted("[A]\n| Cmaj7 |")).expect("a piece is offered");
+        assert!(offer.run_through_available);
+        assert_eq!(offer.sections, vec!["A"]);
+        assert_eq!(offer.title, "Alice in Wonderland");
+
+        let bare = altitude_offer(&sample_item("p2", "Untitled", ItemKind::Piece))
+            .expect("an uncharted piece is still offered the lower altitudes");
+        assert!(
+            !bare.run_through_available,
+            "the sheet says why rather than hiding the option"
+        );
+    }
+
+    #[test]
+    fn an_exercise_is_drilled_rather_than_played_through() {
+        let exercise = sample_item("e1", "Two-fives", ItemKind::Exercise);
+        assert_eq!(altitude_offer(&exercise), None);
+    }
+}

--- a/crates/intrada-core/src/domain/built_session/playthrough.rs
+++ b/crates/intrada-core/src/domain/built_session/playthrough.rs
@@ -1,17 +1,9 @@
 //! Journey B's three altitudes: what a piece can be played at, and where a
 //! gated run-through's verdicts land.
 //!
-//! **Open question 1, resolved (Phase C): v1 has no pipeline.** What a
-//! run-through gates on is the piece's own named chart sections — the `[A]`,
-//! `[Bridge]` labels the user already writes into their chart, in reading
-//! order. There is no stage graph, no authored pipeline entity and nothing
-//! between the piece and its sections. A piece with no chart, or a chart with
-//! no labelled section, cannot be run through: B0 offers the two lower
-//! altitudes instead, which is the graceful degradation B1's note asked for.
-//!
-//! Nothing lands on the piece as a whole. A section verdict is a bounded claim
-//! about a named stretch of music; "the piece held" is not a claim anything can
-//! currently make, so nothing here makes it (Phase B's interim, unchanged).
+//! A run-through gates on the piece's own named chart sections and nothing
+//! else — `specs/built-session.md` open question 1 carries the reasoning and
+//! what it costs.
 
 use serde::{Deserialize, Serialize};
 
@@ -28,8 +20,12 @@ pub fn named_sections(item: &Item) -> Vec<String> {
     chart
         .sections
         .iter()
-        .filter_map(|section| section.label.clone())
-        .filter(|label| !label.trim().is_empty())
+        .filter_map(|section| section.label.as_ref())
+        // Trimmed before it is used, because the label is half the node id: a
+        // stray space in the chart would otherwise strand that section's
+        // evidence on a node nothing else names.
+        .map(|label| label.trim().to_string())
+        .filter(|label| !label.is_empty())
         .collect()
 }
 
@@ -58,7 +54,8 @@ pub struct AltitudeOffer {
 }
 
 /// `None` for anything that is not a piece: an exercise is drilled, not played
-/// through.
+/// through. The one gate on entering an altitude, so the rule cannot hold on
+/// the sheet and not on the event that starts the run.
 pub fn altitude_offer(item: &Item) -> Option<AltitudeOffer> {
     if item.kind != ItemKind::Piece {
         return None;
@@ -72,13 +69,14 @@ pub fn altitude_offer(item: &Item) -> Option<AltitudeOffer> {
     })
 }
 
-/// Whether this altitude can be entered for this piece at all. Only the
-/// run-through has a precondition; the two lower ones need nothing, which is
-/// the point of them.
-pub fn can_enter(item: &Item, altitude: Altitude) -> bool {
-    match altitude {
-        Altitude::RunThrough => !named_sections(item).is_empty(),
-        Altitude::OffPiste | Altitude::Unmonitored => true,
+impl AltitudeOffer {
+    /// Only the run-through has a precondition; the two lower ones need
+    /// nothing, which is the point of them.
+    pub fn allows(&self, altitude: Altitude) -> bool {
+        match altitude {
+            Altitude::RunThrough => self.run_through_available,
+            Altitude::OffPiste | Altitude::Unmonitored => true,
+        }
     }
 }
 
@@ -104,21 +102,22 @@ mod tests {
     #[test]
     fn an_uncharted_piece_has_nothing_to_gate_on() {
         let item = sample_item("p1", "Alice in Wonderland", ItemKind::Piece);
+        let offer = altitude_offer(&item).expect("a piece is still offered");
         assert!(named_sections(&item).is_empty());
         assert!(
-            !can_enter(&item, Altitude::RunThrough),
+            !offer.allows(Altitude::RunThrough),
             "a run-through with no sections would be a whole-piece verdict, which nothing can make"
         );
     }
 
     #[test]
     fn a_chart_with_no_labels_degrades_to_the_lower_altitudes() {
-        let item = charted("| Cmaj7 | Am7 |");
-        assert!(named_sections(&item).is_empty());
-        assert!(!can_enter(&item, Altitude::RunThrough));
-        assert!(can_enter(&item, Altitude::OffPiste));
+        let offer = altitude_offer(&charted("| Cmaj7 | Am7 |")).expect("a piece is offered");
+        assert!(offer.sections.is_empty());
+        assert!(!offer.allows(Altitude::RunThrough));
+        assert!(offer.allows(Altitude::OffPiste));
         assert!(
-            can_enter(&item, Altitude::Unmonitored),
+            offer.allows(Altitude::Unmonitored),
             "the two lower altitudes need nothing authored — that is the point of them"
         );
     }
@@ -141,8 +140,14 @@ mod tests {
     }
 
     #[test]
-    fn two_pieces_with_the_same_section_name_keep_separate_evidence() {
-        assert_ne!(section_node("p1", "A"), section_node("p2", "A"));
+    fn a_stray_space_in_the_chart_does_not_strand_a_sections_evidence() {
+        let item = charted("[ A ]\n| Cmaj7 |");
+        assert_eq!(named_sections(&item), vec!["A"]);
+        assert_eq!(
+            section_node("p1", &named_sections(&item)[0]),
+            section_node("p1", "A"),
+            "the label is half the node id, so it has to be the same label either way"
+        );
     }
 
     #[test]
@@ -162,7 +167,12 @@ mod tests {
 
     #[test]
     fn an_exercise_is_drilled_rather_than_played_through() {
-        let exercise = sample_item("e1", "Two-fives", ItemKind::Exercise);
-        assert_eq!(altitude_offer(&exercise), None);
+        let mut exercise = sample_item("e1", "Two-fives", ItemKind::Exercise);
+        exercise.chord_chart = charted("[A]\n| Cmaj7 |").chord_chart;
+        assert_eq!(
+            altitude_offer(&exercise),
+            None,
+            "a chart on an exercise must not open an altitude the sheet never offers it"
+        );
     }
 }

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -59,10 +59,7 @@ impl CoachState {
     /// session machine must still be the one that runs it, or a steer would be
     /// a second drill loop.
     pub fn adopt_plan(&mut self, plan: Plan, now: DateTime<Utc>) -> CoachWrites {
-        if !matches!(
-            self.session.state,
-            SessionState::Idle | SessionState::Planned { .. }
-        ) {
+        if !self.session.state.accepts_something_new() {
             // A session already running is not something a steer may replace:
             // the blocks in flight have evidence riding on them.
             return CoachWrites::default();
@@ -1388,6 +1385,21 @@ mod tests {
                 item_id: None,
                 now: at(5),
             },
+            CoachEvent::GoOffPiste {
+                item_id: Some("01J000000000000000000PIECE".into()),
+                now: at(5),
+            },
+            CoachEvent::StartRunThrough {
+                item_id: "01J000000000000000000PIECE".into(),
+                title: "Alice in Wonderland".into(),
+                sections: vec!["A".into(), "Bridge".into()],
+                now: at(5),
+            },
+            CoachEvent::JudgeSection {
+                held: true,
+                now: at(6),
+            },
+            CoachEvent::DiscardRunThrough { now: at(7) },
             CoachEvent::GoUnmonitored { now: at(6) },
             CoachEvent::KeepWanderAsDrill { keep: true },
             CoachEvent::CloseSession { now: at(7) },
@@ -1456,6 +1468,28 @@ mod tests {
             now: at(20),
         });
         assert_round_trips(untimed.view());
+
+        // The altitudes, whose view fields are `None` in every case above.
+        let mut run = CoachState::default();
+        run.apply(&CoachEvent::StartRunThrough {
+            item_id: "01J000000000000000000PIECE".into(),
+            title: "Alice in Wonderland".into(),
+            sections: vec!["A".into(), "Bridge".into()],
+            now: at(0),
+        });
+        assert_round_trips(run.view());
+        run.apply(&CoachEvent::JudgeSection {
+            held: false,
+            now: at(30),
+        });
+        assert_round_trips(run.view());
+
+        let mut wandering = CoachState::default();
+        wandering.apply(&CoachEvent::GoOffPiste {
+            item_id: Some("01J000000000000000000PIECE".into()),
+            now: at(0),
+        });
+        assert_round_trips(wandering.view());
     }
 
     #[test]

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -14,8 +14,10 @@ use super::gate::{Requirement, Verdict};
 use super::mastery::MasteryStore;
 use super::plan::{plan, BlockOrigin, ParameterLevel, Plan, PlanContext};
 use super::session::{
-    BlockRecord, CoachEvent, CoachWrites, EngineSession, Exit, Phase, SessionState,
+    section_evidence, Altitude, BlockRecord, CoachEvent, CoachWrites, EngineSession, Exit, Phase,
+    SessionState,
 };
+use crate::domain::built_session::PlayThroughRecord;
 use crate::domain::item::ItemKind;
 
 /// Spec §1 gives this five fields; the judgement track and the interruption
@@ -76,9 +78,13 @@ impl CoachState {
     /// the same one-way replay as the live path in [`Self::apply`]. Replaces
     /// rather than adds, like every other load handler, so a repeated load can
     /// never double-count.
-    pub fn rebuild_mastery(&mut self, records: Vec<BlockRecord>) {
+    pub fn rebuild_mastery(&mut self, records: Vec<BlockRecord>, runs: Vec<PlayThroughRecord>) {
         self.mastery = MasteryStore::seeded_from(ContentIndex::shipped());
         let mut replay = Vec::new();
+        // A run-through's section verdicts are evidence the live close already
+        // recorded, so the rebuild has to know about them too — the same rule
+        // in both paths, through the same function (key decision 7).
+        let run_evidence: Vec<_> = runs.iter().flat_map(section_evidence).collect();
         for record in &records {
             // Decision 17, on the replay path too: a judgement-track block's
             // taps were never evidence, so they must not become evidence at
@@ -89,8 +95,8 @@ impl CoachState {
             for attempt in &record.attempts {
                 replay.push((
                     attempt.at,
+                    record.node.clone(),
                     Replay::Attempt(attempt.verdict, attempt.level),
-                    record,
                 ));
             }
             // `level_up` declines a rung that already has evidence, so a banked
@@ -99,17 +105,29 @@ impl CoachState {
                 .next()
                 .and_then(next_rung)
             {
-                replay.push((record.ended_at, Replay::LevelUp(next), record));
+                replay.push((
+                    record.ended_at,
+                    record.node.clone(),
+                    Replay::LevelUp {
+                        from: record.level,
+                        to: next,
+                    },
+                ));
             }
         }
+        for attempt in run_evidence {
+            replay.push((
+                attempt.at,
+                attempt.node,
+                Replay::Attempt(attempt.verdict, attempt.level),
+            ));
+        }
         replay.sort_by_key(|(at, _, _)| *at);
-        for (at, step, record) in replay {
+        for (at, node, step) in replay {
             match step {
-                Replay::Attempt(verdict, level) => {
-                    self.mastery.record(&record.node, level, verdict, at)
-                }
+                Replay::Attempt(verdict, level) => self.mastery.record(&node, level, verdict, at),
                 // The gate was passed at the level the block closed on.
-                Replay::LevelUp(to) => self.mastery.level_up(&record.node, record.level, to),
+                Replay::LevelUp { from, to } => self.mastery.level_up(&node, from, to),
             }
         }
     }
@@ -161,7 +179,23 @@ impl CoachState {
         CoachView {
             drill: self.drill_view(),
             plan: self.plan_view(),
+            altitude: self.session.state.altitude(),
+            run_through: self.run_through_view(),
         }
+    }
+
+    fn run_through_view(&self) -> Option<RunThroughView> {
+        let run = self.session.run_through()?;
+        Some(RunThroughView {
+            title: run.title.clone(),
+            sections: run.sections.clone(),
+            // Held / broke down, in the order the sections were judged. The
+            // shell draws the dots from this and counts nothing itself.
+            held: run.verdicts.iter().map(|verdict| verdict.held).collect(),
+            current_section: run.current_section().cloned(),
+            complete: run.complete(),
+            elapsed_seconds: run.elapsed_seconds(),
+        })
     }
 
     /// The press-start surface: what today's session is, before it runs. Gone
@@ -264,7 +298,10 @@ impl CoachState {
 
 enum Replay {
     Attempt(Verdict, ParameterLevel),
-    LevelUp(ParameterLevel),
+    LevelUp {
+        from: ParameterLevel,
+        to: ParameterLevel,
+    },
 }
 
 /// The gate passes allowed to move a cursor. One definition, called by both the
@@ -338,6 +375,28 @@ pub struct CoachView {
     pub drill: Option<DrillView>,
     /// `Some` while a session is planned but not yet running.
     pub plan: Option<PlanView>,
+    /// What the AltitudeChip shows, for the whole run. `None` for a prescribed
+    /// session, which is not one of the three altitudes (decision 16).
+    pub altitude: Option<Altitude>,
+    /// `Some` only while a gated run-through is in flight.
+    pub run_through: Option<RunThroughView>,
+}
+
+/// What the run-through screen draws: which section the next tap judges, and
+/// what the ones behind it said.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct RunThroughView {
+    pub title: String,
+    pub sections: Vec<String>,
+    /// One entry per verdict given so far, in order.
+    pub held: Vec<bool>,
+    /// `None` once every section has a verdict.
+    pub current_section: Option<String>,
+    /// Every section judged. The exit is still an explicit tap: "Don't count
+    /// this run" has to stay reachable after the last verdict (B1).
+    pub complete: bool,
+    pub elapsed_seconds: u32,
 }
 
 /// What press-start shows: today's session before it starts.
@@ -1106,11 +1165,14 @@ mod tests {
     #[test]
     fn replaying_a_persisted_record_rebuilds_the_evidence_it_holds() {
         let mut coach = CoachState::default();
-        coach.rebuild_mastery(vec![closed_block(
-            "b1",
-            &[(true, 9), (false, 18)],
-            Exit::SessionEnded,
-        )]);
+        coach.rebuild_mastery(
+            vec![closed_block(
+                "b1",
+                &[(true, 9), (false, 18)],
+                Exit::SessionEnded,
+            )],
+            vec![],
+        );
 
         let mastery = coach
             .mastery
@@ -1132,11 +1194,14 @@ mod tests {
             .get("rootless-a-b", next_rung())
             .expect("the content seeds every runnable rung");
 
-        coach.rebuild_mastery(vec![closed_block(
-            "b1",
-            &[(true, 9), (true, 18), (true, 27)],
-            Exit::GatePassed,
-        )]);
+        coach.rebuild_mastery(
+            vec![closed_block(
+                "b1",
+                &[(true, 9), (true, 18), (true, 27)],
+                Exit::GatePassed,
+            )],
+            vec![],
+        );
 
         let above = coach.mastery.get("rootless-a-b", next_rung()).unwrap();
         assert_ne!(above.prior, seed.prior, "the level-up replayed too");
@@ -1168,7 +1233,7 @@ mod tests {
         );
 
         let mut replayed = CoachState::default();
-        replayed.rebuild_mastery(vec![judgement]);
+        replayed.rebuild_mastery(vec![judgement], vec![]);
         assert_eq!(
             replayed.mastery,
             CoachState::default().mastery,
@@ -1180,10 +1245,10 @@ mod tests {
     fn a_second_load_replaces_what_the_first_one_built() {
         let record = closed_block("b1", &[(true, 9)], Exit::SessionEnded);
         let mut coach = CoachState::default();
-        coach.rebuild_mastery(vec![record.clone()]);
+        coach.rebuild_mastery(vec![record.clone()], vec![]);
         let once = coach.mastery.clone();
 
-        coach.rebuild_mastery(vec![record]);
+        coach.rebuild_mastery(vec![record], vec![]);
 
         assert_eq!(
             coach.mastery, once,
@@ -1197,10 +1262,10 @@ mod tests {
         let later = closed_block("b2", &[(false, 100)], Exit::SessionEnded);
 
         let mut coach = CoachState::default();
-        coach.rebuild_mastery(vec![later.clone(), earlier.clone()]);
+        coach.rebuild_mastery(vec![later.clone(), earlier.clone()], vec![]);
 
         let mut sorted = CoachState::default();
-        sorted.rebuild_mastery(vec![earlier, later]);
+        sorted.rebuild_mastery(vec![earlier, later], vec![]);
         assert_eq!(coach.mastery, sorted.mastery);
         assert_eq!(
             coach
@@ -1225,7 +1290,7 @@ mod tests {
         assert!(!records.is_empty(), "the run must have closed a block");
 
         let mut rebuilt = CoachState::default();
-        rebuilt.rebuild_mastery(records);
+        rebuilt.rebuild_mastery(records, vec![]);
 
         assert_eq!(
             rebuilt.mastery, live.mastery,
@@ -1256,7 +1321,7 @@ mod tests {
         assert!(!records.is_empty(), "the block it ended is written down");
 
         let mut rebuilt = CoachState::default();
-        rebuilt.rebuild_mastery(records);
+        rebuilt.rebuild_mastery(records, vec![]);
 
         assert_eq!(
             rebuilt.mastery, live.mastery,
@@ -1319,7 +1384,10 @@ mod tests {
             CoachEvent::Tick { now: at(3) },
             CoachEvent::LeaveSession { now: at(4) },
             CoachEvent::ClickUnavailable { now: at(8) },
-            CoachEvent::GoOffPiste { now: at(5) },
+            CoachEvent::GoOffPiste {
+                item_id: None,
+                now: at(5),
+            },
             CoachEvent::GoUnmonitored { now: at(6) },
             CoachEvent::KeepWanderAsDrill { keep: true },
             CoachEvent::CloseSession { now: at(7) },

--- a/crates/intrada-core/src/engine/mod.rs
+++ b/crates/intrada-core/src/engine/mod.rs
@@ -15,7 +15,9 @@ mod mastery;
 mod plan;
 mod session;
 
-pub use coach::{CoachState, CoachView, DrillPhase, DrillView, PlanView, PlannedBlockView};
+pub use coach::{
+    CoachState, CoachView, DrillPhase, DrillView, PlanView, PlannedBlockView, RunThroughView,
+};
 pub use content::ContentIndex;
 pub use gate::{
     ClickLevel, EvidenceSource, GateCriteria, GateProgress, Judge, Requirement, Verdict,
@@ -26,6 +28,6 @@ pub use plan::{
     PlannedBlock, Stage, Why,
 };
 pub use session::{
-    AttemptSummary, BlockRecord, BlockState, CoachEvent, CoachWrites, EngineConfig, EngineSession,
-    Exit, Phase, Rung, SessionState, SnapshotAction, WanderRecord,
+    Altitude, AttemptSummary, BlockRecord, BlockState, CoachEvent, CoachWrites, EngineConfig,
+    EngineSession, Exit, Phase, RunThroughState, Rung, SessionState, SnapshotAction, WanderRecord,
 };

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -1536,9 +1536,9 @@ mod tests {
     // wire with no field names. The shell must read the new shape under a new
     // key. Missed three times (#1223, #1244, #1256), each caught by a person.
 
-    const SHELL_SNAPSHOT_KEY: &str = "intrada.coach-session-in-progress.v4";
-    const SNAPSHOT_WIRE_LEN: usize = 1390;
-    const SNAPSHOT_WIRE_HASH: u64 = 0x090a125921cf96fc;
+    const SHELL_SNAPSHOT_KEY: &str = "intrada.coach-session-in-progress.v5";
+    const SNAPSHOT_WIRE_LEN: usize = 1425;
+    const SNAPSHOT_WIRE_HASH: u64 = 0x944c03cb25cfd23e;
 
     /// FNV-1a rather than `DefaultHasher`, whose output is explicitly unstable
     /// across Rust releases — this value is committed.
@@ -1619,6 +1619,9 @@ mod tests {
                 level: spec.level,
             }],
             keep_as_drill: Some(true),
+            // `Some` for the same reason as the record's other options: a
+            // `None` here would hide this field's width from the pin.
+            item_id: Some("01J000000000000000000PIECE".to_string()),
         });
         session.unmonitored_seconds = 90;
         session
@@ -1642,6 +1645,21 @@ mod tests {
              SNAPSHOT_WIRE_LEN = {} and SNAPSHOT_WIRE_HASH = {:#018x} here.",
             bytes.len(),
             fingerprint(&bytes)
+        );
+    }
+
+    /// The key above is only useful if it is the key the shell actually reads.
+    /// Left unchecked it drifts, and then the failure message tells the next
+    /// person to bump past a version that was already retired — which read as
+    /// "the bump was skipped" on #1284 when it had not been.
+    #[test]
+    fn the_pinned_key_is_the_one_the_shell_reads() {
+        let store = include_str!("../../../../ios/Intrada/Core/Store.swift");
+        assert!(
+            store.contains(&format!(
+                "coachSessionInProgressKey = \"{SHELL_SNAPSHOT_KEY}\""
+            )),
+            "SHELL_SNAPSHOT_KEY is {SHELL_SNAPSHOT_KEY}, which Store.swift does not declare"
         );
     }
 

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -5,8 +5,10 @@ use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::content::ContentIndex;
-use super::gate::{EvidenceSource, GateProgress, Verdict};
+use super::gate::{ClickLevel, EvidenceSource, GateProgress, Verdict};
 use super::plan::{BlockOrigin, BlockSpec, Circle, Mode, ParameterLevel, Plan, PlannedBlock};
+use crate::domain::built_session::playthrough::section_node;
+use crate::domain::built_session::{PlayThroughRecord, SectionVerdict};
 
 /// What the shell tells the engine. The whole write half of the bridge surface
 /// for the tap-verdict loop (spec §6, as scoped) — the shell reports clicks,
@@ -88,10 +90,32 @@ pub enum CoachEvent {
     ClickUnavailable {
         now: DateTime<Utc>,
     },
+    /// `item_id` is the piece B0 was opened from, where there was one. `None`
+    /// when off-piste was reached mid-session, which has no piece behind it.
     GoOffPiste {
+        item_id: Option<String>,
         now: DateTime<Utc>,
     },
     GoUnmonitored {
+        now: DateTime<Utc>,
+    },
+    /// Journey B's top altitude: play the piece through, one verdict per named
+    /// section. `sections` comes from the caller because resolving them is a
+    /// library lookup, and the engine never does one.
+    StartRunThrough {
+        item_id: String,
+        title: String,
+        sections: Vec<String>,
+        now: DateTime<Utc>,
+    },
+    /// "Held" / "Broke down" — one tap for the section the run is on.
+    JudgeSection {
+        held: bool,
+        now: DateTime<Utc>,
+    },
+    /// B1's "Don't count this run". Writes the record so the time is still the
+    /// user's, and lands no evidence.
+    DiscardRunThrough {
         now: DateTime<Utc>,
     },
     /// Answer to the off-piste *keep this as a drill?* prompt.
@@ -118,9 +142,29 @@ pub struct CoachWrites {
     /// so a crash costs at most the block in flight.
     pub blocks: Vec<BlockRecord>,
     pub wanders: Vec<WanderRecord>,
+    pub play_throughs: Vec<PlayThroughRecord>,
     /// Attempts the mastery track has yet to hear about (spec §2).
     pub evidence: Vec<ScoredAttempt>,
     pub snapshot: SnapshotAction,
+}
+
+/// What one applied event produced that the session does not keep: evidence for
+/// the mastery track, and the run-through record if one closed. Not held on
+/// `EngineSession`, because a field that is empty at rest would ride the
+/// crash-recovery wire for nothing.
+#[derive(Debug, Default)]
+struct Applied {
+    evidence: Vec<ScoredAttempt>,
+    play_throughs: Vec<PlayThroughRecord>,
+}
+
+impl Applied {
+    fn from_evidence(attempt: Option<ScoredAttempt>) -> Self {
+        Self {
+            evidence: attempt.into_iter().collect(),
+            ..Self::default()
+        }
+    }
 }
 
 /// One attempt, told to the mastery store in the terms it holds state in:
@@ -154,6 +198,8 @@ struct RecoveryKey {
     closed_blocks: usize,
     wanders: usize,
     keep_as_drill: Option<Option<bool>>,
+    /// A verdict already given is the one thing a run-through cannot rebuild.
+    section_verdicts: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -255,6 +301,103 @@ pub struct WanderRecord {
     pub attempts: Vec<AttemptSummary>,
     /// `None` = not yet asked.
     pub keep_as_drill: Option<bool>,
+    /// The piece B0 was opened from (#1256). `None` for a wander reached
+    /// mid-session, which has no piece behind it.
+    #[serde(default)]
+    pub item_id: Option<String>,
+}
+
+/// Journey B's three altitudes (decision 16). Named on the session rather than
+/// inferred by the shell, because the chip that shows which one is running is
+/// the consent signal: absence of instrumentation is what the user is agreeing
+/// to, so it has to be the core that says which altitude they are at.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum Altitude {
+    RunThrough,
+    OffPiste,
+    Unmonitored,
+}
+
+/// A gated run-through in flight: one verdict per named section, in reading
+/// order, given as the music passes. No gate, no ladder and no ceiling — the
+/// piece is what bounds it.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct RunThroughState {
+    pub item_id: String,
+    pub title: String,
+    pub started_at: DateTime<Utc>,
+    pub now: DateTime<Utc>,
+    /// Never empty: a run with nothing to gate on would be a whole-piece
+    /// verdict, and the domain refuses to start one (open question 1).
+    pub sections: Vec<String>,
+    pub verdicts: Vec<SectionVerdict>,
+}
+
+impl RunThroughState {
+    /// The section the next tap judges. `None` once every section has one.
+    pub fn current_section(&self) -> Option<&String> {
+        self.sections.get(self.verdicts.len())
+    }
+
+    pub fn complete(&self) -> bool {
+        self.verdicts.len() >= self.sections.len()
+    }
+
+    pub fn elapsed_seconds(&self) -> u32 {
+        (self.now - self.started_at).num_seconds().max(0) as u32
+    }
+
+    /// Sections reached but not judged are simply absent. A run left half-way
+    /// through says what it saw and invents nothing about the rest.
+    fn record(&self, counted: bool, now: DateTime<Utc>) -> PlayThroughRecord {
+        PlayThroughRecord {
+            id: ulid::Ulid::generate().to_string(),
+            item_id: self.item_id.clone(),
+            started_at: self.started_at,
+            ended_at: now,
+            counted,
+            sections: self.verdicts.clone(),
+            updated_at: now,
+            deleted_at: None,
+        }
+    }
+}
+
+/// The rung a section verdict is given at: l0, where nothing bounds the pass
+/// but the tap itself. Per the #1244 ruling the tap is what bounds the attempt
+/// there, and `TapVerdictUntimed` is already the class that says so.
+pub(crate) fn section_level() -> ParameterLevel {
+    ParameterLevel {
+        tempo_bpm: 0,
+        click_level: ClickLevel::NoClick,
+    }
+}
+
+/// What one run-through's verdicts are worth to the mastery track. One
+/// function, called by the live close and by the launch replay, so a section
+/// cannot be scored one way live and another on rebuild (key decision 7, the
+/// #1214 class).
+pub(crate) fn section_evidence(record: &PlayThroughRecord) -> Vec<ScoredAttempt> {
+    if !record.counted {
+        return Vec::new();
+    }
+    record
+        .sections
+        .iter()
+        .map(|verdict| ScoredAttempt {
+            node: section_node(&record.item_id, &verdict.section),
+            level: section_level(),
+            verdict: if verdict.held {
+                Verdict::Clean
+            } else {
+                Verdict::Missed
+            },
+            at: verdict.at,
+        })
+        .collect()
 }
 
 /// Thresholds the engine must not hard-code: `[escalation]` in
@@ -444,12 +587,19 @@ pub enum SessionState {
     },
     /// A peer of `Running`, not a sub-state: no plan and no gates, still capturing.
     OffPiste {
+        item_id: Option<String>,
         started_at: DateTime<Utc>,
     },
-    /// Nothing captured, nothing inferred (decision 16).
+    /// Nothing captured, nothing inferred (decision 16). Untagged even when B0
+    /// was opened from a piece: off-piste has a record to hang a tag on because
+    /// it captures, and this one captures nothing. The asymmetry is the consent
+    /// gradient, not an oversight.
     Unmonitored {
         started_at: DateTime<Utc>,
     },
+    /// A peer of `Running` too: gated, but by the piece's sections rather than
+    /// by a drill's gate.
+    RunThrough(RunThroughState),
     /// Spec §4 carries a `Summary` here; it arrives with the closing screen.
     Closing,
 }
@@ -467,7 +617,20 @@ impl SessionState {
             SessionState::Running { .. }
                 | SessionState::OffPiste { .. }
                 | SessionState::Unmonitored { .. }
+                | SessionState::RunThrough(_)
         )
+    }
+
+    /// Which altitude is running, for the chip that stays up for the whole run.
+    /// A prescribed session is not one of the three: it is the top of the map,
+    /// not a rung on it.
+    pub fn altitude(&self) -> Option<Altitude> {
+        match self {
+            SessionState::RunThrough(_) => Some(Altitude::RunThrough),
+            SessionState::OffPiste { .. } => Some(Altitude::OffPiste),
+            SessionState::Unmonitored { .. } => Some(Altitude::Unmonitored),
+            _ => None,
+        }
     }
 }
 
@@ -504,6 +667,13 @@ impl EngineSession {
         }
     }
 
+    pub fn run_through(&self) -> Option<&RunThroughState> {
+        match &self.state {
+            SessionState::RunThrough(run) => Some(run),
+            _ => None,
+        }
+    }
+
     fn recovery_key(&self) -> RecoveryKey {
         RecoveryKey {
             state: std::mem::discriminant(&self.state),
@@ -518,6 +688,7 @@ impl EngineSession {
             closed_blocks: self.closed_blocks.len(),
             wanders: self.wanders.len(),
             keep_as_drill: self.wanders.last().map(|wander| wander.keep_as_drill),
+            section_verdicts: self.run_through().map_or(0, |run| run.verdicts.len()),
         }
     }
 
@@ -544,7 +715,7 @@ impl EngineSession {
         let blocks_written = self.closed_blocks.len();
         let wanders_written = self.wanders.len();
 
-        let evidence = self.handle(event, plan);
+        let applied = self.handle(event, plan);
 
         // Recovery replaces the session wholesale, so it can hand back fewer
         // records than the live one had (a swallowed snapshot write leaves an
@@ -563,7 +734,8 @@ impl EngineSession {
         let mut writes = CoachWrites {
             blocks: self.closed_blocks[blocks_from..].to_vec(),
             wanders: self.wanders[wanders_from..].to_vec(),
-            evidence: evidence.into_iter().collect(),
+            play_throughs: applied.play_throughs,
+            evidence: applied.evidence,
             snapshot: if matches!(self.state, SessionState::Closing) {
                 if was_closing {
                     SnapshotAction::Unchanged
@@ -583,7 +755,7 @@ impl EngineSession {
         writes
     }
 
-    fn handle(&mut self, event: &CoachEvent, planned: Option<Plan>) -> Option<ScoredAttempt> {
+    fn handle(&mut self, event: &CoachEvent, planned: Option<Plan>) -> Applied {
         match event {
             CoachEvent::PlanSession { .. } => {
                 if self.accepts_plan(event) {
@@ -603,26 +775,37 @@ impl EngineSession {
             },
             CoachEvent::CountInBeat { remaining } => self.count_in(*remaining),
             CoachEvent::Beat { beat_index } => self.beat(*beat_index),
-            CoachEvent::Tap { clean, now } => return self.tap(*clean, *now),
+            CoachEvent::Tap { clean, now } => {
+                return Applied::from_evidence(self.tap(*clean, *now))
+            }
             CoachEvent::StartBlock { now } => self.start_block(*now),
             CoachEvent::SkipBlock { now } => self.skip_block(*now),
             CoachEvent::DiscardAttempt { now } => self.discard(*now),
             CoachEvent::ClickInterrupted { now } => self.click_interrupted(*now),
             CoachEvent::Stuck { now } => self.stuck(*now),
             CoachEvent::Tick { now } => self.tick(*now),
-            CoachEvent::LeaveSession { now } => self.leave_session(*now),
-            CoachEvent::ClickUnavailable { now } => self.leave_session(*now),
-            CoachEvent::GoOffPiste { now } => self.go_off_piste(*now),
+            CoachEvent::LeaveSession { now } | CoachEvent::ClickUnavailable { now } => {
+                return self.leave_session(*now)
+            }
+            CoachEvent::GoOffPiste { item_id, now } => self.go_off_piste(item_id.clone(), *now),
             CoachEvent::GoUnmonitored { now } => self.go_unmonitored(*now),
+            CoachEvent::StartRunThrough {
+                item_id,
+                title,
+                sections,
+                now,
+            } => self.start_run_through(item_id, title, sections, *now),
+            CoachEvent::JudgeSection { held, now } => self.judge_section(*held, *now),
+            CoachEvent::DiscardRunThrough { now } => return self.close_run_through(false, *now),
             CoachEvent::KeepWanderAsDrill { keep } => {
                 if let Some(wander) = self.wanders.last_mut() {
                     wander.keep_as_drill = Some(*keep);
                 }
             }
-            CoachEvent::CloseSession { now } => self.close_session(*now),
+            CoachEvent::CloseSession { now } => return self.close_session(*now),
             CoachEvent::RecoverSession { session, now } => self.recover(session.clone(), *now),
         }
-        None
+        Applied::default()
     }
 
     /// When the mastery store's cold read applies: the events that carry a
@@ -640,8 +823,11 @@ impl EngineSession {
             | CoachEvent::Tick { now }
             | CoachEvent::LeaveSession { now }
             | CoachEvent::ClickUnavailable { now }
-            | CoachEvent::GoOffPiste { now }
+            | CoachEvent::GoOffPiste { now, .. }
             | CoachEvent::GoUnmonitored { now }
+            | CoachEvent::StartRunThrough { now, .. }
+            | CoachEvent::JudgeSection { now, .. }
+            | CoachEvent::DiscardRunThrough { now }
             | CoachEvent::CloseSession { now }
             | CoachEvent::RecoverSession { now, .. } => Some(*now),
             CoachEvent::CountInBeat { .. }
@@ -678,8 +864,17 @@ impl EngineSession {
                     block.phase = block.opening_phase();
                 }
             }
-            SessionState::OffPiste { started_at } | SessionState::Unmonitored { started_at } => {
+            SessionState::OffPiste { started_at, .. }
+            | SessionState::Unmonitored { started_at } => {
                 *started_at = now;
+            }
+            // The verdicts already given survive; the outage does not become
+            // playing time, so the run comes back having taken what it had
+            // taken and no more.
+            SessionState::RunThrough(run) => {
+                let spent = (run.now - run.started_at).num_milliseconds().max(0);
+                run.started_at = now - TimeDelta::milliseconds(spent);
+                run.now = now;
             }
             SessionState::Idle | SessionState::Planned { .. } | SessionState::Closing => {}
         }
@@ -1055,6 +1250,12 @@ impl EngineSession {
     }
 
     fn tick(&mut self, now: DateTime<Utc>) {
+        // A run-through has no ceiling: the piece is what ends it, so the clock
+        // only ever reports how long it has taken.
+        if let SessionState::RunThrough(run) = &mut self.state {
+            run.now = now;
+            return;
+        }
         let ceiling = self.spec().map(|spec| u32::from(spec.minutes) * 60);
         let hold = self.config.gate_open_hold_s;
         let glance = self.config.glance_hold_s;
@@ -1079,7 +1280,13 @@ impl EngineSession {
         }
     }
 
-    fn leave_session(&mut self, now: DateTime<Utc>) {
+    fn leave_session(&mut self, now: DateTime<Utc>) -> Applied {
+        // A run-through the user walked out of still says what it saw: the
+        // verdicts already given are theirs, and dropping them on the way out
+        // would be the silent-no-op bug one layer up.
+        if matches!(self.state, SessionState::RunThrough(_)) {
+            return self.close_run_through(true, now);
+        }
         match self.block_mut() {
             Some(block) => {
                 block.now = now;
@@ -1090,19 +1297,88 @@ impl EngineSession {
             // recover a session the user has already left.
             None => self.state = SessionState::Closing,
         }
+        Applied::default()
     }
 
-    fn go_off_piste(&mut self, now: DateTime<Utc>) {
+    /// Two doors: mid-session, where the block in flight is skipped and there is
+    /// no piece behind it, and B0, where the user picked the altitude for a
+    /// piece before anything was running.
+    fn go_off_piste(&mut self, item_id: Option<String>, now: DateTime<Utc>) {
         match &mut self.state {
             SessionState::Running { block, .. } => {
                 block.now = now;
                 self.close_block(Exit::Skipped, false);
-                self.state = SessionState::OffPiste { started_at: now };
+                self.state = SessionState::OffPiste {
+                    item_id,
+                    started_at: now,
+                };
             }
-            SessionState::Planned { .. } => {
-                self.state = SessionState::OffPiste { started_at: now };
+            SessionState::Idle | SessionState::Planned { .. } => {
+                self.state = SessionState::OffPiste {
+                    item_id,
+                    started_at: now,
+                };
             }
             _ => {}
+        }
+    }
+
+    fn start_run_through(
+        &mut self,
+        item_id: &str,
+        title: &str,
+        sections: &[String],
+        now: DateTime<Utc>,
+    ) {
+        // Nothing to gate on is not a run-through, and a session already in
+        // flight has evidence riding on it that a new altitude must not replace.
+        if sections.is_empty()
+            || !matches!(
+                self.state,
+                SessionState::Idle | SessionState::Planned { .. }
+            )
+        {
+            return;
+        }
+        self.state = SessionState::RunThrough(RunThroughState {
+            item_id: item_id.to_string(),
+            title: title.to_string(),
+            started_at: now,
+            now,
+            sections: sections.to_vec(),
+            verdicts: Vec::new(),
+        });
+    }
+
+    fn judge_section(&mut self, held: bool, now: DateTime<Utc>) {
+        let SessionState::RunThrough(run) = &mut self.state else {
+            return;
+        };
+        run.now = now;
+        // Past the last section there is nothing left to judge, and a tap that
+        // invented a verdict would put evidence on a section nobody played.
+        let Some(section) = run.current_section().cloned() else {
+            return;
+        };
+        run.verdicts.push(SectionVerdict {
+            section,
+            held,
+            at: now,
+        });
+    }
+
+    /// The exit is always an explicit tap, even once every section has a
+    /// verdict: auto-closing on the last one would write the record before
+    /// "Don't count this run" could be reached.
+    fn close_run_through(&mut self, counted: bool, now: DateTime<Utc>) -> Applied {
+        let SessionState::RunThrough(run) = &self.state else {
+            return Applied::default();
+        };
+        let record = run.record(counted, now);
+        self.state = SessionState::Closing;
+        Applied {
+            evidence: section_evidence(&record),
+            play_throughs: vec![record],
         }
     }
 
@@ -1117,25 +1393,31 @@ impl EngineSession {
         }
     }
 
-    fn close_session(&mut self, now: DateTime<Utc>) {
-        match self.state {
-            SessionState::OffPiste { started_at } => {
+    fn close_session(&mut self, now: DateTime<Utc>) -> Applied {
+        match &self.state {
+            SessionState::OffPiste {
+                item_id,
+                started_at,
+            } => {
                 self.wanders.push(WanderRecord {
                     id: ulid::Ulid::generate().to_string(),
-                    started_at,
+                    started_at: *started_at,
                     ended_at: now,
                     attempts: Vec::new(),
                     keep_as_drill: None,
+                    item_id: item_id.clone(),
                 });
                 self.state = SessionState::Closing;
             }
             SessionState::Unmonitored { started_at } => {
-                self.unmonitored_seconds = (now - started_at).num_seconds().max(0) as u32;
+                self.unmonitored_seconds = (now - *started_at).num_seconds().max(0) as u32;
                 self.state = SessionState::Closing;
             }
-            SessionState::Running { .. } => self.leave_session(now),
+            SessionState::RunThrough(_) => return self.close_run_through(true, now),
+            SessionState::Running { .. } => return self.leave_session(now),
             _ => self.state = SessionState::Closing,
         }
+        Applied::default()
     }
 
     /// Abandoning must never be what the app teaches, so a closed block either
@@ -2667,7 +2949,10 @@ mod tests {
     fn a_recovered_wander_never_counts_the_outage_as_practice() {
         let mut crashed = EngineSession::default();
         crashed.start_fixture(at(0));
-        crashed.apply(&CoachEvent::GoOffPiste { now: at(30) });
+        crashed.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(30),
+        });
 
         let mut restored = EngineSession::default();
         restored.apply(&CoachEvent::RecoverSession {
@@ -2741,7 +3026,10 @@ mod tests {
     fn a_closed_wander_is_handed_over_for_persistence() {
         let mut session = EngineSession::default();
         session.start_fixture(at(0));
-        session.apply(&CoachEvent::GoOffPiste { now: at(0) });
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(0),
+        });
 
         let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
         assert_eq!(writes.wanders.len(), 1);
@@ -2752,7 +3040,10 @@ mod tests {
     fn answering_the_keep_prompt_rewrites_the_record() {
         let mut session = EngineSession::default();
         session.start_fixture(at(0));
-        session.apply(&CoachEvent::GoOffPiste { now: at(0) });
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(0),
+        });
         session.apply(&CoachEvent::CloseSession { now: at(600) });
 
         let writes = session.apply(&CoachEvent::KeepWanderAsDrill { keep: true });
@@ -2770,7 +3061,10 @@ mod tests {
     fn off_piste_banks_its_time_and_asks_about_keeping_it() {
         let mut session = EngineSession::default();
         session.start_fixture(at(0));
-        session.apply(&CoachEvent::GoOffPiste { now: at(30) });
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(30),
+        });
         assert!(matches!(session.state, SessionState::OffPiste { .. }));
 
         session.apply(&CoachEvent::CloseSession { now: at(400) });
@@ -2787,7 +3081,10 @@ mod tests {
     fn going_off_piste_closes_the_block_it_left() {
         let mut session = listening();
         rep(&mut session, true, 9);
-        session.apply(&CoachEvent::GoOffPiste { now: at(30) });
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(30),
+        });
 
         assert_eq!(session.closed_blocks.len(), 1);
         assert_eq!(session.closed_blocks[0].exit, Exit::Skipped);
@@ -2992,5 +3289,310 @@ mod tests {
             1,
             "and the evidence banked before the crash survives it"
         );
+    }
+
+    // ── The run-through altitude (Journey B, #1256) ─────────────────────
+
+    fn sections() -> Vec<String> {
+        vec!["A".to_string(), "B".to_string(), "Bridge".to_string()]
+    }
+
+    fn run_through(now_s: i64) -> EngineSession {
+        let mut session = EngineSession::default();
+        session.apply(&CoachEvent::StartRunThrough {
+            item_id: "p1".into(),
+            title: "Alice in Wonderland".into(),
+            sections: sections(),
+            now: at(now_s),
+        });
+        session
+    }
+
+    fn judge(session: &mut EngineSession, held: bool, second: i64) -> CoachWrites {
+        session.apply(&CoachEvent::JudgeSection {
+            held,
+            now: at(second),
+        })
+    }
+
+    #[test]
+    fn a_run_through_gates_on_the_pieces_sections_in_order() {
+        let mut session = run_through(0);
+        let run = session.run_through().expect("a run is in flight");
+        assert_eq!(run.current_section().map(String::as_str), Some("A"));
+        assert!(!run.complete());
+
+        judge(&mut session, true, 30);
+        assert_eq!(
+            session.run_through().unwrap().current_section(),
+            Some(&"B".to_string()),
+            "one tap moves on one section"
+        );
+    }
+
+    #[test]
+    fn a_run_with_nothing_to_gate_on_never_starts() {
+        let mut session = EngineSession::default();
+        session.apply(&CoachEvent::StartRunThrough {
+            item_id: "p1".into(),
+            title: "Untitled".into(),
+            sections: vec![],
+            now: at(0),
+        });
+        assert_eq!(
+            session.state,
+            SessionState::Idle,
+            "a sectionless run would be a whole-piece verdict, which nothing can make"
+        );
+    }
+
+    #[test]
+    fn a_run_through_never_replaces_a_session_already_in_flight() {
+        let mut session = listening();
+        rep(&mut session, true, 9);
+        session.apply(&CoachEvent::StartRunThrough {
+            item_id: "p1".into(),
+            title: "Alice in Wonderland".into(),
+            sections: sections(),
+            now: at(30),
+        });
+        assert!(
+            matches!(session.state, SessionState::Running { .. }),
+            "the blocks in flight have evidence riding on them"
+        );
+    }
+
+    #[test]
+    fn a_tap_past_the_last_section_invents_no_verdict() {
+        let mut session = run_through(0);
+        for (index, held) in [true, false, true].into_iter().enumerate() {
+            judge(&mut session, held, 30 * (index as i64 + 1));
+        }
+        assert!(session.run_through().unwrap().complete());
+
+        judge(&mut session, false, 200);
+        assert_eq!(
+            session.run_through().unwrap().verdicts.len(),
+            3,
+            "a fourth tap would put evidence on a section nobody played"
+        );
+    }
+
+    #[test]
+    fn a_complete_run_still_waits_for_an_explicit_exit() {
+        let mut session = run_through(0);
+        for (index, _) in sections().iter().enumerate() {
+            judge(&mut session, true, 30 * (index as i64 + 1));
+        }
+        assert!(
+            session.run_through().is_some(),
+            "auto-closing would write the record before \"Don't count this run\" could be reached"
+        );
+    }
+
+    #[test]
+    fn closing_a_run_writes_the_record_and_lands_the_verdicts() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+        judge(&mut session, false, 60);
+
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(90) });
+        assert_eq!(writes.play_throughs.len(), 1);
+        let record = &writes.play_throughs[0];
+        assert!(record.counted);
+        assert_eq!(record.item_id, "p1");
+        assert_eq!(
+            record.sections.len(),
+            2,
+            "the section never reached is absent"
+        );
+        assert_eq!(record.sections[0].section, "A");
+
+        assert_eq!(writes.evidence.len(), 2);
+        assert_eq!(writes.evidence[0].node, "piece:p1#A");
+        assert_eq!(writes.evidence[0].verdict, Verdict::Clean);
+        assert_eq!(writes.evidence[1].node, "piece:p1#B");
+        assert_eq!(writes.evidence[1].verdict, Verdict::Missed);
+        assert!(
+            writes.evidence[0].level.is_untimed(),
+            "the tap is what bounds the attempt at l0 (#1244)"
+        );
+        assert_eq!(writes.snapshot, SnapshotAction::Clear);
+        assert_eq!(session.state, SessionState::Closing);
+    }
+
+    #[test]
+    fn nothing_lands_on_the_piece_as_a_whole() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(60) });
+        assert!(
+            writes
+                .evidence
+                .iter()
+                .all(|attempt| attempt.node != "piece:p1"),
+            "nothing can count a whole piece yet, so nothing claims to"
+        );
+    }
+
+    #[test]
+    fn dont_count_this_run_keeps_the_time_and_lands_no_evidence() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+        judge(&mut session, true, 60);
+
+        let writes = session.apply(&CoachEvent::DiscardRunThrough { now: at(90) });
+        assert_eq!(
+            writes.play_throughs.len(),
+            1,
+            "the time is still the user's"
+        );
+        assert!(!writes.play_throughs[0].counted);
+        assert_eq!(
+            writes.play_throughs[0].sections.len(),
+            2,
+            "what was tapped is still what was tapped"
+        );
+        assert!(
+            writes.evidence.is_empty(),
+            "an uncounted run is not evidence about anything"
+        );
+    }
+
+    #[test]
+    fn walking_out_of_a_run_keeps_the_verdicts_already_given() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+
+        let writes = session.apply(&CoachEvent::LeaveSession { now: at(45) });
+        assert_eq!(writes.play_throughs.len(), 1);
+        assert_eq!(writes.evidence.len(), 1);
+        assert_eq!(
+            session.state,
+            SessionState::Closing,
+            "an open run would leave a blob recovering a session the user has left"
+        );
+    }
+
+    #[test]
+    fn a_run_has_no_ceiling_and_the_clock_only_reports() {
+        let mut session = run_through(0);
+        session.apply(&CoachEvent::Tick { now: at(4000) });
+        let run = session.run_through().expect("the piece is what ends it");
+        assert_eq!(run.elapsed_seconds(), 4000);
+    }
+
+    #[test]
+    fn every_verdict_earns_a_blob_because_it_is_the_one_thing_a_run_cannot_rebuild() {
+        let mut session = run_through(0);
+        assert_eq!(judge(&mut session, true, 30).snapshot, SnapshotAction::Save);
+        assert_eq!(
+            session.apply(&CoachEvent::Tick { now: at(40) }).snapshot,
+            SnapshotAction::Unchanged,
+            "a tick moves the clock a recovered run restarts anyway"
+        );
+    }
+
+    #[test]
+    fn a_recovered_run_keeps_its_verdicts_and_never_counts_the_outage() {
+        let mut crashed = run_through(0);
+        judge(&mut crashed, true, 30);
+        crashed.apply(&CoachEvent::Tick { now: at(60) });
+
+        let mut restored = EngineSession::default();
+        restored.apply(&CoachEvent::RecoverSession {
+            session: crashed,
+            now: at(3600),
+        });
+
+        assert_eq!(
+            restored
+                .run_through()
+                .expect("the run comes back")
+                .verdicts
+                .len(),
+            1,
+            "a verdict given is a verdict kept"
+        );
+        // Ticked past the recovery, because that is the only reading that can
+        // tell a re-anchored clock from one that kept the crash in it.
+        restored.apply(&CoachEvent::Tick { now: at(3700) });
+        assert_eq!(
+            restored.run_through().unwrap().elapsed_seconds(),
+            160,
+            "the hour the app was gone is not playing time, and the minute before it is"
+        );
+    }
+
+    // ── Off-piste, reached from a piece (B2) ────────────────────────────
+
+    #[test]
+    fn off_piste_from_a_piece_keeps_the_piece_on_the_record() {
+        let mut session = EngineSession::default();
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: Some("p1".into()),
+            now: at(0),
+        });
+        assert!(
+            matches!(session.state, SessionState::OffPiste { .. }),
+            "B0 reaches this altitude with nothing else running"
+        );
+
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
+        assert_eq!(writes.wanders[0].item_id.as_deref(), Some("p1"));
+        assert!(
+            writes.evidence.is_empty(),
+            "off-piste produces time entries only, with zero inference (decision 16)"
+        );
+    }
+
+    #[test]
+    fn a_mid_session_wander_has_no_piece_behind_it() {
+        let mut session = listening();
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: None,
+            now: at(30),
+        });
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
+        assert_eq!(writes.wanders[0].item_id, None);
+    }
+
+    #[test]
+    fn unmonitored_banks_time_and_tags_nothing() {
+        let mut session = EngineSession::default();
+        session.apply(&CoachEvent::GoUnmonitored { now: at(0) });
+        assert_eq!(session.state.altitude(), Some(Altitude::Unmonitored));
+
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
+        assert_eq!(session.unmonitored_seconds, 600);
+        assert!(
+            writes.wanders.is_empty(),
+            "nothing captured, nothing to write"
+        );
+        assert!(writes.play_throughs.is_empty());
+        assert!(writes.evidence.is_empty());
+    }
+
+    #[test]
+    fn the_chip_names_the_altitude_for_the_whole_run() {
+        assert_eq!(
+            run_through(0).state.altitude(),
+            Some(Altitude::RunThrough),
+            "absence of instrumentation is the consent signal, so the core says which"
+        );
+        let mut prescribed = EngineSession::default();
+        prescribed.start_fixture(at(0));
+        assert_eq!(
+            prescribed.state.altitude(),
+            None,
+            "a prescribed session is the top of the map, not a rung on it"
+        );
+    }
+
+    #[test]
+    fn a_run_through_round_trips_on_the_wire() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+        crate::domain::types::assert_round_trips(session.state.clone());
     }
 }

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -302,8 +302,10 @@ pub struct WanderRecord {
     /// `None` = not yet asked.
     pub keep_as_drill: Option<bool>,
     /// The piece B0 was opened from (#1256). `None` for a wander reached
-    /// mid-session, which has no piece behind it.
-    #[serde(default)]
+    /// mid-session, which has no piece behind it. No `serde(default)`: this
+    /// crosses a positional wire with no "absent", so one would read as a
+    /// safety it cannot provide — the crash-recovery key bump is what makes
+    /// adding it safe.
     pub item_id: Option<String>,
 }
 
@@ -621,6 +623,19 @@ impl SessionState {
         )
     }
 
+    /// Whether something new may start here. The guard exists to protect a
+    /// session *in flight*, which has evidence riding on it; a closed one has
+    /// no such stake, because its records and evidence left with the event that
+    /// closed it. `Closing` counts, or the first thing the user plays is the
+    /// only thing they can play until the app restarts (#1256 Phase C found
+    /// this; the dead end predates it).
+    pub(crate) fn accepts_something_new(&self) -> bool {
+        matches!(
+            self,
+            SessionState::Idle | SessionState::Planned { .. } | SessionState::Closing
+        )
+    }
+
     /// Which altitude is running, for the chip that stays up for the whole run.
     /// A prescribed session is not one of the three: it is the top of the map,
     /// not a rung on it.
@@ -766,12 +781,12 @@ impl EngineSession {
             }
             CoachEvent::StartPlannedSession { now } => match std::mem::take(&mut self.state) {
                 SessionState::Planned { plan } => self.start(plan, *now),
-                SessionState::Idle => {
+                SessionState::Idle | SessionState::Closing => {
                     if let Some(plan) = planned {
                         self.start(plan, *now);
                     }
                 }
-                running_or_closing => self.state = running_or_closing,
+                running => self.state = running,
             },
             CoachEvent::CountInBeat { remaining } => self.count_in(*remaining),
             CoachEvent::Beat { beat_index } => self.beat(*beat_index),
@@ -1146,12 +1161,11 @@ impl EngineSession {
     /// not run the planner for an answer that would be discarded.
     pub(crate) fn accepts_plan(&self, event: &CoachEvent) -> bool {
         match event {
-            CoachEvent::PlanSession { .. } => matches!(
-                self.state,
-                SessionState::Idle | SessionState::Planned { .. }
-            ),
+            CoachEvent::PlanSession { .. } => self.state.accepts_something_new(),
             // A plan already made wins; from anywhere else the event is ignored.
-            CoachEvent::StartPlannedSession { .. } => matches!(self.state, SessionState::Idle),
+            CoachEvent::StartPlannedSession { .. } => {
+                matches!(self.state, SessionState::Idle | SessionState::Closing)
+            }
             _ => false,
         }
     }
@@ -1313,7 +1327,7 @@ impl EngineSession {
                     started_at: now,
                 };
             }
-            SessionState::Idle | SessionState::Planned { .. } => {
+            state if state.accepts_something_new() => {
                 self.state = SessionState::OffPiste {
                     item_id,
                     started_at: now,
@@ -1332,12 +1346,7 @@ impl EngineSession {
     ) {
         // Nothing to gate on is not a run-through, and a session already in
         // flight has evidence riding on it that a new altitude must not replace.
-        if sections.is_empty()
-            || !matches!(
-                self.state,
-                SessionState::Idle | SessionState::Planned { .. }
-            )
-        {
+        if sections.is_empty() || !self.state.accepts_something_new() {
             return;
         }
         self.state = SessionState::RunThrough(RunThroughState {
@@ -1385,10 +1394,7 @@ impl EngineSession {
     fn go_unmonitored(&mut self, now: DateTime<Utc>) {
         // Never from mid-`Running`: switching part-way would make the
         // already-captured half of the session retrospectively unconsented.
-        if matches!(
-            self.state,
-            SessionState::Idle | SessionState::Planned { .. }
-        ) {
+        if self.state.accepts_something_new() {
             self.state = SessionState::Unmonitored { started_at: now };
         }
     }
@@ -3344,6 +3350,44 @@ mod tests {
             SessionState::Idle,
             "a sectionless run would be a whole-piece verdict, which nothing can make"
         );
+    }
+
+    #[test]
+    fn a_closed_session_is_not_a_session_in_flight() {
+        let mut session = run_through(0);
+        judge(&mut session, true, 30);
+        session.apply(&CoachEvent::CloseSession { now: at(60) });
+        assert_eq!(session.state, SessionState::Closing);
+
+        session.apply(&CoachEvent::StartRunThrough {
+            item_id: "p2".into(),
+            title: "Blue in Green".into(),
+            sections: vec!["Head".into()],
+            now: at(90),
+        });
+        let run = session
+            .run_through()
+            .expect("the second piece of the day starts");
+        assert_eq!(run.item_id, "p2");
+        assert!(
+            run.verdicts.is_empty(),
+            "and it starts fresh rather than inheriting the closed run's taps"
+        );
+    }
+
+    #[test]
+    fn a_closed_session_takes_the_lower_altitudes_too() {
+        let mut session = run_through(0);
+        session.apply(&CoachEvent::CloseSession { now: at(60) });
+        session.apply(&CoachEvent::GoOffPiste {
+            item_id: Some("p2".into()),
+            now: at(90),
+        });
+        assert_eq!(session.state.altitude(), Some(Altitude::OffPiste));
+
+        session.apply(&CoachEvent::CloseSession { now: at(120) });
+        session.apply(&CoachEvent::GoUnmonitored { now: at(150) });
+        assert_eq!(session.state.altitude(), Some(Altitude::Unmonitored));
     }
 
     #[test]

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -22,7 +22,7 @@ use crate::domain::session::{
 };
 use crate::domain::set::Set;
 use crate::domain::{LibrarySort, ListQuery};
-use crate::engine::{CoachState, CoachView, ContentIndex};
+use crate::engine::{BlockRecord, CoachState, CoachView, ContentIndex};
 use crate::persistence::PersistenceOperation;
 
 /// Internal application state — not exposed to shells.
@@ -96,6 +96,11 @@ pub struct Model {
     /// One slot, because the shell resolves persistence synchronously
     /// (`Store.process`), so only one coach write is ever in flight.
     pub coach_write_in_flight: Option<PersistenceOperation>,
+    /// The block records the store handed back at launch. Kept rather than
+    /// consumed, because the mastery rebuild also needs the run-throughs and
+    /// those arrive on a second, independently-ordered load: whichever lands
+    /// last has to be able to rebuild from both.
+    pub coach_blocks: Vec<BlockRecord>,
     // Built-session entities (#1256, `specs/built-session.md`). Tombstoned
     // rows stay out of these: the shell loads live rows only.
     pub user_drills: Vec<UserDrill>,

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -33,13 +33,20 @@ pub enum PersistenceOperation {
     },
     LoadSessions,
     SaveSession(PracticeSession),
-    /// Append coach evidence as it closes (spec §4, #1181). One transaction:
-    /// blocks, wanders and their attempts land together or not at all, so the
-    /// evidence is never half-written. `updated_at` is core-stamped for the
-    /// whole batch — the shell formats no timestamp of its own.
+    /// Append coach evidence as it closes (spec §4, #1181). One transaction,
+    /// one retry slot: blocks, wanders, run-throughs and their attempts land
+    /// together or not at all, so the evidence is never half-written.
+    /// `updated_at` is core-stamped for the whole batch — the shell formats no
+    /// timestamp of its own.
+    ///
+    /// A run-through rides this rather than saving on its own, because its
+    /// section verdicts are already in the mastery track by the time it is
+    /// sent: a write that could fail without being offered again would leave
+    /// the live track ahead of what the launch replay can rebuild.
     SaveCoachRecords {
         blocks: Vec<BlockRecord>,
         wanders: Vec<WanderRecord>,
+        play_throughs: Vec<PlayThroughRecord>,
         updated_at: DateTime<Utc>,
     },
     /// The closed blocks back, so the mastery track can rebuild at launch
@@ -50,7 +57,6 @@ pub enum PersistenceOperation {
     SaveUserDrill(UserDrill),
     SaveJournalItem(JournalItem),
     SaveBuiltSession(BuiltSession),
-    SavePlayThrough(PlayThroughRecord),
     SaveReflection(Reflection),
     SaveFeelEntry(FeelEntry),
     /// One read for the whole surface at launch, like `LoadItems`.
@@ -139,10 +145,6 @@ pub fn save_journal_item(journal: JournalItem) -> Command<Effect, Event> {
 
 pub fn save_built_session(session: BuiltSession) -> Command<Effect, Event> {
     save_built(PersistenceOperation::SaveBuiltSession(session))
-}
-
-pub fn save_play_through(record: PlayThroughRecord) -> Command<Effect, Event> {
-    save_built(PersistenceOperation::SavePlayThrough(record))
 }
 
 pub fn save_reflection(reflection: Reflection) -> Command<Effect, Event> {
@@ -1042,9 +1044,32 @@ mod tests {
             let mut cmd = send(&app, &mut model, CoachEvent::Tick { now: at(30) });
             let blocks = coach_records(&mut cmd).expect("a SaveCoachRecords op");
 
+            // Saturated on purpose: every arm of the batch has to cross, and an
+            // empty vec proves nothing about the one beside it (#846).
             crate::domain::types::assert_round_trips(PersistenceOperation::SaveCoachRecords {
                 blocks,
-                wanders: vec![],
+                wanders: vec![crate::engine::WanderRecord {
+                    id: "01J00000000000000000WANDER".into(),
+                    started_at: at(0),
+                    ended_at: at(30),
+                    attempts: vec![],
+                    keep_as_drill: Some(true),
+                    item_id: Some("01J000000000000000000PIECE".into()),
+                }],
+                play_throughs: vec![crate::domain::built_session::PlayThroughRecord {
+                    id: "01J0000000000000000000RUN1".into(),
+                    item_id: "01J000000000000000000PIECE".into(),
+                    started_at: at(0),
+                    ended_at: at(30),
+                    counted: true,
+                    sections: vec![crate::domain::built_session::SectionVerdict {
+                        section: "A".into(),
+                        held: true,
+                        at: at(12),
+                    }],
+                    updated_at: at(30),
+                    deleted_at: None,
+                }],
                 updated_at: at(30),
             });
         }

--- a/docs/status.md
+++ b/docs/status.md
@@ -31,8 +31,21 @@ countable criteria.
   session with declinable shape advice, and the canonical drill loop running a
   user drill with its evidence on its own node. `BlockOrigin` on the spec *and*
   the record enforces decision 17 on the live path and the launch replay
-  (GRDB v12); #1269 is closed by the row-quarantine rule. Next: Phase C,
-  Journey B's three altitudes
+  (GRDB v12); #1269 is closed by the row-quarantine rule.
+  **Phase C's core landed Journey B's three altitudes** (screens follow in
+  their own PR, per the two-PR rule). Open question 1 is resolved: **v1 has no
+  pipeline** — a run-through gates on the piece's own named chart sections,
+  and a piece with none is offered the two lower altitudes instead. The
+  run-through is a peer state of the drill loop (`SessionState::RunThrough`),
+  one "Held / Broke down" tap per section, closing to a `PlayThroughRecord`
+  whose verdicts land per section at l0; the launch replay reads them through
+  the same function the live close does. Off-piste is now reachable from a
+  piece and carries the tag (GRDB v13); unmonitored stays untagged on purpose.
+  Crash-recovery key bumped to v5. The superseded `RecordPlayThrough` /
+  `SavePlayThrough` door is deleted — run-throughs ride the coach batch, so a
+  failed write is retried rather than silently leaving the mastery track ahead
+  of the store. Next: Phase C's screens (B0 sheet, run-through screen,
+  AltitudeChip)
 
 ## Recently landed
 

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -11,9 +11,12 @@ protocol ItemStore {
   func delete(id: String, deletedAt: String) throws
   func loadSessions() throws -> [PracticeSession]
   func saveSession(_ session: PracticeSession) throws
-  /// Append coach evidence in one transaction — blocks, wanders and their
-  /// attempts land together or not at all (#1181).
-  func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws
+  /// Append coach evidence in one transaction — blocks, wanders, run-throughs
+  /// and their attempts land together or not at all (#1181).
+  func saveCoachRecords(
+    blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
+    updatedAt: String
+  ) throws
   /// The closed blocks back, so the core can rebuild the mastery track at
   /// launch (#1214). Wanders stay write-only: no `(node, level)` to score.
   func loadCoachRecords() throws -> [BlockRecord]
@@ -22,7 +25,6 @@ protocol ItemStore {
   func saveUserDrill(_ drill: UserDrill) throws
   func saveJournalItem(_ journal: JournalItem) throws
   func saveBuiltSession(_ session: BuiltSession) throws
-  func savePlayThrough(_ record: PlayThroughRecord) throws
   func saveReflection(_ reflection: Reflection) throws
   func saveFeelEntry(_ entry: FeelEntry) throws
   func loadBuiltSessionData() throws -> BuiltSessionData
@@ -190,13 +192,19 @@ final class LibraryStore: ItemStore {
   /// never half-land (#1181). Upsert by id: a retry after a failed write is
   /// idempotent, and the off-piste *keep this as a drill?* answer updates the
   /// wander row already written rather than duplicating it.
-  func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws {
+  func saveCoachRecords(
+    blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
+    updatedAt: String
+  ) throws {
     try dbQueue.write { db in
       for block in blocks {
         try Self.upsert(block, updatedAt: updatedAt, in: db)
       }
       for wander in wanders {
         try Self.upsert(wander, updatedAt: updatedAt, in: db)
+      }
+      for record in playThroughs {
+        try Self.upsert(record, in: db)
       }
     }
   }
@@ -445,6 +453,13 @@ final class LibraryStore: ItemStore {
       // block's taps were ever evidence (decision 17).
       try db.execute(
         sql: "ALTER TABLE block_record ADD COLUMN origin TEXT NOT NULL DEFAULT 'authored'")
+    }
+    migrator.registerMigration("v13_wander_item") { db in
+      // #1256 Phase C: off-piste is now reachable from a piece (B0), so a
+      // wander can name what it was played against. Nullable, because the
+      // mid-session door has no piece behind it and every existing row came
+      // through it.
+      try db.execute(sql: "ALTER TABLE wander_record ADD COLUMN item_id TEXT")
     }
     return migrator
   }()
@@ -865,15 +880,16 @@ final class LibraryStore: ItemStore {
     try db.execute(
       sql: """
         INSERT INTO wander_record
-          (id, started_at, ended_at, attempts, keep_as_drill, updated_at, deleted_at)
-        VALUES (?, ?, ?, ?, ?, ?, NULL)
+          (id, started_at, ended_at, attempts, keep_as_drill, item_id, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
         ON CONFLICT(id) DO UPDATE SET
           ended_at = excluded.ended_at, attempts = excluded.attempts,
-          keep_as_drill = excluded.keep_as_drill, updated_at = excluded.updated_at
+          keep_as_drill = excluded.keep_as_drill, item_id = excluded.item_id,
+          updated_at = excluded.updated_at
         """,
       arguments: [
         record.id, record.startedAt, record.endedAt, try encodeAttempts(record.attempts),
-        record.keepAsDrill, updatedAt,
+        record.keepAsDrill, record.itemId, updatedAt,
       ])
   }
 
@@ -1160,24 +1176,22 @@ final class LibraryStore: ItemStore {
     }
   }
 
-  func savePlayThrough(_ record: PlayThroughRecord) throws {
-    try dbQueue.write { db in
-      try db.execute(
-        sql: """
-          INSERT INTO play_through
-            (id, item_id, started_at, ended_at, counted, sections, updated_at, deleted_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(id) DO UPDATE SET
-            item_id = excluded.item_id, started_at = excluded.started_at,
-            ended_at = excluded.ended_at, counted = excluded.counted,
-            sections = excluded.sections, updated_at = excluded.updated_at,
-            deleted_at = excluded.deleted_at
-          """,
-        arguments: [
-          record.id, record.itemId, record.startedAt, record.endedAt, record.counted,
-          try Self.encodeSections(record.sections), record.updatedAt, record.deletedAt,
-        ])
-    }
+  private static func upsert(_ record: PlayThroughRecord, in db: Database) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO play_through
+          (id, item_id, started_at, ended_at, counted, sections, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          item_id = excluded.item_id, started_at = excluded.started_at,
+          ended_at = excluded.ended_at, counted = excluded.counted,
+          sections = excluded.sections, updated_at = excluded.updated_at,
+          deleted_at = excluded.deleted_at
+        """,
+      arguments: [
+        record.id, record.itemId, record.startedAt, record.endedAt, record.counted,
+        try Self.encodeSections(record.sections), record.updatedAt, record.deletedAt,
+      ])
   }
 
   func saveReflection(_ reflection: Reflection) throws {

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -31,12 +31,16 @@ final class Store {
   /// `origin`, all inside `EngineSession`. `#[serde(default)]` buys nothing on a
   /// non-self-describing wire — serde never reaches the default — so a v3 blob
   /// would read the next struct's bytes as this one's tail.
-  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v4"
+  /// v5 (#1256 Phase C): `SessionState` gained a `RunThrough` variant and
+  /// `WanderRecord` gained `item_id`, both inside `EngineSession`. The new
+  /// variant alone would be safe — old blobs never carry it — but the field is
+  /// positional, so a v4 blob would read a wander's tail as the next record.
+  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v5"
   /// Retired keys, cleared on the next write so a dead blob doesn't sit in
   /// UserDefaults for the life of the install.
   static let retiredCoachSessionKeys = [
     "intrada.coach-session-in-progress.v1", "intrada.coach-session-in-progress.v2",
-    "intrada.coach-session-in-progress.v3",
+    "intrada.coach-session-in-progress.v3", "intrada.coach-session-in-progress.v4",
   ]
 
   private let bridge: CoreBridge
@@ -185,8 +189,9 @@ final class Store {
       case .saveSession(let session):
         try store.saveSession(session)
         return .ack
-      case .saveCoachRecords(let blocks, let wanders, let updatedAt):
-        try store.saveCoachRecords(blocks: blocks, wanders: wanders, updatedAt: updatedAt)
+      case .saveCoachRecords(let blocks, let wanders, let playThroughs, let updatedAt):
+        try store.saveCoachRecords(
+          blocks: blocks, wanders: wanders, playThroughs: playThroughs, updatedAt: updatedAt)
         return .ack
       case .loadCoachRecords: return .coachRecords(try store.loadCoachRecords())
       case .saveUserDrill(let drill):
@@ -197,9 +202,6 @@ final class Store {
         return .ack
       case .saveBuiltSession(let session):
         try store.saveBuiltSession(session)
-        return .ack
-      case .savePlayThrough(let record):
-        try store.savePlayThrough(record)
         return .ack
       case .saveReflection(let reflection):
         try store.saveReflection(reflection)

--- a/ios/IntradaTests/BuiltSessionStoreTests.swift
+++ b/ios/IntradaTests/BuiltSessionStoreTests.swift
@@ -91,7 +91,8 @@ struct BuiltSessionStoreTests {
         SectionVerdict(section: "Out head", held: false, at: "2026-08-07T10:03:00Z"),
       ],
       updatedAt: "2026-08-07T10:04:00Z", deletedAt: nil)
-    try store.savePlayThrough(record)
+    try store.saveCoachRecords(
+      blocks: [], wanders: [], playThroughs: [record], updatedAt: "2026-08-07T10:04:00Z")
     let data = try store.loadBuiltSessionData()
     #expect(data.playThroughs == [record])
   }

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -48,11 +48,12 @@ struct CoachRecordStoreTests {
   }
 
   private func wander(
-    _ id: String = "w1", attempts: [AttemptSummary] = [], keepAsDrill: Bool? = nil
+    _ id: String = "w1", attempts: [AttemptSummary] = [], keepAsDrill: Bool? = nil,
+    itemId: String? = nil
   ) -> WanderRecord {
     WanderRecord(
       id: id, startedAt: "2026-08-04T10:05:00Z", endedAt: "2026-08-04T10:09:00Z",
-      attempts: attempts, keepAsDrill: keepAsDrill)
+      attempts: attempts, keepAsDrill: keepAsDrill, itemId: itemId)
   }
 
   /// A store plus its queue, so the write tests can pin the stored rows with
@@ -89,7 +90,7 @@ struct CoachRecordStoreTests {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
       blocks: [block(escalations: [.tempoDown, .shrinkScope], exit: .ceilingHit)],
-      wanders: [], updatedAt: Self.updatedAt)
+      wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let row = try #require(try self.row(queue, "SELECT * FROM block_record WHERE id = 'b1'"))
     #expect(row["node"] as String? == "rootless-a-b")
@@ -115,7 +116,7 @@ struct CoachRecordStoreTests {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
       blocks: [block(exit: .escalated, attemptsToPass: nil, gateOpenedAtAttempt: nil)],
-      wanders: [], updatedAt: Self.updatedAt)
+      wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let row = try #require(try self.row(queue, "SELECT * FROM block_record WHERE id = 'b1'"))
     #expect(row["attempts_to_pass"] as Int? == nil, "never passed reads back as NULL, not 0")
@@ -130,7 +131,7 @@ struct CoachRecordStoreTests {
       attempt(clean: true, at: "2026-08-04T10:00:18Z", source: .midi, selfPredicted: .clean),
     ]
     try store.saveCoachRecords(
-      blocks: [block(attempts: attempts)], wanders: [], updatedAt: Self.updatedAt)
+      blocks: [block(attempts: attempts)], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let row = try #require(try self.row(queue, "SELECT attempts FROM block_record WHERE id = 'b1'"))
     let json = try #require(row["attempts"] as String?)
@@ -153,7 +154,7 @@ struct CoachRecordStoreTests {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
       blocks: [block(escalations: [.tempoDown, .changeMode, .swapDrill])],
-      wanders: [], updatedAt: Self.updatedAt)
+      wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let row = try #require(
       try self.row(queue, "SELECT escalation_fired FROM block_record WHERE id = 'b1'"))
@@ -166,7 +167,7 @@ struct CoachRecordStoreTests {
   func emptyBlobs() throws {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
-      blocks: [block(exit: .skipped)], wanders: [], updatedAt: Self.updatedAt)
+      blocks: [block(exit: .skipped)], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let row = try #require(try self.row(queue, "SELECT * FROM block_record WHERE id = 'b1'"))
     #expect(row["attempts"] as String? == "[]")
@@ -177,7 +178,7 @@ struct CoachRecordStoreTests {
   func wanderColumns() throws {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
-      blocks: [], wanders: [wander(attempts: [attempt(clean: true)])],
+      blocks: [], wanders: [wander(attempts: [attempt(clean: true)])], playThroughs: [],
       updatedAt: Self.updatedAt)
 
     let row = try #require(try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w1'"))
@@ -196,7 +197,8 @@ struct CoachRecordStoreTests {
   func batchWritesBoth() throws {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
-      blocks: [block("b1"), block("b2")], wanders: [wander("w1")], updatedAt: Self.updatedAt)
+      blocks: [block("b1"), block("b2")], wanders: [wander("w1")], playThroughs: [],
+      updatedAt: Self.updatedAt)
 
     #expect(try count(queue, "block_record") == 2)
     #expect(try count(queue, "wander_record") == 1)
@@ -205,9 +207,11 @@ struct CoachRecordStoreTests {
   @Test("answering the keep prompt updates the wander row rather than duplicating it")
   func wanderUpsert() throws {
     let (store, queue) = try makeStore()
-    try store.saveCoachRecords(blocks: [], wanders: [wander()], updatedAt: Self.updatedAt)
     try store.saveCoachRecords(
-      blocks: [], wanders: [wander(keepAsDrill: true)], updatedAt: "2026-08-04T10:10:00Z")
+      blocks: [], wanders: [wander()], playThroughs: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [], wanders: [wander(keepAsDrill: true)], playThroughs: [],
+      updatedAt: "2026-08-04T10:10:00Z")
 
     #expect(try count(queue, "wander_record") == 1, "the same id upserts, never duplicates")
     let row = try #require(try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w1'"))
@@ -219,8 +223,10 @@ struct CoachRecordStoreTests {
   func blockUpsertIsIdempotent() throws {
     let (store, queue) = try makeStore()
     let record = block(attempts: [attempt(clean: true)])
-    try store.saveCoachRecords(blocks: [record], wanders: [], updatedAt: Self.updatedAt)
-    try store.saveCoachRecords(blocks: [record], wanders: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [record], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [record], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     #expect(try count(queue, "block_record") == 1, "a retried write must not double-count evidence")
   }
@@ -239,7 +245,8 @@ struct CoachRecordStoreTests {
         attempt(clean: true, at: "2026-08-04T10:00:27Z", source: .tapVerdictUntimed),
       ],
       escalations: [.tempoDown, .changeMode], exit: .ceilingHit)
-    try store.saveCoachRecords(blocks: [written], wanders: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [written], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     #expect(try store.loadCoachRecords() == [written])
   }
@@ -249,7 +256,7 @@ struct CoachRecordStoreTests {
     let (store, _) = try makeStore()
     try store.saveCoachRecords(
       blocks: [block(exit: .escalated, attemptsToPass: nil, gateOpenedAtAttempt: nil)],
-      wanders: [], updatedAt: Self.updatedAt)
+      wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let loaded = try #require(try store.loadCoachRecords().first)
     #expect(loaded.attemptsToPass == nil)
@@ -260,7 +267,7 @@ struct CoachRecordStoreTests {
   func readSkipsTombstones() throws {
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
-      blocks: [block("b1"), block("b2")], wanders: [], updatedAt: Self.updatedAt)
+      blocks: [block("b1"), block("b2")], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
     try queue.write { db in
       try db.execute(
         sql: "UPDATE block_record SET deleted_at = ? WHERE id = 'b1'",
@@ -280,7 +287,8 @@ struct CoachRecordStoreTests {
   @Test("an unknown stored exit falls back without claiming a gate pass")
   func readUnknownExit() throws {
     let (store, queue) = try makeStore()
-    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [block()], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
     try queue.write { db in
       try db.execute(sql: "UPDATE block_record SET exit = 'from_the_future' WHERE id = 'b1'")
     }
@@ -304,7 +312,7 @@ struct CoachRecordStoreTests {
             attempt(clean: false, at: "2026-08-04T10:00:09Z", level: before),
             attempt(clean: true, at: "2026-08-04T10:00:18Z", level: after),
           ], escalations: [.tempoDown], exit: .gatePassed)
-      ], wanders: [], updatedAt: Self.updatedAt)
+      ], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let read = try #require(try store.loadCoachRecords().first)
     #expect(read.attempts.map(\.level) == [before, after])
@@ -323,7 +331,7 @@ struct CoachRecordStoreTests {
               clean: true, at: "2026-08-04T10:0\(index):09Z",
               level: ParameterLevel(tempoBpm: 80, clickLevel: level))
           ])
-      }, wanders: [], updatedAt: Self.updatedAt)
+      }, wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
 
     let read = try store.loadCoachRecords()
     #expect(
@@ -334,7 +342,8 @@ struct CoachRecordStoreTests {
   @Test("a row written before the per-attempt level falls back to the block's")
   func readBackLegacyAttemptWithoutLevel() throws {
     let (store, queue) = try makeStore()
-    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [block()], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
     try queue.write { db in
       // A level no suite helper uses, so a hardcoded fallback would fail.
       try db.execute(
@@ -361,7 +370,8 @@ struct CoachRecordStoreTests {
     // Returning [] would replay as a block nobody played (invariant 5).
     let (store, queue) = try makeStore()
     try store.saveCoachRecords(
-      blocks: [block(attempts: [attempt(clean: true)])], wanders: [], updatedAt: Self.updatedAt)
+      blocks: [block(attempts: [attempt(clean: true)])], wanders: [], playThroughs: [],
+      updatedAt: Self.updatedAt)
     try queue.write { db in
       try db.execute(sql: "UPDATE block_record SET attempts = 'not json' WHERE id = 'b1'")
     }
@@ -374,7 +384,8 @@ struct CoachRecordStoreTests {
     // Guessing `authored` would replay a judgement-track block's taps into the
     // mastery track at launch, which is the one thing decision 17 forbids.
     let (store, queue) = try makeStore()
-    try store.saveCoachRecords(blocks: [block()], wanders: [], updatedAt: Self.updatedAt)
+    try store.saveCoachRecords(
+      blocks: [block()], wanders: [], playThroughs: [], updatedAt: Self.updatedAt)
     try queue.write { db in
       try db.execute(sql: "UPDATE block_record SET origin = 'from_the_future' WHERE id = 'b1'")
     }
@@ -434,9 +445,40 @@ struct CoachRecordStoreTests {
     #expect(try count(queue, "wander_record") == 0)
     try store.saveCoachRecords(
       blocks: [block(attempts: [attempt(clean: true, cold: true)])], wanders: [wander()],
-      updatedAt: Self.updatedAt)
+      playThroughs: [], updatedAt: Self.updatedAt)
     #expect(try count(queue, "block_record") == 1, "a migrated database accepts evidence")
     #expect(try count(queue, "wander_record") == 1)
+  }
+
+  @Test("a wander written before v13 keeps its rows and reads back untagged")
+  func upgradeFromV12() throws {
+    let queue = try DatabaseQueue()
+    try LibraryStore.migrator.migrate(queue, upTo: "v12_block_origin")
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO wander_record
+            (id, started_at, ended_at, attempts, keep_as_drill, updated_at, deleted_at)
+          VALUES ('w-legacy', '2026-01-01T00:00:00Z', '2026-01-01T00:10:00Z', '[]', 1,
+                  '2026-01-01T00:10:00Z', NULL)
+          """)
+    }
+
+    let store = try LibraryStore(queue)
+
+    let row = try #require(
+      try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w-legacy'"),
+      "the pre-v13 wander survives")
+    #expect(row["keep_as_drill"] as Bool? == true, "its answer survives the migration")
+    #expect(
+      row["item_id"] as String? == nil,
+      "a wander from before B0 existed was reached mid-session, so it has no piece")
+
+    try store.saveCoachRecords(
+      blocks: [], wanders: [wander("w-new", itemId: "p1")], playThroughs: [],
+      updatedAt: Self.updatedAt)
+    let tagged = try #require(try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w-new'"))
+    #expect(tagged["item_id"] as String? == "p1", "a migrated database accepts the tag")
   }
 
   @Test("the migration chain runs cleanly on a fresh database")
@@ -444,6 +486,6 @@ struct CoachRecordStoreTests {
     let queue = try DatabaseQueue()
     _ = try LibraryStore(queue)
     let applied = try queue.read { db in try LibraryStore.migrator.appliedMigrations(db) }
-    #expect(applied.contains("v10_coach_records"), "applied \(applied)")
+    #expect(applied.contains("v13_wander_item"), "applied \(applied)")
   }
 }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -140,7 +140,7 @@ final class StoreEffectLoopTests: XCTestCase {
       id: id,
       effect: .persistence(
         .saveCoachRecords(
-          blocks: [coachBlock], wanders: [], updatedAt: "2026-08-04T10:00:30Z")))
+          blocks: [coachBlock], wanders: [], playThroughs: [], updatedAt: "2026-08-04T10:00:30Z")))
   }
 
   func testCoachRecordsWriteResolvesAck() {
@@ -171,7 +171,7 @@ final class StoreEffectLoopTests: XCTestCase {
   func testCoachRecordsReadResolvesWhatWasWritten() throws {
     let libraryStore = try LibraryStore.inMemory()
     try libraryStore.saveCoachRecords(
-      blocks: [Self.coachBlock], wanders: [], updatedAt: "2026-08-04T10:00:30Z")
+      blocks: [Self.coachBlock], wanders: [], playThroughs: [], updatedAt: "2026-08-04T10:00:30Z")
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in
       [Request(id: 22, effect: .persistence(.loadCoachRecords))]
@@ -777,10 +777,9 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(view.error, "hydration must not surface an error")
   }
 
-  /// Real-bridge journal + play-through writes (#846, #1256): the two write
-  /// legs the other bridge tests don't reach. `CreateJournalItem` carries two
-  /// optional Strings; `RecordPlayThrough` carries a nested struct array.
-  func testRealBridgeJournalAndPlayThroughWritesDecodeOnWire() throws {
+  /// Real-bridge journal write (#846, #1256): `CreateJournalItem` carries two
+  /// optional Strings, the absent-vs-present hazard on a positional wire.
+  func testRealBridgeJournalWriteDecodesOnWire() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
 
@@ -796,24 +795,55 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(journal.id.count, 26, "core-minted ulid")
     XCTAssertNil(journal.notes, "an absent optional stays absent across the wire")
     XCTAssertEqual(journal.linkedItemId, "p1")
+  }
 
-    let playRequests = try bridge.update(
-      .builtSession(
-        .recordPlayThrough(
-          RecordPlayThrough(
-            itemId: "p1", startedAt: "2026-08-07T10:00:00Z", endedAt: "2026-08-07T10:04:00Z",
-            counted: false,
-            sections: [
-              SectionVerdict(section: "The bridge", held: true, at: "2026-08-07T10:01:00Z"),
-              SectionVerdict(section: "Out head", held: false, at: "2026-08-07T10:03:00Z"),
-            ]))))
-    let record = try XCTUnwrap(
-      playRequests.compactMap { request -> PlayThroughRecord? in
-        if case .persistence(.savePlayThrough(let record)) = request.effect { return record }
+  /// Real-bridge run-through (#846, #1256 Phase C): the whole altitude, driven
+  /// over the live bridge to the batch it writes. `SaveCoachRecords` carries a
+  /// nested struct array (`playThroughs[].sections[]`) that a stub bridge could
+  /// not catch a wire break in.
+  func testRealBridgeRunThroughDecodesOnWire() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+
+    let addRequests = try bridge.update(
+      .item(
+        .add(
+          CreateItem(
+            title: "Alice in Wonderland", kind: .piece, composer: "Sammy Fain", key: nil,
+            modality: nil, tempo: nil, notes: nil, tags: []))))
+    let pieceId = try XCTUnwrap(
+      addRequests.compactMap { request -> String? in
+        if case .persistence(.saveItem(let item)) = request.effect { return item.id }
         return nil
-      }.first, "RecordPlayThrough must emit a SavePlayThrough persistence op")
+      }.first, "the piece is written with a core-minted id")
+    _ = try bridge.update(
+      .item(.setChordChart(pieceId: pieceId, rawChart: "[A]\n| Cmaj7 | Am7 |\n[B]\n| Dm7 | G7 |")))
+
+    _ = try bridge.update(
+      .builtSession(
+        .startPlayThrough(
+          itemId: pieceId, altitude: .runThrough, now: "2026-08-07T10:00:00Z")))
+    let run = try XCTUnwrap(
+      try bridge.view().coach.runThrough, "the run-through screen has something to draw")
+    XCTAssertEqual(run.sections, ["A", "B"], "the piece's own named sections cross the wire")
+    XCTAssertEqual(try bridge.view().coach.altitude, .runThrough)
+
+    _ = try bridge.update(.coach(.judgeSection(held: true, now: "2026-08-07T10:01:00Z")))
+    _ = try bridge.update(.coach(.judgeSection(held: false, now: "2026-08-07T10:03:00Z")))
+    let closing = try bridge.update(.coach(.closeSession(now: "2026-08-07T10:04:00Z")))
+
+    let records = try XCTUnwrap(
+      closing.compactMap { request -> [PlayThroughRecord]? in
+        if case .persistence(.saveCoachRecords(_, _, let playThroughs, _)) = request.effect {
+          return playThroughs
+        }
+        return nil
+      }.first, "a closed run must ride the coach batch")
+    let record = try XCTUnwrap(records.first)
     XCTAssertEqual(record.id.count, 26, "core-minted ulid")
-    XCTAssertEqual(record.counted, false)
+    XCTAssertEqual(record.itemId, pieceId)
+    XCTAssertTrue(record.counted)
+    XCTAssertEqual(record.sections.map(\.section), ["A", "B"])
     XCTAssertEqual(record.sections.map(\.held), [true, false], "verdict order survives the wire")
   }
 
@@ -1618,14 +1648,16 @@ private struct FailingStore: ItemStore {
   func delete(id: String, deletedAt: String) throws { throw TestError() }
   func loadSessions() throws -> [PracticeSession] { throw TestError() }
   func saveSession(_ session: PracticeSession) throws { throw TestError() }
-  func saveCoachRecords(blocks: [BlockRecord], wanders: [WanderRecord], updatedAt: String) throws {
+  func saveCoachRecords(
+    blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
+    updatedAt: String
+  ) throws {
     throw TestError()
   }
   func loadCoachRecords() throws -> [BlockRecord] { throw TestError() }
   func saveUserDrill(_ drill: UserDrill) throws { throw TestError() }
   func saveJournalItem(_ journal: JournalItem) throws { throw TestError() }
   func saveBuiltSession(_ session: BuiltSession) throws { throw TestError() }
-  func savePlayThrough(_ record: PlayThroughRecord) throws { throw TestError() }
   func saveReflection(_ reflection: Reflection) throws { throw TestError() }
   func saveFeelEntry(_ entry: FeelEntry) throws { throw TestError() }
   func loadBuiltSessionData() throws -> BuiltSessionData { throw TestError() }

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -105,10 +105,12 @@ system together; no hand-rolled clones.
   clicked rung, no tempo gives l0 — and its gate is the parsed passes (or key
   coverage, where the sentence named keys).
 - **C**: Journey B (B0 sheet, run-through with section gates, off-piste,
-  unmonitored; AltitudeChip). **Ships as two PRs** per CLAUDE.md's rule for a
-  phase spanning core and screens: C-core (the altitudes as engine states, the
-  section gates, evidence and replay, the wander tag and its migration) is
-  reviewed first, and C-screens follows against a settled contract.
+  unmonitored; AltitudeChip). **Ships as two PRs**: C-core (the altitudes as
+  engine states, the section gates, evidence and replay, the wander tag and its
+  migration) is reviewed first, and C-screens follows against a settled
+  contract. The core/screens split is the rule #1283 adds to CLAUDE.md, off the
+  back of Phase B landing 4,300 insertions in one PR with both self-review
+  blockers in core code written in the first third.
 - **D**: Journey C (feel moments, reflection at close, morning proposal).
 
 Each phase is its own PR; every screen ships with snapshots, VoiceOver labels,
@@ -161,6 +163,12 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    claim anything can make. A whole-piece verdict is what a single unnamed
    section would be, which is why an unlabelled chart is refused rather than
    run on one gate.
+
+   **The known cost**: evidence is label-addressed, so renaming `[Bridge]` to
+   `[B]` in the chart orphans that section's mastery silently. Accepted for v1
+   because the alternative is stable per-section ids on a chart the user edits
+   as text, which is a bigger change than the altitude needs — tracked in #1287
+   to fix before there is much user data to strand.
 2. ~~Audio storage/retention for voice notes and reflections.~~ **Settled in
    the Phase A schema review**: `reflection` carries `audio_path` (a
    shell-relative path) and `duration_s`; the bytes are the shell's, the core

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -1,6 +1,7 @@
 # Built session, play-through altitudes, and qualitative capture
 
-**Status**: Phase B landed (Journey A end-to-end) · **Issue**: #1256 · **Tier**: 3
+**Status**: Phase C core landed (Journey B's altitudes; screens next) ·
+**Issue**: #1256 · **Tier**: 3
 **Design**: `specs/built-session/design/` (Built Session A/B/C mockups) ·
 briefs in `design/briefs/2026-08-built-session-journeys.md` (journeys) and
 `design/briefs/2026-08-copy-language.md` (voice, graduated as T13)
@@ -104,7 +105,10 @@ system together; no hand-rolled clones.
   clicked rung, no tempo gives l0 — and its gate is the parsed passes (or key
   coverage, where the sentence named keys).
 - **C**: Journey B (B0 sheet, run-through with section gates, off-piste,
-  unmonitored; AltitudeChip).
+  unmonitored; AltitudeChip). **Ships as two PRs** per CLAUDE.md's rule for a
+  phase spanning core and screens: C-core (the altitudes as engine states, the
+  section gates, evidence and replay, the wander tag and its migration) is
+  reviewed first, and C-screens follows against a settled contract.
 - **D**: Journey C (feel moments, reflection at close, morning proposal).
 
 Each phase is its own PR; every screen ships with snapshots, VoiceOver labels,
@@ -128,19 +132,35 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    back over the only copy of the user's data with less than it had, and a row
    the model never holds is a row no write can reach. One bad row costs that
    row, not the library, and a newer binary still reads it whole.
-7. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
+7. **Off-piste carries the piece; unmonitored carries nothing** (Phase C). B0
+   is reached from a piece for all three altitudes, but only off-piste keeps
+   the tag: it already writes a record, because it captures. Unmonitored writes
+   no record at all, so there is nothing to tag and nothing that could later say
+   what was played. The asymmetry is the consent gradient, not an oversight —
+   "minutes only" means minutes.
+8. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
    It rides the spec *and* the record, because the mastery track is rebuilt
    from records at launch: a decision-17 rule the live path enforces and the
    replay does not is not a rule (the #1214 class).
 
 ## Open questions
 
-1. How much pipeline does v1 need? B1's note argues: a piece + named section
-   gates only, degrading gracefully to off-piste + piece tag when sections
-   aren't authored. Resolve when Phase C is planned. **Phase B's interim**: a
-   piece block in a composed session runs on the judgement track — time is
-   logged, one tap says when it is done, nothing is inferred. Nothing can
-   count a whole piece yet, so nothing claims to.
+1. ~~How much pipeline does v1 need?~~ **Resolved in Phase C: none.** What a
+   run-through gates on is the piece's own named chart sections — the `[A]`,
+   `[Bridge]` labels already in `Item.chord_chart`, in reading order. No stage
+   graph, no authored pipeline entity, nothing between the piece and its
+   sections; the data is the user's own and reads in their words. This is B1's
+   note taken literally, and the degradation it asked for falls out: a piece
+   with no chart, or a chart with no labelled section, cannot be run through,
+   and B0 offers off-piste and just-play instead (saying why, rather than
+   hiding the option).
+
+   Evidence lands per section, on `piece:<item_id>#<label>`, at l0 — the tap is
+   what bounds the attempt there (#1244). **Nothing lands on the piece as a
+   whole**: Phase B's interim stands, because "the piece held" is still not a
+   claim anything can make. A whole-piece verdict is what a single unnamed
+   section would be, which is why an unlabelled chart is refused rather than
+   run on one gate.
 2. ~~Audio storage/retention for voice notes and reflections.~~ **Settled in
    the Phase A schema review**: `reflection` carries `audio_path` (a
    shell-relative path) and `duration_s`; the bytes are the shell's, the core


### PR DESCRIPTION
Phase C of #1256, **core only**. The screens follow in their own PR, per CLAUDE.md's rule that a phase spanning core and screens ships as two, core reviewed first.

## Open question 1, resolved: v1 needs no pipeline

What a run-through gates on is the piece's **own named chart sections** — the `[A]`, `[Bridge]` labels already in `Item.chord_chart`, in reading order. No stage graph, no authored pipeline entity, nothing between the piece and its sections. The data is the user's own and reads in their words.

B1's note asked for graceful degradation, and it falls straight out: a piece with no chart, or a chart with no labelled section, cannot be run through. B0 offers off-piste and just-play instead, and says why rather than hiding the option.

**Nothing lands on the piece as a whole.** A section verdict is a bounded claim about a named stretch of music; "the piece held" still is not a claim anything can make. That is also why an unlabelled chart is *refused* rather than run on one gate — a single unnamed section is exactly the whole-piece verdict Phase B declined to invent.

## The three altitudes

`SessionState::RunThrough` is a peer of `Running`, not a sub-state — the same shape off-piste and unmonitored already had. One "Held / Broke down" tap per section, in order:

- A tap past the last section invents no verdict, and a section never reached is simply absent from the record.
- The exit is **always** an explicit tap, even once every section is judged. Auto-closing on the last verdict would write the record before "Don't count this run" could be reached.
- Walking out mid-run still writes what was seen: the verdicts already given are the user's, and dropping them on the way out is the silent-no-op bug one layer up.
- A run has no ceiling. The piece is what ends it, so the clock only reports.

Evidence lands per section on `piece:<item_id>#<label>` at l0, where the tap is what bounds the attempt (#1244's ruling). Prefixed like `blocks::node_id`, so a section can never collide with an authored node.

## The replay reads it through the same function the live close does

The mastery track is rebuilt from records at launch, so a rule the live path enforces and the replay does not is not a rule (the #1214 class, and key decision 7). `section_evidence()` is called by both.

That surfaced a real ordering hazard: block records and run-throughs arrive on **two independently-ordered loads**. Whichever landed second would previously have missed the other's evidence. The model now keeps the loaded blocks and both loads rebuild; `rebuild_mastery` replaces rather than adds, so running it twice at launch costs a rebuild and can never double-count.

## Off-piste carries the piece, unmonitored carries nothing

B0 is reached from a piece for all three, but only off-piste keeps the tag. It already writes a record, because it captures. Unmonitored writes no record at all, so there is nothing to tag and nothing that could later say what was played. **The asymmetry is the consent gradient, not an oversight** — "minutes only" means minutes. Recorded as key decision 7 in the spec.

## One door, not two

`RecordPlayThrough` / `SavePlayThrough` (Phase A's fire-once scaffold) are **deleted**. Once the engine owns the run there is no caller, and leaving them would mean two writers for one table with different retry semantics — a future screen could pick the wrong one.

Run-throughs now ride the coach batch instead. That matters beyond tidiness: a run's section verdicts are already in the mastery track by the time the write is sent, so a write that could fail without being offered again would leave the live track ahead of what the launch replay can rebuild. The batch has the retry slot; the standalone op did not.

The live-bridge round-trip that `RecordPlayThrough` carried is re-pointed at the path that actually ships — item → chart → altitude → taps → batch — which is strictly better coverage, since `SaveCoachRecords` carries the same nested struct array (`playThroughs[].sections[]`) a stub bridge could not catch a break in.

## Wire and schema

- **Crash-recovery key v4 → v5.** `SessionState` gained a variant and `WanderRecord` gained `item_id`, both inside `EngineSession`. The new variant alone would be safe (old blobs never carry it), but the field is positional, so a v4 blob would read a wander's tail as the next record.
- **GRDB v13** adds the nullable `wander_record.item_id`. Nullable because the mid-session door has no piece behind it and every existing row came through it. Ships with an upgrade-path test that populates at v12 and asserts the row survives with its answer intact and reads back untagged.

## Testing

TDD throughout. Two assertions were **mutation-tested** rather than assumed, per CLAUDE.md's "ask what the value was one line earlier":

- The recovery re-anchor first passed for the wrong reason — the arrange already satisfied it. It now ticks *past* the recovery, which is the only reading that can tell a re-anchored clock from one that kept the crash in it. Breaking the arm fails it (3700 vs 160).
- The replay of run-through evidence fails when `section_evidence` is dropped from the rebuild, showing `piece:p1#A` and `piece:p1#Bridge` missing.

`just check` (1060 tests), `just ios-fmt-check` and `just ios-test-full` all green.

**Coverage**: the new Rust is `playthrough.rs`, the run-through state machine, the `Closing` re-entry guard and the two-load rebuild, all test-covered, so patch coverage should be high. Expected gaps: the `Altitude::Unmonitored` arm of `StartPlayThrough` is one line of routing covered only indirectly, and `RunThroughState::record`'s uncounted path is covered through `DiscardRunThrough` rather than directly. `ios/` is a Codecov-ignored path.

## Self-review found two real bugs

Both fixed in b4ca409, both mutation-tested — see the [self-review comment](https://github.com/jonyardley/intrada/pull/1284#issuecomment-5223031180) for the full account. In short: adding a second `rebuild_mastery` caller on an error-recovery path meant a mid-session reload silently undid every block closed that session, and `Closing` turned out to be a terminal state, so the second thing a user played in a launch was refused in silence.

The second is a pre-existing dead end that a short repeatable action exposed. It is fixed at the root — a closed session has no evidence riding on it, so it accepts something new.

## Not in this PR

The B0 sheet, the run-through screen and the AltitudeChip — Phase C's screens, next PR, against this now-settled contract. `AltitudeOffer` is the read the sheet will use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
