### PR TITLE
docs: weave #1390 (one-pass create with chart and exercises) into the plan

### DIFF
--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -83,7 +83,12 @@ Do now (days, not weeks):
    issues. No code; this answers whether the generated material is any good.
    Entry-friction notes feed the chart-entry rethink (#1387): a friendlier
    manual input is its near half, designed once real use has shown where the
-   current text format grates.
+   current text format grates. **First real use (2026-08-14, Like Someone in
+   Love) filed two:** the parser rejects the Real Book parenthesised-turnaround
+   convention (noted on #1387), and the chord chart plus related exercises are
+   only discoverable *after* creating the item — adding a piece should capture
+   both in one pass (#1390, design-first; rides with this step's findings
+   rather than re-ordering the list).
 3. **The click** — bring the deleted metronome engine back into the Focus
    Player (recoverable from `8af4891^`). iOS-only, no schema, Tier 2; pulled
    forward from audit Phase 4 because the hard part already exists. 1–2 days.

--- a/docs/status.md
+++ b/docs/status.md
@@ -86,6 +86,9 @@ audit backlog and its five-phase build order.
 - The adopted Stage 4 order ([`research/comparison.md`](research/comparison.md)):
   use the chord-chart flow on a real tune, then the metronome click, then
   tempo capture, then per-piece tracking (#1081, where the Tier-3 spec
-  starts).
+  starts). Real use has started (Like Someone in Love, 2026-08-14) and filed
+  its first findings: #1390 (add the chord chart and related exercises while
+  creating the item, not in a second trip) and a parser friction note on
+  #1387. #1390 rides with the chord-chart step's findings, design-first.
 - Follow-up: port the wire-pin test technique (per-variant bincode
   fingerprint) to the `ActiveSession` crash-recovery blob (#1345).


### PR DESCRIPTION
Records the first real-use findings of the chord-chart flow (step 2 of the adopted order) in the plan docs:

- `docs/research/comparison.md`: step 2 now carries its first two findings — the parenthesised-turnaround parser friction (noted on #1387) and #1390, adding the chord chart and related exercises while creating an item rather than in a second trip. #1390 rides with the step's findings; the decided order is unchanged.
- `docs/status.md`: same two handles on the Next list.

Tier 1 docs-only. Gates green locally (`just check`; hygiene clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)