### PR TITLE
feat(core,ios): built session Phase D core — Journey C's qualitative capture (#1256)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -1,6 +1,7 @@
 // The `#[effect]` macro generates large variant size differences and we can't Box through it.
 #![allow(clippy::large_enum_variant)]
 
+use chrono::{DateTime, Utc};
 use crux_core::capability::Operation;
 use crux_core::macros::effect;
 use crux_core::render::RenderOperation;
@@ -10,8 +11,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::analytics::compute_analytics;
 use crate::domain::account::{handle_account_event, AccountEvent};
+use crate::domain::built_session::capture::{self, FeelPrompt};
 use crate::domain::built_session::compose::{compose_view, composed_session_view, BuiltView};
-use crate::domain::built_session::{handle_built_session_event, BuiltSessionEvent};
+use crate::domain::built_session::{blocks, handle_built_session_event, steer, BuiltSessionEvent};
 use crate::domain::item::{handle_item_event, Item, ItemEvent, ItemKind};
 use crate::domain::mcp_audit::{handle_mcp_audit_event, McpAuditEvent};
 use crate::domain::mcp_tokens::{handle_mcp_token_event, McpTokenEvent};
@@ -204,6 +206,54 @@ fn rebuild_mastery(model: &mut Model) {
         .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
 }
 
+/// C3, at the one moment that has both a clock and a plan: what to propose this
+/// morning, and where an already-accepted steer goes.
+///
+/// The proposal is snapshotted rather than derived per render, because the view
+/// is clock-free by construction and "was that last night?" is a question only a
+/// clock can answer. The accepted block is re-derived rather than banked, so a
+/// relaunch before the session rebuilds it: a plan is remade from the content
+/// and the clock, and a steer held only in memory would be remade into nothing.
+fn refresh_steer(model: &mut Model, now: DateTime<Utc>) {
+    model.proposed_steer = steer::propose(&model.reflections, &model.steer_context(), now);
+    let Some(target) = steer::accepted(&model.reflections, &model.steer_context(), now) else {
+        return;
+    };
+    let Some(block) = blocks::steer_block(&target, &model.build_context()) else {
+        return;
+    };
+    model.coach.place_steer(block);
+}
+
+/// Journey C's two questions, set from what the engine just closed (#1256
+/// Phase D). Read here rather than in the engine because both are the domain's
+/// budget, not the state machine's, and neither may ride the crash-recovery
+/// wire — a prompt lost to a crash costs nothing, and a field on `EngineSession`
+/// costs every device its blob.
+fn offer_capture(model: &mut Model, writes: &crate::engine::CoachWrites) {
+    if let Some(record) = writes.blocks.iter().rev().find(|record| {
+        capture::feel_is_the_point(record)
+            // Asked once per block, ever: a re-offered write (#1181) hands the
+            // same record back, and the question is already answered.
+            && !model
+                .feel_entries
+                .iter()
+                .any(|entry| entry.block_id == record.id)
+    }) {
+        let title = blocks::title_of(&record.node, &model.build_context())
+            .unwrap_or_else(|| record.drill.clone());
+        model.feel_prompt = Some(FeelPrompt {
+            block_id: record.id.clone(),
+            title,
+        });
+    }
+    // Only as the session ends, and only once: `Clear` is emitted by the event
+    // that closed it and by no later one.
+    if writes.snapshot == SnapshotAction::Clear && capture::reflection_is_offered(writes) {
+        model.reflection_prompt = true;
+    }
+}
+
 /// What one applied coach event leaves for the shell: the evidence batch and
 /// the crash-recovery blob. Shared, because a built session enters the same
 /// state machine by a different door (#1256) and its writes must not go
@@ -213,6 +263,7 @@ pub(crate) fn coach_write_commands(
     writes: crate::engine::CoachWrites,
 ) -> Vec<Command<Effect, Event>> {
     let mut commands = Vec::new();
+    offer_capture(model, &writes);
     // Banked as they close, not just handed to the store: a later reload — a
     // failed built-session write reissues one — rebuilds the mastery track from
     // the model, and a record the model dropped is evidence the rebuild would
@@ -337,6 +388,13 @@ impl Intrada {
                 }
                 let before = model.coach.view();
                 let writes = model.coach.apply(&coach_event);
+                // Planning is the only event that makes a plan a steer can join,
+                // and a composed session is not one: Journey A's session is
+                // already the user's, so a second steer inside it would be the
+                // app adding a block to a list they wrote themselves.
+                if let CoachEvent::PlanSession { now, .. } = coach_event {
+                    refresh_steer(model, now);
+                }
                 let mut commands = coach_write_commands(model, writes);
                 // Render coalescing (engine spec §6) again: an event the machine
                 // ignored changes nothing, but a write it asked for still goes.
@@ -908,6 +966,9 @@ fn built_view(model: &Model) -> BuiltView {
                 .find(|item| item.id == item_id)
                 .and_then(crate::domain::built_session::playthrough::altitude_offer)
         }),
+        feel: model.feel_prompt.clone(),
+        reflection: model.reflection_prompt,
+        steer: model.proposed_steer.clone(),
     }
 }
 
@@ -5281,6 +5342,230 @@ mod tests {
             ex.variants.iter().all(|v| !v.is_current),
             "a finished ladder has no current step"
         );
+    }
+
+    // ── Journey C, end to end through the real events (#1256 Phase D) ──
+
+    mod capture_journey {
+        use super::*;
+        use crate::domain::built_session::{
+            BuiltBlock, BuiltSession, BuiltTarget, JournalItem, Reflection, ReflectionKind,
+            SteerState,
+        };
+
+        fn at() -> DateTime<Utc> {
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 8, 8, 9, 0, 0).unwrap()
+        }
+
+        /// A one-block session on the judgement track, run to its close.
+        fn run_a_journal_block() -> (Intrada, Model) {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            model.journal_items.push(JournalItem {
+                id: "j1".into(),
+                name: "Rubato in the intro".into(),
+                notes: None,
+                linked_item_id: None,
+                created_at: at(),
+                updated_at: at(),
+                deleted_at: None,
+            });
+            model.built_sessions.push(BuiltSession {
+                id: "bs1".into(),
+                source: None,
+                blocks: vec![BuiltBlock {
+                    id: "b1".into(),
+                    target: BuiltTarget::Journal {
+                        journal_id: "j1".into(),
+                    },
+                    minutes: Some(8),
+                }],
+                created_at: at(),
+                updated_at: at(),
+                deleted_at: None,
+            });
+            let _ = app.update(
+                Event::BuiltSession(BuiltSessionEvent::StartBuiltSession {
+                    session_id: "bs1".into(),
+                    now: at(),
+                }),
+                &mut model,
+            );
+            let _ = app.update(
+                Event::Coach(CoachEvent::LeaveSession {
+                    now: at() + chrono::Duration::minutes(8),
+                }),
+                &mut model,
+            );
+            (app, model)
+        }
+
+        #[test]
+        fn a_closed_journal_block_asks_how_it_felt_and_names_it_in_the_users_words() {
+            let (app, model) = run_a_journal_block();
+            let prompt = model.feel_prompt.clone().expect("C1 is owed a question");
+            assert_eq!(prompt.title, "Rubato in the intro");
+            assert_eq!(
+                app.view(&model).built.feel.map(|feel| feel.block_id),
+                Some(prompt.block_id),
+                "the shell reads it off the view, not off a record"
+            );
+        }
+
+        #[test]
+        fn a_session_that_ran_something_is_asked_to_reflect_on_it() {
+            let (app, model) = run_a_journal_block();
+            assert!(model.reflection_prompt);
+            assert!(app.view(&model).built.reflection);
+        }
+
+        #[test]
+        fn just_play_ends_without_a_question_of_any_kind() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            let _ = app.update(
+                Event::Coach(CoachEvent::GoUnmonitored { now: at() }),
+                &mut model,
+            );
+            let _ = app.update(
+                Event::Coach(CoachEvent::CloseSession {
+                    now: at() + chrono::Duration::minutes(20),
+                }),
+                &mut model,
+            );
+            assert!(
+                !model.reflection_prompt,
+                "minutes only means minutes (decision 16)"
+            );
+            assert!(model.feel_prompt.is_none());
+        }
+
+        fn accepted_reflection() -> Reflection {
+            Reflection {
+                id: "r1".into(),
+                kind: ReflectionKind::SessionClose,
+                session_ref: None,
+                transcript: Some("Rubato in the intro is still not settled.".into()),
+                audio_path: None,
+                duration_s: Some(24),
+                at: at() - chrono::Duration::hours(11),
+                steer: SteerState::Accepted,
+                steer_at: Some(at()),
+                updated_at: at(),
+                deleted_at: None,
+            }
+        }
+
+        fn journal_library(model: &mut Model) {
+            model.journal_items.push(JournalItem {
+                id: "j1".into(),
+                name: "Rubato in the intro".into(),
+                notes: None,
+                linked_item_id: None,
+                created_at: at(),
+                updated_at: at(),
+                deleted_at: None,
+            });
+        }
+
+        #[test]
+        fn an_accepted_steer_joins_todays_plan_marked_as_the_users_own() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            model.reflections.push(accepted_reflection());
+
+            let _ = app.update(
+                Event::Coach(CoachEvent::PlanSession {
+                    now: at(),
+                    available_minutes: Some(40),
+                }),
+                &mut model,
+            );
+            let plan = app.view(&model).coach.plan.expect("today's plan");
+            let steer = plan
+                .blocks
+                .iter()
+                .find(|block| block.added_by_you)
+                .expect("the accepted steer is in the plan");
+            assert_eq!(steer.drill_title, "Rubato in the intro");
+            assert_eq!(steer.minutes, 8);
+            assert!(
+                plan.blocks
+                    .iter()
+                    .filter(|block| block.added_by_you)
+                    .count()
+                    == 1,
+                "one block, and the rest of the plan is still the planner's"
+            );
+        }
+
+        #[test]
+        fn re_planning_does_not_stack_a_second_copy_of_the_same_steer() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            model.reflections.push(accepted_reflection());
+
+            for _ in 0..3 {
+                let _ = app.update(
+                    Event::Coach(CoachEvent::PlanSession {
+                        now: at(),
+                        available_minutes: Some(40),
+                    }),
+                    &mut model,
+                );
+            }
+            let plan = app.view(&model).coach.plan.expect("today's plan");
+            assert_eq!(
+                plan.blocks
+                    .iter()
+                    .filter(|block| block.added_by_you)
+                    .count(),
+                1
+            );
+        }
+
+        #[test]
+        fn an_unanswered_reflection_reaches_the_view_as_a_proposal() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            model.reflections.push(Reflection {
+                steer: SteerState::Unoffered,
+                steer_at: None,
+                ..accepted_reflection()
+            });
+
+            let _ = app.update(
+                Event::Coach(CoachEvent::PlanSession {
+                    now: at(),
+                    available_minutes: Some(40),
+                }),
+                &mut model,
+            );
+            let view = app.view(&model);
+            let proposed = view.built.steer.expect("a morning proposal");
+            assert_eq!(proposed.reflection_id, "r1");
+            assert_eq!(
+                proposed.quote, "Rubato in the intro is still not settled.",
+                "the user's own sentence, verbatim"
+            );
+            assert!(
+                view.coach
+                    .plan
+                    .expect("today's plan")
+                    .blocks
+                    .iter()
+                    .all(|block| !block.added_by_you),
+                "propose, confirm, never plan (decision 12)"
+            );
+        }
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -206,14 +206,16 @@ fn rebuild_mastery(model: &mut Model) {
         .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
 }
 
-/// C3, at the one moment that has both a clock and a plan: what to propose this
-/// morning, and where an already-accepted steer goes.
+/// C3, at the moments that have both a clock and a fresh plan: what to propose
+/// this morning, and where an already-accepted steer goes.
 ///
 /// The proposal is snapshotted rather than derived per render, because the view
 /// is clock-free by construction and "was that last night?" is a question only a
 /// clock can answer. The accepted block is re-derived rather than banked, so a
 /// relaunch before the session rebuilds it: a plan is remade from the content
 /// and the clock, and a steer held only in memory would be remade into nothing.
