### PR TITLE
fix(core,ios): unmonitored play banks minutes that persist (#1285)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -227,12 +227,16 @@ pub(crate) fn coach_write_commands(
         .last()
         .map(|record| record.ended_at)
         .or_else(|| writes.wanders.last().map(|record| record.ended_at))
-        .or_else(|| writes.play_throughs.last().map(|record| record.ended_at));
+        .or_else(|| writes.play_throughs.last().map(|record| record.ended_at))
+        // Never omit an arm: unmonitored's whole output is this record, and
+        // leaving it out of the chain is how its minutes went unwritten (#1285).
+        .or_else(|| writes.unmonitored.last().map(|record| record.ended_at));
     if let Some(recorded_at) = recorded_at {
         let batch = PersistenceOperation::SaveCoachRecords {
             blocks: writes.blocks,
             wanders: writes.wanders,
             play_throughs: writes.play_throughs,
+            unmonitored: writes.unmonitored,
             updated_at: recorded_at,
         };
         model.coach_write_in_flight = Some(batch.clone());

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -114,7 +114,7 @@ pub enum BuiltTarget {
 
 /// One gated run-through (Journey B's run-through altitude): section-level
 /// verdicts only, never note-level. Off-piste and unmonitored play are
-/// already the engine's `WanderRecord` and `unmonitored_seconds`.
+/// already the engine's `WanderRecord` and `UnmonitoredRecord`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct PlayThroughRecord {
@@ -1856,6 +1856,40 @@ mod tests {
             model.last_error.is_some(),
             "a refusal with no surface is the silent-no-op bug (#846)"
         );
+    }
+
+    /// #1285: the minutes were computed on close and dropped, because nothing
+    /// in the batch carried them and `recorded_at` therefore stayed `None`.
+    #[test]
+    fn unmonitored_minutes_reach_the_store() {
+        let mut model = Model::test_default();
+        model
+            .items
+            .push(sample_item("p1", "Untitled", ItemKind::Piece));
+        start_altitude(&mut model, "p1", Altitude::Unmonitored);
+
+        let closed_at = at() + chrono::TimeDelta::minutes(10);
+        let effects = app_update(
+            &mut model,
+            Event::Coach(CoachEvent::CloseSession { now: closed_at }),
+        );
+
+        let (unmonitored, updated_at) = persistence_ops(&effects)
+            .into_iter()
+            .find_map(|op| match op {
+                PersistenceOperation::SaveCoachRecords {
+                    unmonitored,
+                    updated_at,
+                    ..
+                } => Some((unmonitored, updated_at)),
+                _ => None,
+            })
+            .expect("a SaveCoachRecords op carrying the minutes");
+        assert_eq!(unmonitored.len(), 1);
+        assert_eq!(unmonitored[0].started_at, at());
+        assert_eq!(unmonitored[0].ended_at, closed_at);
+        assert_eq!(updated_at, closed_at, "core-stamped, not shell-formatted");
+        assert_no_http(&effects);
     }
 
     #[test]

--- a/crates/intrada-core/src/engine/mod.rs
+++ b/crates/intrada-core/src/engine/mod.rs
@@ -29,5 +29,6 @@ pub use plan::{
 };
 pub use session::{
     Altitude, AttemptSummary, BlockRecord, BlockState, CoachEvent, CoachWrites, EngineConfig,
-    EngineSession, Exit, Phase, RunThroughState, Rung, SessionState, SnapshotAction, WanderRecord,
+    EngineSession, Exit, Phase, RunThroughState, Rung, SessionState, SnapshotAction,
+    UnmonitoredRecord, WanderRecord,
 };

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -143,6 +143,7 @@ pub struct CoachWrites {
     pub blocks: Vec<BlockRecord>,
     pub wanders: Vec<WanderRecord>,
     pub play_throughs: Vec<PlayThroughRecord>,
+    pub unmonitored: Vec<UnmonitoredRecord>,
     /// Attempts the mastery track has yet to hear about (spec §2).
     pub evidence: Vec<ScoredAttempt>,
     pub snapshot: SnapshotAction,
@@ -156,6 +157,7 @@ pub struct CoachWrites {
 struct Applied {
     evidence: Vec<ScoredAttempt>,
     play_throughs: Vec<PlayThroughRecord>,
+    unmonitored: Vec<UnmonitoredRecord>,
 }
 
 impl Applied {
@@ -335,6 +337,18 @@ pub struct WanderRecord {
     /// safety it cannot provide — the crash-recovery key bump is what makes
     /// adding it safe.
     pub item_id: Option<String>,
+}
+
+/// Minutes played, and deliberately nothing else (decision 7, #1285): no
+/// `item_id`, no attempts, and there must never be one. A field added here
+/// fails `an_unmonitored_record_is_nothing_but_an_id_and_two_instants`, which
+/// is what keeps "minutes only" a rule rather than a convention.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct UnmonitoredRecord {
+    pub id: String,
+    pub started_at: DateTime<Utc>,
+    pub ended_at: DateTime<Utc>,
 }
 
 /// Journey B's three altitudes (decision 16). Named on the session rather than
@@ -684,8 +698,6 @@ pub struct EngineSession {
     pub config: EngineConfig,
     pub closed_blocks: Vec<BlockRecord>,
     pub wanders: Vec<WanderRecord>,
-    /// Banked but never interpreted — the whole point of decision 16.
-    pub unmonitored_seconds: u32,
 }
 
 impl EngineSession {
@@ -778,6 +790,7 @@ impl EngineSession {
             blocks: self.closed_blocks[blocks_from..].to_vec(),
             wanders: self.wanders[wanders_from..].to_vec(),
             play_throughs: applied.play_throughs,
+            unmonitored: applied.unmonitored,
             evidence: applied.evidence,
             snapshot: if matches!(self.state, SessionState::Closing) {
                 if was_closing {
@@ -1416,6 +1429,7 @@ impl EngineSession {
         Applied {
             evidence: section_evidence(&record),
             play_throughs: vec![record],
+            ..Applied::default()
         }
     }
 
@@ -1444,8 +1458,16 @@ impl EngineSession {
                 self.state = SessionState::Closing;
             }
             SessionState::Unmonitored { started_at } => {
-                self.unmonitored_seconds = (now - *started_at).num_seconds().max(0) as u32;
+                let record = UnmonitoredRecord {
+                    id: ulid::Ulid::generate().to_string(),
+                    started_at: *started_at,
+                    ended_at: now,
+                };
                 self.state = SessionState::Closing;
+                return Applied {
+                    unmonitored: vec![record],
+                    ..Applied::default()
+                };
             }
             SessionState::RunThrough(_) => return self.close_run_through(true, now),
             SessionState::Running { .. } => return self.leave_session(now),
@@ -1536,9 +1558,9 @@ mod tests {
     // wire with no field names. The shell must read the new shape under a new
     // key. Missed three times (#1223, #1244, #1256), each caught by a person.
 
-    const SHELL_SNAPSHOT_KEY: &str = "intrada.coach-session-in-progress.v5";
-    const SNAPSHOT_WIRE_LEN: usize = 1425;
-    const SNAPSHOT_WIRE_HASH: u64 = 0x944c03cb25cfd23e;
+    const SHELL_SNAPSHOT_KEY: &str = "intrada.coach-session-in-progress.v6";
+    const SNAPSHOT_WIRE_LEN: usize = 1421;
+    const SNAPSHOT_WIRE_HASH: u64 = 0x08c6899544e9c504;
 
     /// FNV-1a rather than `DefaultHasher`, whose output is explicitly unstable
     /// across Rust releases — this value is committed.
@@ -1623,7 +1645,6 @@ mod tests {
             // `None` here would hide this field's width from the pin.
             item_id: Some("01J000000000000000000PIECE".to_string()),
         });
-        session.unmonitored_seconds = 90;
         session
     }
 
@@ -3279,11 +3300,46 @@ mod tests {
         session.apply(&CoachEvent::GoUnmonitored { now: at(0) });
         assert!(matches!(session.state, SessionState::Unmonitored { .. }));
 
-        session.apply(&CoachEvent::CloseSession { now: at(600) });
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
         assert_eq!(session.state, SessionState::Closing);
-        assert_eq!(session.unmonitored_seconds, 600);
+        assert_eq!(writes.unmonitored.len(), 1);
         assert!(session.closed_blocks.is_empty());
         assert!(session.wanders.is_empty(), "decision 16: nothing inferred");
+    }
+
+    #[test]
+    fn closing_unmonitored_writes_the_minutes_it_banked() {
+        let mut session = EngineSession::default();
+        session.apply(&CoachEvent::GoUnmonitored { now: at(0) });
+
+        let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
+
+        let record = writes
+            .unmonitored
+            .first()
+            .expect("the minutes are the only output this altitude has (#1285)");
+        assert_eq!(record.started_at, at(0));
+        assert_eq!(record.ended_at, at(600));
+        assert!(!record.id.is_empty(), "a client-minted ulid, invariant 3");
+    }
+
+    /// A tag added to the type fails here rather than at review (decision 7).
+    #[test]
+    fn an_unmonitored_record_is_nothing_but_an_id_and_two_instants() {
+        let record = UnmonitoredRecord {
+            id: "u0".to_string(),
+            started_at: at(0),
+            ended_at: at(600),
+        };
+        let json = serde_json::to_value(&record).expect("serialize");
+        let mut fields: Vec<&str> = json
+            .as_object()
+            .expect("an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        fields.sort_unstable();
+        assert_eq!(fields, ["ended_at", "id", "started_at"]);
     }
 
     // ── l0: the clickless acquisition block (decision 20) ──
@@ -3773,7 +3829,7 @@ mod tests {
         assert_eq!(session.state.altitude(), Some(Altitude::Unmonitored));
 
         let writes = session.apply(&CoachEvent::CloseSession { now: at(600) });
-        assert_eq!(session.unmonitored_seconds, 600);
+        assert_eq!(writes.unmonitored.len(), 1, "minutes only");
         assert!(
             writes.wanders.is_empty(),
             "nothing captured, nothing to write"

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -13,7 +13,7 @@ use crate::domain::built_session::{
 };
 use crate::domain::item::Item;
 use crate::domain::session::PracticeSession;
-use crate::engine::{BlockRecord, WanderRecord};
+use crate::engine::{BlockRecord, UnmonitoredRecord, WanderRecord};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
@@ -47,10 +47,12 @@ pub enum PersistenceOperation {
         blocks: Vec<BlockRecord>,
         wanders: Vec<WanderRecord>,
         play_throughs: Vec<PlayThroughRecord>,
+        unmonitored: Vec<UnmonitoredRecord>,
         updated_at: DateTime<Utc>,
     },
     /// The closed blocks back, so the mastery track can rebuild at launch
-    /// (#1214). Wanders stay unread: they carry no `(node, level)` to score.
+    /// (#1214). Wanders and unmonitored minutes stay unread: they carry no
+    /// `(node, level)` to score, and inferring one is what decision 16 forbids.
     LoadCoachRecords,
     // Built-session entities (#1256). Saves are upserts by id; deletes are
     // tombstoned saves (invariant 2) — no hard-delete op exists on purpose.
@@ -1069,6 +1071,11 @@ mod tests {
                     }],
                     updated_at: at(30),
                     deleted_at: None,
+                }],
+                unmonitored: vec![crate::engine::UnmonitoredRecord {
+                    id: "01J000000000000000000QUIET".into(),
+                    started_at: at(0),
+                    ended_at: at(30),
                 }],
                 updated_at: at(30),
             });

--- a/docs/status.md
+++ b/docs/status.md
@@ -41,7 +41,15 @@ countable criteria.
   whose verdicts land per section at l0; the launch replay reads them through
   the same function the live close does. Off-piste is now reachable from a
   piece and carries the tag (GRDB v13); unmonitored stays untagged on purpose.
-  Crash-recovery key bumped to v5. The superseded `RecordPlayThrough` /
+  **#1285 gave unmonitored play somewhere to land**: its minutes were computed
+  on close into a field nothing persisted, so decision 16's one output died
+  with the process. They now write an `UnmonitoredRecord` (an id and two
+  instants, nothing else) to its own `unmonitored_play` table (GRDB v14),
+  rather than a discriminated `wander_record`: a table with no column for a
+  piece cannot be made to name one, so "minutes only" is enforced by the
+  schema rather than by every future writer remembering. `unmonitored_seconds`
+  is gone from `EngineSession`, so the crash-recovery key is now v6.
+  The superseded `RecordPlayThrough` /
   `SavePlayThrough` door is deleted — run-throughs ride the coach batch, so a
   failed write is retried rather than silently leaving the mastery track ahead
   of the store. Next: Phase C's screens (B0 sheet, run-through screen,

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -11,14 +11,15 @@ protocol ItemStore {
   func delete(id: String, deletedAt: String) throws
   func loadSessions() throws -> [PracticeSession]
   func saveSession(_ session: PracticeSession) throws
-  /// Append coach evidence in one transaction — blocks, wanders, run-throughs
-  /// and their attempts land together or not at all (#1181).
+  /// Append coach evidence in one transaction — blocks, wanders, run-throughs,
+  /// unmonitored minutes and their attempts land together or not at all (#1181).
   func saveCoachRecords(
     blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
-    updatedAt: String
+    unmonitored: [UnmonitoredRecord], updatedAt: String
   ) throws
   /// The closed blocks back, so the core can rebuild the mastery track at
-  /// launch (#1214). Wanders stay write-only: no `(node, level)` to score.
+  /// launch (#1214). Wanders and unmonitored minutes stay write-only: no
+  /// `(node, level)` to score, and decision 16 forbids inferring one.
   func loadCoachRecords() throws -> [BlockRecord]
   // Built-session entities (#1256): upserts by id; deletes arrive as
   // tombstoned saves, so no delete methods exist.
@@ -194,7 +195,7 @@ final class LibraryStore: ItemStore {
   /// wander row already written rather than duplicating it.
   func saveCoachRecords(
     blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
-    updatedAt: String
+    unmonitored: [UnmonitoredRecord] = [], updatedAt: String
   ) throws {
     try dbQueue.write { db in
       for block in blocks {
@@ -205,6 +206,9 @@ final class LibraryStore: ItemStore {
       }
       for record in playThroughs {
         try Self.upsert(record, in: db)
+      }
+      for record in unmonitored {
+        try Self.upsert(record, updatedAt: updatedAt, in: db)
       }
     }
   }
@@ -460,6 +464,21 @@ final class LibraryStore: ItemStore {
       // mid-session door has no piece behind it and every existing row came
       // through it.
       try db.execute(sql: "ALTER TABLE wander_record ADD COLUMN item_id TEXT")
+    }
+    migrator.registerMigration("v14_unmonitored_play") { db in
+      // #1285: its own table rather than a discriminated `wander_record`,
+      // because a table with no column for a piece cannot be made to name one —
+      // decision 7's "minutes only", enforced by the schema rather than stated.
+      try db.execute(
+        sql: """
+          CREATE TABLE unmonitored_play (
+            id TEXT PRIMARY KEY NOT NULL,
+            started_at TEXT NOT NULL,
+            ended_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+          )
+          """)
     }
     return migrator
   }()
@@ -891,6 +910,19 @@ final class LibraryStore: ItemStore {
         record.id, record.startedAt, record.endedAt, try encodeAttempts(record.attempts),
         record.keepAsDrill, record.itemId, updatedAt,
       ])
+  }
+
+  private static func upsert(
+    _ record: UnmonitoredRecord, updatedAt: String, in db: Database
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO unmonitored_play (id, started_at, ended_at, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, NULL)
+        ON CONFLICT(id) DO UPDATE SET
+          ended_at = excluded.ended_at, updated_at = excluded.updated_at
+        """,
+      arguments: [record.id, record.startedAt, record.endedAt, updatedAt])
   }
 
   /// Throws rather than substituting `[]`: losing the attempts would make a

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -35,12 +35,17 @@ final class Store {
   /// `WanderRecord` gained `item_id`, both inside `EngineSession`. The new
   /// variant alone would be safe — old blobs never carry it — but the field is
   /// positional, so a v4 blob would read a wander's tail as the next record.
-  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v5"
+  /// v6 (#1285): `EngineSession` lost its trailing `unmonitored_seconds`, which
+  /// the minutes now leave as a record instead. A v5 blob carries four trailing
+  /// bytes the new shape never reads; the key bump is what stops it decoding at
+  /// all, since a shorter struct would otherwise read as a valid session.
+  static let coachSessionInProgressKey = "intrada.coach-session-in-progress.v6"
   /// Retired keys, cleared on the next write so a dead blob doesn't sit in
   /// UserDefaults for the life of the install.
   static let retiredCoachSessionKeys = [
     "intrada.coach-session-in-progress.v1", "intrada.coach-session-in-progress.v2",
     "intrada.coach-session-in-progress.v3", "intrada.coach-session-in-progress.v4",
+    "intrada.coach-session-in-progress.v5",
   ]
 
   private let bridge: CoreBridge
@@ -189,9 +194,11 @@ final class Store {
       case .saveSession(let session):
         try store.saveSession(session)
         return .ack
-      case .saveCoachRecords(let blocks, let wanders, let playThroughs, let updatedAt):
+      case .saveCoachRecords(
+        let blocks, let wanders, let playThroughs, let unmonitored, let updatedAt):
         try store.saveCoachRecords(
-          blocks: blocks, wanders: wanders, playThroughs: playThroughs, updatedAt: updatedAt)
+          blocks: blocks, wanders: wanders, playThroughs: playThroughs, unmonitored: unmonitored,
+          updatedAt: updatedAt)
         return .ack
       case .loadCoachRecords: return .coachRecords(try store.loadCoachRecords())
       case .saveUserDrill(let drill):

--- a/ios/IntradaTests/CoachRecordStoreTests.swift
+++ b/ios/IntradaTests/CoachRecordStoreTests.swift
@@ -52,6 +52,13 @@ struct CoachRecordStoreTests {
       attempts: attempts, keepAsDrill: keepAsDrill, itemId: itemId)
   }
 
+  private func unmonitored(
+    _ id: String = "u1", startedAt: String = "2026-08-04T11:00:00Z",
+    endedAt: String = "2026-08-04T11:25:00Z"
+  ) -> UnmonitoredRecord {
+    UnmonitoredRecord(id: id, startedAt: startedAt, endedAt: endedAt)
+  }
+
   /// A store plus its queue, so the write tests can pin the stored rows with
   /// raw SQL rather than trusting the production decoder they share (#1214).
   private func makeStore() throws -> (LibraryStore, DatabaseQueue) {
@@ -69,10 +76,10 @@ struct CoachRecordStoreTests {
 
   // ── Schema (offline-first invariant 2) ────────────────────────────────
 
-  @Test("both evidence tables carry the sync columns")
+  @Test("every evidence table carries the sync columns")
   func syncColumns() throws {
     let (store, _) = try makeStore()
-    for table in ["block_record", "wander_record"] {
+    for table in ["block_record", "wander_record", "unmonitored_play"] {
       let columns = try store.columnNames(ofTable: table)
       #expect(columns.contains("updated_at"), "\(table) must carry updated_at; has \(columns)")
       #expect(columns.contains("deleted_at"), "\(table) must carry deleted_at; has \(columns)")
@@ -213,6 +220,30 @@ struct CoachRecordStoreTests {
     let row = try #require(try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w1'"))
     #expect(row["keep_as_drill"] as Bool? == true)
     #expect(row["updated_at"] as String? == "2026-08-04T10:10:00Z")
+  }
+
+  @Test("unmonitored play writes its minutes and survives the process")
+  func unmonitoredWrite() throws {
+    let (store, queue) = try makeStore()
+    try store.saveCoachRecords(
+      blocks: [], wanders: [], playThroughs: [], unmonitored: [unmonitored()],
+      updatedAt: Self.updatedAt)
+
+    let row = try #require(try self.row(queue, "SELECT * FROM unmonitored_play WHERE id = 'u1'"))
+    #expect(row["started_at"] as String? == "2026-08-04T11:00:00Z")
+    #expect(row["ended_at"] as String? == "2026-08-04T11:25:00Z")
+    #expect(row["updated_at"] as String? == Self.updatedAt)
+    #expect(row["deleted_at"] as String? == nil)
+  }
+
+  /// Decision 7's consent gradient, enforced rather than stated: no column a
+  /// piece could be written into means no later write can tag these minutes.
+  @Test("the unmonitored table has nowhere to record what was played")
+  func unmonitoredIsUntaggable() throws {
+    let (store, _) = try makeStore()
+    let columns = try store.columnNames(ofTable: "unmonitored_play").sorted()
+
+    #expect(columns == ["deleted_at", "ended_at", "id", "started_at", "updated_at"])
   }
 
   @Test("rewriting a record after a failed write is idempotent")
@@ -477,11 +508,39 @@ struct CoachRecordStoreTests {
     #expect(tagged["item_id"] as String? == "p1", "a migrated database accepts the tag")
   }
 
+  @Test("a database populated at v13 keeps its evidence and gains the minutes table")
+  func upgradeFromV13() throws {
+    let queue = try DatabaseQueue()
+    try LibraryStore.migrator.migrate(queue, upTo: "v13_wander_item")
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO wander_record
+            (id, started_at, ended_at, attempts, keep_as_drill, item_id, updated_at, deleted_at)
+          VALUES ('w-legacy', '2026-01-01T00:00:00Z', '2026-01-01T00:10:00Z', '[]', 1, 'p1',
+                  '2026-01-01T00:10:00Z', NULL)
+          """)
+    }
+
+    let store = try LibraryStore(queue)
+
+    let row = try #require(
+      try self.row(queue, "SELECT * FROM wander_record WHERE id = 'w-legacy'"),
+      "the pre-v14 wander survives")
+    #expect(row["item_id"] as String? == "p1", "its tag survives the migration")
+
+    #expect(try count(queue, "unmonitored_play") == 0, "the new table arrives empty")
+    try store.saveCoachRecords(
+      blocks: [], wanders: [], playThroughs: [], unmonitored: [unmonitored()],
+      updatedAt: Self.updatedAt)
+    #expect(try count(queue, "unmonitored_play") == 1, "a migrated database banks the minutes")
+  }
+
   @Test("the migration chain runs cleanly on a fresh database")
   func freshDatabaseReachesHead() throws {
     let queue = try DatabaseQueue()
     _ = try LibraryStore(queue)
     let applied = try queue.read { db in try LibraryStore.migrator.appliedMigrations(db) }
-    #expect(applied.contains("v13_wander_item"), "applied \(applied)")
+    #expect(applied.contains("v14_unmonitored_play"), "applied \(applied)")
   }
 }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -131,7 +131,8 @@ final class StoreEffectLoopTests: XCTestCase {
       id: id,
       effect: .persistence(
         .saveCoachRecords(
-          blocks: [coachBlock], wanders: [], playThroughs: [], updatedAt: "2026-08-04T10:00:30Z")))
+          blocks: [coachBlock], wanders: [], playThroughs: [], unmonitored: [],
+          updatedAt: "2026-08-04T10:00:30Z")))
   }
 
   func testCoachRecordsWriteResolvesAck() {
@@ -825,7 +826,7 @@ final class StoreEffectLoopTests: XCTestCase {
 
     let records = try XCTUnwrap(
       closing.compactMap { request -> [PlayThroughRecord]? in
-        if case .persistence(.saveCoachRecords(_, _, let playThroughs, _)) = request.effect {
+        if case .persistence(.saveCoachRecords(_, _, let playThroughs, _, _)) = request.effect {
           return playThroughs
         }
         return nil
@@ -1634,7 +1635,7 @@ private struct FailingStore: ItemStore {
   func saveSession(_ session: PracticeSession) throws { throw TestError() }
   func saveCoachRecords(
     blocks: [BlockRecord], wanders: [WanderRecord], playThroughs: [PlayThroughRecord],
-    updatedAt: String
+    unmonitored: [UnmonitoredRecord], updatedAt: String
   ) throws {
     throw TestError()
   }

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -62,7 +62,8 @@ full). New domain surface, sketched for Phase A:
 - **Entities** (GRDB, client ulids, `updated_at`/`deleted_at`): `UserDrill`
   (criterion text, parsed gate params, serves tag, low-band mastery state),
   `JournalItem`, `BuiltSession` (ordered blocks + provenance), `PlayThrough`
-  (altitude, per-section verdicts for run-throughs, elapsed for the others),
+  (per-section verdicts for run-throughs; Phase C split the other two
+  altitudes into `WanderRecord` and `UnmonitoredRecord`, which carry elapsed),
   `Reflection` / feel entries (judgement track: never feed mastery, may retire
   a target, decision 17).
 - **Events/Effects**: compose/resolve/reorder events; existing drill-loop
@@ -136,10 +137,24 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    row, not the library, and a newer binary still reads it whole.
 7. **Off-piste carries the piece; unmonitored carries nothing** (Phase C). B0
    is reached from a piece for all three altitudes, but only off-piste keeps
-   the tag: it already writes a record, because it captures. Unmonitored writes
-   no record at all, so there is nothing to tag and nothing that could later say
-   what was played. The asymmetry is the consent gradient, not an oversight —
-   "minutes only" means minutes.
+   the tag: it already writes a record, because it captures. Unmonitored's
+   record is an id and two instants and nothing else, so there is nothing to
+   tag and nothing that could later say what was played. The asymmetry is the
+   consent gradient, not an oversight — "minutes only" means minutes.
+
+   **Amended 2026-08-08 (#1285).** This decision originally read "unmonitored
+   writes no record at all", and the engine took it literally: the minutes were
+   computed on close into a field nothing persisted, so decision 16's one
+   promised output died with the process. The consent rule was never about
+   writing nothing — it is about writing nothing *attributable*. So the minutes
+   land in their own `unmonitored_play` table (v14), whose columns are `id`,
+   `started_at`, `ended_at` and the two sync columns. Deliberately **not** a
+   discriminated `wander_record`: that table has an `item_id`, an `attempts`
+   blob and the keep-prompt answer, so reusing it would leave "minutes only"
+   resting on every future writer remembering the discriminator. A table with
+   no column for a piece cannot be made to name one. The rows are write-only,
+   as wanders already are — nothing reads them back, because reading them into
+   anything is the inference decision 16 forbids.
 8. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
    It rides the spec *and* the record, because the mastery track is rebuilt
    from records at launch: a decision-17 rule the live path enforces and the


### PR DESCRIPTION
Closes #1285.

`EngineSession::unmonitored_seconds` was computed on `close_session` and then
thrown away: nothing carried it into a write, so `coach_write_commands` saw no
`recorded_at` and emitted no persistence op at all. Decision 16 promises "just
play" produces a time entry and nothing else; it was producing nothing, and the
count died with the process. Pre-existing since the state landed in 2a, but
Phase C's B0 sheet is what makes the altitude user-reachable.

## The schema decision

The issue offered two shapes: a new table, or `wander_record` with a kind
discriminator. **New table** (`unmonitored_play`, GRDB v14), because key
decision 7's "unmonitored stays untagged" is worth enforcing rather than
stating.

A wander row carries an `item_id`, an `attempts` blob and the keep-prompt
answer. Reusing it would leave the consent rule resting on every future writer
remembering the discriminator — one migration, one backfill or one query that
forgets it and the minutes acquire a piece. `unmonitored_play` has `id`,
`started_at`, `ended_at` and the two sync columns, and nothing else: a table
with no column for a piece cannot be made to name one. The same discipline runs
up the stack — `UnmonitoredRecord` has three fields, so a tag fails to compile
rather than being caught at review.

The rows are write-only, exactly as wanders already are. Nothing reads them
back, because reading them into anything is the inference decision 16 forbids.

## What changed

- `UnmonitoredRecord` (id + two instants) leaves `close_session` on `CoachWrites`
  and rides the existing `SaveCoachRecords` batch, so a failed write is offered
  again rather than dropped.
- It rides `Applied` rather than living on `EngineSession`, for the reason
  `PlayThroughRecord` already does: a field empty at rest would ride the
  crash-recovery wire for nothing.
- `unmonitored_seconds` is deleted. The record supersedes it and nothing read
  it, so it was an unread field under CLAUDE.md's "nothing unread stays in the
  tree".
- Crash-recovery wire: dropping that `u32` shortens `EngineSession`, so
  `coachSessionInProgressKey` moves to `.v6`, `.v5` joins the retired list, and
  `SNAPSHOT_WIRE_LEN`/`HASH` are re-pinned from what the gate printed
  (1425 → 1421).
- GRDB `v14_unmonitored_play`, appended, additive, nothing edited.

## Tests

TDD throughout; every test below was watched failing first.

- `closing_unmonitored_writes_the_minutes_it_banked` — the record carries the
  real span, not a zero.
- `unmonitored_minutes_reach_the_store` — the #1285 regression proper: a
  `SaveCoachRecords` op exists at all, carries the span, and is stamped with the
  core's own clock.
- `an_unmonitored_record_is_nothing_but_an_id_and_two_instants` and
  `unmonitoredIsUntaggable` — the untagged invariant, asserted against the type
  and the schema rather than left to prose.
- `upgradeFromV13` — a database populated at v13 keeps its tagged wander and
  gains a working minutes table.
- The saturated `assert_round_trips` batch gains an unmonitored arm, so the new
  payload crosses the real bincode wire.

Mutation-checked rather than assumed: renaming the created table made exactly
the four new Swift tests fail, so none of them passes for the wrong reason.

**Coverage**: expect no gaps. Every new branch (the `recorded_at` arm, the
close arm, the upsert, the migration) has a test that fails without it.

## Verification

`just check` (1068 passed), `just ios-fmt-check`, `just ios-test-full` all green
locally. Three XCUITests unrelated to this change (`LibrarySearchUITests`,
`StepManagementUITests`) failed once on simulator launch contention ("Busy",
preflight) with a foreign sim booted; they pass in isolation and the full gate
is green on the pushed HEAD.

No UI in this PR — core plus the store, no SwiftUI, so it stays one PR under the
core/screens split rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
