### PR TITLE
chore: upgrade the Rust toolchain to 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
   security-events: write
 
 env:
-  RUST_VERSION: "1.90.0"
+  RUST_VERSION: "1.97.1"
   SENTRY_ORG: jon-yardley
 
 jobs:
@@ -46,21 +46,33 @@ jobs:
             rust:
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
               - 'crates/**'
               - '.github/workflows/ci.yml'
             api:
               - 'Dockerfile'
+              - 'rust-toolchain.toml'
               - 'crates/intrada-api/**'
               - '.github/workflows/ci.yml'
             native:
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
               - 'crates/intrada-core/**'
               - 'crates/intrada-ffi/**'
               - 'ios/**'
               - 'scripts/ios-run-sim.sh'
               - 'justfile'
               - '.github/workflows/ci.yml'
+      # Drift installs clippy/rustfmt for the env's version, then cargo resolves
+      # to the file's: "clippy is not installed", or a silent second download.
+      - name: Toolchain pins agree
+        run: |
+          pinned=$(grep -oE 'channel = "[^"]+"' rust-toolchain.toml | cut -d'"' -f2)
+          if [ "$pinned" != "$RUST_VERSION" ]; then
+            echo "rust-toolchain.toml pins $pinned but RUST_VERSION is $RUST_VERSION"
+            exit 1
+          fi
 
   test:
     name: Test
@@ -127,6 +139,31 @@ jobs:
           files: codecov.json
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      # Read the floor from Cargo.toml rather than pinning it again here: the
+      # toolchain we build with is seven minors above it, so nothing else fails.
+      - id: floor
+        run: |
+          version=$(grep -oE 'package.rust-version = "[^"]+"' Cargo.toml | cut -d'"' -f2)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.floor.outputs.version }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "msrv"
+          cache-on-failure: true
+      # `+toolchain` beats rust-toolchain.toml, which would otherwise pull the
+      # current pin straight back in.
+      - run: cargo +${{ steps.floor.outputs.version }} check --workspace --all-targets
 
   clippy:
     name: Clippy

--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 env:
-  RUST_VERSION: "1.90.0"
+  RUST_VERSION: "1.97.1"
 
 jobs:
   testflight:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ specs/                   # Spec docs for major features (Tier 3 only)
 
 ## Tech Stack
 
-- **Rust** stable (1.90.0 CI; MSRV 1.90 via crux_core 0.20, intrada-api 1.78+)
+- **Rust** stable (1.97.1 CI; MSRV 1.90 via crux_core 0.20, intrada-api 1.78+)
 - **Core**: crux_core 0.20.0, serde, ulid, chrono, thiserror
 - **API**: axum 0.8, tokio, libsql 0.9 (Turso), tower-http (CORS), jsonwebtoken 10
 - **Native iOS**: SwiftUI, iOS 17.0+, UniFFI + facet typegen, GRDB (on-device)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
   "crates/intrada-api",
 ]
 resolver = "2"
-# Set by crux_core 0.20, which declares rust-version 1.90 (rust-toolchain.toml
-# already pins it). intrada-api keeps its own lower floor: it has no crux.
+# MSRV floor, set by crux_core 0.20's own rust-version. The dev/CI toolchain is
+# newer (rust-toolchain.toml). intrada-api keeps its own lower floor: no crux.
 package.rust-version = "1.90"
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
+# rust-toolchain.toml overrides the base image's rustc for every cargo command
+# below it, including the final build — copy it in first so cook and build
+# resolve the same toolchain and the cooked deps aren't fingerprint-mismatched
+# and discarded.
+COPY rust-toolchain.toml .
 # Build dependencies — this is the caching Docker layer.
 # --bin intrada-api scopes to only intrada-api's dependency graph, excluding
 # crates/intrada-mobile's Tauri/GTK chain (gdk-sys etc.) which doesn't build

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Intrada follows the **Crux pure-core pattern**: `intrada-core` contains all busi
 
 ## Prerequisites
 
