### PR TITLE
chore(ios): bump MARKETING_VERSION to 0.7.0

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -15,7 +15,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     DEVELOPMENT_TEAM: "9S5FG4LQAF"
-    MARKETING_VERSION: "0.6.0"
+    MARKETING_VERSION: "0.7.0"
     CURRENT_PROJECT_VERSION: "1"
 
 # Local packages = generated bindings (a build precondition via `just ios-gen`,


### PR DESCRIPTION
One-line version bump ahead of tagging v0.7.0, the first TestFlight build of the restored session builder (#1344). The release lane takes the version from the tag; this keeps project.yml's local-build fallback in sync, same convention as the v0.6.0 bump (#1336).

Tier 1 trivia: gates run (just check + ios-fmt-check green), review subagent skipped per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)