### PR TITLE
docs: Phase R rethink plan (audit → design → implement → next direction)

### DIFF
--- a/docs/rethink-plan.md
+++ b/docs/rethink-plan.md
@@ -1,0 +1,74 @@
+# Phase R — the post-revert consolidation and rethink plan
+
+*Agreed 2026-08-14. This is the working plan for the phase that follows the
+coach revert (#1344): audit the restored builder, design and implement the
+improvements, and choose the next major direction through research-backed,
+iterative decision making. [`status.md`](status.md) tracks which step is live;
+when this doc and the issues disagree, the issues are right.*
+
+## Ground rules for the whole phase
+
+- **API is descoped.** `crates/intrada-api` gets compile-keeping fixes only.
+  No audit findings, no design work, no feature work there this phase.
+- **Every step names its model, effort and run location** before it starts.
+  Defaults: Fable 5 high for synthesis and judgement, Sonnet 5 medium for
+  mechanical or well-templated work.
+- **Iterative, not wholesale.** Every slice shipped is independently valuable
+  and cheaply reversible. That is the anti-coach-pivot discipline.
+- Agreed plans with work in them become GitHub issues immediately, sized and
+  labelled. PR descriptions are not tracking.
+- One core+iOS vertical stream at a time; a second stream only in the
+  decoupled set (docs, CI, design). The simulator is machine-global: one iOS
+  test runner at a time.
+
+## Stage 1 — Audit (2-3 sessions, ~2 days elapsed)
+
+Three independent sweeps, then one synthesis. Output:
+`docs/audit-2026-08.md` (prioritised findings) plus a cleaned issue board.
+
+| Step | What | Model / effort | Where | Parallel with |
+|------|------|----------------|-------|---------------|
+| 1.1 | Code-health audit via the `improve` skill: core, ffi, ios. Correctness, coach leftovers, offline-first invariant violations, design-system drift, test-coverage gaps. Read-only, findings only. | Fable 5 high (lead); fans out ≤4 Explore subagents | Lead session; subagents in-process | 1.2, 1.3 |
+| 1.2 | Product walk-through: drive the app on the simulator through each journey in `docs/journeys.md`, screenshot per screen, record friction. The builder has not been used critically since the revert. | Fable 5 high (needs vision + judgement) | Lead session, after 1.1's subagents return (sim is global, keep it serial) | 1.3 |
+| 1.3 | Issue triage: all ~40 open issues re-checked against post-revert reality. Coach-tainted or stale ones (#1346, #1082, #1104 at minimum) closed, re-scoped or re-labelled. | Sonnet 5 medium (mechanical cross-check) | Separate session or subagent | 1.1, 1.2 |
+| 1.4 | Synthesis: merge the three sweeps into `docs/audit-2026-08.md`, ranked by leverage. Open issues for everything actionable. | Fable 5 high | Lead session | Nothing (waits on 1.1-1.3) |
+
+## Stage 2 — Design the improvements (2-3 days, overlaps Stage 1's tail)
+
+| Step | What | Model / effort | Where | Parallel with |
+|------|------|----------------|-------|---------------|
+| 2.1 | Partition audit findings: UI-shaped vs not. Non-UI items skip straight to Stage 3 issues. | Fable 5 high | Lead session | — |
+| 2.2 | Claude Design mocks for UI-shaped findings, against the existing kit. Decisions appended to the design-principles log. **Blocked on the Claude Design account sort-out (2026-08-07 hold)** unless Jon lifts it. | Fable 5 high | Claude Design project | 2.3 |
+| 2.3 | Write the sized, labelled GitHub issues for all improvement work, with dependency order. | Sonnet 5 medium | Separate session or subagent | 2.2 |
+
+## Stage 3 — Implement (1-2 weeks)
+
+Work the Stage 2 issue list strictly by tier (CLAUDE.md Workflow). Standing
+debt items #1348 (shell-dead `Set` domain) and #1345 (wire-pin port to the
+`ActiveSession` blob) are in scope regardless of what the audit finds.
+
+- **Vertical stream** (core + iOS): one at a time, one worktree, TDD by
+  default for core changes. Fable 5 high for bridge/domain work; Sonnet 5
+  medium for Tier 1 and well-templated Tier 2 screens.
+- **Decoupled stream** (docs, CI, design tokens): may run in parallel.
+  Sonnet 5 medium unless judgement-heavy.
+- Every PR through the `ship` skill; review per PR; Codecov checked (Tier 2+).
+
+## Stage 4 — The next major phase (research starts during Stage 3)
+
+Decision 2026-08-14: research runs as the decoupled second stream while
+Stage 3 implementation is the vertical stream, so the direction decision
+lands as Stage 3 finishes.
+
+| Step | What | Model / effort | Where | Parallel with |
+|------|------|----------------|-------|---------------|
+| 4.1 | One research note per candidate: goals-rebuilt-small (roadmap Q5), the Space layer (spaced repetition / mastery decay), lesson-to-mastery (#1087), chart-to-scaffold Phase B (#1106), metronome (roadmap Q1). Practice-pedagogy evidence plus Jon's own use. Docs only. | Fable 5 high, web research on | One session per candidate, or parallel subagents | Stage 3, and each other |
+| 4.2 | One-page comparison of the candidates; Jon picks the direction. | Fable 5 high | Lead session | — |
+| 4.3 | Tier-3 spec for the chosen direction, then Claude Design, then phased slices. **Each slice is shipped and used before the next is specced.** | Fable 5 high (spec + design); implementation models per Stage 3 rules | Spec in lead session; slices as vertical streams | — |
+
+## Exit criteria for the phase
+
+- `docs/audit-2026-08.md` exists and its actionable findings are issues,
+  shipped or consciously parked.
+- The issue board carries no coach-tainted or stale items.
+- A direction is chosen with a Tier-3 spec, and its first slice has shipped.

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,8 +33,9 @@ Nothing in flight. The product rethink (see Next) has not started.
 
 ## Next
 
-- The product rethink: what direction the restored builder product grows in.
-  Parked builder-era issues (#1087, #1101, #1107) are eligible again but stay
-  parked until that conversation happens.
+- The product rethink is now planned: see [`rethink-plan.md`](rethink-plan.md)
+  (agreed 2026-08-14). First up is Stage 1, the post-revert audit. Parked
+  builder-era issues (#1087, #1101, #1107) are eligible again but stay parked
+  until Stage 4 chooses a direction.
 - Follow-up: port the wire-pin test technique (per-variant bincode
   fingerprint) to the `ActiveSession` crash-recovery blob.


### PR DESCRIPTION
Documents the agreed plan for the phase following the coach revert (#1344), before any of it starts.

- New [`docs/rethink-plan.md`](https://github.com/jonyardley/intrada/blob/claude/coach-revert-next-phase-f8d5c3/docs/rethink-plan.md): four stages (audit, design improvements, implement, choose the next major phase), each step with model/effort, run location, and what runs in parallel.
- API is descoped for the phase: compile-keeping fixes only.
- Stage 4 research runs as the decoupled second stream during Stage 3 (decision 2026-08-14).
- `docs/status.md` Next section points at the plan.

Tier 1 docs-only change; `just hygiene` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)