### PR TITLE
fix(core,ios): the coach's outstanding evidence writes are a queue (#1286)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -28,9 +28,9 @@ use crate::domain::types::{LibrarySort, ListQuery, SortDirection, SortField};
 use crate::engine::{CoachEvent, EngineSession, SnapshotAction};
 use crate::http;
 use crate::model::{
-    build_active_session_view, build_summary_view, session_to_view, ItemPracticeSummary,
-    LibraryItemView, LinkedExerciseView, Model, PieceRefView, ScaffoldPreviewView,
-    ScaffoldSpecView, SessionStatusView, ViewModel,
+    build_active_session_view, build_summary_view, session_to_view, CoachWriteInFlight,
+    ItemPracticeSummary, LibraryItemView, LinkedExerciseView, Model, PieceRefView,
+    ScaffoldPreviewView, ScaffoldSpecView, SessionStatusView, ViewModel,
 };
 use crate::persistence::{self, PersistenceOperation, PersistenceOutput};
 
@@ -287,7 +287,10 @@ pub(crate) fn coach_write_commands(
             unmonitored: writes.unmonitored,
             updated_at: recorded_at,
         };
-        model.coach_write_in_flight = Some(batch.clone());
+        model.coach_writes_in_flight.push_back(CoachWriteInFlight {
+            batch: batch.clone(),
+            retried: false,
+        });
         commands.push(persistence::save_coach_records(batch));
     }
     match writes.snapshot {
@@ -559,16 +562,25 @@ impl Intrada {
                 | PersistenceOutput::Sessions(_)
                 | PersistenceOutput::CoachRecords(_)
                 | PersistenceOutput::BuiltSessionData(_) => {
-                    model.coach_write_in_flight = None;
+                    model.coach_writes_in_flight.pop_front();
                     Command::done()
                 }
                 // Nothing reads these rows back, so a failure has nothing to
                 // reload to and the block would simply be gone. Offer the batch
                 // again first (the store upserts by id, so a repeat is safe) and
                 // surface only if that fails too.
-                PersistenceOutput::Failed => match model.coach_write_in_flight.take() {
-                    Some(batch) => persistence::save_coach_records(batch),
-                    None => {
+                // Front, not back: the retry settles before the batch behind
+                // it, or that one loses its own. Pinned on the shell by
+                // `testARetryResolvesBeforeTheEffectQueuedBehindIt`.
+                PersistenceOutput::Failed => match model.coach_writes_in_flight.pop_front() {
+                    Some(write) if !write.retried => {
+                        model.coach_writes_in_flight.push_front(CoachWriteInFlight {
+                            retried: true,
+                            ..write.clone()
+                        });
+                        persistence::save_coach_records(write.batch)
+                    }
+                    _ => {
                         model.surface_error("Couldn't save what you just practised.");
                         crux_core::render::render()
                     }

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,13 @@ use crate::domain::set::Set;
 use crate::domain::{LibrarySort, ListQuery};
 use crate::engine::{BlockRecord, CoachState, CoachView, ContentIndex};
 use crate::persistence::PersistenceOperation;
+
+#[derive(Debug, Clone)]
+pub struct CoachWriteInFlight {
+    pub batch: PersistenceOperation,
+    /// Back once and no further, or a store that is not having it loops.
+    pub retried: bool,
+}
 
 /// Internal application state — not exposed to shells.
 #[derive(Debug, Default)]
@@ -93,11 +100,10 @@ pub struct Model {
     /// The practice coach's own state, quarantined in `engine/`
     /// (`specs/intrada-coach-engine.md` §1).
     pub coach: CoachState,
-    /// The coach evidence a store write is outstanding for, kept so a failure
-    /// can be offered again once before it becomes the user's problem (#1181).
-    /// One slot, because the shell resolves persistence synchronously
-    /// (`Store.process`), so only one coach write is ever in flight.
-    pub coach_write_in_flight: Option<PersistenceOperation>,
+    /// The coach evidence store writes are outstanding for, oldest first, so a
+    /// failure can be offered again once (#1181). A queue rather than one slot,
+    /// which a second close used to overwrite (#1286).
+    pub coach_writes_in_flight: VecDeque<CoachWriteInFlight>,
     /// The block records the store handed back at launch. Kept rather than
     /// consumed, because the mastery rebuild also needs the run-throughs and
     /// those arrive on a second, independently-ordered load: whichever lands

--- a/crates/intrada-core/src/persistence.rs
+++ b/crates/intrada-core/src/persistence.rs
@@ -908,6 +908,72 @@ mod tests {
             assert!(model.last_error.is_some());
         }
 
+        fn close_a_second_block(app: &Intrada, model: &mut Model) {
+            let _ = send(app, model, CoachEvent::LeaveSession { now: at(60) });
+        }
+
+        /// One slot meant the second batch overwrote the first's retry.
+        #[test]
+        fn a_second_batch_does_not_take_the_first_batchs_retry() {
+            let (app, mut model) = local_first();
+            close_a_block(&app, &mut model);
+            close_a_second_block(&app, &mut model);
+
+            let first = model.coach_blocks[0].id.clone();
+            let mut cmd = app.update(
+                Event::CoachStoreWritten(PersistenceOutput::Failed),
+                &mut model,
+            );
+
+            let retried = coach_records(&mut cmd).expect("the first batch goes back to the store");
+            assert_eq!(
+                retried[0].id, first,
+                "the batch that failed, not whichever closed most recently"
+            );
+        }
+
+        #[test]
+        fn an_ack_for_the_first_batch_leaves_the_seconds_retry_intact() {
+            let (app, mut model) = local_first();
+            close_a_block(&app, &mut model);
+            close_a_second_block(&app, &mut model);
+
+            let _ = app.update(Event::CoachStoreWritten(PersistenceOutput::Ack), &mut model);
+            let mut cmd = app.update(
+                Event::CoachStoreWritten(PersistenceOutput::Failed),
+                &mut model,
+            );
+
+            let retried = coach_records(&mut cmd).expect("the second batch is offered again");
+            assert_eq!(
+                retried[0].id, model.coach_blocks[1].id,
+                "the batch that failed, not the one already acked"
+            );
+            assert!(model.last_error.is_none());
+        }
+
+        /// Push the retry at the back instead and this loses the other's.
+        #[test]
+        fn a_retry_that_lands_leaves_the_batch_behind_it_its_own_retry() {
+            let (app, mut model) = local_first();
+            close_a_block(&app, &mut model);
+            close_a_second_block(&app, &mut model);
+
+            let _ = app.update(
+                Event::CoachStoreWritten(PersistenceOutput::Failed),
+                &mut model,
+            );
+            let _ = app.update(Event::CoachStoreWritten(PersistenceOutput::Ack), &mut model);
+            let mut cmd = app.update(
+                Event::CoachStoreWritten(PersistenceOutput::Failed),
+                &mut model,
+            );
+
+            let retried = coach_records(&mut cmd).expect("the second batch is offered again");
+            assert_eq!(retried[0].id, model.coach_blocks[1].id);
+            assert!(model.last_error.is_none());
+        }
+
         #[test]
         fn a_failed_evidence_write_surfaces_rather_than_vanishing() {
             let (app, mut model) = local_first();

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,9 +21,28 @@ tap-verdicts against countable criteria.
 ## In flight
 
 - #1143 — Phase 0 fortnight practising from `content/`
-- Evidence integrity, the rest of the sequence — #1286
 
 ## Recently landed
+
+- #1286 — the coach's outstanding evidence writes are a queue, not one slot.
+  `coach_write_in_flight` held a single `SaveCoachRecords` batch and was
+  overwritten on every call, so a second close before the first was acked took
+  the first's retry: a failure then offered the wrong batch back and lost the
+  right one, and an ack for either emptied the slot for both, surfacing
+  "Couldn't save what you just practised" for a batch that could have been
+  retried. #1256 Phase C made that ordinary rather than exotic, since a
+  play-through is a short repeatable action rather than one prescribed session
+  a day. The queue is FIFO and each entry carries whether it has had its one
+  retry, so the offer-once rule survives having more than one batch out. A
+  failed batch goes back at the *front*, because its retry has to settle before
+  the batch behind it or that one loses its own. Both halves of the issue are
+  taken: the queue, and a shell-side test pinning the assumption it rests on.
+  That assumption is not merely "synchronous and in order" but the stronger
+  "an effect issued during a resolve settles before the effect queued behind
+  it", which is `Store.process` recursing inside its own loop, so
+  `testARetryResolvesBeforeTheEffectQueuedBehindIt` asserts the retry lands
+  between the two batches rather than after both. Flatten that recursion to a
+  work queue and the test fails rather than the evidence going quiet.
 
 - #1221 — the cold test turns the day over where the user is. "First rep of the
   day on returning material" compared UTC calendar days, so in British summer

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -160,6 +160,28 @@ final class StoreEffectLoopTests: XCTestCase {
       "a lost block must surface as .failed, never a phantom .ack (#816)")
   }
 
+  // The core's front-of-queue retry is sound only while an effect issued during
+  // a resolve settles before the effect queued behind it: `Store.process`
+  // recursing inside its own loop (#1286). Flatten that to a work queue and the
+  // retry lands after 31, still synchronous and still in issue order. No
+  // `await` here either, so asynchrony fails it too.
+  func testARetryResolvesBeforeTheEffectQueuedBehindIt() {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [Self.saveCoachRecords(id: 30), Self.saveCoachRecords(id: 31)]
+    }
+    bridge.persistenceResolveHandler = { id, _ in
+      id == 30 ? [Self.saveCoachRecords(id: 300)] : []
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    store.send(.setQuery(nil))
+
+    XCTAssertEqual(
+      bridge.persistenceResolved.map(\.id), [30, 300, 31],
+      "30's retry settles before 31, or the core's front-of-queue retry is void")
+  }
+
   func testCoachRecordsReadResolvesWhatWasWritten() throws {
     let libraryStore = try LibraryStore.inMemory()
     try libraryStore.saveCoach(
@@ -1790,6 +1812,7 @@ private func emptyViewModel() throws -> ViewModel {
 private final class FakeBridge: CoreBridge {
   var updateHandler: (Event) -> [Request] = { _ in [] }
   var resolveHandler: (UInt32, HttpResult) -> [Request] = { _, _ in [] }
+  var persistenceResolveHandler: (UInt32, PersistenceOutput) -> [Request] = { _, _ in [] }
   var nextViewModel: (() throws -> ViewModel)?
   var onResolve: (() -> Void)?
   /// When set, the corresponding bridge call throws — drives the Store's
@@ -1818,7 +1841,7 @@ private final class FakeBridge: CoreBridge {
   func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] {
     persistenceResolved.append((id, persistenceOutput))
     onResolve?()
-    return []
+    return persistenceResolveHandler(id, persistenceOutput)
   }
 
   func resolveEmpty(_ id: UInt32) throws -> [Request] {


### PR DESCRIPTION
Closes #1286.

Last of four evidence-integrity fixes. **Stacked on #1329** (base is `claude/1221-shell-utc-offset`); GitHub retargets this to `main` when that merges. Review only the top commit.

## The defect

`Model::coach_write_in_flight` held one `SaveCoachRecords` batch and `coach_write_commands` overwrote it on every call. With two batches outstanding:

- a failure offered the **second** batch back for the first's failure, and lost the first;
- an ack for either emptied the slot for both, so the next failure had nothing to retry and surfaced "Couldn't save what you just practised" for a batch it could have offered again.

The field's own doc said one slot was enough "because the shell resolves persistence synchronously (`Store.process`)". That is true today, and it is also a core invariant resting on a shell scheduling detail with nothing holding it there. #1256 Phase C made a second close ordinary rather than exotic: a play-through is a short, repeatable action, not one prescribed session a day.

## The fix, both halves

The issue offered "either make it a queue, or add a test that pins the synchronous-resolution assumption". Both, because they answer different failure modes.

**The queue.** `VecDeque<CoachWriteInFlight>`, oldest first, each entry carrying whether it has already had its second chance, so the offer-once-then-tell-the-user rule survives having more than one batch out:

- ack pops the front;
- failure pops the front, puts it back **at the front** marked retried, and reissues it;
- a second failure of the same batch surfaces to the user, exactly as before.

Front rather than back, because the retry has to settle before the batch queued behind it. Push it at the back and the sibling silently loses its own retry, which the self-review found and which now has a test.

**The pin.** Matching an outcome to a batch by position is sound only while **an effect issued during a resolve settles before the effect queued behind it**. That is `Store.process` recursing inside its own loop, and it is a stronger property than "synchronous and in order": flattening the recursion into an iterative work queue would keep persistence synchronous and in issue order while breaking the retry. `testARetryResolvesBeforeTheEffectQueuedBehindIt` asserts the retry lands *between* the two batches (`[30, 300, 31]`), with no `await` and no expectation, so it catches asynchrony too. `FakeBridge` gained a `persistenceResolveHandler` to make that expressible.

## Tests

TDD, three in the core and one in Swift, each mutation-tested:

- `a_second_batch_does_not_take_the_first_batchs_retry`: two blocks closed, the first fails, and the batch that goes back is the one that failed. Its first draft asserted on the record's node and passed against the bug, because both batches happened to carry the same node; it compares ids now
- `an_ack_for_the_first_batch_leaves_the_seconds_retry_intact`: the symptom the issue names, comparing ids rather than just `is_some()`, so a LIFO pop would fail it
- `a_retry_that_lands_leaves_the_batch_behind_it_its_own_retry`: `push_back` passes the rest of the suite and fails only this
- `testARetryResolvesBeforeTheEffectQueuedBehindIt`: the shell-side pin

The three pre-existing retry tests are unchanged and still pass, so the offer-once behaviour is preserved rather than re-specified, including the empty-queue `Failed` path (invariant 5).

Coverage: expected high. Core logic with tests first; no new uncovered branches.

Tier 2 (core state plus shell tests; no bridge, DB, auth or migration surface. `PersistenceOperation` is unchanged, so nothing crosses the wire differently, and `Model` is never serialised).

Gates: `just check` green (948 tests). `just ios-fmt-check` green. `just ios-test-full` green: 322 tests, 0 failures, on this worktree's isolated sim, read from the result bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)