### PR TITLE
docs: merge-not-rebase to clear false PR conflicts; native stacked-PR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,6 +760,16 @@ issue; these rules stop two streams colliding in the same *files*. Both apply.
 - One git worktree per stream, branched from fresh `origin/main`. Follow the
   simulator safety rule under Commands. Close the second session when its task
   ships; do not keep it warm.
+- **Clear a "conflicting" PR by merging main in, never by rebasing.**
+  `git fetch origin main && git merge origin/main && git push`. `docs/status.md`
+  is union-merged (`.gitattributes`), which local git honours but GitHub's
+  conflict checker does not — so the flag is usually false and the merge
+  resolves clean with no manual conflict work. Union keeps both sides' lines,
+  so eyeball status.md for duplicated prose before pushing.
+- **Dependent PRs stack natively, depth 2 max.** Open the child PR with base =
+  the parent's branch; GitHub retargets it to main when the parent merges.
+  After the parent squash-merges, rebase the child:
+  `git rebase --onto origin/main <parent-old-head>`. No stacking tooling.
 
 ### One agent per slice; fan out only on independent work
 


### PR DESCRIPTION
## What

Two additions to CLAUDE.md's stream rules, from today's investigation:

1. **Clear a "conflicting" PR by merging main in, never rebasing.** #1252's `merge=union` on `docs/status.md` works — but only locally. GitHub's conflict checker ignores `.gitattributes` merge settings, so its flag is usually false. Verified against #1380: `git merge-tree` resolves it completely clean while GitHub reports it dirty. A local merge of main clears the flag with zero manual conflict work. Caveat documented: union keeps both sides' lines, so status.md needs an eyeball for duplicated prose.

2. **Dependent PRs stack natively, depth 2 max.** Child PR based on the parent's branch; GitHub auto-retargets on parent merge (delete-branch-on-merge is on). After a squash-merge of the parent, `git rebase --onto origin/main <parent-old-head>`. No Graphite or other tooling.

Tier 1 docs-only; hygiene gate green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)