### PR TITLE
ci: upload coverage from main, so Codecov has a base to compare against (#1288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    # Runs on push to main as well as on PRs, and it has to: a PR comment is a
+    # comparison, so with no report on the base commit there is nothing to
+    # compare and Codecov posts nothing. `main` had never uploaded once, which
+    # is why the dashboard was empty and no PR had been commented on (#1288).
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master

--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,11 @@ comment:
   # Show the Codecov PR comment but keep it compact.
   layout: "reach,diff,flags,files"
   behavior: default
-  require_changes: true      # only comment when coverage data changes
+  # Comment on every PR that has a report, changed coverage or not. Always(6)
+  # has the author compare this comment against the PR's `Coverage:` line, and
+  # a check that only sometimes produces the thing being compared is one nobody
+  # can tell has stopped running (#1288).
+  require_changes: false
   require_base: false        # don't fail if base commit has no coverage
   require_head: true
 


### PR DESCRIPTION
Fixes #1288.

## What was actually wrong

Not the token, not the app, not the action. **The coverage job had never run on `main`.**

```yaml
if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
```

Codecov's API has no `main` branch record for this repo at all, and main's HEAD commit has no report. That single fact explains both symptoms:

- **The dashboard is empty** — it shows the default branch, which has never had an upload. Hence "No coverage reports found in this timespan" and the "Once merged to your default branch…" empty state.
- **No PR comments** — a comment is a *comparison*. With no report on the base commit and `require_changes: true`, there is nothing to compare and Codecov stays quiet.

The uploads were working the whole time. #1284's report processed to `state: complete`, 90.97% over 66 files. I had guessed in #1288 that the GitHub App had lost access; that was wrong, and the issue is corrected.

## The fix

- The coverage job now runs on push to main as well as on PRs, mirroring the guard Clippy and the other jobs already use (`github.event_name == 'push' || needs.changes.outputs.rust == 'true'`).
- `require_changes: false`, so a PR with a report always gets a comment. CLAUDE.md's Always(6) has the author compare that comment against the PR's `Coverage:` line — a check that only sometimes emits the thing being compared is one nobody can tell has stopped running, which is precisely how this went unnoticed across several PRs.

## What to expect

Merging this does not immediately produce a comment. The **first main build after it lands** is what backfills the base; PR comments should return on the next PR after that. If they don't, the app really is the problem and #1288 reopens with the guess I originally made.

Cost: one extra coverage build per main commit, ~2-3 minutes, off the critical path.

**Coverage**: no Rust changed, so no patch coverage applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)