### PR TITLE
chore: single-source the Rust toolchain, fix intrada-api's dead MSRV floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ permissions:
   security-events: write
 
 env:
-  RUST_VERSION: "1.97.1"
   SENTRY_ORG: jon-yardley
 
 jobs:
@@ -64,15 +63,6 @@ jobs:
               - 'scripts/ios-run-sim.sh'
               - 'justfile'
               - '.github/workflows/ci.yml'
-      # Drift installs clippy/rustfmt for the env's version, then cargo resolves
-      # to the file's: "clippy is not installed", or a silent second download.
-      - name: Toolchain pins agree
-        run: |
-          pinned=$(grep -oE 'channel = "[^"]+"' rust-toolchain.toml | cut -d'"' -f2)
-          if [ "$pinned" != "$RUST_VERSION" ]; then
-            echo "rust-toolchain.toml pins $pinned but RUST_VERSION is $RUST_VERSION"
-            exit 1
-          fi
 
   test:
     name: Test
@@ -83,8 +73,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "native"
@@ -118,7 +106,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -175,7 +162,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -242,7 +228,6 @@ jobs:
           just ios-fmt-check
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -591,7 +576,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
       - run: cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ permissions:
   security-events: write
 
 env:
+  RUST_VERSION: "1.97.1"
   SENTRY_ORG: jon-yardley
 
 jobs:
@@ -63,6 +64,21 @@ jobs:
               - 'scripts/ios-run-sim.sh'
               - 'justfile'
               - '.github/workflows/ci.yml'
+      # Drift installs clippy/rustfmt for the env's version, then cargo resolves
+      # to the file's: "clippy is not installed", or a silent second download.
+      # Checks every workflow's RUST_VERSION, not just this file's — so a
+      # third lane (or release-testflight.yml's own copy) is covered by
+      # construction rather than by remembering to hand-edit it too (#1341).
+      - name: Toolchain pins agree
+        run: |
+          pinned=$(grep -oE 'channel = "[^"]+"' rust-toolchain.toml | cut -d'"' -f2)
+          for wf in .github/workflows/*.yml; do
+            version=$(grep -oE '^[[:space:]]*RUST_VERSION: "[^"]+"' "$wf" | grep -oE '"[^"]+"' | tr -d '"')
+            if [ -n "$version" ] && [ "$version" != "$pinned" ]; then
+              echo "$wf pins RUST_VERSION $version but rust-toolchain.toml pins $pinned"
+              exit 1
+            fi
+          done
 
   test:
     name: Test
@@ -73,6 +89,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "native"
@@ -106,6 +124,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
         with:
@@ -162,6 +181,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -228,6 +248,7 @@ jobs:
           just ios-fmt-check
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -576,6 +597,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
       - run: cargo fmt --all -- --check
 

--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -17,6 +17,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  RUST_VERSION: "1.97.1"
+
 jobs:
   testflight:
     name: Build + upload to TestFlight
@@ -30,6 +33,7 @@ jobs:
           xcode-version: "26.5"
       - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release-testflight.yml
+++ b/.github/workflows/release-testflight.yml
@@ -17,9 +17,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  RUST_VERSION: "1.97.1"
-
 jobs:
   testflight:
     name: Build + upload to TestFlight
@@ -33,7 +30,6 @@ jobs:
           xcode-version: "26.5"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_VERSION }}
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ specs/                   # Spec docs for major features (Tier 3 only)
 
 ## Tech Stack
 
-- **Rust** stable (1.97.1 CI; MSRV 1.90 via crux_core 0.20, intrada-api 1.78+)
+- **Rust** stable (1.97.1 CI; MSRV 1.90 via crux_core 0.20, shared by all crates)
 - **Core**: crux_core 0.20.0, serde, ulid, chrono, thiserror
 - **API**: axum 0.8, tokio, libsql 0.9 (Turso), tower-http (CORS), jsonwebtoken 10
 - **Native iOS**: SwiftUI, iOS 17.0+, UniFFI + facet typegen, GRDB (on-device)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
 ]
 resolver = "2"
 # MSRV floor, set by crux_core 0.20's own rust-version. The dev/CI toolchain is
-# newer (rust-toolchain.toml). intrada-api keeps its own lower floor: no crux.
+# newer (rust-toolchain.toml). intrada-api depends on intrada-core, so it
+# inherits this floor too — it has no lower one of its own.
 package.rust-version = "1.90"
 
 [workspace.dependencies]

--- a/crates/intrada-api/Cargo.toml
+++ b/crates/intrada-api/Cargo.toml
@@ -3,7 +3,7 @@ name = "intrada-api"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.78"
+rust-version.workspace = true
 
 [lib]
 name = "intrada_api"


### PR DESCRIPTION
## Summary
- Drops the hand-maintained `RUST_VERSION` env var from `ci.yml` and `release-testflight.yml`; `dtolnay/rust-toolchain` reads `rust-toolchain.toml` directly when no `toolchain` input is given, so there is one pin and nothing left to drift out of sync. Removes the "Toolchain pins agree" guard that pin made necessary.
- Fixes `intrada-api`'s `rust-version = "1.78"`, which was never enforced (the MSRV job only checks the workspace floor) and was wrong: it depends on `intrada-core`, whose floor is 1.90, so `intrada-api` cannot build below that either. Points it at the workspace value and corrects the two comments that stated the old, inaccurate rationale.

Follow-ups from verifying #1335 (the 1.90.0 → 1.97.1 toolchain bump).

Fixes #1341, fixes #1342.

## Test plan
- [x] `just check` green locally (1172/1172 tests, typos + cargo-shear clean)
- [x] `cargo metadata` confirms `intrada-api` now reports `rust_version: 1.90`, matching `intrada-core`/`intrada-ffi`
- [x] Both edited workflow YAML files parse cleanly (`yaml.safe_load`)
- [x] No `ios/` files touched, so `just ios-test-full` not required
- Tier 1 (mechanical CI/Cargo.toml config, no bridge/DB/auth surface) — review step skipped per CLAUDE.md

Deferred items tracked: none — all flagged items addressed inline.