### PR TITLE
docs: the v0.7.0 audit synthesis — audit-2026-08.md and the five-phase build order

### DIFF
--- a/docs/audit-2026-08.md
+++ b/docs/audit-2026-08.md
@@ -1,0 +1,100 @@
+# Audit — 2026-08 (v0.7.0, the restored builder)
+
+*Stage 1 synthesis for the [Phase R plan](rethink-plan.md). This is the
+definitive cross-session reference for what the audit found and the order the
+work runs in. Every finding is an issue; **when this doc and the issues
+disagree, the issues are right.** [`status.md`](status.md) tracks which step
+is live.*
+
+## How Stage 1 actually ran
+
+- **1.1 code health** — ran as a reduced post-revert health check rather than
+  the full `improve`-skill audit: all gates green on main, remnant sweep clean
+  (no live coach leftovers, no stranded dead code, dead migrations correctly
+  kept), docs reconciled (#1350). The deeper code-health audit stays available
+  if Stage 3 hits friction; it is not blocking.
+- **1.2 product walk-through** — done by Jon on-device against the v0.7.0
+  TestFlight build (2026-08-14), two passes covering every screen. Findings
+  below.
+- **1.3 issue triage** — done: 30 defunct coach-era issues closed, the
+  builder-era issues unparked, the `superseded-by-pivot` label emptied.
+- **1.4 synthesis** — this doc.
+
+## The build order
+
+Phases run in order; within a phase, order is by convenience. Tiers per
+CLAUDE.md Workflow.
+
+### Phase 1 — Fix and trim (small, shippable now)
+
+- [#1357](https://github.com/jonyardley/intrada/issues/1357) — Today shows no
+  sessions while the calendar indicator shows one. The one functional bug
+  found; suspected UTC day-boundary class (see #1330 / #1346, still open).
+- [#1354](https://github.com/jonyardley/intrada/issues/1354) — Library: drop
+  the scroll-triggered fade-in, keep the page-load fade.
+- [#1365](https://github.com/jonyardley/intrada/issues/1365) — Live view:
+  tempo display is too small.
+- [#1368](https://github.com/jonyardley/intrada/issues/1368) — Session
+  Complete: remove the celebration animation and the reflect trio.
+- [#1358](https://github.com/jonyardley/intrada/issues/1358) — Practice:
+  remove the custom-session entry point (styling recoverable later).
+- [#1356](https://github.com/jonyardley/intrada/issues/1356) — Validate the
+  Piece/Exercise pill animation jank (iOS 27 beta suspect).
+
+### Phase 2 — Say it right (tone of voice)
+
+- [#1359](https://github.com/jonyardley/intrada/issues/1359) — write
+  `docs/tone-of-voice.md`, Jon red-pens it, then one sweep PR over all copy.
+  Scope includes the Library header, the Practice header text, and the
+  builder's "Where do you want to focus?" title.
+- Then, wording from the doc:
+  [#1360](https://github.com/jonyardley/intrada/issues/1360) — Practice hero
+  repurposed (last session + one-tap start) and the subline replaced with
+  "Last practised Tuesday";
+  [#1361](https://github.com/jonyardley/intrada/issues/1361) — one-line
+  Piece/Exercise caption under the create-form pills.
+
+### Phase 3 — Round out the loop (small features)
+
+- [#1362](https://github.com/jonyardley/intrada/issues/1362) — builder:
+  "Recently practised" quick-add section.
+- [#1370](https://github.com/jonyardley/intrada/issues/1370) — Session
+  Complete: add/edit notes per item.
+- [#1371](https://github.com/jonyardley/intrada/issues/1371) — Practice
+  history: tap a session card to open a detail view.
+- [#1364](https://github.com/jonyardley/intrada/issues/1364) — live view:
+  overall session timer (placement to design first).
+
+### Phase 4 — Practice instruments (spec-first, Tier 3)
+
+- [#1366](https://github.com/jonyardley/intrada/issues/1366) — metronome;
+  tempo becomes a tracked unit of measure. `ios/Reference/` keeps the
+  background-audio Swift for reuse.
+- [#1367](https://github.com/jonyardley/intrada/issues/1367) — pass counter,
+  0 to 10, +1 perfect / -1 wrong, every increment recorded. Predecessor
+  review (builder rep counter vs coach tap-verdicts) parked on the issue.
+- [#1355](https://github.com/jonyardley/intrada/issues/1355) — photo
+  aide-memoire on items; iteration 1 is exactly one photo.
+
+### Phase 5 — Explorations (conversation before code)
+
+- [#1363](https://github.com/jonyardley/intrada/issues/1363) — related
+  exercises: many-to-many links, standalone exercises, score attribution.
+- [#1369](https://github.com/jonyardley/intrada/issues/1369) — Session
+  Complete scoring redesign: density, overall score, mood tracker.
+- Parked topics awaiting a design conversation: user guidance / onboarding,
+  sections + chord charts for fine-grained tracking (and their later display
+  in the live view), the keyboard-covers-field UX on expanding form fields.
+
+## Decisions taken (Jon, 2026-08-14)
+
+- Tone of voice: doc first, then the sweep (1a).
+- Practice hero: repurpose with real content, keep the visual weight (2a).
+- Practice subline: relative last-practised line (3a).
+- Create form: captions under the type pills, worded by the tone doc (4a).
+- Attempt counter: predecessor question deliberately parked until pickup.
+
+## Not covered
+
+`crates/intrada-api` (descoped for the phase), accessibility beyond what the
+per-screen gates enforce, and the deeper code-health audit noted under 1.1.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,11 +23,12 @@ and [open issues](https://github.com/jonyardley/intrada/issues).*
 >
 > What the product does today is the restored builder flow: build a session
 > from the library, group and reorder, play it through the Focus Player,
-> reflect on the summary. **What direction it grows in next is an open
-> question**: the rethink follows the revert. Issues parked under
-> [`superseded-by-pivot`](https://github.com/jonyardley/intrada/labels/superseded-by-pivot)
-> (#1087, #1101, #1107) are eligible again but stay parked until that
-> conversation happens.
+> reflect on the summary. The near-term direction is the audit backlog in
+> [`audit-2026-08.md`](audit-2026-08.md) (refine the builder, step by step);
+> **the next major direction stays open** and is Stage 4 of
+> [`rethink-plan.md`](rethink-plan.md). The post-revert triage (2026-08-14)
+> closed the defunct coach-era issues and unparked the builder-era ones; the
+> `superseded-by-pivot` label is empty and retired.
 
 ---
 
@@ -67,9 +68,11 @@ Filter `is:open is:issue` on the board to see what's currently in flight.
 
 ### Current focus (2026-08)
 
-The coach pivot is reversed (see the banner at the top); the restored
-session-builder product is current. The immediate work is the revert's
-follow-ups and the product rethink. See [`status.md`](status.md) and the
+The coach pivot is reversed (see the banner at the top); v0.7.0, the
+restored session-builder product, is on TestFlight. The immediate work is
+the five-phase audit backlog in [`audit-2026-08.md`](audit-2026-08.md),
+run under [`rethink-plan.md`](rethink-plan.md). See
+[`status.md`](status.md) and the
 [project board](https://github.com/users/jonyardley/projects/2)
 for what's actually in flight.
 
@@ -174,9 +177,11 @@ multiple items share the same horizon.
 These are unresolved product questions. Each one likely produces issues
 (or a Tier-3 spec) once answered.
 
-1. **Metronome (re-opened 2026-08).** A native click shipped with the coach
-   and was removed with it (#1344, recoverable from history). If the builder
-   product wants a metronome, that code is the starting point.
+1. **Metronome (answered 2026-08-14).** The builder product does want one:
+   tracked as #1366 (audit Phase 4), with tempo as a tracked unit of
+   measure. The coach-era click (removed in #1344, recoverable from
+   history) and the preserved `ios/Reference/` audio-session Swift are the
+   starting points.
 
 2. **Offline-first architecture (resolved 2026-07).** The native app is
    offline-first by design — on-device SQLite is the source of truth, with

--- a/docs/status.md
+++ b/docs/status.md
@@ -10,32 +10,31 @@ ask git: `git log -1 --format=%cs docs/status.md`.*
 
 ## Where we are
 
-**The coach pivot is reversed (2026-08-13, #1344).** The practice-coach
-direction built through Phase 2b went too far too fast; the decision was to
-restore the session-builder product and remove the coach. The builder as it
-stood at 9e92ab2 is back on today's toolchain (Rust 1.97.1, crux 0.20,
-current CI): build a setlist from the library, group and reorder blocks, edit
-reps and duration per entry, play through the Focus Player, reflect on the
-summary. All coach machinery (engine, drill loop, mastery track, built
-sessions, click) is removed; it stays recoverable from commit 071b85b, and
-the design record keeps its bannered specs.
-
-What replaces the coach as product direction is an open question. The
-rethink follows this revert, it did not precede it.
+**v0.7.0, the restored session builder, is on TestFlight (2026-08-14).**
+The coach revert (#1344) landed clean: gates green, remnant sweep clean,
+docs reconciled (#1350). Phase R ([`rethink-plan.md`](rethink-plan.md))
+Stage 1 is complete: Jon's on-device audit of v0.7.0 covered every screen,
+the triage closed 30 defunct coach-era issues and emptied the
+`superseded-by-pivot` label, and the synthesis is
+[`audit-2026-08.md`](audit-2026-08.md) — the definitive reference for the
+audit backlog and its five-phase build order.
 
 ## In flight
 
-Nothing in flight. The product rethink (see Next) has not started.
+- Nothing. Next slice is audit Phase 1 (fix and trim).
 
 ## Recently landed
 
-- #1344 — the session-builder revert, merged 2026-08-13 (commit 9b8da6d).
+- v0.7.0 tagged and uploaded to TestFlight (version bump #1351).
+- #1352 — the Phase R rethink plan.
+- Stage 1 of Phase R: audit, triage and synthesis
+  ([`audit-2026-08.md`](audit-2026-08.md)); findings filed as #1354–#1371.
 
 ## Next
 
-- The product rethink is now planned: see [`rethink-plan.md`](rethink-plan.md)
-  (agreed 2026-08-14). First up is Stage 1, the post-revert audit. Parked
-  builder-era issues (#1087, #1101, #1107) are eligible again but stay parked
-  until Stage 4 chooses a direction.
+- Audit Phase 1, fix and trim: #1357 (Today bug), then #1354, #1365, #1368,
+  #1358, #1356. Then Phase 2 starts with the tone-of-voice doc (#1359).
+- Stage 4 direction research (per the rethink plan) may run as the decoupled
+  second stream once Phase 1 is under way.
 - Follow-up: port the wire-pin test technique (per-variant bincode
-  fingerprint) to the `ActiveSession` crash-recovery blob.
+  fingerprint) to the `ActiveSession` crash-recovery blob (#1345).


### PR DESCRIPTION
Stage 1.4 of the Phase R plan: Jon's two-pass on-device audit of the v0.7.0 TestFlight build, synthesised into docs/audit-2026-08.md as the definitive cross-session reference. Every finding is an issue (#1354 to #1371); the doc carries the five-phase build order (fix and trim, tone of voice, round out the loop, practice instruments, explorations), the decisions taken, and the deliberately parked topics.

Also: status.md moved on to Stage-1-complete reality, and three roadmap corrections (banner no longer claims the near-term direction is open, current-focus points at the audit doc, metronome open question answered by #1366).

Tier 1 docs change: gates run, review subagent skipped per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)