-- Rust stable (2021 edition, 1.75+)
+- Rust stable (2021 edition); the pinned toolchain is in `rust-toolchain.toml`
 - [just](https://github.com/casey/just) (`brew install just` or `cargo install just`)
 - Xcode 26+, iOS 17.0+ target, [xcodegen](https://github.com/yonaskolb/XcodeGen) (`brew install xcodegen`), and the iOS Simulator runtime (Xcode → Settings → Platforms → iOS Simulator)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -305,7 +305,8 @@ Local parity (after the one-time setup): `just testflight`.
 
 Install Rust first (mise's `cargo:` backend builds with it):
 
-- Rust stable (1.75+) via [rustup](https://rustup.rs)
+- Rust via [rustup](https://rustup.rs); `rust-toolchain.toml` pins the version
+  and rustup installs it on first build
 
 Then the rest of the dev toolchain (just, xcodegen, oxipng, typos, Ruby for
 fastlane, pinned cargo tools like cargo-swift 0.9.0) is declared in

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -1,6 +1,7 @@
 //! Analytics computations. All functions are pure and take `today: NaiveDate`
 //! (rather than reading the clock) so they're deterministic under test.
 
+use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
 use chrono::{Datelike, NaiveDate};
@@ -274,7 +275,7 @@ pub fn compute_top_items(sessions: &[PracticeSession]) -> Vec<ItemRanking> {
         )
         .collect();
 
-    rankings.sort_by(|a, b| b.total_minutes.cmp(&a.total_minutes));
+    rankings.sort_by_key(|r| Reverse(r.total_minutes));
     rankings.truncate(10);
     rankings
 }
@@ -460,7 +461,7 @@ pub fn compute_score_changes(sessions: &[PracticeSession], today: NaiveDate) -> 
         }
     }
 
-    changes.sort_by(|a, b| b.delta.unsigned_abs().cmp(&a.delta.unsigned_abs()));
+    changes.sort_by_key(|c| Reverse(c.delta.unsigned_abs()));
 
     changes.truncate(5);
     changes

--- a/crates/intrada-core/src/analytics.rs
+++ b/crates/intrada-core/src/analytics.rs
@@ -275,7 +275,7 @@ pub fn compute_top_items(sessions: &[PracticeSession]) -> Vec<ItemRanking> {
         )
         .collect();
 
-    rankings.sort_by_key(|r| Reverse(r.total_minutes));
+    rankings.sort_by_key(|r| (Reverse(r.total_minutes), r.item_id.clone()));
     rankings.truncate(10);
     rankings
 }
@@ -461,7 +461,7 @@ pub fn compute_score_changes(sessions: &[PracticeSession], today: NaiveDate) -> 
         }
     }
 
-    changes.sort_by_key(|c| Reverse(c.delta.unsigned_abs()));
+    changes.sort_by_key(|c| (Reverse(c.delta.unsigned_abs()), c.item_id.clone()));
 
     changes.truncate(5);
     changes
@@ -926,6 +926,28 @@ mod tests {
         assert_eq!(ranking[2].item_id, "e2"); // 25 min
         assert_eq!(ranking[3].item_id, "p3"); // 20 min
         assert_eq!(ranking[4].item_id, "e1"); // 15 min
+    }
+
+    #[test]
+    fn test_top_items_ties_break_by_item_id() {
+        // 3 items tied on total_minutes → order is deterministic (item_id asc),
+        // not whatever order the underlying HashMap happened to iterate in.
+        let today = NaiveDate::from_ymd_opt(2026, 2, 18).unwrap();
+
+        let sessions = vec![make_session(
+            "s1",
+            today,
+            5400,
+            vec![
+                make_entry("zeta", "Zeta", ItemKind::Piece, 1800, None),
+                make_entry("alpha", "Alpha", ItemKind::Piece, 1800, None),
+                make_entry("mid", "Mid", ItemKind::Piece, 1800, None),
+            ],
+        )];
+
+        let ranking = compute_top_items(&sessions);
+        let ids: Vec<&str> = ranking.iter().map(|r| r.item_id.as_str()).collect();
+        assert_eq!(ids, vec!["alpha", "mid", "zeta"]);
     }
 
     #[test]
