### PR TITLE
fix(core,ios): the cold test turns the day over where the user is (#1221)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -391,7 +391,7 @@ impl Intrada {
                 // session is not a door — Journey A's list is already theirs.
                 match coach_event {
                     CoachEvent::PlanSession { now, .. }
-                    | CoachEvent::StartPlannedSession { now } => refresh_steer(model, now),
+                    | CoachEvent::StartPlannedSession { now, .. } => refresh_steer(model, now),
                     _ => {}
                 }
                 let mut commands = coach_write_commands(model, writes);
@@ -5500,6 +5500,7 @@ mod tests {
                 Event::Coach(CoachEvent::PlanSession {
                     now: at(),
                     available_minutes: Some(40),
+                    utc_offset_minutes: 0,
                 }),
                 model,
             );
@@ -5599,7 +5600,10 @@ mod tests {
             assert_eq!(steer_blocks(&model), 1, "the plan carries it");
 
             let _ = app.update(
-                Event::Coach(CoachEvent::StartPlannedSession { now: at() }),
+                Event::Coach(CoachEvent::StartPlannedSession {
+                    now: at(),
+                    utc_offset_minutes: 0,
+                }),
                 &mut model,
             );
             assert_eq!(
@@ -5619,7 +5623,10 @@ mod tests {
             model.reflections.push(accepted_reflection());
 
             let _ = app.update(
-                Event::Coach(CoachEvent::StartPlannedSession { now: at() }),
+                Event::Coach(CoachEvent::StartPlannedSession {
+                    now: at(),
+                    utc_offset_minutes: 0,
+                }),
                 &mut model,
             );
             assert_eq!(
@@ -5861,6 +5868,7 @@ mod tests {
                 Event::Coach(CoachEvent::PlanSession {
                     now: at(),
                     available_minutes: Some(40),
+                    utc_offset_minutes: 0,
                 }),
                 &mut model,
             );

--- a/crates/intrada-core/src/engine/coach.rs
+++ b/crates/intrada-core/src/engine/coach.rs
@@ -26,6 +26,9 @@ use crate::domain::item::ItemKind;
 pub struct CoachState {
     pub session: EngineSession,
     pub mastery: MasteryStore,
+    /// Last reported by the shell on `PlanSession` (#1221). Off
+    /// `EngineSession` so it costs no blob: the next plan re-supplies it.
+    pub utc_offset_minutes: i32,
 }
 
 impl Default for CoachState {
@@ -33,6 +36,7 @@ impl Default for CoachState {
         Self {
             session: EngineSession::default(),
             mastery: MasteryStore::seeded_from(ContentIndex::shipped()),
+            utc_offset_minutes: 0,
         }
     }
 }
@@ -52,6 +56,11 @@ pub enum SteerPlacement {
 
 impl CoachState {
     pub fn apply(&mut self, event: &CoachEvent) -> CoachWrites {
+        // Every door that can open a session reports it, so skipping the
+        // preview cannot silently put the cold test back on UTC (#1221).
+        if let Some(offset) = reported_offset(event) {
+            self.utc_offset_minutes = offset;
+        }
         self.mark_cold(event);
         let planned = self.plan_for(event);
         let writes = self.session.apply_with_plan(event, planned);
@@ -80,8 +89,13 @@ impl CoachState {
         // Clearing to `Idle` is what makes the machine take the plan it is
         // handed rather than the prescribed one it made for itself.
         self.session.state = SessionState::Idle;
-        self.session
-            .apply_with_plan(&CoachEvent::StartPlannedSession { now }, Some(plan))
+        self.session.apply_with_plan(
+            &CoachEvent::StartPlannedSession {
+                now,
+                utc_offset_minutes: self.utc_offset_minutes,
+            },
+            Some(plan),
+        )
     }
 
     /// Place C3's accepted steer in today's plan (#1256 Phase D): one block
@@ -191,8 +205,9 @@ impl CoachState {
             CoachEvent::PlanSession {
                 now,
                 available_minutes,
+                ..
             } => (*now, *available_minutes),
-            CoachEvent::StartPlannedSession { now } => (*now, None),
+            CoachEvent::StartPlannedSession { now, .. } => (*now, None),
             _ => return None,
         };
         let content = ContentIndex::shipped();
@@ -218,7 +233,9 @@ impl CoachState {
         else {
             return;
         };
-        let cold = self.mastery.is_cold(&node, level, now);
+        let cold = self
+            .mastery
+            .is_cold(&node, level, now, self.utc_offset_minutes);
         self.session.mark_cold(cold);
     }
 
@@ -379,6 +396,21 @@ enum Replay {
 /// live path and the launch replay, so decision 17 cannot hold in one and not
 /// the other — and so it rests on `BlockOrigin` rather than on a judgement
 /// node's id happening to be unknown to the content.
+fn reported_offset(event: &CoachEvent) -> Option<i32> {
+    match event {
+        CoachEvent::PlanSession {
+            utc_offset_minutes, ..
+        }
+        | CoachEvent::StartPlannedSession {
+            utc_offset_minutes, ..
+        }
+        | CoachEvent::RecoverSession {
+            utc_offset_minutes, ..
+        } => Some(*utc_offset_minutes),
+        _ => None,
+    }
+}
+
 fn banked_passes(records: &[BlockRecord]) -> impl Iterator<Item = &BlockRecord> {
     records
         .iter()
@@ -925,6 +957,7 @@ mod tests {
         coach.apply(&CoachEvent::PlanSession {
             now: at(0),
             available_minutes: Some(20),
+            utc_offset_minutes: 0,
         });
         coach
     }
@@ -957,7 +990,10 @@ mod tests {
             .drill_title
             .clone();
 
-        coach.apply(&CoachEvent::StartPlannedSession { now: at(1) });
+        coach.apply(&CoachEvent::StartPlannedSession {
+            now: at(1),
+            utc_offset_minutes: 0,
+        });
 
         let drill = coach.view().drill.expect("a running drill");
         assert_eq!(
@@ -978,6 +1014,7 @@ mod tests {
         let writes = coach.apply(&CoachEvent::PlanSession {
             now: at(0),
             available_minutes: Some(20),
+            utc_offset_minutes: 0,
         });
 
         assert_eq!(
@@ -996,6 +1033,7 @@ mod tests {
         let planning = coach.apply(&CoachEvent::PlanSession {
             now: at(0),
             available_minutes: Some(20),
+            utc_offset_minutes: 0,
         });
 
         // The shell's rule (DrillLoopHost.run): a blob means recover, no blob
@@ -1005,9 +1043,13 @@ mod tests {
             coach.apply(&CoachEvent::RecoverSession {
                 session: blob,
                 now: at(1),
+                utc_offset_minutes: 0,
             });
         } else {
-            coach.apply(&CoachEvent::StartPlannedSession { now: at(1) });
+            coach.apply(&CoachEvent::StartPlannedSession {
+                now: at(1),
+                utc_offset_minutes: 0,
+            });
         }
 
         assert!(
@@ -1020,7 +1062,10 @@ mod tests {
     #[test]
     fn a_block_in_flight_is_still_saved_for_crash_recovery() {
         let mut coach = CoachState::default();
-        let writes = coach.apply(&CoachEvent::StartPlannedSession { now: at(0) });
+        let writes = coach.apply(&CoachEvent::StartPlannedSession {
+            now: at(0),
+            utc_offset_minutes: 0,
+        });
 
         assert_eq!(
             writes.snapshot,
@@ -1032,12 +1077,16 @@ mod tests {
     #[test]
     fn arriving_back_on_practice_leaves_the_block_in_flight_alone() {
         let mut coach = CoachState::default();
-        coach.apply(&CoachEvent::StartPlannedSession { now: at(0) });
+        coach.apply(&CoachEvent::StartPlannedSession {
+            now: at(0),
+            utc_offset_minutes: 0,
+        });
         let running = coach.view().drill.expect("a running drill").drill_title;
 
         let writes = coach.apply(&CoachEvent::PlanSession {
             now: at(5),
             available_minutes: Some(20),
+            utc_offset_minutes: 0,
         });
 
         assert_eq!(
@@ -1055,7 +1104,10 @@ mod tests {
     #[test]
     fn pressing_start_with_nothing_planned_plans_first() {
         let mut coach = CoachState::default();
-        coach.apply(&CoachEvent::StartPlannedSession { now: at(0) });
+        coach.apply(&CoachEvent::StartPlannedSession {
+            now: at(0),
+            utc_offset_minutes: 0,
+        });
 
         assert!(
             coach.view().drill.is_some(),
@@ -1069,6 +1121,7 @@ mod tests {
         coach.apply(&CoachEvent::PlanSession {
             now: at(0),
             available_minutes: None,
+            utc_offset_minutes: 0,
         });
 
         let plan = coach.view().plan.expect("a plan");
@@ -1090,8 +1143,12 @@ mod tests {
 
     /// One pass of the phrase, answered, from wherever the block has got to.
     fn tap(coach: &mut CoachState, clean: bool, second: i64) {
+        tap_at(coach, clean, at(second));
+    }
+
+    fn tap_at(coach: &mut CoachState, clean: bool, now: DateTime<Utc>) {
         if coach.session.phase() == Some(&Phase::BlockEntry) {
-            coach.apply(&CoachEvent::StartBlock { now: at(0) });
+            coach.apply(&CoachEvent::StartBlock { now });
         }
         if matches!(coach.session.phase(), Some(Phase::CountIn { .. })) {
             coach.apply(&CoachEvent::Beat { beat_index: 0 });
@@ -1102,10 +1159,7 @@ mod tests {
         coach.apply(&CoachEvent::Beat {
             beat_index: boundary,
         });
-        coach.apply(&CoachEvent::Tap {
-            clean,
-            now: at(second),
-        });
+        coach.apply(&CoachEvent::Tap { clean, now });
     }
 
     #[test]
@@ -1206,6 +1260,69 @@ mod tests {
         tap(&mut coach, true, 9);
 
         assert!(!coach.session.block().unwrap().attempts[0].cold);
+    }
+
+    /// Without the wiring the same instant reads as one warm evening (#1221).
+    #[test]
+    fn the_cold_test_turns_the_day_over_where_the_shell_says_the_user_is() {
+        let last_night = Utc.with_ymd_and_hms(2026, 8, 4, 21, 0, 0).unwrap();
+        // 00:30 local in BST, which UTC still calls the 4th.
+        let after_midnight = Utc.with_ymd_and_hms(2026, 8, 4, 23, 30, 0).unwrap();
+
+        let mut in_london = CoachState::default();
+        in_london
+            .mastery
+            .record("rootless-a-b", fixture_level(), Verdict::Clean, last_night);
+        in_london.apply(&CoachEvent::PlanSession {
+            now: after_midnight,
+            available_minutes: Some(20),
+            utc_offset_minutes: 60,
+        });
+        in_london.session.start_fixture(after_midnight);
+        tap_at(&mut in_london, true, after_midnight);
+
+        assert!(
+            in_london.session.block().unwrap().attempts[0].cold,
+            "half past midnight is a new day, and the first rep of it is cold"
+        );
+
+        let mut in_utc = CoachState::default();
+        in_utc
+            .mastery
+            .record("rootless-a-b", fixture_level(), Verdict::Clean, last_night);
+        in_utc.apply(&CoachEvent::PlanSession {
+            now: after_midnight,
+            available_minutes: Some(20),
+            utc_offset_minutes: 0,
+        });
+        in_utc.session.start_fixture(after_midnight);
+        tap_at(&mut in_utc, true, after_midnight);
+
+        assert!(
+            !in_utc.session.block().unwrap().attempts[0].cold,
+            "the same instant reported from UTC is still the same evening"
+        );
+    }
+
+    /// The no-preview door is documented as one a shell may use alone, so it
+    /// has to report the offset too or it silently puts #1221 back.
+    #[test]
+    fn starting_without_a_preview_still_decides_cold_on_the_users_day() {
+        let last_night = Utc.with_ymd_and_hms(2026, 8, 4, 21, 0, 0).unwrap();
+        let after_midnight = Utc.with_ymd_and_hms(2026, 8, 4, 23, 30, 0).unwrap();
+
+        let mut coach = CoachState::default();
+        coach
+            .mastery
+            .record("rootless-a-b", fixture_level(), Verdict::Clean, last_night);
+        coach.apply(&CoachEvent::StartPlannedSession {
+            now: after_midnight,
+            utc_offset_minutes: 60,
+        });
+        coach.session.start_fixture(after_midnight);
+        tap_at(&mut coach, true, after_midnight);
+
+        assert!(coach.session.block().unwrap().attempts[0].cold);
     }
 
     fn next_rung() -> ParameterLevel {
@@ -1452,8 +1569,12 @@ mod tests {
             CoachEvent::PlanSession {
                 now: at(0),
                 available_minutes: Some(20),
+                utc_offset_minutes: -330,
             },
-            CoachEvent::StartPlannedSession { now: at(0) },
+            CoachEvent::StartPlannedSession {
+                now: at(0),
+                utc_offset_minutes: -330,
+            },
             CoachEvent::CountInBeat { remaining: 3 },
             CoachEvent::Beat { beat_index: 12 },
             CoachEvent::Tap {
@@ -1498,11 +1619,15 @@ mod tests {
     #[test]
     fn a_recovered_session_carries_the_whole_plan_across_the_wire() {
         let mut coach = press_start_preview();
-        coach.apply(&CoachEvent::StartPlannedSession { now: at(1) });
+        coach.apply(&CoachEvent::StartPlannedSession {
+            now: at(1),
+            utc_offset_minutes: 0,
+        });
 
         assert_round_trips(crate::app::Event::Coach(CoachEvent::RecoverSession {
             session: coach.session.clone(),
             now: at(2),
+            utc_offset_minutes: 0,
         }));
     }
 
@@ -1590,6 +1715,7 @@ mod tests {
         assert_round_trips(crate::app::Event::Coach(CoachEvent::RecoverSession {
             session: coach.session.clone(),
             now: at(30),
+            utc_offset_minutes: 0,
         }));
     }
 }

--- a/crates/intrada-core/src/engine/mastery.rs
+++ b/crates/intrada-core/src/engine/mastery.rs
@@ -8,7 +8,7 @@
 
 use std::collections::BTreeMap;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::content::{Band, ContentIndex};
@@ -251,11 +251,28 @@ impl MasteryStore {
 
     /// First rep of the day on returning material (spec §2), which is the
     /// highest-information tap-verdict there is.
-    pub fn is_cold(&self, node: &str, level: ParameterLevel, now: DateTime<Utc>) -> bool {
+    /// `utc_offset_minutes` is where the user is: midnight UTC is the wrong
+    /// hour to turn the day over for anyone practising in the evening (#1221).
+    pub fn is_cold(
+        &self,
+        node: &str,
+        level: ParameterLevel,
+        now: DateTime<Utc>,
+        utc_offset_minutes: i32,
+    ) -> bool {
+        let local = local_offset(utc_offset_minutes);
         self.get(node, level)
             .and_then(|mastery| mastery.last_attempt_at)
-            .is_some_and(|last| last.date_naive() < now.date_naive())
+            .is_some_and(|last| {
+                last.with_timezone(&local).date_naive() < now.with_timezone(&local).date_naive()
+            })
     }
+}
+
+/// Real offsets run from UTC-12 to UTC+14. `FixedOffset` would accept a great
+/// deal more, and a date built from that is wrong rather than refused.
+fn local_offset(minutes: i32) -> FixedOffset {
+    FixedOffset::east_opt(minutes.clamp(-12 * 60, 14 * 60) * 60).expect("clamped to a real offset")
 }
 
 fn band_strength(band: Band) -> f32 {
@@ -735,11 +752,104 @@ mod tests {
         let mut store = MasteryStore::default();
         store.record("rootless-a-b", level(60), Verdict::Clean, at(0));
 
-        assert!(store.is_cold("rootless-a-b", level(60), at(1)));
+        assert!(store.is_cold("rootless-a-b", level(60), at(1), 0));
         assert!(
-            !store.is_cold("rootless-a-b", level(60), at(0) + TimeDelta::hours(2)),
+            !store.is_cold("rootless-a-b", level(60), at(0) + TimeDelta::hours(2), 0),
             "a second block the same day is warm"
         );
+    }
+
+    /// In BST, 00:30 local is 23:30 the previous day in UTC, so a new day's
+    /// first rep was recorded warm (#1221).
+    #[test]
+    fn the_day_boundary_is_the_users_midnight_not_utcs() {
+        let mut store = MasteryStore::default();
+        let bst = 60;
+        // 22:00 on the 4th, where the user is.
+        let last_night = Utc.with_ymd_and_hms(2026, 8, 4, 21, 0, 0).unwrap();
+        store.record("rootless-a-b", level(60), Verdict::Clean, last_night);
+
+        assert!(
+            store.is_cold(
+                "rootless-a-b",
+                level(60),
+                Utc.with_ymd_and_hms(2026, 8, 4, 23, 30, 0).unwrap(),
+                bst
+            ),
+            "00:30 local is a new day where the user is"
+        );
+        assert!(
+            !store.is_cold(
+                "rootless-a-b",
+                level(60),
+                Utc.with_ymd_and_hms(2026, 8, 4, 22, 0, 0).unwrap(),
+                bst
+            ),
+            "23:00 local is still the same evening"
+        );
+        assert!(
+            !store.is_cold(
+                "rootless-a-b",
+                level(60),
+                Utc.with_ymd_and_hms(2026, 8, 5, 3, 0, 0).unwrap(),
+                -5 * 60
+            ),
+            "and in New York the pair straddle no boundary at all"
+        );
+    }
+
+    /// UTC+13 puts midnight UTC at 1pm local, so an afternoon session reads as
+    /// a new day from a morning one and two evening sessions read as one.
+    #[test]
+    fn a_far_eastern_offset_moves_the_boundary_the_whole_way() {
+        let mut store = MasteryStore::default();
+        let auckland = 13 * 60;
+        // 09:00 on the 5th local, which is 20:00 on the 4th in UTC.
+        let morning = Utc.with_ymd_and_hms(2026, 8, 4, 20, 0, 0).unwrap();
+        store.record("rootless-a-b", level(60), Verdict::Clean, morning);
+
+        assert!(
+            !store.is_cold(
+                "rootless-a-b",
+                level(60),
+                // 15:00 the same local day, which UTC calls the 5th.
+                Utc.with_ymd_and_hms(2026, 8, 5, 2, 0, 0).unwrap(),
+                auckland
+            ),
+            "the afternoon of the same local day is warm"
+        );
+        assert!(
+            store.is_cold(
+                "rootless-a-b",
+                level(60),
+                // 09:00 the next local day.
+                Utc.with_ymd_and_hms(2026, 8, 5, 20, 0, 0).unwrap(),
+                auckland
+            ),
+            "and the next local morning is cold"
+        );
+    }
+
+    /// `FixedOffset` accepts anything under 24 hours, so without the clamp a
+    /// nonsense offset builds a real date on the wrong day.
+    #[test]
+    fn an_impossible_offset_is_clamped_to_the_furthest_real_one() {
+        let mut store = MasteryStore::default();
+        store.record(
+            "rootless-a-b",
+            level(60),
+            Verdict::Clean,
+            Utc.with_ymd_and_hms(2026, 8, 4, 9, 0, 0).unwrap(),
+        );
+
+        // Clamped to +14:00 the day has turned over (23:00 then 00:00); at the
+        // +20:00 asked for it has not (05:00 then 06:00).
+        assert!(store.is_cold(
+            "rootless-a-b",
+            level(60),
+            Utc.with_ymd_and_hms(2026, 8, 4, 10, 0, 0).unwrap(),
+            20 * 60
+        ));
     }
 
     #[test]
@@ -747,7 +857,7 @@ mod tests {
         let store = MasteryStore::seeded_from(ContentIndex::shipped());
 
         assert!(
-            !store.is_cold("rootless-a-b", level(60), at(400)),
+            !store.is_cold("rootless-a-b", level(60), at(400), 0),
             "a cold test is a test of what came back, and this has not been away"
         );
     }

--- a/crates/intrada-core/src/engine/session.rs
+++ b/crates/intrada-core/src/engine/session.rs
@@ -29,11 +29,16 @@ pub enum CoachEvent {
     PlanSession {
         now: DateTime<Utc>,
         available_minutes: Option<u16>,
+        /// Minutes east of UTC. Without it the cold test turns the day over
+        /// at midnight UTC, in the middle of an evening's practice (#1221).
+        utc_offset_minutes: i32,
     },
     /// Run the plan already made. From `Idle` this plans today's session first,
-    /// so a shell that wants no preview can send this alone.
+    /// so a shell that wants no preview can send this alone. Which is why it
+    /// carries the offset too: skipping `PlanSession` must not skip #1221.
     StartPlannedSession {
         now: DateTime<Utc>,
+        utc_offset_minutes: i32,
     },
     /// One count-in click, reported as it sounds; `remaining` is beats left
     /// *after* this one, counting down to 0 on the last click (#1184).
@@ -131,6 +136,7 @@ pub enum CoachEvent {
     RecoverSession {
         session: EngineSession,
         now: DateTime<Utc>,
+        utc_offset_minutes: i32,
     },
 }
 
@@ -838,7 +844,7 @@ impl EngineSession {
                     }
                 }
             }
-            CoachEvent::StartPlannedSession { now } => match std::mem::take(&mut self.state) {
+            CoachEvent::StartPlannedSession { now, .. } => match std::mem::take(&mut self.state) {
                 SessionState::Planned { plan } => self.start(plan, *now),
                 SessionState::Idle | SessionState::Closing => {
                     if let Some(plan) = planned {
@@ -877,7 +883,7 @@ impl EngineSession {
                 }
             }
             CoachEvent::CloseSession { now } => return self.close_session(*now),
-            CoachEvent::RecoverSession { session, now } => self.recover(session.clone(), *now),
+            CoachEvent::RecoverSession { session, now, .. } => self.recover(session.clone(), *now),
         }
         Applied::default()
     }
@@ -887,7 +893,7 @@ impl EngineSession {
     pub fn now_of(event: &CoachEvent) -> Option<DateTime<Utc>> {
         match event {
             CoachEvent::PlanSession { now, .. }
-            | CoachEvent::StartPlannedSession { now }
+            | CoachEvent::StartPlannedSession { now, .. }
             | CoachEvent::Tap { now, .. }
             | CoachEvent::StartBlock { now }
             | CoachEvent::SkipBlock { now }
@@ -1938,6 +1944,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
 
         assert_eq!(
@@ -2167,6 +2174,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(9000),
+            utc_offset_minutes: 0,
         });
 
         let block = restored.block().expect("the block came back");
@@ -2457,7 +2465,10 @@ mod tests {
         let mut session = EngineSession::default();
         let content = ContentIndex::shipped();
         session.apply_with_plan(
-            &CoachEvent::StartPlannedSession { now: at(0) },
+            &CoachEvent::StartPlannedSession {
+                now: at(0),
+                utc_offset_minutes: 0,
+            },
             Some(crate::engine::plan::plan(
                 &crate::engine::coach::CoachState::default(),
                 crate::engine::plan::PlanContext {
@@ -2692,6 +2703,7 @@ mod tests {
             &CoachEvent::PlanSession {
                 now: at(5),
                 available_minutes: Some(20),
+                utc_offset_minutes: 0,
             },
             Some(Plan::fixture()),
         );
@@ -3156,6 +3168,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
 
         let block = restored.block().expect("the block came back");
@@ -3182,6 +3195,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
 
         let block = restored.block().expect("the block came back");
@@ -3205,6 +3219,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
         restored.apply(&CoachEvent::CountInBeat { remaining: 0 });
         restored.apply(&CoachEvent::Beat { beat_index: 0 });
@@ -3230,6 +3245,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
         assert_eq!(restored.phase(), Some(&Phase::GateOpen));
 
@@ -3254,6 +3270,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(4000),
+            utc_offset_minutes: 0,
         });
         restored.apply(&CoachEvent::CloseSession { now: at(4100) });
 
@@ -3277,6 +3294,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3000),
+            utc_offset_minutes: 0,
         });
         let writes = restored.apply(&CoachEvent::CloseSession { now: at(3000) });
 
@@ -3301,6 +3319,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(9000),
+            utc_offset_minutes: 0,
         });
         restored.apply(&CoachEvent::CloseSession { now: at(9060) });
 
@@ -3346,6 +3365,7 @@ mod tests {
         let writes = live.apply(&CoachEvent::RecoverSession {
             session: EngineSession::default(),
             now: at(3600),
+            utc_offset_minutes: 0,
         });
         assert!(writes.blocks.is_empty(), "an empty blob closed nothing");
     }
@@ -3360,6 +3380,7 @@ mod tests {
         let writes = restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
         assert_eq!(
             writes.blocks.len(),
@@ -3677,6 +3698,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
 
         assert_eq!(
@@ -3941,6 +3963,7 @@ mod tests {
         restored.apply(&CoachEvent::RecoverSession {
             session: crashed,
             now: at(3600),
+            utc_offset_minutes: 0,
         });
 
         assert_eq!(

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -723,7 +723,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             for second in [9, 18, 27] {
                 rep(&app, &mut model, true, second);
@@ -750,7 +753,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             play_to_the_boundary(&app, &mut model);
 
@@ -780,7 +786,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             play_to_the_boundary(&app, &mut model);
             let mut cmd = send(
@@ -808,7 +817,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             let mut cmd = send(&app, &mut model, CoachEvent::LeaveSession { now: at(20) });
 
@@ -825,7 +837,14 @@ mod tests {
         /// Runs the first block to its gate and past the hold, so a record has
         /// been offered to the store and the retry has something to hold.
         fn close_a_block(app: &Intrada, model: &mut Model) {
-            let _ = send(app, model, CoachEvent::StartPlannedSession { now: at(0) });
+            let _ = send(
+                app,
+                model,
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
+            );
             rep(app, model, true, 9);
             let _ = send(app, model, CoachEvent::Tick { now: at(30) });
         }
@@ -920,7 +939,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             play_to_the_boundary(&app, &mut model);
             let _ = send(
@@ -940,6 +962,7 @@ mod tests {
                 CoachEvent::RecoverSession {
                     session: crashed,
                     now: at(3600),
+                    utc_offset_minutes: 0,
                 },
             );
             let block = fresh.coach.session.block().expect("the block came back");
@@ -951,7 +974,14 @@ mod tests {
 
         /// Run a session far enough to close one block, and keep what it wrote.
         fn recorded_blocks(app: &Intrada, model: &mut Model) -> Vec<BlockRecord> {
-            let _ = send(app, model, CoachEvent::StartPlannedSession { now: at(0) });
+            let _ = send(
+                app,
+                model,
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
+            );
             rep(app, model, true, 9);
             let mut cmd = send(app, model, CoachEvent::Tick { now: at(30) });
             coach_records(&mut cmd).expect("a SaveCoachRecords op")
@@ -997,7 +1027,8 @@ mod tests {
                 fresh.coach.mastery.is_cold(
                     &blocks[0].node,
                     blocks[0].level,
-                    at(30) + chrono::TimeDelta::days(1)
+                    at(30) + chrono::TimeDelta::days(1),
+                    0
                 ),
                 "so tomorrow's first rep is the cold test again (#1214's dead path)"
             );
@@ -1038,7 +1069,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             for second in [9, 18, 27] {
                 rep(&app, &mut model, true, second);
@@ -1087,7 +1121,10 @@ mod tests {
             let _ = send(
                 &app,
                 &mut model,
-                CoachEvent::StartPlannedSession { now: at(0) },
+                CoachEvent::StartPlannedSession {
+                    now: at(0),
+                    utc_offset_minutes: 0,
+                },
             );
             play_to_the_boundary(&app, &mut model);
             let _ = send(
@@ -1106,6 +1143,7 @@ mod tests {
             crate::domain::types::assert_round_trips(Event::Coach(CoachEvent::RecoverSession {
                 session,
                 now: at(3600),
+                utc_offset_minutes: -330,
             }));
         }
     }

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,9 +21,30 @@ tap-verdicts against countable criteria.
 ## In flight
 
 - #1143 — Phase 0 fortnight practising from `content/`
-- Evidence integrity, the rest of the sequence — #1221, #1286
+- Evidence integrity, the rest of the sequence — #1286
 
 ## Recently landed
+
+- #1221 — the cold test turns the day over where the user is. "First rep of the
+  day on returning material" compared UTC calendar days, so in British summer
+  time the boundary sat at 01:00 local and a session starting at 00:30 was
+  recorded warm; at UTC+13 it lands at 1pm, splitting an afternoon from a
+  morning and joining two evenings either side of local midnight. Evening
+  practice is the normal case, which puts the boundary exactly where it bites.
+  Every event that can open a session now carries `utc_offset_minutes` from
+  the shell (`PlanSession`, `StartPlannedSession`, `RecoverSession`, fed by
+  `SessionClock.utcOffsetMinutes()`); `CoachState` holds the last one reported
+  and `is_cold` compares local dates. All three, not just `PlanSession`,
+  because the core documents the no-preview door as one a shell may use alone,
+  and a session opened through it would have decided cold on UTC. The offset
+  rides the events rather than a settings singleton so the core stays a
+  function of its inputs, and sits on `CoachState` rather than `EngineSession`
+  so it costs no crash-recovery blob. An offset outside UTC-12 to UTC+14
+  clamps: `FixedOffset` accepts anything under 24 hours, so a shell bug would
+  otherwise build a real date on the wrong day. Landed before 2b weights cold
+  attempts, per the issue: today the flag is recorded and unread, so nothing
+  was wrong for a user yet. Deferred with an issue: analytics still counts the
+  day in UTC, which is the same flaw where the user can see it (#1330).
 
 - #1291 — a recovered off-piste or unmonitored session keeps the minutes it
   played. `recover` reset `started_at = now` for the two ungated altitudes, so

--- a/ios/Intrada/Core/SessionClock.swift
+++ b/ios/Intrada/Core/SessionClock.swift
@@ -13,6 +13,13 @@ enum SessionClock {
     fractionalFormatter().string(from: date)
   }
 
+  /// Minutes east of UTC, for the core's cold test (#1221): the fact about
+  /// where the user is, never the verdict. `zone` is injectable because CI
+  /// runs in UTC, where a seconds-for-minutes slip would assert 0 == 0.
+  static func utcOffsetMinutes(_ date: Date = Date(), in zone: TimeZone = .current) -> Int32 {
+    Int32(zone.secondsFromGMT(for: date) / 60)
+  }
+
   /// `MM:SS` (or `H:MM:SS` past an hour) for the live count-up timer. Negative
   /// inputs clamp to zero.
   static func clockDisplay(_ seconds: Int) -> String {

--- a/ios/Intrada/Views/Screens/DrillLoopHost.swift
+++ b/ios/Intrada/Views/Screens/DrillLoopHost.swift
@@ -104,9 +104,16 @@ struct DrillLoopHost: View {
     // than starting fresh, or the evidence already banked is discarded (#1181).
     let now = SessionClock.nowRFC3339()
     if let crashed = store.pendingCoachSession() {
-      store.send(.coach(.recoverSession(session: crashed, now: now)))
+      store.send(
+        .coach(
+          .recoverSession(
+            session: crashed, now: now,
+            utcOffsetMinutes: SessionClock.utcOffsetMinutes())))
     } else {
-      store.send(.coach(.startPlannedSession(now: now)))
+      store.send(
+        .coach(
+          .startPlannedSession(
+            now: now, utcOffsetMinutes: SessionClock.utcOffsetMinutes())))
     }
     // No block came back — the core could not plan one, and has said why. Now
     // that press-start is a user path (#1182), holding a blank screen instead

--- a/ios/Intrada/Views/Screens/PracticeScreen.swift
+++ b/ios/Intrada/Views/Screens/PracticeScreen.swift
@@ -110,7 +110,11 @@ struct PracticeScreen: View {
   /// declaration surfaces that would ask are Phase 2b.
   private func planToday() {
     guard store.viewModel?.coach.plan == nil else { return }
-    store.send(.coach(.planSession(now: SessionClock.nowRFC3339(), availableMinutes: nil)))
+    store.send(
+      .coach(
+        .planSession(
+          now: SessionClock.nowRFC3339(), availableMinutes: nil,
+          utcOffsetMinutes: SessionClock.utcOffsetMinutes())))
   }
 
   // MARK: - (0) One-tap hero

--- a/ios/IntradaTests/SessionClockTests.swift
+++ b/ios/IntradaTests/SessionClockTests.swift
@@ -48,4 +48,26 @@ final class SessionClockTests: XCTestCase {
   func testNowRoundTrips() {
     assertSameSecond(SessionClock.parseRFC3339(SessionClock.nowRFC3339(expected)), "now round-trip")
   }
+
+  // Fixed zones, not `TimeZone.current`: CI runs in UTC, where an offset in
+  // seconds and one in minutes are both zero (#1221).
+  func testUTCOffsetIsReportedInMinutes() {
+    let kolkata = TimeZone(identifier: "Asia/Kolkata")!
+    XCTAssertEqual(
+      SessionClock.utcOffsetMinutes(expected, in: kolkata), 330,
+      "half-hour offsets are why this is minutes rather than hours")
+  }
+
+  // The offset is asked for an instant, not for now: DST makes them differ.
+  func testUTCOffsetFollowsTheInstantItIsAskedAbout() {
+    let newYork = TimeZone(identifier: "America/New_York")!
+    var winter = DateComponents()
+    (winter.year, winter.month, winter.day) = (2026, 1, 5)
+    (winter.hour, winter.minute) = (12, 0)
+    winter.timeZone = utc
+    let january = Calendar(identifier: .gregorian).date(from: winter)!
+
+    XCTAssertEqual(SessionClock.utcOffsetMinutes(expected, in: newYork), -240, "June is EDT")
+    XCTAssertEqual(SessionClock.utcOffsetMinutes(january, in: newYork), -300, "January is EST")
+  }
 }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -207,7 +207,8 @@ final class StoreEffectLoopTests: XCTestCase {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
     return try coachSession(
-      in: try bridge.update(.coach(.startPlannedSession(now: "2026-08-04T10:00:00Z"))))
+      in: try bridge.update(
+        .coach(.startPlannedSession(now: "2026-08-04T10:00:00Z", utcOffsetMinutes: 0))))
   }
 
   func testSaveCoachSessionEffectWritesBlobAndClearRemovesIt() throws {
@@ -247,7 +248,7 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().coach.drill, "a fresh core has no drill running")
 
     _ = try bridge.update(
-      .coach(.recoverSession(session: restored, now: "2026-08-04T11:00:00Z")))
+      .coach(.recoverSession(session: restored, now: "2026-08-04T11:00:00Z", utcOffsetMinutes: 0)))
 
     let drill = try XCTUnwrap(
       try bridge.view().coach.drill, "the recovered session must put the drill back on screen")
@@ -1102,7 +1103,11 @@ final class StoreEffectLoopTests: XCTestCase {
     let store = Store(bridge: LiveBridge(), session: mockSession(), sortDefaults: defaults)
     store.send(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
 
-    store.send(.coach(.planSession(now: SessionClock.nowRFC3339(), availableMinutes: nil)))
+    store.send(
+      .coach(
+        .planSession(
+          now: SessionClock.nowRFC3339(), availableMinutes: nil,
+          utcOffsetMinutes: SessionClock.utcOffsetMinutes())))
     XCTAssertNotNil(store.viewModel?.coach.plan, "the hero needs a plan to press start on")
     XCTAssertNil(
       store.pendingCoachSession(),
@@ -1111,9 +1116,9 @@ final class StoreEffectLoopTests: XCTestCase {
     // Verbatim the branch in DrillLoopHost.run().
     let now = SessionClock.nowRFC3339()
     if let crashed = store.pendingCoachSession() {
-      store.send(.coach(.recoverSession(session: crashed, now: now)))
+      store.send(.coach(.recoverSession(session: crashed, now: now, utcOffsetMinutes: 0)))
     } else {
-      store.send(.coach(.startPlannedSession(now: now)))
+      store.send(.coach(.startPlannedSession(now: now, utcOffsetMinutes: 0)))
     }
 
     XCTAssertNotNil(
@@ -1139,7 +1144,10 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().coach.plan, "no plan until one is asked for")
 
     _ = try bridge.update(
-      .coach(.planSession(now: SessionClock.nowRFC3339(), availableMinutes: nil)))
+      .coach(
+        .planSession(
+          now: SessionClock.nowRFC3339(), availableMinutes: nil,
+          utcOffsetMinutes: SessionClock.utcOffsetMinutes())))
     let plan = try XCTUnwrap(
       try bridge.view().coach.plan, "planning must reach the shell (#846)")
     let first = try XCTUnwrap(plan.blocks.first, "a plan press-start can run has a first block")
@@ -1147,7 +1155,8 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertFalse(first.why.isEmpty, "every block cites why it is here (spec §5)")
     XCTAssertGreaterThan(plan.totalMinutes, 0, "the hero promises a length")
 
-    _ = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    _ = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     XCTAssertNotNil(try bridge.view().coach.drill, "running the plan opens its first block")
     XCTAssertNil(try bridge.view().coach.plan, "the plan gives way once the block opens")
   }
@@ -1167,7 +1176,8 @@ final class StoreEffectLoopTests: XCTestCase {
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
     XCTAssertNil(try bridge.view().coach.drill, "no drill until one is started")
 
-    _ = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    _ = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     let card = try XCTUnwrap(try bridge.view().coach.drill)
     XCTAssertEqual(card.phase, .blockEntry, "a session opens on block 1's card (#1223)")
     XCTAssertFalse(card.pulseRunning, "the card is silent — nothing sounds until Start")
@@ -1233,7 +1243,8 @@ final class StoreEffectLoopTests: XCTestCase {
   func testRealBridgeOnlyATappedPassBanks() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
-    _ = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    _ = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     _ = try bridge.update(.coach(.startBlock(now: SessionClock.nowRFC3339())))
     let opening = try XCTUnwrap(try bridge.view().coach.drill)
     let phrase = opening.phraseBeats
@@ -1264,7 +1275,8 @@ final class StoreEffectLoopTests: XCTestCase {
   func testRealBridgeDiscardRecordsNothing() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
-    _ = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    _ = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     _ = try bridge.update(.coach(.startBlock(now: SessionClock.nowRFC3339())))
     let opening = try XCTUnwrap(try bridge.view().coach.drill)
     _ = try bridge.update(.coach(.beat(beatIndex: 0)))
@@ -1291,7 +1303,8 @@ final class StoreEffectLoopTests: XCTestCase {
   func testRealBridgeSkipBlockAdvancesToTheNextCard() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
-    _ = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    _ = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     let card = try XCTUnwrap(try bridge.view().coach.drill)
     XCTAssertEqual(card.phase, .blockEntry)
 
@@ -1318,7 +1331,9 @@ final class StoreEffectLoopTests: XCTestCase {
 
     _ = try bridge.resolve(id, persistenceOutput: .coachRecords(Self.overdueEvidence))
     _ = try bridge.update(
-      .coach(.planSession(now: "2026-09-20T10:00:00Z", availableMinutes: 30)))
+      .coach(
+        .planSession(
+          now: "2026-09-20T10:00:00Z", availableMinutes: 30, utcOffsetMinutes: 0)))
 
     let plan = try XCTUnwrap(try bridge.view().coach.plan, "a planned session")
     XCTAssertNil(try bridge.view().error, "a clean read leaves nothing to surface")
@@ -1355,7 +1370,8 @@ final class StoreEffectLoopTests: XCTestCase {
   func testRealBridgeStuckDropsTheTempoInTheCore() throws {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
-    let started = try bridge.update(.coach(.startPlannedSession(now: SessionClock.nowRFC3339())))
+    let started = try bridge.update(
+      .coach(.startPlannedSession(now: SessionClock.nowRFC3339(), utcOffsetMinutes: 0)))
     let config = try coachSession(in: started).config
     _ = try bridge.update(.coach(.startBlock(now: SessionClock.nowRFC3339())))
     let opening = try XCTUnwrap(try bridge.view().coach.drill)


### PR DESCRIPTION
Closes #1221.

Third of four evidence-integrity fixes. **Stacked on #1326** (base is `claude/1291-rebase-ungated-started-at`); GitHub retargets this to `main` when that merges. Review only the top commit.

## The defect

`MasteryStore::is_cold` decided "first rep of the day on returning material" (spec §2) by comparing `last_attempt_at.date_naive()` with `now.date_naive()`, both UTC calendar days. The engine only ever holds UTC timestamps, so the day turned over at midnight UTC rather than midnight where the user is.

- **British summer time**, the author's own case: the boundary sits at 01:00 local, so a session starting at 00:30 is recorded warm on a genuinely new day.
- **UTC+13**: the boundary lands at 1pm local, so an afternoon session counts as a new day from a morning one, and two evening sessions either side of local midnight count as the same day.

Evening practice is the normal case for this app, which puts the boundary exactly where the error bites. The cold flag is the highest-information tap-verdict there is, and it was being decided by a boundary in the wrong place.

## The fix

Every event that can open a session carries `utc_offset_minutes`, supplied by the shell from `SessionClock.utcOffsetMinutes()`: `PlanSession`, `StartPlannedSession` and `RecoverSession`. `CoachState` holds the last one reported, and `is_cold` compares local dates.

All three rather than `PlanSession` alone, because `mark_cold` runs before the block exists, so the flag is really decided on the first `StartBlock` using whatever offset was last stored, and `session.rs` documents the no-preview door as one a shell may use alone: a session opened through it would have decided cold on UTC. The sixteen mid-session events do not carry it, because the offset is a property of the device, not of the event, and sixteen copies would add a way for two of them to disagree.

Two placement decisions, both deliberate:

- **On the events, not in a `crux_kv` singleton** (#1221's second option). The core stays a function of its inputs, and the shell supplies the fact about where the user is rather than the verdict.
- **On `CoachState`, not `EngineSession`.** A field inside `EngineSession` would invalidate every crash-recovery blob on every device, and this one does not deserve that: a lost offset is re-supplied by the very next plan, and until then UTC is exactly today's behaviour.

An offset outside UTC-12 to UTC+14 clamps rather than being trusted. `FixedOffset` accepts anything under 24 hours, so a shell bug would otherwise quietly build a real date on the wrong day.

## Tests

TDD, five in the core and two in Swift, each mutation-tested rather than assumed:

- the day boundary is the user's midnight, not UTC's (BST at 00:30, plus a New York case so a negative offset touches the date maths)
- a far eastern offset moves the boundary the whole way (UTC+13: morning, afternoon, next morning)
- an impossible offset is clamped to the furthest real one. **Rewritten after its first draft passed for the wrong reason**: `+99:00` is rejected by `FixedOffset::east_opt` anyway, so with or without the clamp the answer was UTC. It now uses `+20:00`, which `east_opt` accepts, at an instant where +14:00 and +20:00 disagree about the date
- the cold test turns the day over where the shell says the user is: the offset reaching an actual tap's `cold` flag, which the unit tests alone do not prove
- starting without a preview still decides cold on the user's day: the door the first review round found still open
- `SessionClock.utcOffsetMinutes` reports minutes, not seconds (`Asia/Kolkata` = 330, so a half-hour offset also proves the unit), and follows the instant it is asked about (`America/New_York` = -240 in June, -300 in January). The zone is injectable because CI runs in UTC, where the first draft of this test asserted `0 == 0`

The three new event fields cross the real bincode wire in `every_coach_event_survives_the_ffi_wire` and `assert_round_trips`, at `-330` (India) rather than a round hour, so a seconds-for-minutes or hours-for-minutes slip fails there too.

Bridge safety, verified rather than assumed: `CoachState` lives only in `Model`, never in `crux_kv` or the crash blob, so `utc_offset_minutes` is outside `EngineSession`'s transitive graph. `SNAPSHOT_WIRE` is untouched and no `coachSessionInProgressKey` bump was needed.

Coverage: expected high. Core logic with tests first, and the previously-uncovered `local_offset` fallback is gone, since the clamp makes it unreachable and `.expect` states why.

Tier 3 by the domain-sensitivity rule (FFI bridge contract: new fields on three `Event` variants).

Gates: `just check` green (945 tests). `just ios-fmt-check` green. `just ios-test-full` green: 321 tests, 0 failures, on this worktree's isolated sim, read from the result bundle.

Deferred: #1330 (analytics still counts the day in UTC, which is the same flaw where the user can see it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)