+/// Placing it again on a plan that already carries it is `place_steer`'s to
+/// refuse, which is what makes calling this from two doors safe.
 fn refresh_steer(model: &mut Model, now: DateTime<Utc>) {
     model.proposed_steer = steer::propose(&model.reflections, &model.steer_context(), now);
     let Some(target) = steer::accepted(&model.reflections, &model.steer_context(), now) else {
@@ -240,12 +242,14 @@ fn offer_capture(model: &mut Model, writes: &crate::engine::CoachWrites) {
                 .iter()
                 .any(|entry| entry.block_id == record.id)
     }) {
-        let title = blocks::title_of(&record.node, &model.build_context())
-            .unwrap_or_else(|| record.drill.clone());
-        model.feel_prompt = Some(FeelPrompt {
-            block_id: record.id.clone(),
-            title,
-        });
+        // No title, no question: C1's whole frame is the target in the user's
+        // own words, and a headline over a blank is worse than not asking.
+        if let Some(title) = blocks::title_of(&record.node, &model.build_context()) {
+            model.feel_prompt = Some(FeelPrompt {
+                block_id: record.id.clone(),
+                title,
+            });
+        }
     }
     // Only as the session ends, and only once: `Clear` is emitted by the event
     // that closed it and by no later one.
@@ -388,12 +392,16 @@ impl Intrada {
                 }
                 let before = model.coach.view();
                 let writes = model.coach.apply(&coach_event);
-                // Planning is the only event that makes a plan a steer can join,
-                // and a composed session is not one: Journey A's session is
-                // already the user's, so a second steer inside it would be the
-                // app adding a block to a list they wrote themselves.
-                if let CoachEvent::PlanSession { now, .. } = coach_event {
-                    refresh_steer(model, now);
+                // Both planning doors, because `StartPlannedSession` from
+                // `Idle` plans and starts in one step for a shell that wants no
+                // preview — a steer placed only on the previewed door would be
+                // lost through that one. A composed session is deliberately not
+                // a door: Journey A's list is already the user's, so a steer
+                // inside it would be the app adding a block to what they wrote.
+                match coach_event {
+                    CoachEvent::PlanSession { now, .. }
+                    | CoachEvent::StartPlannedSession { now } => refresh_steer(model, now),
+                    _ => {}
                 }
                 let mut commands = coach_write_commands(model, writes);
                 // Render coalescing (engine spec §6) again: an event the machine
@@ -5478,13 +5486,7 @@ mod tests {
             journal_library(&mut model);
             model.reflections.push(accepted_reflection());
 
-            let _ = app.update(
-                Event::Coach(CoachEvent::PlanSession {
-                    now: at(),
-                    available_minutes: Some(40),
-                }),
-                &mut model,
-            );
+            plan_today(&app, &mut model);
             let plan = app.view(&model).coach.plan.expect("today's plan");
             let steer = plan
                 .blocks
@@ -5503,6 +5505,144 @@ mod tests {
             );
         }
 
+        fn plan_today(app: &Intrada, model: &mut Model) {
+            let _ = app.update(
+                Event::Coach(CoachEvent::PlanSession {
+                    now: at(),
+                    available_minutes: Some(40),
+                }),
+                model,
+            );
+        }
+
+        fn unanswered(model: &mut Model) {
+            model.reflections.push(Reflection {
+                steer: SteerState::Unoffered,
+                steer_at: None,
+                ..accepted_reflection()
+            });
+        }
+
+        fn steer_blocks(model: &Model) -> usize {
+            let blocks = match &model.coach.session.state {
+                crate::engine::SessionState::Planned { plan } => &plan.blocks,
+                crate::engine::SessionState::Running { plan, .. } => &plan.blocks,
+                other => panic!("expected a plan, got {other:?}"),
+            };
+            blocks
+                .iter()
+                .filter(|block| block.why.placed_by == crate::engine::Stage::Steer)
+                .count()
+        }
+
+        /// The defect this test exists for: the plan is remade only when the
+        /// Practice screen has none, so an accept that waited for the next
+        /// planning run would leave the card up over an unchanged plan for the
+        /// rest of the app run.
+        #[test]
+        fn accepting_puts_the_block_in_the_plan_already_on_screen_and_takes_the_card_down() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            unanswered(&mut model);
+            plan_today(&app, &mut model);
+            assert!(app.view(&model).built.steer.is_some(), "the card is up");
+
+            let _ = app.update(
+                Event::BuiltSession(BuiltSessionEvent::AcceptProposedSteer {
+                    reflection_id: "r1".into(),
+                }),
+                &mut model,
+            );
+
+            let view = app.view(&model);
+            assert!(view.built.steer.is_none(), "the card is answered and down");
+            assert_eq!(
+                view.coach
+                    .plan
+                    .expect("today's plan")
+                    .blocks
+                    .iter()
+                    .filter(|block| block.added_by_you)
+                    .map(|block| block.drill_title.clone())
+                    .collect::<Vec<_>>(),
+                vec!["Rubato in the intro".to_string()],
+                "no second planning run is needed to see it"
+            );
+        }
+
+        #[test]
+        fn declining_takes_the_card_down_and_adds_nothing() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            unanswered(&mut model);
+            plan_today(&app, &mut model);
+
+            let _ = app.update(
+                Event::BuiltSession(BuiltSessionEvent::DeclineProposedSteer {
+                    reflection_id: "r1".into(),
+                }),
+                &mut model,
+            );
+            let view = app.view(&model);
+            assert!(view.built.steer.is_none());
+            assert!(view
+                .coach
+                .plan
+                .expect("today's plan")
+                .blocks
+                .iter()
+                .all(|block| !block.added_by_you));
+        }
+
+        /// Accept places it in the planned session, and starting that session
+        /// carries it into the running one — where the start-from-`Idle` door
+        /// would place it a second time if nothing refused.
+        #[test]
+        fn starting_the_plan_that_already_carries_the_steer_does_not_place_it_twice() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            model.reflections.push(accepted_reflection());
+            plan_today(&app, &mut model);
+            assert_eq!(steer_blocks(&model), 1, "the plan carries it");
+
+            let _ = app.update(
+                Event::Coach(CoachEvent::StartPlannedSession { now: at() }),
+                &mut model,
+            );
+            assert_eq!(
+                steer_blocks(&model),
+                1,
+                "and starting it does not repeat it"
+            );
+        }
+
+        /// The no-preview door: a shell that starts without planning first still
+        /// gets the steer it accepted this morning.
+        #[test]
+        fn starting_without_a_preview_still_carries_the_accepted_steer() {
+            let app = Intrada;
+            let mut model = Model::test_default();
+            model.local_first = true;
+            journal_library(&mut model);
+            model.reflections.push(accepted_reflection());
+
+            let _ = app.update(
+                Event::Coach(CoachEvent::StartPlannedSession { now: at() }),
+                &mut model,
+            );
+            assert_eq!(
+                steer_blocks(&model),
+                1,
+                "the steer must not be lost through this door"
+            );
+        }
+
         #[test]
         fn re_planning_does_not_stack_a_second_copy_of_the_same_steer() {
             let app = Intrada;
@@ -5512,13 +5652,7 @@ mod tests {
             model.reflections.push(accepted_reflection());
 
             for _ in 0..3 {
-                let _ = app.update(
-                    Event::Coach(CoachEvent::PlanSession {
-                        now: at(),
-                        available_minutes: Some(40),
-                    }),
-                    &mut model,
-                );
+                plan_today(&app, &mut model);
             }
             let plan = app.view(&model).coach.plan.expect("today's plan");
             assert_eq!(

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -206,15 +206,10 @@ fn rebuild_mastery(model: &mut Model) {
         .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
 }
 
-/// C3, at the moments that have both a clock and a fresh plan.
-///
-/// The proposal is snapshotted rather than derived per render, because the view
-/// is clock-free by construction and "was that last night?" is a question only a
-/// clock can answer. The accepted block is re-derived rather than banked, so a
-/// relaunch before the session rebuilds it: a plan is remade from the content
-/// and the clock, and a steer held only in memory would be remade into nothing.
-/// Placing it again on a plan that already carries it is `place_steer`'s to
-/// refuse, which is what makes calling this from two doors safe.
+/// C3, at the moments that have both a clock and a fresh plan. The proposal is
+/// snapshotted because the view is clock-free and "was that last night?" needs a
+/// clock; the accepted block is re-derived because a plan is remade rather than
+/// recovered, so one held in memory would be remade into nothing.
 fn refresh_steer(model: &mut Model, now: DateTime<Utc>) {
     model.proposed_steer = steer::propose(&model.reflections, &model.steer_context(), now);
     let Some(target) = steer::accepted(&model.reflections, &model.steer_context(), now) else {
@@ -226,11 +221,10 @@ fn refresh_steer(model: &mut Model, now: DateTime<Utc>) {
     model.coach.place_steer(block);
 }
 
-/// Journey C's two questions, set from what the engine just closed (#1256
-/// Phase D). Read here rather than in the engine because both are the domain's
-/// budget, not the state machine's, and neither may ride the crash-recovery
-/// wire — a prompt lost to a crash costs nothing, and a field on `EngineSession`
-/// costs every device its blob.
+/// Journey C's two questions, set from what the engine just closed. Read here
+/// rather than in the engine because both are the domain's budget, and because
+/// a field on `EngineSession` would cost every device its crash-recovery blob
+/// to carry a prompt that costs nothing to lose (#1256 Phase D).
 fn offer_capture(model: &mut Model, writes: &crate::engine::CoachWrites) {
     if let Some(record) = writes.blocks.iter().rev().find(|record| {
         capture::feel_is_the_point(record)
@@ -391,12 +385,10 @@ impl Intrada {
                 }
                 let before = model.coach.view();
                 let writes = model.coach.apply(&coach_event);
-                // Both planning doors, because `StartPlannedSession` from
-                // `Idle` plans and starts in one step for a shell that wants no
-                // preview — a steer placed only on the previewed door would be
-                // lost through that one. A composed session is deliberately not
-                // a door: Journey A's list is already the user's, so a steer
-                // inside it would be the app adding a block to what they wrote.
+                // Both planning doors: `StartPlannedSession` from `Idle` plans
+                // and starts in one step, so a steer placed only on the
+                // previewed door would be lost through that one. A composed
+                // session is not a door — Journey A's list is already theirs.
                 match coach_event {
                     CoachEvent::PlanSession { now, .. }
                     | CoachEvent::StartPlannedSession { now } => refresh_steer(model, now),
@@ -5533,10 +5525,8 @@ mod tests {
                 .count()
         }
 
-        /// The defect this test exists for: the plan is remade only when the
-        /// Practice screen has none, so an accept that waited for the next
-        /// planning run would leave the card up over an unchanged plan for the
-        /// rest of the app run.
+        /// The defect this test exists for: the Practice screen asks for a plan
+        /// only when it has none, so a deferred accept never lands at all.
         #[test]
         fn accepting_puts_the_block_in_the_plan_already_on_screen_and_takes_the_card_down() {
             let app = Intrada;
@@ -5596,9 +5586,8 @@ mod tests {
                 .all(|block| !block.added_by_you));
         }
 
-        /// Accept places it in the planned session, and starting that session
-        /// carries it into the running one — where the start-from-`Idle` door
-        /// would place it a second time if nothing refused.
+        /// The plan carries it into the running session, where the
+        /// start-from-`Idle` door would place it again if nothing refused.
         #[test]
         fn starting_the_plan_that_already_carries_the_steer_does_not_place_it_twice() {
             let app = Intrada;
@@ -5620,8 +5609,7 @@ mod tests {
             );
         }
 
-        /// The no-preview door: a shell that starts without planning first still
-        /// gets the steer it accepted this morning.
+        /// The no-preview door must not lose it.
         #[test]
         fn starting_without_a_preview_still_carries_the_accepted_steer() {
             let app = Intrada;

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -206,8 +206,7 @@ fn rebuild_mastery(model: &mut Model) {
         .rebuild_mastery(model.coach_blocks.clone(), model.play_throughs.clone());
 }
 
-/// C3, at the moments that have both a clock and a fresh plan: what to propose
-/// this morning, and where an already-accepted steer goes.
+/// C3, at the moments that have both a clock and a fresh plan.
 ///
 /// The proposal is snapshotted rather than derived per render, because the view
 /// is clock-free by construction and "was that last night?" is a question only a
@@ -5365,7 +5364,6 @@ mod tests {
             chrono::TimeZone::with_ymd_and_hms(&Utc, 2026, 8, 8, 9, 0, 0).unwrap()
         }
 
-        /// A one-block session on the judgement track, run to its close.
         fn run_a_journal_block() -> (Intrada, Model) {
             let app = Intrada;
             let mut model = Model::test_default();

--- a/crates/intrada-core/src/domain/built_session/blocks.rs
+++ b/crates/intrada-core/src/domain/built_session/blocks.rs
@@ -54,22 +54,18 @@ pub fn node_id(target: &BuiltTarget) -> String {
     }
 }
 
-/// The player's own words for a node this module minted — the inverse of
-/// [`node_id`], for a surface holding a closed record rather than a target.
-/// `None` for an authored node, whose title the content index carries.
+/// The player's own words for a judgement-track node — the inverse of
+/// [`node_id`] for the two kinds it mints, for a surface holding a closed
+/// record rather than a target. `None` for anything else, which is every node
+/// whose taps were evidence and so has a gate to end on instead.
 pub fn title_of(node: &str, ctx: &BuildContext) -> Option<String> {
     if let Some(id) = node.strip_prefix("journal:") {
         return ctx.journal(id).map(|journal| journal.name.clone());
     }
-    if let Some(id) = node.strip_prefix("drill:") {
-        return ctx.drill(id).map(|drill| drill.name.clone());
-    }
-    if let Some(id) = node.strip_prefix("piece:") {
-        // A section-addressed node (`piece:<id>#<label>`) is a run-through's,
-        // never a block's, so the id runs to the end here.
-        return ctx.item(id).map(|item| item.title.clone());
-    }
-    ctx.content.node(node).map(|node| node.title.clone())
+    // A section-addressed node (`piece:<id>#<label>`) is a run-through's, never
+    // a block's, so the id runs to the end here.
+    let id = node.strip_prefix("piece:")?;
+    ctx.item(id).map(|item| item.title.clone())
 }
 
 /// The composed session as today's plan. A block whose target has since been

--- a/crates/intrada-core/src/domain/built_session/blocks.rs
+++ b/crates/intrada-core/src/domain/built_session/blocks.rs
@@ -54,10 +54,8 @@ pub fn node_id(target: &BuiltTarget) -> String {
     }
 }
 
-/// The player's own words for a judgement-track node — the inverse of
-/// [`node_id`] for the two kinds it mints, for a surface holding a closed
-/// record rather than a target. `None` for anything else, which is every node
-/// whose taps were evidence and so has a gate to end on instead.
+/// The inverse of [`node_id`] for the two kinds the judgement track mints.
+/// `None` for every other node, which is every node with a gate to end on.
 pub fn title_of(node: &str, ctx: &BuildContext) -> Option<String> {
     if let Some(id) = node.strip_prefix("journal:") {
         return ctx.journal(id).map(|journal| journal.name.clone());

--- a/crates/intrada-core/src/domain/built_session/blocks.rs
+++ b/crates/intrada-core/src/domain/built_session/blocks.rs
@@ -12,6 +12,7 @@ use crate::engine::{
 };
 
 use super::compose::normalised;
+use super::steer::{SteerTarget, STEER_MINUTES};
 use super::{BuiltBlock, BuiltSession, BuiltTarget, JournalItem, Serves, UserDrill};
 
 /// A6's one-line, declinable suggestion. Advice, never applied on its own:
@@ -53,6 +54,24 @@ pub fn node_id(target: &BuiltTarget) -> String {
     }
 }
 
+/// The player's own words for a node this module minted — the inverse of
+/// [`node_id`], for a surface holding a closed record rather than a target.
+/// `None` for an authored node, whose title the content index carries.
+pub fn title_of(node: &str, ctx: &BuildContext) -> Option<String> {
+    if let Some(id) = node.strip_prefix("journal:") {
+        return ctx.journal(id).map(|journal| journal.name.clone());
+    }
+    if let Some(id) = node.strip_prefix("drill:") {
+        return ctx.drill(id).map(|drill| drill.name.clone());
+    }
+    if let Some(id) = node.strip_prefix("piece:") {
+        // A section-addressed node (`piece:<id>#<label>`) is a run-through's,
+        // never a block's, so the id runs to the end here.
+        return ctx.item(id).map(|item| item.title.clone());
+    }
+    ctx.content.node(node).map(|node| node.title.clone())
+}
+
 /// The composed session as today's plan. A block whose target has since been
 /// deleted is reported in `deferred`, never dropped in silence (spec §5's rule,
 /// and the same reason A2 states its price out loud).
@@ -61,24 +80,7 @@ pub fn plan_from_built(session: &BuiltSession, ctx: &BuildContext) -> Plan {
     let mut deferred = Vec::new();
     for block in &session.blocks {
         match spec_for(block, ctx) {
-            Some(spec) => blocks.push(PlannedBlock {
-                why: Why {
-                    destination: spec.destination.clone(),
-                    node_state: NodeState {
-                        estimate_pct: 0,
-                        evidence: 0,
-                        overdue_pct: 0,
-                        maturity: Maturity::New,
-                    },
-                    placed_by: Stage::Steer,
-                },
-                spec,
-                // The ladder never swaps material the user chose themselves:
-                // an escalation into something they did not ask for would be
-                // the app taking the session back.
-                alternatives: Vec::new(),
-                new_keys: None,
-            }),
+            Some(spec) => blocks.push(steered_block(spec)),
             None => deferred.push(missing_line(block)),
         }
     }
@@ -87,6 +89,47 @@ pub fn plan_from_built(session: &BuiltSession, ctx: &BuildContext) -> Plan {
         rng_seed: 0,
         deferred,
     }
+}
+
+/// A block the user placed themselves, whether by composing it (A6) or by
+/// accepting this morning's proposal (C3). Both are the same claim — this one
+/// is theirs — so both carry the same stage and the same refusal to be swapped.
+fn steered_block(spec: BlockSpec) -> PlannedBlock {
+    PlannedBlock {
+        why: Why {
+            destination: spec.destination.clone(),
+            node_state: NodeState {
+                estimate_pct: 0,
+                evidence: 0,
+                overdue_pct: 0,
+                maturity: Maturity::New,
+            },
+            placed_by: Stage::Steer,
+        },
+        spec,
+        // The ladder never swaps material the user chose themselves: an
+        // escalation into something they did not ask for would be the app
+        // taking the session back.
+        alternatives: Vec::new(),
+        new_keys: None,
+    }
+}
+
+/// C3's accepted steer, as the one block it inserts into today's plan. Built
+/// through the same `spec_for` a composed block goes through, so accepting a
+/// proposal and composing the same target by hand run the identical block.
+pub fn steer_block(target: &SteerTarget, ctx: &BuildContext) -> Option<PlannedBlock> {
+    let block = BuiltBlock {
+        id: ulid::Ulid::generate().to_string(),
+        target: target.target.clone(),
+        minutes: Some(STEER_MINUTES),
+    };
+    let mut spec = spec_for(&block, ctx)?;
+    // The section is what makes the offer honest: "the bridge" was the sentence
+    // the user said, and a block that quietly meant the whole piece would be a
+    // different offer than the one they accepted.
+    spec.section = target.section.clone();
+    Some(steered_block(spec))
 }
 
 fn missing_line(block: &BuiltBlock) -> String {

--- a/crates/intrada-core/src/domain/built_session/capture.rs
+++ b/crates/intrada-core/src/domain/built_session/capture.rs
@@ -1,10 +1,8 @@
 //! Journey C's two in-session moments: the feel question at a block boundary
 //! (C1) and the reflection at close (C2).
 //!
-//! Both are budget decisions, and the budget is the core's (decision 17). A
-//! surface that asked whenever it felt like it would be a second answer to the
-//! same question, and the one thing the measurement budget cannot survive is
-//! two things believing they own it.
+//! Both are budget decisions, and the budget is the core's (decision 17): the
+//! one thing a measurement budget cannot survive is two things owning it.
 
 use serde::{Deserialize, Serialize};
 
@@ -42,18 +40,12 @@ fn misses(record: &BlockRecord) -> usize {
         .count()
 }
 
-/// C2, offered once as a session closes.
+/// C2, offered once as a session closes. Unmonitored play promised minutes and
+/// nothing else (decision 16), and off-piste has already asked twice on the way
+/// out, so neither may be asked again.
 ///
-/// Two altitudes are silent here on purpose. Unmonitored play promised minutes
-/// and nothing else, so a question at its exit would be the app going back on
-/// the one thing it agreed to (decision 16). Off-piste has already asked twice
-/// on the way out — the "found something?" mic and the keep-as-drill prompt —
-/// and a third is past any budget.
-///
-/// Neither guard is load-bearing today: as the engine stands, an altitude close
-/// carries its own record and no block, so the positive rule below already
-/// declines both. They are here because "which altitude was this?" is the
-/// question the consent gradient turns on, and a rule that holds only while
+/// Neither guard is load-bearing today — an altitude close carries no block, so
+/// the positive rule already declines both — but a rule that holds only while
 /// nobody changes what a close bundles is not a rule (the #1214 class).
 pub fn reflection_is_offered(writes: &CoachWrites) -> bool {
     if !writes.unmonitored.is_empty() || !writes.wanders.is_empty() {
@@ -154,10 +146,8 @@ mod tests {
         assert!(!reflection_is_offered(&CoachWrites::default()));
     }
 
-    /// A close carrying blocks *and* an unmonitored record is not a shape the
-    /// engine writes today. It is exactly the shape the guard exists for: which
-    /// altitude was running outranks what else was in the batch, because the
-    /// altitude is what the user consented to.
+    /// Not a shape the engine writes today, and exactly the shape the guard
+    /// exists for: the altitude outranks whatever else was in the batch.
     #[test]
     fn unmonitored_play_keeps_its_promptless_exit_whatever_else_closed_with_it() {
         assert!(!reflection_is_offered(&CoachWrites {

--- a/crates/intrada-core/src/domain/built_session/capture.rs
+++ b/crates/intrada-core/src/domain/built_session/capture.rs
@@ -1,0 +1,193 @@
+//! Journey C's two in-session moments: the feel question at a block boundary
+//! (C1) and the reflection at close (C2).
+//!
+//! Both are budget decisions, and the budget is the core's (decision 17). A
+//! surface that asked whenever it felt like it would be a second answer to the
+//! same question, and the one thing the measurement budget cannot survive is
+//! two things believing they own it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::engine::{BlockOrigin, BlockRecord, CoachWrites, Exit, Verdict};
+
+/// Misses in one block that take the feel question off the table. "The budget
+/// shrinks on a bad day": having just missed twice, being asked how it felt is
+/// the app rubbing it in.
+pub const FEEL_MISS_BUDGET: usize = 2;
+
+/// C1, asked at most once per block and only where feel is the point. Held on
+/// the model rather than the engine session: a prompt lost to a crash costs
+/// nothing, because the block record it follows is already written, and putting
+/// it on `EngineSession` would invalidate every crash-recovery blob for it.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct FeelPrompt {
+    pub block_id: String,
+    /// The target in the user's own words, joined where the library lives.
+    pub title: String,
+}
+
+/// Whether the block that just closed earns the feel question.
+///
+/// Only the judgement track: a gated block ends with its GateDots, and asking
+/// both would spend two of the one interruption the block is allowed. A skipped
+/// block is not asked either — there is nothing it could be about.
+pub fn feel_is_the_point(record: &BlockRecord) -> bool {
+    record.origin == BlockOrigin::Judgement
+        && record.exit != Exit::Skipped
+        && misses(record) < FEEL_MISS_BUDGET
+}
+
+fn misses(record: &BlockRecord) -> usize {
+    record
+        .attempts
+        .iter()
+        .filter(|attempt| attempt.verdict == Verdict::Missed)
+        .count()
+}
+
+/// C2, offered once as a session closes.
+///
+/// Two altitudes are silent here on purpose. Unmonitored play promised minutes
+/// and nothing else, so a question at its exit would be the app going back on
+/// the one thing it agreed to (decision 16). Off-piste has already asked twice
+/// on the way out — the "found something?" mic and the keep-as-drill prompt —
+/// and a third is past any budget.
+///
+/// Neither guard is load-bearing today: as the engine stands, an altitude close
+/// carries its own record and no block, so the positive rule below already
+/// declines both. They are here because "which altitude was this?" is the
+/// question the consent gradient turns on, and a rule that holds only while
+/// nobody changes what a close bundles is not a rule (the #1214 class).
+pub fn reflection_is_offered(writes: &CoachWrites) -> bool {
+    if !writes.unmonitored.is_empty() || !writes.wanders.is_empty() {
+        return false;
+    }
+    !writes.blocks.is_empty() || !writes.play_throughs.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::{
+        AttemptSummary, ClickLevel, EvidenceSource, ParameterLevel, UnmonitoredRecord,
+    };
+    use chrono::{DateTime, Utc};
+
+    fn attempt(verdict: Verdict) -> AttemptSummary {
+        AttemptSummary {
+            at: DateTime::UNIX_EPOCH,
+            verdict,
+            source: EvidenceSource::TapVerdictUntimed,
+            cold: false,
+            self_predicted: None,
+            level: ParameterLevel {
+                tempo_bpm: 0,
+                click_level: ClickLevel::NoClick,
+            },
+        }
+    }
+
+    fn judgement_block() -> BlockRecord {
+        BlockRecord {
+            origin: BlockOrigin::Judgement,
+            exit: Exit::CeilingHit,
+            ..BlockRecord::fixture()
+        }
+    }
+
+    #[test]
+    fn a_judgement_block_is_asked_how_it_felt() {
+        assert!(feel_is_the_point(&judgement_block()));
+    }
+
+    #[test]
+    fn a_gated_block_ends_with_its_gate_and_is_never_also_asked() {
+        for origin in [BlockOrigin::Authored, BlockOrigin::UserDrill] {
+            assert!(!feel_is_the_point(&BlockRecord {
+                origin,
+                ..judgement_block()
+            }));
+        }
+    }
+
+    #[test]
+    fn a_skipped_block_is_not_asked_how_it_felt() {
+        assert!(!feel_is_the_point(&BlockRecord {
+            exit: Exit::Skipped,
+            ..judgement_block()
+        }));
+    }
+
+    #[test]
+    fn two_misses_in_the_block_take_the_question_off_the_table() {
+        let one_miss = BlockRecord {
+            attempts: vec![attempt(Verdict::Missed), attempt(Verdict::Clean)],
+            ..judgement_block()
+        };
+        assert!(feel_is_the_point(&one_miss));
+
+        let two_misses = BlockRecord {
+            attempts: vec![
+                attempt(Verdict::Missed),
+                attempt(Verdict::Clean),
+                attempt(Verdict::Missed),
+            ],
+            ..judgement_block()
+        };
+        assert!(!feel_is_the_point(&two_misses));
+    }
+
+    fn record_at(at: DateTime<Utc>) -> BlockRecord {
+        BlockRecord {
+            ended_at: at,
+            ..BlockRecord::fixture()
+        }
+    }
+
+    #[test]
+    fn a_session_that_ran_blocks_is_offered_the_reflection() {
+        assert!(reflection_is_offered(&CoachWrites {
+            blocks: vec![record_at(DateTime::UNIX_EPOCH)],
+            ..CoachWrites::default()
+        }));
+    }
+
+    #[test]
+    fn a_session_that_ran_nothing_is_not_asked_to_reflect_on_it() {
+        assert!(!reflection_is_offered(&CoachWrites::default()));
+    }
+
+    /// A close carrying blocks *and* an unmonitored record is not a shape the
+    /// engine writes today. It is exactly the shape the guard exists for: which
+    /// altitude was running outranks what else was in the batch, because the
+    /// altitude is what the user consented to.
+    #[test]
+    fn unmonitored_play_keeps_its_promptless_exit_whatever_else_closed_with_it() {
+        assert!(!reflection_is_offered(&CoachWrites {
+            blocks: vec![record_at(DateTime::UNIX_EPOCH)],
+            unmonitored: vec![UnmonitoredRecord {
+                id: "u1".into(),
+                started_at: DateTime::UNIX_EPOCH,
+                ended_at: DateTime::UNIX_EPOCH,
+            }],
+            ..CoachWrites::default()
+        }));
+    }
+
+    #[test]
+    fn off_piste_has_already_asked_twice_and_is_not_asked_again() {
+        assert!(!reflection_is_offered(&CoachWrites {
+            blocks: vec![record_at(DateTime::UNIX_EPOCH)],
+            wanders: vec![crate::engine::WanderRecord {
+                id: "w1".into(),
+                started_at: DateTime::UNIX_EPOCH,
+                ended_at: DateTime::UNIX_EPOCH,
+                attempts: vec![],
+                keep_as_drill: None,
+                item_id: None,
+            }],
+            ..CoachWrites::default()
+        }));
+    }
+}

--- a/crates/intrada-core/src/domain/built_session/capture.rs
+++ b/crates/intrada-core/src/domain/built_session/capture.rs
@@ -15,15 +15,11 @@ use crate::engine::{BlockOrigin, BlockRecord, CoachWrites, Exit, Verdict};
 /// the app rubbing it in.
 pub const FEEL_MISS_BUDGET: usize = 2;
 
-/// C1, asked at most once per block and only where feel is the point. Held on
-/// the model rather than the engine session: a prompt lost to a crash costs
-/// nothing, because the block record it follows is already written, and putting
-/// it on `EngineSession` would invalidate every crash-recovery blob for it.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct FeelPrompt {
     pub block_id: String,
-    /// The target in the user's own words, joined where the library lives.
+    /// Joined where the library lives: the engine holds ids, never titles.
     pub title: String,
 }
 

--- a/crates/intrada-core/src/domain/built_session/compose.rs
+++ b/crates/intrada-core/src/domain/built_session/compose.rs
@@ -234,6 +234,12 @@ pub struct BuiltView {
     /// than snapshotted at open, so editing the chart behind the sheet cannot
     /// leave it offering a run-through the piece no longer supports.
     pub play_through: Option<super::playthrough::AltitudeOffer>,
+    /// `Some` while the block that just closed is owed C1's question.
+    pub feel: Option<super::capture::FeelPrompt>,
+    /// C2's question, up from the close until it is answered either way.
+    pub reflection: bool,
+    /// `Some` while last night's reflection has an offer worth making (C3).
+    pub steer: Option<super::steer::ProposedSteer>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -4,14 +4,16 @@
 //! - [`compose`] is the steer sheet and decision 19's three-way resolution.
 //! - [`criterion`] reads a dictated sentence back as gate parameters.
 //! - [`blocks`] turns a composed session into a plan the drill loop runs.
-//!
-//! Journey B's altitudes (Phase C) and Journey C's capture (Phase D) still have
-//! only their entities here.
+//! - [`capture`] is Journey C's measurement budget: when feel is asked, and
+//!   when the close may ask for a reflection.
+//! - [`steer`] is last night's reflection, back as one morning proposal.
 
 pub mod blocks;
+pub mod capture;
 pub mod compose;
 pub mod criterion;
 pub mod playthrough;
+pub mod steer;
 #[cfg(test)]
 pub(crate) mod tests_support;
 
@@ -152,8 +154,25 @@ pub struct Reflection {
     pub audio_path: Option<String>,
     pub duration_s: Option<u32>,
     pub at: DateTime<Utc>,
+    /// C3: what became of the morning proposal this reflection earned. The
+    /// whole memory of the offer, so a declined one leaves no trace beyond the
+    /// fact that it will not be asked again, and an accepted one rebuilds its
+    /// block after a relaunch rather than losing it with the plan.
+    pub steer: SteerState,
+    /// When it was answered. Bounds how long an accepted steer stays today's.
+    pub steer_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
     pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum SteerState {
+    #[default]
+    Unoffered,
+    Accepted,
+    Declined,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -240,9 +259,33 @@ pub enum BuiltSessionEvent {
         audio_path: Option<String>,
         duration_s: Option<u32>,
     },
+    /// Transcription is opportunistic and may land long after the audio was
+    /// kept (C2), so the transcript arrives as its own event rather than
+    /// holding the save open until the shell has one.
+    AttachTranscript {
+        reflection_id: String,
+        transcript: String,
+    },
     RecordFeel {
         block_id: String,
         feel: Feel,
+    },
+
+    // ── Qualitative capture (Journey C) ──────────────────────────────
+    /// C1's first-class exit. Nothing is written: a skipped feel is not a
+    /// fourth feel, it is the absence of one.
+    SkipFeel,
+    /// C2's "Not tonight", respected without a follow-up nudge.
+    DismissReflection,
+    /// C3's "Add it to today". Carries only the reflection: the target is
+    /// re-derived here, so a card left up while the library changed cannot
+    /// insert a block for something that is no longer there.
+    AcceptProposedSteer {
+        reflection_id: String,
+    },
+    /// C3's "Not today" — no block, no trace, and never proposed again.
+    DeclineProposedSteer {
+        reflection_id: String,
     },
 
     // ── The steer sheet (Journey A) ──────────────────────────────────
@@ -432,13 +475,43 @@ pub fn handle_built_session_event(
                 audio_path,
                 duration_s,
                 at: now,
+                steer: SteerState::Unoffered,
+                steer_at: None,
                 updated_at: now,
                 deleted_at: None,
             };
+            // The close asked once and has its answer, whichever way it went.
+            model.reflection_prompt = false;
             model.reflections.push(reflection.clone());
             save_and_render(persistence::save_reflection(reflection))
         }
+        BuiltSessionEvent::AttachTranscript {
+            reflection_id,
+            transcript,
+        } => {
+            let Some(reflection) = model
+                .reflections
+                .iter_mut()
+                .find(|reflection| reflection.id == reflection_id)
+            else {
+                return crux_core::render::render();
+            };
+            reflection.transcript = Some(transcript);
+            reflection.updated_at = now;
+            let reflection = reflection.clone();
+            save_and_render(persistence::save_reflection(reflection))
+        }
         BuiltSessionEvent::RecordFeel { block_id, feel } => {
+            // One per block, ever — the budget is the core's, so a shell that
+            // asked twice still only writes one (decision 17).
+            if model
+                .feel_entries
+                .iter()
+                .any(|entry| entry.block_id == block_id)
+            {
+                model.feel_prompt = None;
+                return crux_core::render::render();
+            }
             let entry = FeelEntry {
                 id: mint_id(),
                 block_id,
@@ -447,8 +520,25 @@ pub fn handle_built_session_event(
                 updated_at: now,
                 deleted_at: None,
             };
+            model.feel_prompt = None;
             model.feel_entries.push(entry.clone());
             save_and_render(persistence::save_feel_entry(entry))
+        }
+
+        // ── Qualitative capture ──────────────────────────────────────
+        BuiltSessionEvent::SkipFeel => {
+            model.feel_prompt = None;
+            crux_core::render::render()
+        }
+        BuiltSessionEvent::DismissReflection => {
+            model.reflection_prompt = false;
+            crux_core::render::render()
+        }
+        BuiltSessionEvent::AcceptProposedSteer { reflection_id } => {
+            answer_steer(model, &reflection_id, SteerState::Accepted, now)
+        }
+        BuiltSessionEvent::DeclineProposedSteer { reflection_id } => {
+            answer_steer(model, &reflection_id, SteerState::Declined, now)
         }
 
         // ── The steer sheet ──────────────────────────────────────────
@@ -742,6 +832,33 @@ fn save_and_render(save: Command<Effect, Event>) -> Command<Effect, Event> {
     Command::all([save, crux_core::render::render()])
 }
 
+/// Both answers to the morning card write the same column: the offer is spent
+/// either way, and that is what stops it coming back tomorrow.
+fn answer_steer(
+    model: &mut Model,
+    reflection_id: &str,
+    answer: SteerState,
+    now: DateTime<Utc>,
+) -> Command<Effect, Event> {
+    let Some(reflection) = model
+        .reflections
+        .iter_mut()
+        .find(|reflection| reflection.id == reflection_id)
+    else {
+        return crux_core::render::render();
+    };
+    // Answering twice is a double tap, not a change of mind: the second would
+    // move `steer_at` and quietly extend how long the block rides today's plan.
+    if reflection.steer != SteerState::Unoffered {
+        return crux_core::render::render();
+    }
+    reflection.steer = answer;
+    reflection.steer_at = Some(now);
+    reflection.updated_at = now;
+    let reflection = reflection.clone();
+    save_and_render(persistence::save_reflection(reflection))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -879,6 +996,31 @@ mod tests {
                 audio_path: Some("reflections/01J.m4a".into()),
                 duration_s: Some(24),
                 at: at(),
+                steer: SteerState::Unoffered,
+                steer_at: None,
+                updated_at: at(),
+                deleted_at: None,
+            });
+        }
+    }
+
+    #[test]
+    fn every_steer_state_round_trips_on_the_wire() {
+        for steer in [
+            SteerState::Unoffered,
+            SteerState::Accepted,
+            SteerState::Declined,
+        ] {
+            assert_round_trips(Reflection {
+                id: "01J0000000000000000000REFL".into(),
+                kind: ReflectionKind::SessionClose,
+                session_ref: None,
+                transcript: None,
+                audio_path: None,
+                duration_s: None,
+                at: at(),
+                steer,
+                steer_at: Some(at()),
                 updated_at: at(),
                 deleted_at: None,
             });
@@ -2339,6 +2481,8 @@ mod tests {
             audio_path: Some("reflections/r1.m4a".into()),
             duration_s: Some(24),
             at: at(),
+            steer: SteerState::Unoffered,
+            steer_at: None,
             updated_at: at(),
             deleted_at: None,
         }
@@ -2491,5 +2635,190 @@ mod tests {
             reflections: vec![sample_reflection()],
             feel_entries: vec![sample_feel_entry()],
         }));
+    }
+
+    // ── Qualitative capture (Phase D handlers) ────────────────────────
+
+    #[test]
+    fn a_feel_is_recorded_once_per_block_and_never_twice() {
+        let mut model = Model::test_default();
+        model.feel_prompt = Some(capture::FeelPrompt {
+            block_id: "b1".into(),
+            title: "Rubato in the intro".into(),
+        });
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordFeel {
+                block_id: "b1".into(),
+                feel: Feel::ItSang,
+            },
+        );
+        assert_eq!(model.feel_entries.len(), 1);
+        assert!(model.feel_prompt.is_none(), "the question is answered");
+        assert_no_http(&effects);
+
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordFeel {
+                block_id: "b1".into(),
+                feel: Feel::FoughtIt,
+            },
+        );
+        assert_eq!(model.feel_entries.len(), 1, "one per block, ever");
+        assert_eq!(model.feel_entries[0].feel, Feel::ItSang);
+        assert!(persistence_ops(&effects).is_empty());
+    }
+
+    #[test]
+    fn skipping_the_feel_writes_nothing_at_all() {
+        let mut model = Model::test_default();
+        model.feel_prompt = Some(capture::FeelPrompt {
+            block_id: "b1".into(),
+            title: "Rubato in the intro".into(),
+        });
+        let effects = update(&mut model, BuiltSessionEvent::SkipFeel);
+        assert!(model.feel_prompt.is_none());
+        assert!(model.feel_entries.is_empty(), "a skip is not a fourth feel");
+        assert!(persistence_ops(&effects).is_empty());
+    }
+
+    #[test]
+    fn not_tonight_closes_the_reflection_without_a_row() {
+        let mut model = Model::test_default();
+        model.reflection_prompt = true;
+        let effects = update(&mut model, BuiltSessionEvent::DismissReflection);
+        assert!(!model.reflection_prompt);
+        assert!(model.reflections.is_empty());
+        assert!(persistence_ops(&effects).is_empty());
+    }
+
+    #[test]
+    fn a_kept_reflection_persists_and_closes_the_question() {
+        let mut model = Model::test_default();
+        model.reflection_prompt = true;
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::RecordReflection {
+                kind: ReflectionKind::SessionClose,
+                session_ref: Some("built".into()),
+                transcript: None,
+                audio_path: Some("reflections/r1.m4a".into()),
+                duration_s: Some(24),
+            },
+        );
+        assert!(!model.reflection_prompt);
+        assert_eq!(model.reflections.len(), 1);
+        let kept = &model.reflections[0];
+        assert_eq!(kept.id.len(), 26, "client-minted ulid (invariant 3)");
+        assert_eq!(kept.steer, SteerState::Unoffered);
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveReflection(kept.clone())]
+        );
+        assert_no_http(&effects);
+    }
+
+    #[test]
+    fn a_transcript_that_lands_late_reaches_the_reflection_it_belongs_to() {
+        let mut model = Model::test_default();
+        update(
+            &mut model,
+            BuiltSessionEvent::RecordReflection {
+                kind: ReflectionKind::SessionClose,
+                session_ref: None,
+                transcript: None,
+                audio_path: Some("reflections/r1.m4a".into()),
+                duration_s: Some(24),
+            },
+        );
+        let id = model.reflections[0].id.clone();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::AttachTranscript {
+                reflection_id: id.clone(),
+                transcript: "The bridge still rushes.".into(),
+            },
+        );
+        assert_eq!(
+            model.reflections[0].transcript.as_deref(),
+            Some("The bridge still rushes.")
+        );
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveReflection(
+                model.reflections[0].clone()
+            )]
+        );
+        assert_eq!(model.reflections[0].id, id, "the audio keeps its row");
+    }
+
+    fn model_with_unanswered_steer() -> (Model, String) {
+        let mut model = Model::test_default();
+        let reflection = sample_reflection();
+        let id = reflection.id.clone();
+        model.reflections.push(reflection);
+        (model, id)
+    }
+
+    #[test]
+    fn accepting_the_morning_steer_spends_the_offer_and_persists_it() {
+        let (mut model, id) = model_with_unanswered_steer();
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::AcceptProposedSteer {
+                reflection_id: id.clone(),
+            },
+        );
+        let answered = &model.reflections[0];
+        assert_eq!(answered.steer, SteerState::Accepted);
+        assert!(answered.steer_at.is_some());
+        assert_eq!(
+            persistence_ops(&effects),
+            vec![PersistenceOperation::SaveReflection(answered.clone())]
+        );
+        assert_no_http(&effects);
+        assert_eq!(answered.id, id);
+    }
+
+    #[test]
+    fn declining_leaves_the_reflection_but_spends_the_offer() {
+        let (mut model, id) = model_with_unanswered_steer();
+        update(
+            &mut model,
+            BuiltSessionEvent::DeclineProposedSteer {
+                reflection_id: id.clone(),
+            },
+        );
+        assert_eq!(model.reflections.len(), 1, "the reflection itself is kept");
+        assert_eq!(model.reflections[0].steer, SteerState::Declined);
+
+        // Changing the answer would move `steer_at` and quietly extend how long
+        // the block rides today's plan.
+        let declined_at = model.reflections[0].steer_at;
+        let effects = update(
+            &mut model,
+            BuiltSessionEvent::AcceptProposedSteer { reflection_id: id },
+        );
+        assert_eq!(model.reflections[0].steer, SteerState::Declined);
+        assert_eq!(model.reflections[0].steer_at, declined_at);
+        assert!(persistence_ops(&effects).is_empty());
+    }
+
+    #[test]
+    fn feel_prompt_round_trips_on_the_wire() {
+        assert_round_trips(capture::FeelPrompt {
+            block_id: "01J000000000000000000BREC".into(),
+            title: "Rubato in the intro".into(),
+        });
+    }
+
+    #[test]
+    fn the_proposed_steer_round_trips_on_the_wire() {
+        assert_round_trips(steer::ProposedSteer {
+            reflection_id: "01J000000000000000000REFL".into(),
+            quote: "The bridge still rushes when I go from memory.".into(),
+            offer: "Give Alice in Wonderland, bridge 8 minutes today?".into(),
+            minutes: 8,
+        });
     }
 }

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -832,14 +832,10 @@ fn save_and_render(save: Command<Effect, Event>) -> Command<Effect, Event> {
     Command::all([save, crux_core::render::render()])
 }
 
-/// Both answers to the morning card write the same column: the offer is spent
-/// either way, and that is what stops it coming back tomorrow.
-///
-/// Accepting also places the block *now*, in this handler. The plan is remade
-/// only when the Practice screen has none, so a steer that waited for the next
-/// planning run would land after the session it was meant for — the card would
-/// stay up over an unchanged plan, and neither half of the contract the frame
-/// shows would be true.
+/// Both answers write the same column: the offer is spent either way, which is
+/// what stops it coming back tomorrow. Accepting also places the block *now*,
+/// because the Practice screen asks for a plan only when it has none — a steer
+/// that waited would leave the card up over an unchanged plan.
 fn answer_steer(
     model: &mut Model,
     reflection_id: &str,
@@ -866,9 +862,8 @@ fn answer_steer(
     // The card is answered whichever way it went, so it comes down either way.
     model.proposed_steer = None;
     if answer == SteerState::Accepted {
-        // Re-derived here rather than taken from the card: a proposal left up
-        // while the library changed behind it must not insert a block for
-        // something that is no longer there.
+        // Re-derived, not taken from the card: a proposal left up while the
+        // library changed must not insert a block for something that is gone.
         if let Some(block) = steer::target_of(&reflection, &model.steer_context())
             .and_then(|target| blocks::steer_block(&target, &model.build_context()))
         {

--- a/crates/intrada-core/src/domain/built_session/mod.rs
+++ b/crates/intrada-core/src/domain/built_session/mod.rs
@@ -277,9 +277,9 @@ pub enum BuiltSessionEvent {
     SkipFeel,
     /// C2's "Not tonight", respected without a follow-up nudge.
     DismissReflection,
-    /// C3's "Add it to today". Carries only the reflection: the target is
-    /// re-derived here, so a card left up while the library changed cannot
-    /// insert a block for something that is no longer there.
+    /// C3's "Add it to today": takes the card down and puts the block in
+    /// today's plan. Carries only the reflection, because the target is
+    /// re-derived from it rather than taken from the card.
     AcceptProposedSteer {
         reflection_id: String,
     },
@@ -489,11 +489,11 @@ pub fn handle_built_session_event(
             reflection_id,
             transcript,
         } => {
-            let Some(reflection) = model
-                .reflections
-                .iter_mut()
-                .find(|reflection| reflection.id == reflection_id)
-            else {
+            // A tombstoned row is one the user deleted while the transcription
+            // was still running: writing to it would resurrect their words.
+            let Some(reflection) = model.reflections.iter_mut().find(|reflection| {
+                reflection.id == reflection_id && reflection.deleted_at.is_none()
+            }) else {
                 return crux_core::render::render();
             };
             reflection.transcript = Some(transcript);
@@ -834,6 +834,12 @@ fn save_and_render(save: Command<Effect, Event>) -> Command<Effect, Event> {
 
 /// Both answers to the morning card write the same column: the offer is spent
 /// either way, and that is what stops it coming back tomorrow.
+///
+/// Accepting also places the block *now*, in this handler. The plan is remade
+/// only when the Practice screen has none, so a steer that waited for the next
+/// planning run would land after the session it was meant for — the card would
+/// stay up over an unchanged plan, and neither half of the contract the frame
+/// shows would be true.
 fn answer_steer(
     model: &mut Model,
     reflection_id: &str,
@@ -843,8 +849,9 @@ fn answer_steer(
     let Some(reflection) = model
         .reflections
         .iter_mut()
-        .find(|reflection| reflection.id == reflection_id)
+        .find(|reflection| reflection.id == reflection_id && reflection.deleted_at.is_none())
     else {
+        model.surface_error("That note is no longer there.");
         return crux_core::render::render();
     };
     // Answering twice is a double tap, not a change of mind: the second would
@@ -856,6 +863,18 @@ fn answer_steer(
     reflection.steer_at = Some(now);
     reflection.updated_at = now;
     let reflection = reflection.clone();
+    // The card is answered whichever way it went, so it comes down either way.
+    model.proposed_steer = None;
+    if answer == SteerState::Accepted {
+        // Re-derived here rather than taken from the card: a proposal left up
+        // while the library changed behind it must not insert a block for
+        // something that is no longer there.
+        if let Some(block) = steer::target_of(&reflection, &model.steer_context())
+            .and_then(|target| blocks::steer_block(&target, &model.build_context()))
+        {
+            model.coach.place_steer(block);
+        }
+    }
     save_and_render(persistence::save_reflection(reflection))
 }
 

--- a/crates/intrada-core/src/domain/built_session/steer.rs
+++ b/crates/intrada-core/src/domain/built_session/steer.rs
@@ -1,12 +1,10 @@
 //! C3 — last night's reflection, back as a proposal (decision 12: propose,
 //! confirm, never plan).
 //!
-//! v1 is rule-based, which settles open question 3 in `specs/built-session.md`.
-//! The narrated version — an LLM reading the reflection and writing the offer —
-//! is Phase 3 of the coach roadmap; what ships now quotes the user's own
-//! sentence back and names a target it can actually resolve. Everything about
-//! it is deliberately conservative: **a wrong quote-back is worse than none**,
-//! so an ambiguous match proposes nothing rather than guessing.
+//! v1 is rule-based, settling open question 3 in `specs/built-session.md`; the
+//! narrated version is Phase 3 of the coach roadmap. Everything here is timid on
+//! purpose: **a wrong quote-back is worse than none**, so an ambiguous match
+//! proposes nothing rather than guessing.
 
 use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
@@ -23,16 +21,11 @@ const MAX_AGE_HOURS: i64 = 20;
 /// The morning card is a return, not an echo: quoting someone back to
 /// themselves twenty minutes later is the app being strange at them.
 const MIN_AGE_HOURS: i64 = 6;
-/// A name shorter than this may not resolve a sentence on its own. Chart
-/// sections are routinely labelled `[A]`, which normalises to "a" — the
-/// commonest word in English — so without a floor "It was a good session"
-/// proposes the piece that has an A section, which is exactly the confidently
-/// wrong quote-back the whole module is built to avoid.
+/// Chart sections are routinely labelled `[A]`, which normalises to "a", so
+/// without a floor "It was a good session" proposes the piece that has one.
 const MIN_MATCHABLE_CHARS: usize = 3;
-/// Longer than this and the card is quoting a paragraph, not a sentence.
 /// Dictation often returns a whole reflection with no full stop in it, and the
-/// serif quote is designed around one short thought; past the cap the honest
-/// answer is the one the rest of this module gives — no card.
+/// card is designed around one short thought. Past the cap: no card.
 const MAX_QUOTE_WORDS: usize = 30;
 /// How long an accepted steer rides today's plan. Today, approximated in hours
 /// because the core is handed UTC and never the user's calendar.
@@ -71,9 +64,8 @@ pub struct SteerTarget {
 
 /// The reflection worth proposing this morning, if there is one.
 ///
-/// **The most recent one, or none** — never the one behind it. Falling through
-/// to an older reflection would put a different night's words under a card
-/// headed "you said, last night", and decision 12 allows one offer anyway.
+/// **The most recent one, or none.** Falling through to an older reflection
+/// would put a different night under a card headed "you said, last night".
 pub fn propose(
     reflections: &[Reflection],
     ctx: &SteerContext,
@@ -104,10 +96,9 @@ pub fn accepted(
         .iter()
         .filter(|reflection| reflection.deleted_at.is_none())
         .filter(|reflection| reflection.steer == SteerState::Accepted)
-        // Upper bound only. The accept is stamped on the core's clock and the
-        // plan is made against the shell's, so a reading a few milliseconds
-        // apart can put the answer marginally "ahead" of now — and dropping the
-        // block over that would lose a steer the user explicitly asked for.
+        // Upper bound only: the accept is stamped on the core's clock and the
+        // plan made against the shell's, so one may read marginally ahead of the
+        // other, and that must not lose a steer the user asked for.
         .filter(|reflection| {
             reflection
                 .steer_at
@@ -351,12 +342,9 @@ mod tests {
 
     // ── What a musician actually dictates ─────────────────────────────
     //
-    // Not sentences written to match the scanner (CLAUDE.md's parser rule, off
-    // the back of this feature's own criterion parser). The property every row
-    // asserts is the one the card rests on: **a proposal names something the
-    // sentence is really about, and there is no proposal otherwise.** The
-    // library underneath is the ordinary one — a charted piece with `[A]` and
-    // `[Bridge]` sections, which is what Journey B's run-through needs anyway.
+    // Not sentences written to match the scanner (CLAUDE.md's parser rule). Every
+    // row asserts the property the card rests on: a proposal names something the
+    // sentence was really about, and there is no proposal otherwise.
 
     const DICTATED: &[(&str, Option<&str>)] = &[
         ("It was a good session.", None),
@@ -399,9 +387,7 @@ mod tests {
         }
     }
 
-    /// The article, against the commonest chart label there is. Nothing else in
-    /// "It was a good session" is a target, and offering one would be the
-    /// confidently-wrong quote-back the module exists to avoid.
+    /// The article, against the commonest chart label there is.
     #[test]
     fn a_single_letter_section_label_is_never_what_a_sentence_was_about() {
         let items = vec![alice()];

--- a/crates/intrada-core/src/domain/built_session/steer.rs
+++ b/crates/intrada-core/src/domain/built_session/steer.rs
@@ -41,7 +41,6 @@ const ACCEPTED_ACTIVE_HOURS: i64 = 24;
 /// the proposal never reshapes the rest of the session.
 pub const STEER_MINUTES: u16 = 8;
 
-/// What the resolver may name a target from.
 pub struct SteerContext<'a> {
     pub items: &'a [Item],
     pub user_drills: &'a [UserDrill],
@@ -62,12 +61,11 @@ pub struct ProposedSteer {
     pub minutes: u16,
 }
 
-/// A target the quote-back resolved to, and how it should read in the plan.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SteerTarget {
     pub target: BuiltTarget,
     pub title: String,
-    /// Where in the piece, when the sentence named a chart section.
+    /// Set only where the sentence named a chart section rather than a piece.
     pub section: Option<String>,
 }
 
@@ -119,8 +117,8 @@ pub fn accepted(
     target_of(reflection, ctx)
 }
 
-/// The target a named reflection resolves to, whatever its steer state — what
-/// accepting has to be able to build a block from.
+/// Resolved whatever the steer state, because accepting has to build a block
+/// from a reflection the proposal has already been spent on.
 pub fn target_of(reflection: &Reflection, ctx: &SteerContext) -> Option<SteerTarget> {
     quoted_target(reflection, ctx).map(|(_, target)| target)
 }
@@ -139,8 +137,6 @@ fn within(at: DateTime<Utc>, now: DateTime<Utc>, min_hours: i64, max_hours: i64)
     age >= TimeDelta::hours(min_hours) && age <= TimeDelta::hours(max_hours)
 }
 
-/// The first sentence of the transcript that names something the library can
-/// resolve, and what it named.
 fn quoted_target(reflection: &Reflection, ctx: &SteerContext) -> Option<(String, SteerTarget)> {
     let transcript = reflection.transcript.as_deref()?;
     sentences(transcript)
@@ -248,8 +244,8 @@ fn mentions(said: &str, name: &str) -> bool {
         .any(|window| window == wanted_words.as_slice())
 }
 
-/// The one match, or none. Two candidates is an ambiguity the core refuses to
-/// resolve on the user's behalf.
+/// Two candidates is an ambiguity the core will not resolve on the user's
+/// behalf.
 fn only<T>(mut candidates: impl Iterator<Item = T>) -> Option<T> {
     let first = candidates.next()?;
     candidates.next().is_none().then_some(first)

--- a/crates/intrada-core/src/domain/built_session/steer.rs
+++ b/crates/intrada-core/src/domain/built_session/steer.rs
@@ -1,0 +1,480 @@
+//! C3 — last night's reflection, back as a proposal (decision 12: propose,
+//! confirm, never plan).
+//!
+//! v1 is rule-based, which settles open question 3 in `specs/built-session.md`.
+//! The narrated version — an LLM reading the reflection and writing the offer —
+//! is Phase 3 of the coach roadmap; what ships now quotes the user's own
+//! sentence back and names a target it can actually resolve. Everything about
+//! it is deliberately conservative: **a wrong quote-back is worse than none**,
+//! so an ambiguous match proposes nothing rather than guessing.
+
+use chrono::{DateTime, TimeDelta, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::compose::normalised;
+use super::playthrough::named_sections;
+use super::{BuiltTarget, JournalItem, Reflection, ReflectionKind, SteerState, UserDrill};
+use crate::domain::item::{Item, ItemKind};
+
+/// Older than this and "you said, last night" is not true any more.
+const MAX_AGE_HOURS: i64 = 48;
+/// Younger than this and the reflection is still the evening it was said in.
+/// The morning card is a return, not an echo: quoting someone back to
+/// themselves twenty minutes later is the app being strange at them.
+const MIN_AGE_HOURS: i64 = 6;
+/// How long an accepted steer rides today's plan. Today, approximated in hours
+/// because the core is handed UTC and never the user's calendar.
+const ACCEPTED_ACTIVE_HOURS: i64 = 24;
+/// What one steer block is worth. A single concrete offer, per decision 12 —
+/// the proposal never reshapes the rest of the session.
+pub const STEER_MINUTES: u16 = 8;
+
+/// What the resolver may name a target from. The same shape as composition's
+/// context, minus everything a quote-back has no use for.
+pub struct SteerContext<'a> {
+    pub items: &'a [Item],
+    pub user_drills: &'a [UserDrill],
+    pub journal_items: &'a [JournalItem],
+}
+
+/// The morning card (C3). `quote` is the user's own sentence, verbatim: the
+/// serif voice is reserved for the user's words, so the core hands them over
+/// untouched rather than tidied.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct ProposedSteer {
+    pub reflection_id: String,
+    pub quote: String,
+    /// The one concrete offer, written by the core so the shell composes no
+    /// sentence of its own.
+    pub offer: String,
+    pub minutes: u16,
+}
+
+/// A target the quote-back resolved to, and how it should read in the plan.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SteerTarget {
+    pub target: BuiltTarget,
+    pub title: String,
+    /// Where in the piece, when the sentence named a chart section.
+    pub section: Option<String>,
+}
+
+/// The reflection worth proposing this morning, if there is one.
+///
+/// One at a time, and only the most recent: a queue of yesterdays is a nag, and
+/// decision 12 allows one offer.
+pub fn propose(
+    reflections: &[Reflection],
+    ctx: &SteerContext,
+    now: DateTime<Utc>,
+) -> Option<ProposedSteer> {
+    let reflection = candidates(reflections, now)
+        .filter(|reflection| reflection.steer == SteerState::Unoffered)
+        .find(|reflection| target_of(reflection, ctx).is_some())?;
+    let (quote, target) = quoted_target(reflection, ctx)?;
+    Some(ProposedSteer {
+        reflection_id: reflection.id.clone(),
+        quote,
+        offer: offer_line(&target),
+        minutes: STEER_MINUTES,
+    })
+}
+
+/// The steer already accepted, for as long as it is still today's.
+///
+/// Derived every time rather than banked as a block: the accepted state is one
+/// column on the reflection, so a relaunch before the session rebuilds the same
+/// block instead of losing it with the plan (a plan is remade, never recovered).
+pub fn accepted(
+    reflections: &[Reflection],
+    ctx: &SteerContext,
+    now: DateTime<Utc>,
+) -> Option<SteerTarget> {
+    let reflection = reflections
+        .iter()
+        .filter(|reflection| reflection.deleted_at.is_none())
+        .filter(|reflection| reflection.steer == SteerState::Accepted)
+        .filter(|reflection| {
+            reflection
+                .steer_at
+                .is_some_and(|at| within(at, now, 0, ACCEPTED_ACTIVE_HOURS))
+        })
+        .max_by_key(|reflection| reflection.steer_at)?;
+    target_of(reflection, ctx)
+}
+
+/// The target a named reflection resolves to, whatever its steer state — what
+/// accepting has to be able to build a block from.
+pub fn target_of(reflection: &Reflection, ctx: &SteerContext) -> Option<SteerTarget> {
+    quoted_target(reflection, ctx).map(|(_, target)| target)
+}
+
+fn candidates(
+    reflections: &[Reflection],
+    now: DateTime<Utc>,
+) -> impl Iterator<Item = &Reflection> + '_ {
+    let mut ordered: Vec<&Reflection> = reflections
+        .iter()
+        .filter(|reflection| reflection.deleted_at.is_none())
+        .filter(|reflection| reflection.kind == ReflectionKind::SessionClose)
+        .filter(|reflection| within(reflection.at, now, MIN_AGE_HOURS, MAX_AGE_HOURS))
+        .collect();
+    ordered.sort_by_key(|reflection| std::cmp::Reverse(reflection.at));
+    ordered.into_iter()
+}
+
+fn within(at: DateTime<Utc>, now: DateTime<Utc>, min_hours: i64, max_hours: i64) -> bool {
+    let age = now - at;
+    age >= TimeDelta::hours(min_hours) && age <= TimeDelta::hours(max_hours)
+}
+
+/// The first sentence of the transcript that names something the library can
+/// resolve, and what it named.
+fn quoted_target(reflection: &Reflection, ctx: &SteerContext) -> Option<(String, SteerTarget)> {
+    let transcript = reflection.transcript.as_deref()?;
+    sentences(transcript).find_map(|sentence| {
+        resolve_sentence(&sentence, ctx).map(|target| (sentence.clone(), target))
+    })
+}
+
+/// Sentence-ended, and nothing cleverer. A dash or a comma inside a thought is
+/// still that thought, so only a full stop, a question mark or an exclamation
+/// mark ends one.
+fn sentences(transcript: &str) -> impl Iterator<Item = String> + '_ {
+    transcript
+        .split_inclusive(['.', '?', '!'])
+        .map(|sentence| sentence.trim().to_string())
+        .filter(|sentence| !sentence.is_empty())
+}
+
+/// What one sentence named, in the order of what the user has already paid a
+/// resolution for. A name matching more than one thing resolves to nothing:
+/// "the bridge" in a library with two pieces that have one is not an answer.
+fn resolve_sentence(sentence: &str, ctx: &SteerContext) -> Option<SteerTarget> {
+    let said = normalised(sentence);
+    if said.is_empty() {
+        return None;
+    }
+
+    let drills = ctx
+        .user_drills
+        .iter()
+        .filter(|drill| drill.deleted_at.is_none() && mentions(&said, &drill.name))
+        .map(|drill| SteerTarget {
+            target: BuiltTarget::UserDrill {
+                drill_id: drill.id.clone(),
+            },
+            title: drill.name.clone(),
+            section: None,
+        });
+    if let Some(target) = only(drills) {
+        return Some(target);
+    }
+
+    let journals = ctx
+        .journal_items
+        .iter()
+        .filter(|journal| journal.deleted_at.is_none() && mentions(&said, &journal.name))
+        .map(|journal| SteerTarget {
+            target: BuiltTarget::Journal {
+                journal_id: journal.id.clone(),
+            },
+            title: journal.name.clone(),
+            section: None,
+        });
+    if let Some(target) = only(journals) {
+        return Some(target);
+    }
+
+    let titles = ctx
+        .items
+        .iter()
+        .filter(|item| mentions(&said, &item.title))
+        .map(|item| piece_target(item, None));
+    if let Some(target) = only(titles) {
+        return Some(target);
+    }
+
+    // "The bridge still rushes" — a section names its piece, but only while
+    // exactly one piece has a section by that name.
+    let sections = ctx
+        .items
+        .iter()
+        .filter(|item| item.kind == ItemKind::Piece)
+        .flat_map(|item| {
+            named_sections(item)
+                .into_iter()
+                .filter(|label| mentions(&said, label))
+                .map(move |label| piece_target(item, Some(label)))
+        });
+    only(sections)
+}
+
+fn piece_target(item: &Item, section: Option<String>) -> SteerTarget {
+    SteerTarget {
+        target: BuiltTarget::Piece {
+            item_id: item.id.clone(),
+        },
+        title: item.title.clone(),
+        section,
+    }
+}
+
+/// Word-boundary containment over normalised text: "bridge" must be a word the
+/// sentence said, not a run of letters inside "bridges".
+fn mentions(said: &str, name: &str) -> bool {
+    let wanted = normalised(name);
+    if wanted.is_empty() {
+        return false;
+    }
+    let said_words: Vec<&str> = said.split(' ').collect();
+    let wanted_words: Vec<&str> = wanted.split(' ').collect();
+    said_words
+        .windows(wanted_words.len())
+        .any(|window| window == wanted_words.as_slice())
+}
+
+/// The one match, or none. Two candidates is an ambiguity the core refuses to
+/// resolve on the user's behalf.
+fn only<T>(mut candidates: impl Iterator<Item = T>) -> Option<T> {
+    let first = candidates.next()?;
+    candidates.next().is_none().then_some(first)
+}
+
+/// The offer, in plain peer voice: the morning card is a set-up surface, so it
+/// may speak, but it still names no engine vocabulary and makes no claim about
+/// what the session will do (T13).
+fn offer_line(target: &SteerTarget) -> String {
+    let what = match &target.section {
+        Some(section) => format!("{}, {}", target.title, lower_first(section)),
+        None => target.title.clone(),
+    };
+    format!("Give {what} {STEER_MINUTES} minutes today?")
+}
+
+fn lower_first(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(first) => first.to_lowercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::built_session::tests_support::{journal_item, sample_item, user_drill};
+    use crate::domain::chart::parse_chart;
+    use crate::domain::item::Modality;
+    use chrono::TimeZone;
+
+    fn last_night() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 7, 22, 0, 0).unwrap()
+    }
+
+    fn morning() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 8, 9, 0, 0).unwrap()
+    }
+
+    fn reflection(transcript: &str) -> Reflection {
+        Reflection {
+            id: "01J00000000000000000REFLE".into(),
+            kind: ReflectionKind::SessionClose,
+            session_ref: None,
+            transcript: Some(transcript.into()),
+            audio_path: None,
+            duration_s: Some(24),
+            at: last_night(),
+            steer: SteerState::Unoffered,
+            steer_at: None,
+            updated_at: last_night(),
+            deleted_at: None,
+        }
+    }
+
+    fn alice() -> Item {
+        let mut item = sample_item(
+            "01J0000000000000000000PIEC",
+            "Alice in Wonderland",
+            ItemKind::Piece,
+        );
+        item.chord_chart = parse_chart(
+            "[A]\n| Cmaj7 | Dm7 |\n[Bridge]\n| Fmaj7 | G7 |",
+            "C",
+            Modality::Major,
+        )
+        .ok();
+        item
+    }
+
+    fn ctx<'a>(
+        items: &'a [Item],
+        drills: &'a [UserDrill],
+        journals: &'a [JournalItem],
+    ) -> SteerContext<'a> {
+        SteerContext {
+            items,
+            user_drills: drills,
+            journal_items: journals,
+        }
+    }
+
+    /// The brief's own transcript, read by the rules that ship.
+    #[test]
+    fn a_section_named_in_the_reflection_becomes_the_morning_offer() {
+        let items = vec![alice()];
+        let said = reflection(
+            "Stride's nearly there at 72. The bridge still rushes when I go from memory \
+             — that's the thing to hit next. And the rubato idea from the lesson works.",
+        );
+        let proposed = propose(&[said], &ctx(&items, &[], &[]), morning()).expect("an offer");
+        assert_eq!(
+            proposed.quote,
+            "The bridge still rushes when I go from memory — that's the thing to hit next."
+        );
+        assert_eq!(
+            proposed.offer,
+            "Give Alice in Wonderland, bridge 8 minutes today?"
+        );
+        assert_eq!(proposed.minutes, STEER_MINUTES);
+    }
+
+    #[test]
+    fn a_drill_the_user_already_named_wins_over_a_section() {
+        let items = vec![alice()];
+        let drills = vec![user_drill("01J0000000000000000000DRIL", "Stride")];
+        let said = reflection("Stride's nearly there at 72. The bridge still rushes.");
+        let proposed = propose(&[said], &ctx(&items, &drills, &[]), morning()).expect("an offer");
+        assert_eq!(proposed.quote, "Stride's nearly there at 72.");
+        assert_eq!(proposed.offer, "Give Stride 8 minutes today?");
+    }
+
+    #[test]
+    fn a_journal_target_resolves_too() {
+        let journals = vec![journal_item(
+            "01J0000000000000000000JRNL",
+            "Rubato in the intro",
+        )];
+        let said = reflection("Rubato in the intro is still not settled.");
+        let proposed = propose(&[said], &ctx(&[], &[], &journals), morning()).expect("an offer");
+        assert_eq!(proposed.offer, "Give Rubato in the intro 8 minutes today?");
+    }
+
+    #[test]
+    fn a_name_two_things_answer_to_proposes_nothing() {
+        let mut other = alice();
+        other.id = "01J000000000000000000PIEC2".into();
+        other.title = "Blue in Green".into();
+        let items = vec![alice(), other];
+        let said = reflection("The bridge still rushes when I go from memory.");
+        assert!(propose(&[said], &ctx(&items, &[], &[]), morning()).is_none());
+    }
+
+    #[test]
+    fn a_reflection_naming_nothing_the_library_knows_proposes_nothing() {
+        let items = vec![alice()];
+        let said = reflection("Good session. Hands felt loose for once.");
+        assert!(propose(&[said], &ctx(&items, &[], &[]), morning()).is_none());
+    }
+
+    #[test]
+    fn a_reflection_said_this_evening_is_not_quoted_back_the_same_evening() {
+        let items = vec![alice()];
+        let said = reflection("The bridge still rushes.");
+        let an_hour_later = last_night() + TimeDelta::hours(1);
+        assert!(propose(&[said], &ctx(&items, &[], &[]), an_hour_later).is_none());
+    }
+
+    #[test]
+    fn a_reflection_from_last_week_is_not_last_night() {
+        let items = vec![alice()];
+        let said = reflection("The bridge still rushes.");
+        let next_week = last_night() + TimeDelta::days(7);
+        assert!(propose(&[said], &ctx(&items, &[], &[]), next_week).is_none());
+    }
+
+    #[test]
+    fn a_declined_steer_leaves_no_trace_and_never_asks_again() {
+        let items = vec![alice()];
+        let said = Reflection {
+            steer: SteerState::Declined,
+            steer_at: Some(morning()),
+            ..reflection("The bridge still rushes.")
+        };
+        assert!(propose(
+            std::slice::from_ref(&said),
+            &ctx(&items, &[], &[]),
+            morning()
+        )
+        .is_none());
+        assert!(accepted(&[said], &ctx(&items, &[], &[]), morning()).is_none());
+    }
+
+    #[test]
+    fn an_accepted_steer_is_not_proposed_a_second_time() {
+        let items = vec![alice()];
+        let said = Reflection {
+            steer: SteerState::Accepted,
+            steer_at: Some(morning()),
+            ..reflection("The bridge still rushes.")
+        };
+        assert!(propose(&[said], &ctx(&items, &[], &[]), morning()).is_none());
+    }
+
+    #[test]
+    fn an_accepted_steer_rides_todays_plan_and_stops_riding_tomorrows() {
+        let items = vec![alice()];
+        let said = Reflection {
+            steer: SteerState::Accepted,
+            steer_at: Some(morning()),
+            ..reflection("The bridge still rushes.")
+        };
+        let target = accepted(
+            std::slice::from_ref(&said),
+            &ctx(&items, &[], &[]),
+            morning(),
+        )
+        .expect("a block");
+        assert_eq!(
+            target.target,
+            BuiltTarget::Piece {
+                item_id: "01J0000000000000000000PIEC".into()
+            }
+        );
+        assert_eq!(target.section.as_deref(), Some("Bridge"));
+
+        let tomorrow = morning() + TimeDelta::hours(25);
+        assert!(accepted(&[said], &ctx(&items, &[], &[]), tomorrow).is_none());
+    }
+
+    #[test]
+    fn the_most_recent_reflection_is_the_one_proposed() {
+        let items = vec![alice()];
+        let older = Reflection {
+            id: "01J00000000000000000OLDER".into(),
+            at: last_night() - TimeDelta::hours(24),
+            ..reflection("The bridge still rushes.")
+        };
+        let newer = reflection("The bridge still rushes.");
+        let proposed =
+            propose(&[older, newer], &ctx(&items, &[], &[]), morning()).expect("an offer");
+        assert_eq!(proposed.reflection_id, "01J00000000000000000REFLE");
+    }
+
+    #[test]
+    fn a_voice_note_is_not_a_session_close_reflection() {
+        let items = vec![alice()];
+        let said = Reflection {
+            kind: ReflectionKind::VoiceNote,
+            ..reflection("The bridge still rushes.")
+        };
+        assert!(propose(&[said], &ctx(&items, &[], &[]), morning()).is_none());
+    }
+
+    #[test]
+    fn a_word_inside_a_longer_word_is_not_a_mention() {
+        assert!(mentions("the bridge still rushes", "bridge"));
+        assert!(!mentions("the bridges still rush", "bridge"));
+    }
+}

--- a/crates/intrada-core/src/domain/built_session/steer.rs
+++ b/crates/intrada-core/src/domain/built_session/steer.rs
@@ -16,12 +16,24 @@ use super::playthrough::named_sections;
 use super::{BuiltTarget, JournalItem, Reflection, ReflectionKind, SteerState, UserDrill};
 use crate::domain::item::{Item, ItemKind};
 
-/// Older than this and "you said, last night" is not true any more.
-const MAX_AGE_HOURS: i64 = 48;
+/// Older than this and the card's own words stop being true: it says "you
+/// said, last night", so it may not quote the night before that.
+const MAX_AGE_HOURS: i64 = 20;
 /// Younger than this and the reflection is still the evening it was said in.
 /// The morning card is a return, not an echo: quoting someone back to
 /// themselves twenty minutes later is the app being strange at them.
 const MIN_AGE_HOURS: i64 = 6;
+/// A name shorter than this may not resolve a sentence on its own. Chart
+/// sections are routinely labelled `[A]`, which normalises to "a" — the
+/// commonest word in English — so without a floor "It was a good session"
+/// proposes the piece that has an A section, which is exactly the confidently
+/// wrong quote-back the whole module is built to avoid.
+const MIN_MATCHABLE_CHARS: usize = 3;
+/// Longer than this and the card is quoting a paragraph, not a sentence.
+/// Dictation often returns a whole reflection with no full stop in it, and the
+/// serif quote is designed around one short thought; past the cap the honest
+/// answer is the one the rest of this module gives — no card.
+const MAX_QUOTE_WORDS: usize = 30;
 /// How long an accepted steer rides today's plan. Today, approximated in hours
 /// because the core is handed UTC and never the user's calendar.
 const ACCEPTED_ACTIVE_HOURS: i64 = 24;
@@ -29,8 +41,7 @@ const ACCEPTED_ACTIVE_HOURS: i64 = 24;
 /// the proposal never reshapes the rest of the session.
 pub const STEER_MINUTES: u16 = 8;
 
-/// What the resolver may name a target from. The same shape as composition's
-/// context, minus everything a quote-back has no use for.
+/// What the resolver may name a target from.
 pub struct SteerContext<'a> {
     pub items: &'a [Item],
     pub user_drills: &'a [UserDrill],
@@ -62,16 +73,16 @@ pub struct SteerTarget {
 
 /// The reflection worth proposing this morning, if there is one.
 ///
-/// One at a time, and only the most recent: a queue of yesterdays is a nag, and
-/// decision 12 allows one offer.
+/// **The most recent one, or none** — never the one behind it. Falling through
+/// to an older reflection would put a different night's words under a card
+/// headed "you said, last night", and decision 12 allows one offer anyway.
 pub fn propose(
     reflections: &[Reflection],
     ctx: &SteerContext,
     now: DateTime<Utc>,
 ) -> Option<ProposedSteer> {
-    let reflection = candidates(reflections, now)
-        .filter(|reflection| reflection.steer == SteerState::Unoffered)
-        .find(|reflection| target_of(reflection, ctx).is_some())?;
+    let reflection = most_recent(reflections, now)
+        .filter(|reflection| reflection.steer == SteerState::Unoffered)?;
     let (quote, target) = quoted_target(reflection, ctx)?;
     Some(ProposedSteer {
         reflection_id: reflection.id.clone(),
@@ -95,10 +106,14 @@ pub fn accepted(
         .iter()
         .filter(|reflection| reflection.deleted_at.is_none())
         .filter(|reflection| reflection.steer == SteerState::Accepted)
+        // Upper bound only. The accept is stamped on the core's clock and the
+        // plan is made against the shell's, so a reading a few milliseconds
+        // apart can put the answer marginally "ahead" of now — and dropping the
+        // block over that would lose a steer the user explicitly asked for.
         .filter(|reflection| {
             reflection
                 .steer_at
-                .is_some_and(|at| within(at, now, 0, ACCEPTED_ACTIVE_HOURS))
+                .is_some_and(|at| now - at <= TimeDelta::hours(ACCEPTED_ACTIVE_HOURS))
         })
         .max_by_key(|reflection| reflection.steer_at)?;
     target_of(reflection, ctx)
@@ -110,18 +125,13 @@ pub fn target_of(reflection: &Reflection, ctx: &SteerContext) -> Option<SteerTar
     quoted_target(reflection, ctx).map(|(_, target)| target)
 }
 
-fn candidates(
-    reflections: &[Reflection],
-    now: DateTime<Utc>,
-) -> impl Iterator<Item = &Reflection> + '_ {
-    let mut ordered: Vec<&Reflection> = reflections
+fn most_recent(reflections: &[Reflection], now: DateTime<Utc>) -> Option<&Reflection> {
+    reflections
         .iter()
         .filter(|reflection| reflection.deleted_at.is_none())
         .filter(|reflection| reflection.kind == ReflectionKind::SessionClose)
         .filter(|reflection| within(reflection.at, now, MIN_AGE_HOURS, MAX_AGE_HOURS))
-        .collect();
-    ordered.sort_by_key(|reflection| std::cmp::Reverse(reflection.at));
-    ordered.into_iter()
+        .max_by_key(|reflection| reflection.at)
 }
 
 fn within(at: DateTime<Utc>, now: DateTime<Utc>, min_hours: i64, max_hours: i64) -> bool {
@@ -133,9 +143,11 @@ fn within(at: DateTime<Utc>, now: DateTime<Utc>, min_hours: i64, max_hours: i64)
 /// resolve, and what it named.
 fn quoted_target(reflection: &Reflection, ctx: &SteerContext) -> Option<(String, SteerTarget)> {
     let transcript = reflection.transcript.as_deref()?;
-    sentences(transcript).find_map(|sentence| {
-        resolve_sentence(&sentence, ctx).map(|target| (sentence.clone(), target))
-    })
+    sentences(transcript)
+        .filter(|sentence| sentence.split_whitespace().count() <= MAX_QUOTE_WORDS)
+        .find_map(|sentence| {
+            resolve_sentence(&sentence, ctx).map(|target| (sentence.clone(), target))
+        })
 }
 
 /// Sentence-ended, and nothing cleverer. A dash or a comma inside a thought is
@@ -222,10 +234,11 @@ fn piece_target(item: &Item, section: Option<String>) -> SteerTarget {
 }
 
 /// Word-boundary containment over normalised text: "bridge" must be a word the
-/// sentence said, not a run of letters inside "bridges".
+/// sentence said, not a run of letters inside "bridges". A name below
+/// [`MIN_MATCHABLE_CHARS`] never matches at all.
 fn mentions(said: &str, name: &str) -> bool {
     let wanted = normalised(name);
-    if wanted.is_empty() {
+    if wanted.chars().count() < MIN_MATCHABLE_CHARS {
         return false;
     }
     let said_words: Vec<&str> = said.split(' ').collect();
@@ -247,7 +260,7 @@ fn only<T>(mut candidates: impl Iterator<Item = T>) -> Option<T> {
 /// what the session will do (T13).
 fn offer_line(target: &SteerTarget) -> String {
     let what = match &target.section {
-        Some(section) => format!("{}, {}", target.title, lower_first(section)),
+        Some(section) => format!("the {} of {}", lower_first(section), target.title),
         None => target.title.clone(),
     };
     format!("Give {what} {STEER_MINUTES} minutes today?")
@@ -335,9 +348,85 @@ mod tests {
         );
         assert_eq!(
             proposed.offer,
-            "Give Alice in Wonderland, bridge 8 minutes today?"
+            "Give the bridge of Alice in Wonderland 8 minutes today?"
         );
         assert_eq!(proposed.minutes, STEER_MINUTES);
+    }
+
+    // ── What a musician actually dictates ─────────────────────────────
+    //
+    // Not sentences written to match the scanner (CLAUDE.md's parser rule, off
+    // the back of this feature's own criterion parser). The property every row
+    // asserts is the one the card rests on: **a proposal names something the
+    // sentence is really about, and there is no proposal otherwise.** The
+    // library underneath is the ordinary one — a charted piece with `[A]` and
+    // `[Bridge]` sections, which is what Journey B's run-through needs anyway.
+
+    const DICTATED: &[(&str, Option<&str>)] = &[
+        ("It was a good session.", None),
+        ("Felt like a slog tonight, honestly.", None),
+        ("Need a metronome next time.", None),
+        ("Hands were loose for once and it just worked.", None),
+        ("Not much to say. Tired.", None),
+        ("Bar four is a mess.", None),
+        ("The A section is fine now.", None),
+        (
+            "The bridge still rushes when I go from memory.",
+            Some("Give the bridge of Alice in Wonderland 8 minutes today?"),
+        ),
+        (
+            "Alice in Wonderland is nearly ready to play for someone.",
+            Some("Give Alice in Wonderland 8 minutes today?"),
+        ),
+        (
+            "Good session. The bridge is the thing to hit next.",
+            Some("Give the bridge of Alice in Wonderland 8 minutes today?"),
+        ),
+    ];
+
+    #[test]
+    fn every_proposal_names_something_the_sentence_was_about() {
+        let items = vec![alice()];
+        for (said, expected) in DICTATED {
+            let proposed = propose(&[reflection(said)], &ctx(&items, &[], &[]), morning());
+            assert_eq!(
+                proposed.as_ref().map(|steer| steer.offer.as_str()),
+                *expected,
+                "dictated: {said:?}"
+            );
+            if let Some(proposed) = proposed {
+                assert!(
+                    said.contains(proposed.quote.trim_end_matches('.')),
+                    "the quote must be the user's own words: {said:?}"
+                );
+            }
+        }
+    }
+
+    /// The article, against the commonest chart label there is. Nothing else in
+    /// "It was a good session" is a target, and offering one would be the
+    /// confidently-wrong quote-back the module exists to avoid.
+    #[test]
+    fn a_single_letter_section_label_is_never_what_a_sentence_was_about() {
+        let items = vec![alice()];
+        assert_eq!(named_sections(&items[0])[0], "A", "the fixture has one");
+        assert!(propose(
+            &[reflection("It was a good session.")],
+            &ctx(&items, &[], &[]),
+            morning()
+        )
+        .is_none());
+    }
+
+    /// Dictation regularly returns a whole reflection with no full stop in it.
+    #[test]
+    fn an_unpunctuated_ramble_is_not_quoted_as_a_sentence() {
+        let items = vec![alice()];
+        let rambled = (0..40)
+            .map(|_| "the bridge still rushes when I go from memory")
+            .collect::<Vec<_>>()
+            .join(" and ");
+        assert!(propose(&[reflection(&rambled)], &ctx(&items, &[], &[]), morning()).is_none());
     }
 
     #[test]
@@ -451,15 +540,31 @@ mod tests {
     #[test]
     fn the_most_recent_reflection_is_the_one_proposed() {
         let items = vec![alice()];
+        // Both inside the window, so recency is what decides rather than the
+        // age bounds doing the work for it.
         let older = Reflection {
             id: "01J00000000000000000OLDER".into(),
-            at: last_night() - TimeDelta::hours(24),
+            at: last_night() - TimeDelta::hours(6),
             ..reflection("The bridge still rushes.")
         };
         let newer = reflection("The bridge still rushes.");
         let proposed =
             propose(&[older, newer], &ctx(&items, &[], &[]), morning()).expect("an offer");
         assert_eq!(proposed.reflection_id, "01J00000000000000000REFLE");
+    }
+
+    /// The card says "you said, last night". Falling through to the reflection
+    /// behind an unresolvable one would put a different night under it.
+    #[test]
+    fn an_unresolvable_reflection_does_not_hand_the_card_to_an_older_one() {
+        let items = vec![alice()];
+        let older = Reflection {
+            id: "01J00000000000000000OLDER".into(),
+            at: last_night() - TimeDelta::hours(6),
+            ..reflection("The bridge still rushes.")
+        };
+        let newer = reflection("Good session. Hands felt loose for once.");
+        assert!(propose(&[older, newer], &ctx(&items, &[], &[]), morning()).is_none());
     }
 
     #[test]

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -71,23 +71,18 @@ impl CoachState {
             .apply_with_plan(&CoachEvent::StartPlannedSession { now }, Some(plan))
     }
 
-    /// Place C3's accepted steer in today's plan (#1256 Phase D). One block,
-    /// added to the plan the planner made rather than replacing it: decision 12
-    /// is propose, confirm, never plan, and a proposal that reshaped the
-    /// session would be planning. The extra minutes are the user's own, so the
-    /// plan runs longer rather than dropping one of the planner's blocks to pay
-    /// for it.
+    /// Place C3's accepted steer in today's plan (#1256 Phase D): one block
+    /// added to the planner's plan rather than replacing it, because decision 12
+    /// is propose, confirm, never plan. The extra minutes run over the session
+    /// length rather than costing one of the planner's blocks.
     ///
-    /// Second, not last, in a plan not yet started: its first block is the
-    /// warm-up the template puts there, and a steer accepted this morning
-    /// should be the first real thing the session does, not the thing it runs
-    /// out of time for. In a session already running it goes after the block in
-    /// flight, never before — `BlockState::spec_index` points into this vector,
-    /// so an insert at or below it would silently re-aim the running block.
-    /// Placing the same steer twice is a live risk, not a theoretical one: the
-    /// accept places it in the plan on screen, and starting that plan carries it
-    /// into the running one, where the start-from-`Idle` door would otherwise
-    /// place it again.
+    /// Second in a plan not yet started, so a steer is the first real thing the
+    /// session does rather than what it runs out of time for. In a running one
+    /// it goes after the block in flight, never at or below
+    /// `BlockState::spec_index`, which would silently re-aim it.
+    ///
+    /// The duplicate refusal is live, not theoretical: the accept places it on
+    /// screen, and starting that plan carries it into the running one.
     pub fn place_steer(&mut self, block: PlannedBlock) -> bool {
         let (plan, floor) = match &mut self.session.state {
             SessionState::Planned { plan } => (plan, 1),

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use super::content::ContentIndex;
 use super::gate::{Requirement, Verdict};
 use super::mastery::MasteryStore;
-use super::plan::{plan, BlockOrigin, ParameterLevel, Plan, PlanContext};
+use super::plan::{plan, BlockOrigin, ParameterLevel, Plan, PlanContext, PlannedBlock, Stage};
 use super::session::{
     section_evidence, Altitude, BlockRecord, CoachEvent, CoachWrites, EngineSession, Exit, Phase,
     SessionState,
@@ -69,6 +69,32 @@ impl CoachState {
         self.session.state = SessionState::Idle;
         self.session
             .apply_with_plan(&CoachEvent::StartPlannedSession { now }, Some(plan))
+    }
+
+    /// Place C3's accepted steer in today's plan (#1256 Phase D). One block,
+    /// added to the plan the planner made rather than replacing it: decision 12
+    /// is propose, confirm, never plan, and a proposal that reshaped the
+    /// session would be planning.
+    ///
+    /// Second, not last. The plan's first block is the warm-up the template
+    /// puts there, and a steer the user accepted this morning should be the
+    /// first real thing they do, not the thing they run out of time for.
+    ///
+    /// Idempotent by node, because the steer is re-derived on every plan rather
+    /// than banked: re-planning must not stack a second copy of it.
+    pub fn place_steer(&mut self, block: PlannedBlock) -> bool {
+        let SessionState::Planned { plan } = &mut self.session.state else {
+            return false;
+        };
+        if plan
+            .blocks
+            .iter()
+            .any(|placed| placed.spec.node == block.spec.node)
+        {
+            return false;
+        }
+        plan.blocks.insert(plan.blocks.len().min(1), block);
+        true
     }
 
     /// Rebuild the mastery track from the persisted evidence at launch (#1214):
@@ -234,6 +260,7 @@ impl CoachState {
                     kind: block.spec.kind.clone(),
                     minutes: block.spec.minutes,
                     why: block.why_line(),
+                    added_by_you: block.why.placed_by == Stage::Steer,
                 })
                 .collect(),
             deferred: plan.deferred.clone(),
@@ -459,6 +486,9 @@ pub struct PlannedBlockView {
     /// One sentence, written by the core. The shell renders it and never
     /// composes one.
     pub why: String,
+    /// C3's "you added this": provenance stays legible in the shape, so an
+    /// accepted steer never reads as something the app decided (decision 12).
+    pub added_by_you: bool,
 }
 
 /// What the drill screen shows. Deliberately presentational: `Escalating`

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -74,17 +74,28 @@ impl CoachState {
     /// Place C3's accepted steer in today's plan (#1256 Phase D). One block,
     /// added to the plan the planner made rather than replacing it: decision 12
     /// is propose, confirm, never plan, and a proposal that reshaped the
-    /// session would be planning.
+    /// session would be planning. The extra minutes are the user's own, so the
+    /// plan runs longer rather than dropping one of the planner's blocks to pay
+    /// for it.
     ///
-    /// Second, not last. The plan's first block is the warm-up the template
-    /// puts there, and a steer the user accepted this morning should be the
-    /// first real thing they do, not the thing they run out of time for.
-    ///
-    /// Idempotent by node, because the steer is re-derived on every plan rather
-    /// than banked: re-planning must not stack a second copy of it.
+    /// Second, not last, in a plan not yet started: its first block is the
+    /// warm-up the template puts there, and a steer accepted this morning
+    /// should be the first real thing the session does, not the thing it runs
+    /// out of time for. In a session already running it goes after the block in
+    /// flight, never before — `BlockState::spec_index` points into this vector,
+    /// so an insert at or below it would silently re-aim the running block.
+    /// Placing the same steer twice is a live risk, not a theoretical one: the
+    /// accept places it in the plan on screen, and starting that plan carries it
+    /// into the running one, where the start-from-`Idle` door would otherwise
+    /// place it again.
     pub fn place_steer(&mut self, block: PlannedBlock) -> bool {
-        let SessionState::Planned { plan } = &mut self.session.state else {
-            return false;
+        let (plan, floor) = match &mut self.session.state {
+            SessionState::Planned { plan } => (plan, 1),
+            SessionState::Running {
+                plan,
+                block: running,
+            } => (plan, running.spec_index + 1),
+            _ => return false,
         };
         if plan
             .blocks
@@ -93,7 +104,8 @@ impl CoachState {
         {
             return false;
         }
-        plan.blocks.insert(plan.blocks.len().min(1), block);
+        let at = floor.min(plan.blocks.len());
+        plan.blocks.insert(at, block);
         true
     }
 

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -6,9 +6,11 @@ use serde::{Deserialize, Serialize};
 use crate::analytics::AnalyticsView;
 use crate::domain::account::AccountPreferences;
 use crate::domain::built_session::blocks::BuildContext;
+use crate::domain::built_session::capture::FeelPrompt;
 use crate::domain::built_session::compose::{
     BuiltView, ComposeDraft, Resolution, ResolutionContext,
 };
+use crate::domain::built_session::steer::{ProposedSteer, SteerContext};
 use crate::domain::built_session::{
     BuiltSession, BuiltTarget, FeelEntry, JournalItem, PlayThroughRecord, Reflection, UserDrill,
 };
@@ -120,6 +122,18 @@ pub struct Model {
     /// itself is re-derived per render, so the sheet cannot go stale against a
     /// chart edited behind it.
     pub play_through_item: Option<String>,
+    /// C1's question, set by the block that just closed. Not on the engine
+    /// session and so not on the crash-recovery wire: the block record is
+    /// already written, so a prompt lost to a crash costs nothing, and a field
+    /// there would cost every device its blob.
+    pub feel_prompt: Option<FeelPrompt>,
+    /// C2's question, set once as a session closes. False again the moment it
+    /// is answered either way — "Not tonight" is respected without a nudge.
+    pub reflection_prompt: bool,
+    /// C3's morning card, snapshotted when the session was planned. Held rather
+    /// than derived per render because whether a reflection was "last night" is
+    /// a question only a clock can answer, and the view has none.
+    pub proposed_steer: Option<ProposedSteer>,
 }
 
 impl Model {
@@ -142,6 +156,15 @@ impl Model {
             user_drills: &self.user_drills,
             journal_items: &self.journal_items,
             content: ContentIndex::shipped(),
+        }
+    }
+
+    /// What a quoted-back reflection may name (C3).
+    pub fn steer_context(&self) -> SteerContext<'_> {
+        SteerContext {
+            items: &self.items,
+            user_drills: &self.user_drills,
+            journal_items: &self.journal_items,
         }
     }
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -67,8 +67,24 @@ countable criteria.
   change. Deferred with issues: off-piste's mic and its keep-as-drill exit,
   which need an audio effect that does not exist yet (#1304), and resuming a
   crash mid-altitude without pressing start on the hero (#1305).
-  Next: Phase D (Journey C — feel moments, reflection at close, the morning
-  proposal)
+  **Phase D's core landed Journey C's rules** (screens follow in their own PR).
+  The feel question is asked only where a block closed on the judgement track,
+  never alongside GateDots, and never after two misses in that block; the
+  close reflection is offered once per session and never after unmonitored
+  play or off-piste, which have already spent what they may ask. Both prompts
+  live on the `Model`, deliberately outside the crash-recovery blob. Open
+  question 3 is resolved: **C3 ships rule-based** — the most recent unanswered
+  reflection between six and forty-eight hours old, its first sentence naming
+  exactly one thing the library can resolve, quoted back verbatim with one
+  eight-minute offer. An ambiguous name proposes nothing, because a wrong
+  quote-back is worse than none. Accepting writes `steer`/`steer_at` on the
+  reflection (GRDB v15) and the block is re-derived into each plan from there,
+  so a relaunch rebuilds it rather than losing it; declining leaves no trace
+  beyond never asking again. A transcript that lands late reaches its
+  reflection through `AttachTranscript`, so keeping the audio never waits on
+  transcription.
+  Next: Phase D's screens (the feel moment, the reflection sheet, the morning
+  proposed-steer card)
 
 ## Recently landed
 

--- a/ios/Intrada/Core/LibraryStore.swift
+++ b/ios/Intrada/Core/LibraryStore.swift
@@ -480,6 +480,15 @@ final class LibraryStore: ItemStore {
           )
           """)
     }
+    migrator.registerMigration("v15_reflection_steer") { db in
+      // #1256 Phase D: what became of the morning proposal a reflection earned
+      // (C3). 'unoffered' is the honest backfill — a reflection written before
+      // the card existed was never offered one — and it is also what stops a
+      // reflection from last month arriving as this morning's steer on upgrade.
+      try db.execute(
+        sql: "ALTER TABLE reflection ADD COLUMN steer TEXT NOT NULL DEFAULT 'unoffered'")
+      try db.execute(sql: "ALTER TABLE reflection ADD COLUMN steer_at TEXT")
+    }
     return migrator
   }()
 
@@ -1231,18 +1240,21 @@ final class LibraryStore: ItemStore {
       try db.execute(
         sql: """
           INSERT INTO reflection
-            (id, kind, session_ref, transcript, audio_path, duration_s, at, updated_at, deleted_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, kind, session_ref, transcript, audio_path, duration_s, at, steer, steer_at,
+             updated_at, deleted_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             kind = excluded.kind, session_ref = excluded.session_ref,
             transcript = excluded.transcript, audio_path = excluded.audio_path,
             duration_s = excluded.duration_s, at = excluded.at,
+            steer = excluded.steer, steer_at = excluded.steer_at,
             updated_at = excluded.updated_at, deleted_at = excluded.deleted_at
           """,
         arguments: [
           reflection.id, Self.reflectionKindString(reflection.kind), reflection.sessionRef,
           reflection.transcript, reflection.audioPath, reflection.durationS.map { Int($0) },
-          reflection.at, reflection.updatedAt, reflection.deletedAt,
+          reflection.at, Self.steerStateString(reflection.steer), reflection.steerAt,
+          reflection.updatedAt, reflection.deletedAt,
         ])
     }
   }
@@ -1369,7 +1381,8 @@ final class LibraryStore: ItemStore {
       id: row["id"], kind: try reflectionKind(from: row["kind"]), sessionRef: row["session_ref"],
       transcript: row["transcript"], audioPath: row["audio_path"],
       durationS: (row["duration_s"] as Int?).map { UInt32(clamping: $0) },
-      at: row["at"], updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
+      at: row["at"], steer: try steerState(from: row["steer"]), steerAt: row["steer_at"],
+      updatedAt: row["updated_at"], deletedAt: row["deleted_at"])
   }
 
   private static func feelEntry(from row: Row) throws -> FeelEntry {
@@ -1495,6 +1508,23 @@ final class LibraryStore: ItemStore {
     case "voice_note": return .voiceNote
     case "session_close": return .sessionClose
     default: throw UnknownStoredEnum(kind: "ReflectionKind", raw: raw)
+    }
+  }
+
+  private static func steerStateString(_ steer: SteerState) -> String {
+    switch steer {
+    case .unoffered: "unoffered"
+    case .accepted: "accepted"
+    case .declined: "declined"
+    }
+  }
+
+  private static func steerState(from raw: String) throws -> SteerState {
+    switch raw {
+    case "unoffered": return .unoffered
+    case "accepted": return .accepted
+    case "declined": return .declined
+    default: throw UnknownStoredEnum(kind: "SteerState", raw: raw)
     }
   }
 

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -151,21 +151,27 @@
       Store(
         bridge: PreviewBridge(
           items: [.previewPiece],
-          built: BuiltView(compose: .previewFirstUse, session: nil, playThrough: nil)))
+          built: BuiltView(
+            compose: .previewFirstUse, session: nil, playThrough: nil, feel: nil,
+            reflection: false, steer: nil)))
     }
 
     /// Repeat use (A2r): every row lands already known, so the price is zero.
     static var previewComposingAllKnown: Store {
       Store(
         bridge: PreviewBridge(
-          built: BuiltView(compose: .previewAllKnown, session: nil, playThrough: nil)))
+          built: BuiltView(
+            compose: .previewAllKnown, session: nil, playThrough: nil, feel: nil,
+            reflection: false, steer: nil)))
     }
 
     /// A3 — the proposed authored-node match, evidence on the card.
     static var previewResolvingNodeMatch: Store {
       Store(
         bridge: PreviewBridge(
-          built: BuiltView(compose: .previewNodeMatch, session: nil, playThrough: nil)))
+          built: BuiltView(
+            compose: .previewNodeMatch, session: nil, playThrough: nil, feel: nil,
+            reflection: false, steer: nil)))
     }
 
     /// A6 — the composed session, shape offered.
@@ -173,7 +179,9 @@
       Store(
         bridge: PreviewBridge(
           sessions: [.previewCompleted],
-          built: BuiltView(compose: nil, session: .preview, playThrough: nil)))
+          built: BuiltView(
+            compose: nil, session: .preview, playThrough: nil, feel: nil,
+            reflection: false, steer: nil)))
     }
 
     /// Practice home with a crash-recovery blob pending (#962) — drives the

--- a/ios/Intrada/Views/Components/SessionOverview.swift
+++ b/ios/Intrada/Views/Components/SessionOverview.swift
@@ -102,16 +102,17 @@ struct SessionOverview: View {
         blocks: [
           PlannedBlockView(
             drillTitle: "Rootless voicings", section: "A section", kind: .exercise, minutes: 8,
-            why: "Shells and rootless are what sit between you and improvising over Strasbourg."),
+            why: "Shells and rootless are what sit between you and improvising over Strasbourg.",
+            addedByYou: false),
           PlannedBlockView(
             drillTitle: "Strasbourg / St. Denis", section: "A section", kind: .piece, minutes: 10,
-            why: "The tune you are building towards."),
+            why: "The tune you are building towards.", addedByYou: false),
           PlannedBlockView(
             drillTitle: "Scales · D flat major", section: nil, kind: .exercise, minutes: 6,
-            why: "D flat is the key the head sits in."),
+            why: "D flat is the key the head sits in.", addedByYou: false),
           PlannedBlockView(
             drillTitle: "Clair de Lune", section: "Opening", kind: .piece, minutes: 6,
-            why: "Kept warm while the jazz work leads."),
+            why: "Kept warm while the jazz work leads.", addedByYou: false),
         ],
         totalMinutes: 30,
         deferred: [

--- a/ios/IntradaTests/BuiltSessionStoreTests.swift
+++ b/ios/IntradaTests/BuiltSessionStoreTests.swift
@@ -105,12 +105,50 @@ struct BuiltSessionStoreTests {
         Reflection(
           id: id, kind: kind, sessionRef: "01BUILT0000000000000000001",
           transcript: "The bridge still rushes", audioPath: "reflections/\(id).m4a",
-          durationS: 24, at: "2026-08-07T10:30:00Z",
+          durationS: 24, at: "2026-08-07T10:30:00Z", steer: .unoffered, steerAt: nil,
           updatedAt: "2026-08-07T10:30:00Z", deletedAt: nil))
     }
     let data = try store.loadBuiltSessionData()
     #expect(data.reflections.count == 2)
     #expect(data.reflections.map(\.kind) == [.voiceNote, .sessionClose])
+  }
+
+  @Test func reflectionRoundTripsForEverySteerState() throws {
+    let store = try LibraryStore.inMemory()
+    let states: [(String, SteerState)] = [
+      ("r1", .unoffered), ("r2", .accepted), ("r3", .declined),
+    ]
+    for (id, steer) in states {
+      try store.saveReflection(
+        Reflection(
+          id: id, kind: .sessionClose, sessionRef: nil,
+          transcript: "The bridge still rushes", audioPath: nil,
+          durationS: 24, at: "2026-08-07T22:00:00Z", steer: steer,
+          steerAt: steer == .unoffered ? nil : "2026-08-08T09:00:00Z",
+          updatedAt: "2026-08-08T09:00:00Z", deletedAt: nil))
+    }
+    let data = try store.loadBuiltSessionData()
+    #expect(data.reflections.map(\.steer) == [.unoffered, .accepted, .declined])
+    #expect(data.reflections[1].steerAt == "2026-08-08T09:00:00Z")
+  }
+
+  /// #1256 Phase D, v15. A reflection written before the morning card existed
+  /// was never offered a steer, and must not arrive as one on upgrade.
+  @Test func reflectionsFromBeforeTheSteerColumnUpgradeAsUnoffered() throws {
+    let store = try LibraryStore.upgradeTestStore(
+      migratedTo: "v14_unmonitored_play",
+      seed: """
+        INSERT INTO reflection
+          (id, kind, session_ref, transcript, audio_path, duration_s, at, updated_at, deleted_at)
+        VALUES ('01REFLECTION00000000000001', 'session_close', NULL,
+          'The bridge still rushes', 'reflections/r1.m4a', 24,
+          '2026-07-01T22:00:00Z', '2026-07-01T22:00:00Z', NULL);
+        """)
+    let data = try store.loadBuiltSessionData()
+    #expect(data.reflections.count == 1, "the historic reflection survives the upgrade")
+    #expect(data.reflections[0].transcript == "The bridge still rushes")
+    #expect(data.reflections[0].steer == .unoffered)
+    #expect(data.reflections[0].steerAt == nil)
   }
 
   // ── #1269: an unreadable value quarantines its row ──────────────────

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -1,6 +1,6 @@
 # Built session, play-through altitudes, and qualitative capture
 
-**Status**: Phase C landed (Journey B end to end); Phase D next ·
+**Status**: Phase D core landed (Journey C's rules); D-screens next ·
 **Issue**: #1256 · **Tier**: 3
 **Design**: `specs/built-session/design/` (Built Session A/B/C mockups) ·
 briefs in `design/briefs/2026-08-built-session-journeys.md` (journeys) and
@@ -113,6 +113,9 @@ system together; no hand-rolled clones.
   back of Phase B landing 4,300 insertions in one PR with both self-review
   blockers in core code written in the first third.
 - **D**: Journey C (feel moments, reflection at close, morning proposal).
+  **Ships as two PRs** like C: D-core (the feel budget, the close offer, the
+  rule-based steer and its migration) is reviewed first, D-screens follows
+  against a settled contract.
 
 Each phase is its own PR; every screen ships with snapshots, VoiceOver labels,
 Dynamic Type and iPad SplitView per the per-screen quality rule.
@@ -155,7 +158,26 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    no column for a piece cannot be made to name one. The rows are write-only,
    as wanders already are — nothing reads them back, because reading them into
    anything is the inference decision 16 forbids.
-8. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
+8. **The feel question follows `BlockOrigin`, and the reflection follows the
+   altitude** (Phase D). C1 is asked only where a block closed on the
+   judgement track, never alongside GateDots, and never after two misses in
+   that block — one question per block, and the budget shrinks on a bad day.
+   C2 is offered once as a session closes and never after unmonitored play,
+   whose promptless exit is the whole of what "minutes only" agreed to, nor
+   after off-piste, which has already asked twice on the way out.
+
+   Both prompts live on the `Model`, not on `EngineSession`. A prompt lost to
+   a crash costs nothing — the record it follows is already written — and a
+   field anywhere in the crash-recovery graph costs every device its blob.
+
+9. **An accepted steer is one column, not a banked block** (Phase D). The
+   reflection carries `steer` and `steer_at`; the block is re-derived from
+   them each time a plan is made, and rides for twenty-four hours from the
+   accept. A block held only in memory would be lost by the relaunch that
+   remakes the plan, while the answered column would stop it ever being
+   proposed again — losing the steer silently, which is the #846 class.
+
+10. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
    It rides the spec *and* the record, because the mastery track is rebuilt
    from records at launch: a decision-17 rule the live path enforces and the
    replay does not is not a rule (the #1214 class).
@@ -190,5 +212,21 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    never reads them, and a tombstoned row leaves its file for the shell to
    reap. A size cap and the reaping pass are deferred to Phase D, when there
    is recorded audio to cap (#1267).
-3. C3's v1 trigger (rule-based vs deferred to coach Phase 3): decide at
-   Phase D, informed by what reflections actually look like by then.
+3. ~~C3's v1 trigger (rule-based vs deferred to coach Phase 3)?~~ **Resolved in
+   Phase D: rule-based, and deliberately timid.** The most recent unanswered
+   session-close reflection between six and forty-eight hours old is scanned
+   sentence by sentence; the first sentence naming exactly one thing the
+   library can resolve — a user drill, a journal target, a piece, or a chart
+   section label — is quoted back verbatim with one eight-minute offer.
+
+   The three thresholds each buy something. Six hours stops the app quoting
+   someone back to themselves the same evening, which reads as strange rather
+   than attentive. Forty-eight hours is the outer edge of "last night".
+   **Exactly one** is the important one: an ambiguous name proposes nothing,
+   because a wrong quote-back is worse than no card at all — the whole
+   affordance rests on the user recognising their own words and the app
+   having understood them.
+
+   **The known cost**: a reflection whose target the library cannot name never
+   returns, however useful it was. That is the LLM's job in coach Phase 3, and
+   the rules here are the floor it replaces, not a design it has to keep.

--- a/specs/built-session.md
+++ b/specs/built-session.md
@@ -177,6 +177,15 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    remakes the plan, while the answered column would stop it ever being
    proposed again — losing the steer silently, which is the #846 class.
 
+   **Accepting also places the block there and then**, in the same handler,
+   rather than waiting for the next planning run. The Practice screen asks for
+   a plan only when it has none, so a steer that waited would leave the card up
+   over an unchanged plan for the rest of the app run — and neither of the two
+   halves the C3 frame shows at once would be true. The re-derivation on each
+   plan is what survives a relaunch; the immediate placement is what makes the
+   accept mean something. Placing the same steer twice is refused by node, and
+   in a running session it goes after the block in flight, never before it.
+
 10. **Judgement-track blocks are enforced by `BlockOrigin`, not by convention.**
    It rides the spec *and* the record, because the mastery track is rebuilt
    from records at launch: a decision-17 rule the live path enforces and the
@@ -214,14 +223,22 @@ Dynamic Type and iPad SplitView per the per-screen quality rule.
    is recorded audio to cap (#1267).
 3. ~~C3's v1 trigger (rule-based vs deferred to coach Phase 3)?~~ **Resolved in
    Phase D: rule-based, and deliberately timid.** The most recent unanswered
-   session-close reflection between six and forty-eight hours old is scanned
+   session-close reflection between six and twenty hours old is scanned
    sentence by sentence; the first sentence naming exactly one thing the
    library can resolve — a user drill, a journal target, a piece, or a chart
    section label — is quoted back verbatim with one eight-minute offer.
 
-   The three thresholds each buy something. Six hours stops the app quoting
-   someone back to themselves the same evening, which reads as strange rather
-   than attentive. Forty-eight hours is the outer edge of "last night".
+   The thresholds each buy something. Six hours stops the app quoting someone
+   back to themselves the same evening, which reads as strange rather than
+   attentive; twenty is the outer edge of a card that says "last night", and
+   the reason the scan never falls through to the reflection behind an
+   unresolvable one. Names below three characters never match, because charts
+   are routinely labelled `[A]` and "a" is the commonest word in English — a
+   floor is what stops "It was a good session" proposing the piece with an A
+   section. A quote longer than thirty words is declined rather than shown,
+   because dictation often returns a whole reflection with no full stop in it
+   and the card is designed around one short thought.
+
    **Exactly one** is the important one: an ambiguous name proposes nothing,
    because a wrong quote-back is worse than no card at all — the whole
    affordance rests on the user recognising their own words and the app


### PR DESCRIPTION
Phase D's **core only** for #1256, per CLAUDE.md's core-then-screens rule. No UI: the feel moment, the reflection sheet and the morning proposed-steer card ship in their own PR against this contract.

Closes nothing on its own — #1256 stays open for Phase D's screens.

## What lands

**C1, the feel moment.** Asked only where a block closed on the judgement track — a gated block ends with its GateDots, and asking both would spend two of the one interruption a block gets — and never after two misses in that block, because the budget shrinks on a bad day. One per block, ever: a second `RecordFeel` for the same block writes nothing, so a shell that asked twice still records one.

**C2, the reflection at close.** Offered once as a session closes, and never after unmonitored play, whose promptless exit is the whole of what "minutes only" agreed to, nor after off-piste, which already asked twice on the way out. "Not tonight" clears it with no follow-up. `AttachTranscript` lets an opportunistic transcript reach its row later, so keeping the audio never waits on transcription, and it will not write to a row the user has since deleted.

**C3, the morning proposed steer.** The most recent unanswered reflection between six and twenty hours old is scanned sentence by sentence; the first sentence naming exactly one thing the library can resolve is quoted back verbatim with one eight-minute offer. Accepting takes the card down and puts the block in today's plan **now**, second in the order, marked `added_by_you`; declining leaves no trace beyond never asking again.

Both prompts live on the `Model`, deliberately outside the crash-recovery blob: the record a prompt follows is already written, so losing one to a crash costs nothing, while a field anywhere in `EngineSession`'s graph would cost every device its blob.

## Open question 3, resolved

**C3 ships rule-based** (`specs/built-session.md` updated). Everything about it is timid on purpose, because a wrong quote-back is worse than no card — the affordance rests entirely on the user recognising their own words and the app having understood them:

- an ambiguous name proposes nothing (two pieces with a `[Bridge]` is not an answer);
- names below three characters never match, because charts are routinely labelled `[A]` and "a" is the commonest word in English;
- a quote over thirty words is declined, because dictation regularly returns a whole reflection with no full stop in it;
- the scan never falls through to an older reflection, since the card says "last night".

The narrated version is Phase 3 of the coach roadmap; #1310 records what these rules cannot reach.

## Schema

GRDB **v15**: `reflection.steer` (`NOT NULL DEFAULT 'unoffered'`) and `reflection.steer_at`. Additive, append-only, with an upgrade-path test that seeds at v14 and migrates forward with the row intact. `'unoffered'` is the honest backfill and is also what stops a reflection from last month arriving as this morning's steer on upgrade.

## Self-review

Ran through the code-reviewer subagent. It found **two Critical defects in the C3 contract**, both fixed in d4ee929 before this PR opened:

1. **Accepting inserted nothing.** The block waited for the next planning run, but `PracticeScreen.planToday()` asks for a plan only when it has none — so the card stayed up over an unchanged plan for the rest of the app run, and neither half of the contract the C3 frame shows was true. Neither workaround available to the screens PR respects the state boundary. The accept now places the block itself; the re-derivation on each plan stays, because that is what survives a relaunch.
2. **"It was a good session" proposed a piece.** The `[A]` section label normalised to "a". Fixed by the three-character floor above.

Also from the review: both planning doors refresh the steer (`StartPlannedSession` from `Idle` plans and starts in one step and would otherwise lose it); `place_steer` takes a running session, inserting after the block in flight rather than at or below `spec_index`, which would silently re-aim it; `accepted` drops its lower time bound so a core-stamped accept read against a marginally earlier shell clock cannot lose the block; the feel question is skipped rather than headlined over a blank; `title_of` loses two branches with no reader; three doc comments that stated invariants the code did not hold are corrected.

Every fix has a test that fails when its line is broken — I mutation-tested the accept path, both planning doors, the duplicate refusal, the matcher floor and the two consent guards, after finding that two of the first-cut tests passed for the wrong reason.

## Testing

- A table of sentences a musician would actually dictate, asserting the property the card rests on: every proposal names something the sentence was really about, and the rest propose nothing. Both matcher rules fail it when removed. (CLAUDE.md's parser rule, off the back of this feature's own criterion parser.)
- Journey C end to end through the real events: a judgement block closing owes the feel question and names it in the user's words; a session that ran something is asked to reflect; just-play ends with no question of any kind.
- Round-trips for `FeelPrompt`, `ProposedSteer` and all three `SteerState` values, plus the Swift codec per state and the v15 upgrade path.
- 932 core tests, `just check` green, `just ios-fmt-check` and `just ios-test-full` green.

## Coverage

Expect high patch coverage on `capture.rs`, `steer.rs` and the new handlers. Expected gaps: `LibraryStore.swift` is in Codecov's ignore list (`ios/`), and the two view-projection lines in `built_view` have no assertion beyond the journey tests reading them back.

## Not in this PR

The screens, and with them anything needing audio: C2's mic waits on the capture effect #1304 asks for.

Deferred items tracked: #1309, #1310, #1311, #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)