@@ -1441,6 +1463,34 @@ mod tests {
         assert_eq!(changes.len(), 5);
         // Should be sorted by largest absolute delta
         assert!(changes[0].delta.unsigned_abs() >= changes[1].delta.unsigned_abs());
+    }
+
+    #[test]
+    fn test_score_changes_ties_break_by_item_id() {
+        // 3 items tied on |delta| → order is deterministic (item_id asc), not
+        // whatever order the underlying HashMap happened to iterate in.
+        let today = NaiveDate::from_ymd_opt(2026, 2, 18).unwrap();
+        let last_wed = NaiveDate::from_ymd_opt(2026, 2, 11).unwrap();
+
+        let last_entries = vec![
+            make_entry("zeta", "Zeta", ItemKind::Piece, 600, Some(3)),
+            make_entry("alpha", "Alpha", ItemKind::Piece, 600, Some(3)),
+            make_entry("mid", "Mid", ItemKind::Piece, 600, Some(3)),
+        ];
+        let this_entries = vec![
+            make_entry("zeta", "Zeta", ItemKind::Piece, 600, Some(5)),
+            make_entry("alpha", "Alpha", ItemKind::Piece, 600, Some(5)),
+            make_entry("mid", "Mid", ItemKind::Piece, 600, Some(5)),
+        ];
+
+        let sessions = vec![
+            make_session("s1", last_wed, 1800, last_entries),
+            make_session("s2", today, 1800, this_entries),
+        ];
+
+        let changes = compute_score_changes(&sessions, today);
+        let ids: Vec<&str> = changes.iter().map(|c| c.item_id.as_str()).collect();
+        assert_eq!(ids, vec!["alpha", "mid", "zeta"]);
     }
 
     #[test]

--- a/crates/intrada-core/src/domain/built_session/criterion.rs
+++ b/crates/intrada-core/src/domain/built_session/criterion.rs
@@ -177,10 +177,7 @@ fn keys(words: &[String]) -> Vec<String> {
         ) {
             cursor += 1;
         }
