### PR TITLE
docs: fix post-revert staleness after #1344

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,7 +4,7 @@
 > *what* to do and stays short because it loads into every session; this one says
 > *how* and *why*, and is read on demand.
 >
-> Last reviewed: 2026-08-07.
+> Last reviewed: 2026-08-14.
 
 ## Commands
 
@@ -275,11 +275,13 @@ optimistic entry, since the server-assigned ulid differs from the client one.
 fire-and-forget: `SessionSaved` just clears the error state and the model keeps
 the optimistic write.
 
-**Save-counter + refetch** (`Set`) — optimistic push, bump
-`set_saves_committed`, then a full refetch via `SetSaveSucceeded`. The counter
-drives the save-form's optimistic-to-confirmed UI flip. This is tracked as tech
-debt to migrate to temp-id once the counter is decoupled from the UI state; do
-not copy it for a new entity.
+**Save-counter + refetch** (`Set`) — designed as optimistic push, bump
+`set_saves_committed`, then a full refetch via `SetSaveSucceeded`, with the
+counter driving a save-form's optimistic-to-confirmed UI flip. **Shell-dead
+since the coach-pivot builder deletion (#1344):** no Swift screen sends a
+`SetEvent`, and `domain/set.rs` fires HTTP unconditionally with no
+`local_first` branch. Tracked in #1348 — don't wire a new caller to it, and
+don't copy this variant for a new entity, until that's resolved.
 
 Updates use `*Updated { entity }` (the server echoes the row). Deletes use
 `DeleteConfirmed`, since the model is already mutated optimistically.

--- a/docs/status.md
+++ b/docs/status.md
@@ -25,11 +25,11 @@ rethink follows this revert, it did not precede it.
 
 ## In flight
 
-- The revert PR (#1344) — through review and merge.
+Nothing in flight. The product rethink (see Next) has not started.
 
 ## Recently landed
 
-- #1344 — the session-builder revert (this PR).
+- #1344 — the session-builder revert, merged 2026-08-13 (commit 9b8da6d).
 
 ## Next
 


### PR DESCRIPTION
## Summary

Audit of docs for staleness after the coach-pivot revert (#1344, merged 9b8da6d). Most of the tree was already correctly updated by #1344/#1347 (CLAUDE.md, roadmap.md's banner, all coach-era specs bannered). Two genuine issues found and fixed:

- **`docs/status.md`**: "In flight" still listed #1344 as "through review and merge" while it also appeared under "Recently landed" — contradictory, since it had already merged. Removed the stale in-flight entry and dated the landed entry.
- **`docs/reference.md`**: the mutate-response variants section described `Set`'s save-counter pattern as driving a live "save-form's optimistic-to-confirmed UI flip". Verified against the code (`grep`'d for `SetEvent` callers in `ios/Intrada`, `local_first` in `domain/set.rs`, and `set_saves_committed`/`SetSaveSucceeded` in Swift — none found) that this is now false: no Swift screen sends a `SetEvent`, matching CLAUDE.md's Known Tech Debt entry (#1348). Updated the section to say so.

No direction rewritten or roadmap content invented — only statements that were now factually false.

Tier 1 doc change: gates run (`just check`, all 788 tests pass, typos/cargo-shear clean), review subagent skipped per CLAUDE.md's docs-only exception.

## Test plan
- [x] `just check` green