### PR TITLE
ci: pin xcodegen to 2.46.0 across the three native-ios CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,14 +236,31 @@ jobs:
       - name: Install cargo-swift
         if: steps.cargo-swift-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-swift --version "=0.9.0" --locked
-      - name: Cache Homebrew packages
-        id: brew-cache
+      - name: Cache xcodegen
+        id: xcodegen-cache
         uses: actions/cache@v6
         with:
-          path: ~/Library/Caches/Homebrew/downloads
-          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/bin/xcodegen
+            /usr/local/share/xcodegen
+          key: xcodegen-2.46.0-${{ runner.os }}-${{ runner.arch }}
+      # Pinned to 2.46.0, installed from XcodeGen's own GitHub release zip
+      # rather than `brew install xcodegen`: Homebrew has no `xcodegen@2.46.0`
+      # formula to pin to, and current Homebrew rejects installing a loose
+      # formula file outside a tap, so a version pin would need a full
+      # homebrew-core git clone at a fixed commit — much heavier than the
+      # 4MB release zip. Since #1207's fan-out, all three native-ios jobs
+      # resolve xcodegen independently within one CI run; native-ios-build's
+      # prebuilt test products are matched against the .xcodeproj it
+      # generated, and a formula bump landing mid-run could drift that
+      # against the .xcodeproj a test job regenerates locally. Bump this WITH
+      # the two identical steps below, in lockstep.
       - name: Install xcodegen
-        run: brew install xcodegen
+        if: steps.xcodegen-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp
+          /tmp/xcodegen/install.sh
       # The generated bindings (ios/generated: cargo-swift's IntradaCoreFFI
       # xcframework + facet's SharedTypes) are a pure function of the core/ffi
       # source, the locked dep versions (uniffi/crux contract — Cargo.lock), and
@@ -352,13 +369,22 @@ jobs:
       - uses: taiki-e/install-action@v2.85.5
         with:
           tool: just
-      - name: Cache Homebrew packages
+      - name: Cache xcodegen
+        id: xcodegen-cache
         uses: actions/cache@v6
         with:
-          path: ~/Library/Caches/Homebrew/downloads
-          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/bin/xcodegen
+            /usr/local/share/xcodegen
+          key: xcodegen-2.46.0-${{ runner.os }}-${{ runner.arch }}
+      # See the identical step + comment in native-ios-build: pinned
+      # to 2.46.0 in lockstep across all three jobs.
       - name: Install xcodegen
-        run: brew install xcodegen
+        if: steps.xcodegen-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp
+          /tmp/xcodegen/install.sh
       # project.yml declares IntradaCoreFFI/SharedTypes as local Swift
       # packages under ios/generated — xcodegen fails ("Invalid local
       # package") if that directory is missing, even though this job runs no
@@ -438,13 +464,22 @@ jobs:
       - uses: taiki-e/install-action@v2.85.5
         with:
           tool: just
-      - name: Cache Homebrew packages
+      - name: Cache xcodegen
+        id: xcodegen-cache
         uses: actions/cache@v6
         with:
-          path: ~/Library/Caches/Homebrew/downloads
-          key: brew-xcodegen-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            /usr/local/bin/xcodegen
+            /usr/local/share/xcodegen
+          key: xcodegen-2.46.0-${{ runner.os }}-${{ runner.arch }}
+      # See the identical step + comment in native-ios-build: pinned
+      # to 2.46.0 in lockstep across all three jobs.
       - name: Install xcodegen
-        run: brew install xcodegen
+        if: steps.xcodegen-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL -o /tmp/xcodegen.zip https://github.com/yonaskolb/XcodeGen/releases/download/2.46.0/xcodegen.zip
+          unzip -q /tmp/xcodegen.zip -d /tmp
+          /tmp/xcodegen/install.sh
       # See the identical step + comment in native-ios-test-unit: xcodegen
       # fails without ios/generated present, even though this job regenerates
       # nothing itself.


### PR DESCRIPTION
Fixes #1263.

Each of `native-ios-build`, `native-ios-test-unit`, `native-ios-test-ui` ran a bare `brew install xcodegen`, resolved independently. Since #1207's fan-out split these across three separate macOS runner VMs within one CI run, a formula bump mid-run could desync the `.xcodeproj` `native-ios-build`'s prebuilt test products are matched against from the one each test job regenerates locally.

## Mechanism

Pinned to XcodeGen 2.46.0, installed from XcodeGen's own GitHub release zip rather than a versioned Homebrew formula:

- Homebrew has no `xcodegen@2.46.0` formula to pin to.
- Current Homebrew (v4+) rejects installing a loose formula `.rb` file outside a tap, so a Homebrew-based pin would need a full `homebrew-core` git clone checked out at a fixed commit — much heavier than the 4MB official release zip.
- Downloads `xcodegen.zip` from the XcodeGen GitHub releases, unzips, runs the bundled `install.sh` (copies `bin/xcodegen` + `share/xcodegen` into `/usr/local`).
- Cached via `actions/cache` keyed on `xcodegen-2.46.0-${{ runner.os }}-${{ runner.arch }}`, mirroring the existing `cargo-swift` binary-cache pattern in the same file. All three jobs are pinned identically and comment-linked so a future version bump touches all three in lockstep.

Tier 1, no spec. `just check` green locally (1065/1065 tests, fmt/clippy/hygiene clean). No `ios/` files touched, so `just ios-fmt-check`/`ios-test-full` don't apply.

**Coverage:** n/a — CI config only, no code paths.

## Self-review

Ran the code-reviewer subagent (`requesting-code-review`). Verdict: **Ready to merge, Yes** — no Critical or Important-blocking issues. One Important note (can't be settled by static review): whether `/usr/local` is writable without `sudo` on GitHub-hosted `macos-26` runners for `install.sh`'s copy step — this PR's own CI run is the verification. Two Minor suggestions (post-install `xcodegen --version` sanity check; note on the release zip's top-level dir name stability) — left as-is, not worth a tracked issue for two one-line polish items on a Tier 1 CI change.

Deferred items tracked: none — all flagged items addressed inline.

## Test plan
- [ ] All three native-ios CI jobs (`native-ios-build`, `native-ios-test-unit`, `native-ios-test-ui`) go green on this PR