-        loop {
-            let Some((key, next)) = key_at(words, cursor) else {
-                break;
-            };
+        while let Some((key, next)) = key_at(words, cursor) {
             if !found.contains(&key) {
                 found.push(key);
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.97.1"


### PR DESCRIPTION
## Why

rust-analyzer no longer supports toolchains below 1.94, so the `1.90.0` pin in
`rust-toolchain.toml` left the editor with no analysis at all:

> Workspace is using outdated toolchain version `1.90.0` but rust-analyzer only
> supports `1.94.0` and higher.

## What changed

**The bump**

- `rust-toolchain.toml`: `1.90.0` to `1.97.1` (current stable, released 2026-07-14).
- `RUST_VERSION` in `ci.yml` and `release-testflight.yml` bumped to match, so CI
  and local stay in lockstep.

**Three clippy lints that arrived with the newer toolchain, cleared mechanically**

- `analytics.rs` x2 — `sort_by(|a, b| b.k.cmp(&a.k))` to `sort_by_key(|x| Reverse(x.k))`
  (`unnecessary_sort_by`). `impl Ord for Reverse<T>` is `other.0.cmp(&self.0)`, and
  both sorts are stable, so the output is identical including tie order at the point
  of the rewrite.
- `criterion.rs` — `loop { let Some(..) = .. else { break }; .. }` to `while let`
  (`while_let_loop`). `continue` in a `while let` re-evaluates the scrutinee, which
  is what the `loop` plus let-else did, so `continue` and `break` behave identically.

**Keeping the pin honest**

- `rust-toolchain.toml` joins all three CI path filters. It was in none of them, so
  the *next* toolchain bump, which would plausibly touch only that file, would have
  skipped `test`, `clippy`, `fmt` and all four `native-ios` jobs and merged unvalidated.
  This PR was covered only because it also happens to touch `Cargo.toml` and `ci.yml`.
- A guard in the `changes` job fails the build if `rust-toolchain.toml` and
  `RUST_VERSION` drift. They select the toolchain by different routes: the env drives
  what `dtolnay/rust-toolchain` installs (with clippy/rustfmt), the file drives what
  `cargo` then resolves to. Drift means components installed for one version and the
  other one running.
- A new `MSRV` job runs `cargo +<floor> check --workspace --all-targets`, reading the
  floor from `Cargo.toml` so there is no third place to keep in sync.

**Two bugs the self-review found, folded into this PR rather than left as separately
tracked issues (originally #1337, #1338 — see comments there)**

- `compute_top_items` and `compute_score_changes` (`analytics.rs`) both sort a
  `HashMap`'s iteration order, which is arbitrary, then `truncate(N)`. The sort is
  stable, so it faithfully preserved that arbitrary order among rows tied on the sort
  key — meaning the top-N could drop a *different* row on every recompute with no
  cause visible to the user. Fixed with `item_id` as a secondary sort key in both, and
  a genuine tie-order test added for each (the existing tests all use distinct values,
  so none of them could have caught this).
- The Dockerfile's `cargo chef cook` layer ran before `rust-toolchain.toml` was copied
  in, so it built with the base image's default rustc while the final `cargo build`
  picked up the pin. Any drift between the two discards every cooked dependency —
  cargo-chef's entire purpose. Fixed by copying the file in before `cook`. Verified with
  a full local `docker build`: the cook layer compiled all deps once (28s), the final
  build reused that cache and only recompiled the two workspace crates (10s).

**Docs**

- `CLAUDE.md` Tech Stack line, and the `Cargo.toml` MSRV comment, which previously
  claimed `rust-toolchain.toml` "already pins it" and is no longer true.
- `README.md` and `SETUP.md` both still said "Rust stable (1.75+)", stale since the
  floor moved to 1.90. They now point at `rust-toolchain.toml` rather than restating
  a number that goes out of date.

## MSRV is unchanged at 1.90

That floor comes from crux_core 0.20's own `rust-version`, not from what we build
with. Only the dev and CI toolchain moved.

The gap used to be zero minors, which made the floor self-enforcing: CI built with
exactly the MSRV. It is seven minors now, so any 1.91 to 1.97 stdlib API would compile
green in CI while silently breaking the declared floor. Per the "a stated invariant
must be an enforced invariant" rule, the MSRV job closes that rather than leaving the
claim decorative. Verified locally: `cargo +1.90.0 check --workspace --all-targets`
passes in 24s, and CI's MSRV job passed on the first run.

## Verification

- `just check` green: fmt, clippy `-D warnings`, 1142 tests (two new), typos and
  cargo-shear.
- `cargo build -p intrada-ffi --target aarch64-apple-ios --target aarch64-apple-ios-sim`
  green, so the xcframework path compiles on the new toolchain. facet `=0.46.5` and
  uniffi 0.29.4 are the compiler-sensitive pins and neither hit a ceiling.
- `cargo +1.90.0 check --workspace --all-targets` green.
- Full `docker build .` green locally, confirming the chef-layer fix.
- `Cargo.lock` unchanged. A toolchain bump does not move resolution, and cargo 1.97
  preserves the existing lockfile version rather than upgrading it.
- CI ran green end to end on the toolchain-bump-only commit (Test, Clippy, MSRV,
  Coverage, all four native-iOS jobs, Security & hygiene) before the two fixes above
  were added; re-running now with them included.

## Not verified here

`just ios-test-full` was **not** run locally: another session held the booted
simulator for the whole of this work, and the simulator-safety rule in CLAUDE.md says
pause rather than risk killing it. No files under `ios/` changed and the generated
Swift bindings are build artefacts, not committed. CI's `native-ios` jobs already
passed once on the toolchain-only commit and are re-running now.

`api-docker-build` never runs on PRs by design (narrowly gated to push-to-main so
routine PRs don't pay an ~8 min Docker build), so the Dockerfile fix has no CI
coverage on this PR. Verified manually instead, per above; will be exercised for real
the next time `intrada-api` or the `Dockerfile` changes on `main`.

## Coverage

Tier 1 for the toolchain bump itself. The two folded-in fixes are small, targeted
changes to pure functions with a genuine test each, both green.

Closes #1337, closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)