### PR TITLE
docs: Stage 4.2 comparison, the decided quick-wins-first order, and the plain-language rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -742,6 +742,16 @@ issue; these rules stop two streams colliding in the same *files*. Both apply.
   list item** in a structured doc (`docs/status.md`, `docs/roadmap.md`,
   `design/CLAUDE.md` and this file's own lists) is house style, so match the
   siblings there. Sentences never take one, in a list item or anywhere else.
+- **Plain language in docs, issues and PR bodies** (Jon, 2026-08-14). Name
+  features by the musician-visible outcome ("exercises from a chord chart",
+  "the Up next card"), with the codename in brackets once if git archaeology
+  needs it. Issue numbers are the only stable handles — never bare workstream
+  letters ("B1", "Phase B") across docs; three unrelated "Phase B"s existed
+  at once when this rule was made. Issue titles state the outcome. Sweep
+  test: would you say the sentence to a musician? Process terms (slice,
+  stream, tier…) live in the glossary in
+  [`docs/reference.md`](docs/reference.md); older docs are renamed as
+  touched, not swept.
 
 ### Stream rules
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -285,3 +285,26 @@ don't copy this variant for a new entity, until that's resolved.
 
 Updates use `*Updated { entity }` (the server echoes the row). Deletes use
 `DeleteConfirmed`, since the model is already mutated optimistically.
+
+## Glossary
+
+Process words that recur in docs, issues and PR bodies. Feature names don't
+belong here: they follow the plain-language rule (CLAUDE.md → Conventions),
+which names the musician-visible outcome and allows a codename in brackets
+once.
+
+- **slice** — the smallest independently shippable piece of a feature; each
+  one is shipped and used before the next is built.
+- **stream** — one line of work in one worktree and session; *vertical* means
+  core + iOS together.
+- **tier** — ceremony level per CLAUDE.md Workflow: 1 just do it, 2 plan
+  mode, 3 spec first.
+- **worktree** — a separate git checkout so parallel streams don't collide.
+- **bridge** — the generated FFI boundary (Event / Effect / ViewModel)
+  between the Rust core and the Swift shell.
+- **local-first** — works offline against the on-device store; no HTTP on
+  the path.
+- **projection / derived** — computed from existing session history; no new
+  stored data.
+- **shell-dead** — core code no Swift screen calls any more; a deletion
+  candidate (the #1348 pattern).

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -1,0 +1,101 @@
+# Stage 4.2 — choosing the next direction
+
+*Phase R, Stage 4.2 ([`rethink-plan.md`](../rethink-plan.md)): the one-page
+comparison of the five Stage 4.1 notes in this folder. Jon picks; Stage 4.3
+(Tier-3 spec, then design, then slices) follows the pick. Written 2026-08-14.*
+
+## What the research changed about the choice
+
+The five notes were commissioned as equals. They did not come back as equals:
+
+- **Chart-to-scaffold Phase B is already shipped.** #1110 merged 2026-07-17,
+  Phase C (#1111) the same week; the coach pivot froze it before it was ever
+  used critically. #1106 is stale and should close as shipped; the only unbuilt
+  residue is the twelve-key ladder wiring (#1107), plausibly Tier 2 now that
+  the `Variant` mechanism it was blocked on has landed. What remains here is
+  *validation through use*, not a build direction.
+- **The metronome is already committed** as audit Phase 4 (#1366, spec-first,
+  Tier 3), so it ships through the Stage 3 pipeline whichever direction wins.
+  Its note mostly de-risks that work: the click engine is recoverable intact
+  from `8af4891^`, the tempo plumbing (target, per-entry capture, computed
+  history) already spans the core, and the differentiating claim, tempo as a
+  tracked measure, is genuinely unoccupied ground. Picking it as *the
+  direction* would re-badge scheduled work.
+- **The other three are stages of one pipeline, not rivals.** Lesson-to-mastery
+  B derives the (exercise × piece) grain; R (the Up next card, #1082) is the
+  one consumer surface; spacing urgency (Space layer) and goal alignment
+  (goals) are *inputs to that consumer*. Neither input has anywhere to land
+  until B and R exist. The real question is where the pipeline starts.
+
+## Side by side
+
+| Candidate | Smallest slice | Slice tier | Evidence strength | Killer risk |
+|---|---|---|---|---|
+| Lesson-to-mastery (B→R) | B1: derive per-piece contexts, read-only | 2 (bridge override) | Strong on the regulatory gap it serves | A's capture shape still unproven (twice-deleted class) |
+| Space layer | Passive "getting cold" signal, pure projection | 2 (bridge override) | Principle robust; every formula unvalidated for repertoire | Coach-shaped opinion; sparse self-rated data |
+| Goals rebuilt small | `Goal` entity + "Practise this goal" | 3 (new entity, FFI + schema) | Goal-setting theory robust; apparatus unsupported | Third build of a twice-deleted feature; star untested |
+| Metronome + tempo | Resurrect `ClickEngine` into Focus Player | 2 (iOS-only, zero schema) | Measurement claim solid; strategy claims contested | Audio quality bar; already scheduled anyway |
+| Chart-to-scaffold residue | Use the shipped flow; close #1106, re-scope #1107 | Docs/sim only | Tradition strong, trials thin | Shipped but never validated in anger |
+
+## The cases in brief
+
+- **Lesson-to-mastery** — the strongest candidate on every axis that has bitten
+  this repo before. B1 is the smallest honest slice in the field (read-side
+  derivation over data that already exists, no migration). It is
+  tracking-shaped, and the repo's pattern is blunt: capture-shaped surfaces
+  (lessons #273, goals #769) get deleted, tracking-shaped structure (variants,
+  scaffold links) survives. Jon's weekly lesson gives every slice authentic
+  use within days, the fastest feedback loop available to an n=1 product. And
+  B is a prerequisite investment: whatever wins later, the scheduler needs
+  this grain.
+- **Space layer** — the right second act. Slice 1 (graded freshness replacing
+  the binary 14-day flag) is cheap and honest, but its natural consumer is R's
+  reason strings, so shipping it first would build a signal with nowhere good
+  to land. The full scheduler is the known-unknown end state; nothing published
+  validates any interval formula for repertoire.
+- **Goals rebuilt small** — evidence supports exactly the small shape ruled in
+  roadmap Q5, but two facts say not yet: the flat priority star has not been
+  given its full chance (#764 unshipped, and `specs/priority-items.md`
+  explicitly deferred grouping until the flat list proves insufficient), and
+  the planning consumer goals feed does not exist. Building the third goals
+  feature before either exists would repeat the setup-burden-before-value
+  diagnosis that killed the second.
+- **Metronome** — ships regardless via audit Phase 4. The note's findings
+  (engine recoverable, schema gap smaller than #1366 assumed, analytics slice
+  blocked on roadmap Q3) fold into that spec when Stage 3 reaches it.
+- **Chart-to-scaffold** — the bookkeeping (#1106 closed, #1107 re-scoped) and
+  the validation ride along free: the weekly lesson's tunes are jazz
+  standards, so lesson-to-mastery use *is* chart-to-scaffold use. The ladder
+  wiring (#1107) becomes a natural follow-on once real use says the generated
+  material is good.
+
+## Recommendation
+
+**Lesson-to-mastery, B-first, as the Stage 4.3 direction.** It is the smallest
+honest start, the shape that survives in this codebase, the fastest to real
+use, and the prerequisite for both other genuine directions rather than a bet
+against them. Sequence: B1/B2 (per-piece tracking), then R (Up next, held to
+suggest-never-gate), with Space slice 1 as R's first new reason signal and
+goals revisited only if lived use of star + goals-shaped ambitions says the
+flat list is insufficient. Metronome continues on its audit Phase 4 track;
+chart-to-scaffold gets validated through the same lessons and its books trued
+up now.
+
+## Decisions
+
+**1. The Stage 4.3 direction** — which candidate gets the Tier-3 spec and the
+first slice.
+
+&nbsp;&nbsp;a. Lesson-to-mastery, B→R, spacing and goals sequenced behind it
+(recommended)
+&nbsp;&nbsp;b. Space layer, slice 1 first
+&nbsp;&nbsp;c. Goals rebuilt small
+&nbsp;&nbsp;d. Chart-to-scaffold: ladder wiring (#1107) as the next vertical
+&nbsp;&nbsp;e. Metronome, pulled forward from audit Phase 4
+
+**2. Chart-to-scaffold bookkeeping** — decision-independent; default is to do
+it now: close #1106 as shipped (#1110), re-scope #1107 to the twelve-key
+ladder residue, noting the dependency (#1083) is met.
+
+&nbsp;&nbsp;a. Do it now (recommended)
+&nbsp;&nbsp;b. Hold until the direction pick

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -81,6 +81,9 @@ Do now (days, not weeks):
 2. **Use the chord-chart flow** on the week's lesson tune — enter the chart,
    commit the exercises, practise them through the builder; file friction as
    issues. No code; this answers whether the generated material is any good.
+   Entry-friction notes feed the chart-entry rethink (#1387): a friendlier
+   manual input is its near half, designed once real use has shown where the
+   current text format grates.
 3. **The click** — bring the deleted metronome engine back into the Focus
    Player (recoverable from `8af4891^`). iOS-only, no schema, Tier 2; pulled
    forward from audit Phase 4 because the hard part already exists. 1–2 days.
@@ -107,7 +110,11 @@ Big bets, last, each a fresh decision gated on lived use:
 9. **Remembering when to resurface pieces** — the cold shelf in the builder,
    then stored per-item scheduling state (the real Tier 3 of the
    `space-layer` note).
-10. **Quick lesson entry (#1080) and goals** — the twice-deleted
+10. **A chart from a photo (#1387)** — photograph a lead sheet and the app
+    reads the changes into a chart for review, entirely on-device.
+    Feasibility spike first (OCR + the existing parser vs an on-device
+    model); changes only, never melodies.
+11. **Quick lesson entry (#1080) and goals** — the twice-deleted
     admin-shaped features; revisited only if use says the star list and a
     fast add path are not enough.
 

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -69,33 +69,59 @@ The five notes were commissioned as equals. They did not come back as equals:
   wiring (#1107) becomes a natural follow-on once real use says the generated
   material is good.
 
-## Recommendation
+## Recommended order — quick wins first, big bets last
 
-**Lesson-to-mastery, B-first, as the Stage 4.3 direction.** It is the smallest
-honest start, the shape that survives in this codebase, the fastest to real
-use, and the prerequisite for both other genuine directions rather than a bet
-against them. Sequence: B1/B2 (per-piece tracking), then R (Up next, held to
-suggest-never-gate), with Space slice 1 as R's first new reason signal and
-goals revisited only if lived use of star + goals-shaped ambitions says the
-flat list is insufficient. Metronome continues on its audit Phase 4 track;
-chart-to-scaffold gets validated through the same lessons and its books trued
-up now.
+*(Reshaped 2026-08-14 on Jon's direction: one sequence across the candidates,
+smallest first, each later step gated on use of the one before. The direction
+underneath is lesson-to-mastery B-first; the early steps pull the cheap,
+already-paid-for wins forward.)*
+
+Do now (days, not weeks):
+
+1. **Chart-to-scaffold bookkeeping** — close #1106 as shipped (#1110),
+   re-scope #1107 to the twelve-key ladder residue (#1083 dependency met).
+   Minutes.
+2. **Use the shipped scaffold flow** on the week's lesson tune — chart entry,
+   commit, practise through the builder; file friction as issues. No code;
+   this is the validation slice its note asks for.
+3. **Metronome slice 1: the click** — resurrect `ClickEngine` (recoverable
+   from `8af4891^`) into the Focus Player. iOS-only, zero schema, Tier 2;
+   pulled forward from audit Phase 4 because the engine already exists. 1–2
+   days.
+4. **Tempo capture prefill** — reflection stepper pre-fills from the click and
+   shows without a declared target. Small core touch. About a day.
+5. **B1 + B2: per-piece tracking** — the (exercise × piece) derivation (core,
+   read-only, bridge tests) then the "By piece" UI. 3–5 days total; the first
+   step needing the Tier-3 spec discipline.
+
+Then, each building on the last:
+
+6. **R: Up next card** — one dismissible suggested session, reasons in plain
+   words, held to suggest-never-gate. Needs B's grain. 2–3 days.
+7. **Tempo trend surface** — render the computed `tempo_history`; blocked on
+   roadmap Q3 (score vs score-at-tempo) being answered first.
+8. **Space slice 1** — the graded "getting cold" signal, landing as Up next
+   reason strings rather than a surface of its own. 1–2 days once R exists.
+
+Big bets, last, each a fresh decision gated on lived use:
+
+9. **Space slices 2–3** — the cold shelf in the builder, then persisted
+   scheduling state (the real Tier 3 of the Space layer).
+10. **A revisited and goals** — the twice-deleted capture-shaped features;
+    revisited only if use says the flat star list and a fast add path are
+    insufficient.
 
 ## Decisions
 
-**1. The Stage 4.3 direction** — which candidate gets the Tier-3 spec and the
-first slice.
+**1. Adopt the order above** — it takes lesson-to-mastery as the Stage 4.3
+direction, pulls the metronome click forward from audit Phase 4, and defers
+the capture-shaped builds to the end.
 
-&nbsp;&nbsp;a. Lesson-to-mastery, B→R, spacing and goals sequenced behind it
-(recommended)
-&nbsp;&nbsp;b. Space layer, slice 1 first
-&nbsp;&nbsp;c. Goals rebuilt small
-&nbsp;&nbsp;d. Chart-to-scaffold: ladder wiring (#1107) as the next vertical
-&nbsp;&nbsp;e. Metronome, pulled forward from audit Phase 4
+&nbsp;&nbsp;a. Adopt as sequenced (recommended)
+&nbsp;&nbsp;b. Adopt but keep the metronome on its audit Phase 4 slot
+&nbsp;&nbsp;c. Different direction underneath (Space / goals / ladder first)
 
-**2. Chart-to-scaffold bookkeeping** — decision-independent; default is to do
-it now: close #1106 as shipped (#1110), re-scope #1107 to the twelve-key
-ladder residue, noting the dependency (#1083) is met.
+**2. Chart-to-scaffold bookkeeping** — step 1 above, decision-independent.
 
 &nbsp;&nbsp;a. Do it now (recommended)
 &nbsp;&nbsp;b. Hold until the direction pick

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -1,127 +1,121 @@
 # Stage 4.2 — choosing the next direction
 
 *Phase R, Stage 4.2 ([`rethink-plan.md`](../rethink-plan.md)): the one-page
-comparison of the five Stage 4.1 notes in this folder. Jon picks; Stage 4.3
-(Tier-3 spec, then design, then slices) follows the pick. Written 2026-08-14.*
+comparison of the five research notes in this folder. **Decided 2026-08-14:
+Jon adopted the ordered sequence below.** Feature names follow the
+plain-language rule (CLAUDE.md → Conventions); each note's codename appears
+once, in brackets, for the git history.*
 
 ## What the research changed about the choice
 
 The five notes were commissioned as equals. They did not come back as equals:
 
-- **Chart-to-scaffold Phase B is already shipped.** #1110 merged 2026-07-17,
-  Phase C (#1111) the same week; the coach pivot froze it before it was ever
-  used critically. #1106 is stale and should close as shipped; the only unbuilt
-  residue is the twelve-key ladder wiring (#1107), plausibly Tier 2 now that
-  the `Variant` mechanism it was blocked on has landed. What remains here is
-  *validation through use*, not a build direction.
-- **The metronome is already committed** as audit Phase 4 (#1366, spec-first,
-  Tier 3), so it ships through the Stage 3 pipeline whichever direction wins.
-  Its note mostly de-risks that work: the click engine is recoverable intact
-  from `8af4891^`, the tempo plumbing (target, per-entry capture, computed
-  history) already spans the core, and the differentiating claim, tempo as a
-  tracked measure, is genuinely unoccupied ground. Picking it as *the
-  direction* would re-badge scheduled work.
-- **The other three are stages of one pipeline, not rivals.** Lesson-to-mastery
-  B derives the (exercise × piece) grain; R (the Up next card, #1082) is the
-  one consumer surface; spacing urgency (Space layer) and goal alignment
-  (goals) are *inputs to that consumer*. Neither input has anywhere to land
-  until B and R exist. The real question is where the pipeline starts.
+- **The chord-chart feature is already built.** Enter a tune's chord changes
+  and the app writes its practice exercises — shells, guide-tone lines,
+  scales, constrained improvisation (note:
+  [`chart-to-scaffold-phase-b.md`](chart-to-scaffold-phase-b.md)). It shipped
+  in #1110 and #1111 on 2026-07-17 and froze, unused, behind the coach pivot;
+  the issue asking for it (#1106) was simply never closed. The one missing
+  part is generating those exercises in all twelve keys (#1107). What remains
+  is *using it for real*, not building it.
+- **The metronome is already scheduled** as audit Phase 4 (#1366, spec-first),
+  so it ships through the Stage 3 pipeline whichever direction won. Its note
+  ([`metronome.md`](metronome.md)) mostly de-risks that work: the click engine
+  survived deletion intact (recoverable from `8af4891^`), the tempo plumbing
+  already spans the core, and tempo-as-a-tracked-measure is genuinely
+  unoccupied ground among competitors.
+- **The other three are stages of one pipeline, not rivals.** Per-piece
+  tracking (#1081) works out how each exercise is going for each tune it
+  serves; the Up next card (#1082) is the one place suggestions appear; the
+  getting-cold signal ([`space-layer.md`](space-layer.md)) and goals
+  ([`goals-rebuilt-small.md`](goals-rebuilt-small.md)) are *inputs to that
+  card*, with nowhere to land until it exists. The real question was never
+  which one, but where the pipeline starts.
 
 ## Side by side
 
-| Candidate | Smallest slice | Slice tier | Evidence strength | Killer risk |
+| Candidate (research note) | Smallest step | Size | Evidence | Biggest risk |
 |---|---|---|---|---|
-| Lesson-to-mastery (B→R) | B1: derive per-piece contexts, read-only | 2 (bridge override) | Strong on the regulatory gap it serves | A's capture shape still unproven (twice-deleted class) |
-| Space layer | Passive "getting cold" signal, pure projection | 2 (bridge override) | Principle robust; every formula unvalidated for repertoire | Coach-shaped opinion; sparse self-rated data |
-| Goals rebuilt small | `Goal` entity + "Practise this goal" | 3 (new entity, FFI + schema) | Goal-setting theory robust; apparatus unsupported | Third build of a twice-deleted feature; star untested |
-| Metronome + tempo | Resurrect `ClickEngine` into Focus Player | 2 (iOS-only, zero schema) | Measurement claim solid; strategy claims contested | Audio quality bar; already scheduled anyway |
-| Chart-to-scaffold residue | Use the shipped flow; close #1106, re-scope #1107 | Docs/sim only | Tradition strong, trials thin | Shipped but never validated in anger |
+| The weekly-lesson loop (`lesson-to-mastery`, #1087) | Show per-piece progress from existing data (#1081) | Days | Strong: unsupervised practice measurably fails without structure | Lesson *entry* is the twice-deleted kind of feature |
+| The getting-cold signal (`space-layer`) | Staleness estimate from existing history | Days | Spacing between sessions is solid; no formula is validated for repertoire | The app forming opinions is the road the coach died on |
+| Goals, kept small (`goals-rebuilt-small`) | A goal + "Practise this goal" | Weeks: new entity, FFI + schema | Goal-setting theory robust; the old heavy apparatus unsupported | Third build of a twice-deleted feature; the star never got its trial |
+| Metronome + tempo (`metronome`) | The click, inside the Focus Player | 1–2 days | Tempo as a measure is solid; practice-strategy claims contested | Musicians hear milliseconds; and it's already scheduled anyway |
+| Exercises from chord charts (`chart-to-scaffold-phase-b`) | Use the shipped flow; fix the stale issues | Minutes to hours | Matches how jazz is actually taught; formal trials thin | Built but never used in anger |
 
 ## The cases in brief
 
-- **Lesson-to-mastery** — the strongest candidate on every axis that has bitten
-  this repo before. B1 is the smallest honest slice in the field (read-side
-  derivation over data that already exists, no migration). It is
-  tracking-shaped, and the repo's pattern is blunt: capture-shaped surfaces
-  (lessons #273, goals #769) get deleted, tracking-shaped structure (variants,
-  scaffold links) survives. Jon's weekly lesson gives every slice authentic
-  use within days, the fastest feedback loop available to an n=1 product. And
-  B is a prerequisite investment: whatever wins later, the scheduler needs
-  this grain.
-- **Space layer** — the right second act. Slice 1 (graded freshness replacing
-  the binary 14-day flag) is cheap and honest, but its natural consumer is R's
-  reason strings, so shipping it first would build a signal with nowhere good
-  to land. The full scheduler is the known-unknown end state; nothing published
-  validates any interval formula for repertoire.
-- **Goals rebuilt small** — evidence supports exactly the small shape ruled in
-  roadmap Q5, but two facts say not yet: the flat priority star has not been
-  given its full chance (#764 unshipped, and `specs/priority-items.md`
-  explicitly deferred grouping until the flat list proves insufficient), and
-  the planning consumer goals feed does not exist. Building the third goals
-  feature before either exists would repeat the setup-burden-before-value
-  diagnosis that killed the second.
-- **Metronome** — ships regardless via audit Phase 4. The note's findings
-  (engine recoverable, schema gap smaller than #1366 assumed, analytics slice
-  blocked on roadmap Q3) fold into that spec when Stage 3 reaches it.
-- **Chart-to-scaffold** — the bookkeeping (#1106 closed, #1107 re-scoped) and
-  the validation ride along free: the weekly lesson's tunes are jazz
-  standards, so lesson-to-mastery use *is* chart-to-scaffold use. The ladder
-  wiring (#1107) becomes a natural follow-on once real use says the generated
-  material is good.
+- **The weekly-lesson loop** — strongest on every axis that has bitten this
+  repo before. Its first step is the smallest in the field: no new data
+  entry, no new storage, just reading the practice history that already
+  exists and slicing it by piece. It is a *tracking* feature, and the
+  repo's pattern is blunt: features that track what you did survive; features
+  that ask you to fill in admin (lesson entry #273, goals #769) have been
+  built and deleted twice. Jon's real weekly lesson means every step gets
+  honest use within days.
+- **The getting-cold signal** — the right second act. Cheap and honest as a
+  first step, but its natural home is the Up next card's reason lines
+  ("six days since you played it"), so shipping it first would build a signal
+  with nowhere good to land.
+- **Goals, kept small** — the evidence supports exactly the small shape ruled
+  in roadmap Q5, but two facts say not yet: the priority star has not had its
+  full trial (#764 unshipped), and the planning surface goals feed does not
+  exist. Building goals a third time before either exists would repeat the
+  mistake that killed the second build.
+- **Metronome** — ships regardless via the audit backlog; the research folds
+  into that spec. The click alone is worth pulling forward: the engine is
+  already written and tested, and it ends leaving the app mid-session.
+- **Exercises from chord charts** — the fix-the-books and the validation ride
+  along free: the weekly lesson's tunes are jazz standards, so lesson use
+  *is* chord-chart use.
 
-## Recommended order — quick wins first, big bets last
+## The adopted order — quick wins first, big bets last
 
-*(Reshaped 2026-08-14 on Jon's direction: one sequence across the candidates,
-smallest first, each later step gated on use of the one before. The direction
-underneath is lesson-to-mastery B-first; the early steps pull the cheap,
-already-paid-for wins forward.)*
+Each later step is gated on real use of the one before, not on a schedule.
 
 Do now (days, not weeks):
 
-1. **Chart-to-scaffold bookkeeping** — close #1106 as shipped (#1110),
-   re-scope #1107 to the twelve-key ladder residue (#1083 dependency met).
-   Minutes.
-2. **Use the shipped scaffold flow** on the week's lesson tune — chart entry,
-   commit, practise through the builder; file friction as issues. No code;
-   this is the validation slice its note asks for.
-3. **Metronome slice 1: the click** — resurrect `ClickEngine` (recoverable
-   from `8af4891^`) into the Focus Player. iOS-only, zero schema, Tier 2;
-   pulled forward from audit Phase 4 because the engine already exists. 1–2
-   days.
-4. **Tempo capture prefill** — reflection stepper pre-fills from the click and
-   shows without a declared target. Small core touch. About a day.
-5. **B1 + B2: per-piece tracking** — the (exercise × piece) derivation (core,
-   read-only, bridge tests) then the "By piece" UI. 3–5 days total; the first
-   step needing the Tier-3 spec discipline.
+1. **Fix the stale issues** — close #1106 (built and merged in #1110);
+   rewrite #1107 down to the one unbuilt part, generating chord-chart
+   exercises in all twelve keys (its blocker, exercise steps #1083, has since
+   shipped). Minutes. **Done 2026-08-14.**
+2. **Use the chord-chart flow** on the week's lesson tune — enter the chart,
+   commit the exercises, practise them through the builder; file friction as
+   issues. No code; this answers whether the generated material is any good.
+3. **The click** — bring the deleted metronome engine back into the Focus
+   Player (recoverable from `8af4891^`). iOS-only, no schema, Tier 2; pulled
+   forward from audit Phase 4 because the hard part already exists. 1–2 days.
+4. **Tempo capture** — the end-of-item tempo stepper pre-fills from the click
+   and shows even when the item has no declared target. Small core touch.
+   About a day.
+5. **Per-piece tracking (#1081)** — the core derivation (read-only, real
+   bridge tests) then the "By piece" screens. 3–5 days; the first step that
+   needs the Tier-3 spec discipline.
 
 Then, each building on the last:
 
-6. **R: Up next card** — one dismissible suggested session, reasons in plain
-   words, held to suggest-never-gate. Needs B's grain. 2–3 days.
-7. **Tempo trend surface** — render the computed `tempo_history`; blocked on
-   roadmap Q3 (score vs score-at-tempo) being answered first.
-8. **Space slice 1** — the graded "getting cold" signal, landing as Up next
-   reason strings rather than a surface of its own. 1–2 days once R exists.
+6. **The Up next card (#1082)** — one dismissible suggested session with its
+   reasons in plain words; held to suggest-never-gate. Needs step 5. 2–3 days.
+7. **The tempo trend** — draw the already-computed tempo history per item;
+   blocked on roadmap Q3 (does a mastery score mean anything without its
+   tempo?) being answered first.
+8. **The getting-cold signal** — a graded staleness estimate replacing the
+   binary 14-day flag, landing as Up next reason lines rather than a surface
+   of its own. 1–2 days once step 6 exists.
 
 Big bets, last, each a fresh decision gated on lived use:
 
-9. **Space slices 2–3** — the cold shelf in the builder, then persisted
-   scheduling state (the real Tier 3 of the Space layer).
-10. **A revisited and goals** — the twice-deleted capture-shaped features;
-    revisited only if use says the flat star list and a fast add path are
-    insufficient.
+9. **Remembering when to resurface pieces** — the cold shelf in the builder,
+   then stored per-item scheduling state (the real Tier 3 of the
+   `space-layer` note).
+10. **Quick lesson entry (#1080) and goals** — the twice-deleted
+    admin-shaped features; revisited only if use says the star list and a
+    fast add path are not enough.
 
-## Decisions
+## Decisions (Jon, 2026-08-14)
 
-**1. Adopt the order above** — it takes lesson-to-mastery as the Stage 4.3
-direction, pulls the metronome click forward from audit Phase 4, and defers
-the capture-shaped builds to the end.
-
-&nbsp;&nbsp;a. Adopt as sequenced (recommended)
-&nbsp;&nbsp;b. Adopt but keep the metronome on its audit Phase 4 slot
-&nbsp;&nbsp;c. Different direction underneath (Space / goals / ladder first)
-
-**2. Chart-to-scaffold bookkeeping** — step 1 above, decision-independent.
-
-&nbsp;&nbsp;a. Do it now (recommended)
-&nbsp;&nbsp;b. Hold until the direction pick
+- Adopt the order above; the direction underneath is the weekly-lesson loop.
+- Fix the stale chord-chart issues immediately (done: #1106 closed, #1107
+  re-scoped).
+- Plain language in docs and issues from here on: rule in CLAUDE.md →
+  Conventions, glossary in [`../reference.md`](../reference.md); older docs
+  renamed as touched.

--- a/docs/rethink-plan.md
+++ b/docs/rethink-plan.md
@@ -62,9 +62,9 @@ lands as Stage 3 finishes.
 
 | Step | What | Model / effort | Where | Parallel with |
 |------|------|----------------|-------|---------------|
-| 4.1 | One research note per candidate: goals-rebuilt-small (roadmap Q5), the Space layer (spaced repetition / mastery decay), lesson-to-mastery (#1087), chart-to-scaffold Phase B (#1106), metronome (roadmap Q1). Practice-pedagogy evidence plus Jon's own use. Docs only. | Fable 5 high, web research on | One session per candidate, or parallel subagents | Stage 3, and each other |
-| 4.2 | One-page comparison of the candidates; Jon picks the direction. | Fable 5 high | Lead session | — |
-| 4.3 | Tier-3 spec for the chosen direction, then Claude Design, then phased slices. **Each slice is shipped and used before the next is specced.** | Fable 5 high (spec + design); implementation models per Stage 3 rules | Spec in lead session; slices as vertical streams | — |
+| 4.1 | **Done (2026-08-14, #1384).** One research note per candidate, in `docs/research/`: goals kept small (roadmap Q5), the getting-cold signal / spaced returns, the weekly-lesson loop (#1087), exercises from chord charts (found already shipped in #1110; #1106 closed, #1107 re-scoped), metronome (roadmap Q1). Practice-pedagogy evidence plus Jon's own use. | Fable 5 high, web research on | One session per candidate, or parallel subagents | Stage 3, and each other |
+| 4.2 | **Done and decided (2026-08-14, #1385).** [`research/comparison.md`](research/comparison.md): Jon adopted a quick-wins-first order with the weekly-lesson loop as the direction underneath. | Fable 5 high | Lead session | — |
+| 4.3 | Work the adopted order in `research/comparison.md`: use the shipped chord-chart flow, the metronome click, tempo capture, then per-piece tracking (#1081, where the Tier-3 spec discipline starts), the Up next card (#1082), the getting-cold signal. **Each slice is shipped and used before the next is specced.** | Fable 5 high (spec + design); implementation models per Stage 3 rules | Spec in lead session; slices as vertical streams | — |
 
 ## Exit criteria for the phase
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,6 +33,12 @@ audit backlog and its five-phase build order.
 
 ## Recently landed
 
+- Stage 4.2 of Phase R: [`research/comparison.md`](research/comparison.md),
+  the one-page comparison of the five candidates. Recommended lean:
+  lesson-to-mastery, B-first, with the Space layer and goals sequenced behind
+  the Up next consumer; metronome stays on its audit Phase 4 track;
+  chart-to-scaffold bookkeeping (#1106 close, #1107 re-scope) is
+  decision-independent. Awaiting Jon's pick; Stage 4.3 (Tier-3 spec) follows.
 - Stage 4.1 of Phase R: five research notes under
   [`docs/research/`](research/) — goals-rebuilt-small, the Space layer,
   lesson-to-mastery (#1087), chart-to-scaffold Phase B (#1106), metronome
@@ -73,7 +79,7 @@ audit backlog and its five-phase build order.
 - Audit Phase 1, fix and trim: #1357 (Today bug), then #1356.
 - Phase 2, say it right: #1360 (Practice hero/subline) and #1361 (create-form
   captions), with wordings the tone-of-voice doc already settled.
-- Stage 4.2: one-page comparison of the five research notes; Jon picks the
-  direction.
+- Stage 4.3: Jon answers [`research/comparison.md`](research/comparison.md)'s
+  decisions, then the Tier-3 spec for the chosen direction.
 - Follow-up: port the wire-pin test technique (per-variant bincode
   fingerprint) to the `ActiveSession` crash-recovery blob (#1345).

--- a/docs/status.md
+++ b/docs/status.md
@@ -34,11 +34,11 @@ audit backlog and its five-phase build order.
 ## Recently landed
 
 - Stage 4.2 of Phase R: [`research/comparison.md`](research/comparison.md),
-  the one-page comparison of the five candidates. Recommended lean:
-  lesson-to-mastery, B-first, with the Space layer and goals sequenced behind
-  the Up next consumer; metronome stays on its audit Phase 4 track;
-  chart-to-scaffold bookkeeping (#1106 close, #1107 re-scope) is
-  decision-independent. Awaiting Jon's pick; Stage 4.3 (Tier-3 spec) follows.
+  the one-page comparison of the five candidates, reshaped on Jon's direction
+  into one ordered sequence, quick wins first: scaffold bookkeeping and
+  real use, the metronome click pulled forward, then lesson-to-mastery B→R,
+  then the Space layer, with capture-shaped builds (A, goals) last and gated
+  on use. Awaiting Jon's confirm; Stage 4.3 (Tier-3 spec) follows.
 - Stage 4.1 of Phase R: five research notes under
   [`docs/research/`](research/) — goals-rebuilt-small, the Space layer,
   lesson-to-mastery (#1087), chart-to-scaffold Phase B (#1106), metronome

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,12 +33,18 @@ audit backlog and its five-phase build order.
 
 ## Recently landed
 
-- Stage 4.2 of Phase R: [`research/comparison.md`](research/comparison.md),
-  the one-page comparison of the five candidates, reshaped on Jon's direction
-  into one ordered sequence, quick wins first: scaffold bookkeeping and
-  real use, the metronome click pulled forward, then lesson-to-mastery B→R,
-  then the Space layer, with capture-shaped builds (A, goals) last and gated
-  on use. Awaiting Jon's confirm; Stage 4.3 (Tier-3 spec) follows.
+- Stage 4.2 of Phase R **decided** (Jon, 2026-08-14):
+  [`research/comparison.md`](research/comparison.md) compares the five
+  research notes and carries the adopted order, quick wins first: fix the
+  stale chord-chart issues (done: #1106 closed as shipped, #1107 re-scoped to
+  twelve-key generation), use the chord-chart flow for real, the metronome
+  click pulled forward, then per-piece tracking (#1081) and the Up next card
+  (#1082), then the getting-cold signal, with the twice-deleted admin-shaped
+  features (quick lesson entry, goals) last and gated on use.
+- Plain-language rule for docs and issues (Jon, 2026-08-14): name features by
+  the musician-visible outcome, issue numbers as the only stable handles.
+  Rule in CLAUDE.md → Conventions, glossary in
+  [`reference.md`](reference.md); older docs renamed as touched.
 - Stage 4.1 of Phase R: five research notes under
   [`docs/research/`](research/) — goals-rebuilt-small, the Space layer,
   lesson-to-mastery (#1087), chart-to-scaffold Phase B (#1106), metronome
@@ -79,7 +85,9 @@ audit backlog and its five-phase build order.
 - Audit Phase 1, fix and trim: #1357 (Today bug), then #1356.
 - Phase 2, say it right: #1360 (Practice hero/subline) and #1361 (create-form
   captions), with wordings the tone-of-voice doc already settled.
-- Stage 4.3: Jon answers [`research/comparison.md`](research/comparison.md)'s
-  decisions, then the Tier-3 spec for the chosen direction.
+- The adopted Stage 4 order ([`research/comparison.md`](research/comparison.md)):
+  use the chord-chart flow on a real tune, then the metronome click, then
+  tempo capture, then per-piece tracking (#1081, where the Tier-3 spec
+  starts).
 - Follow-up: port the wire-pin test technique (per-variant bincode
   fingerprint) to the `ActiveSession` crash-recovery blob (#1345).


### PR DESCRIPTION
Stage 4.2 of [`docs/rethink-plan.md`](https://github.com/jonyardley/intrada/blob/main/docs/rethink-plan.md), taken through to decision in-session with Jon (2026-08-14).

## What's in here

- `docs/research/comparison.md` — the one-page comparison of the five research notes (#1384), reshaped into the **adopted** order: quick wins first (fix stale chord-chart issues, use the shipped chord-chart flow, the metronome click, tempo capture), then per-piece tracking (#1081) and the Up next card (#1082), then the getting-cold signal, with the twice-deleted admin-shaped features (quick lesson entry, goals) last and gated on use.
- **Plain-language rule** (Jon's call, same session): docs and issues name features by the musician-visible outcome, codename in brackets once, issue numbers as the only stable handles. Rule added to CLAUDE.md → Conventions; process glossary added to `docs/reference.md`; older docs renamed as touched.
- `docs/status.md` updated to match.

## Tracker changes made alongside (not in the diff)

- #1106 closed: everything it asked for shipped in #1110 (2026-07-17) and froze unused behind the coach pivot.
- #1107 retitled and re-scoped to the one unbuilt part: generate chord-chart exercises in all twelve keys (its old blocker #1083 has shipped).
- #1081 and #1082 retitled per the plain-language rule.

Docs only; Tier 1 (hygiene gate green, review skipped per the Tier 1 carve-out). Coverage: n/a, no code.

Deferred items tracked: none — the sequenced work is carried by existing issues (#1107, #1081, #1082, #1366) and the comparison doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)