### PR TITLE
chore(deps): bump the json gem to 2.21.2 (Dependabot alert 31)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.20.0)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)


### PR DESCRIPTION
Closes the one open Dependabot alert on main ([31](https://github.com/jonyardley/intrada/security/dependabot/31), low).

`json` is a transitive dependency of fastlane, so it is only exercised by the TestFlight lane. The advisory is a crash in `JSON::ResumableParser#partial_value` on truncated duplicate-key streams, affecting >= 2.20.0 and <= 2.21.1; 2.21.2 is patched, and fastlane's constraint (`json < 3.0.0`) is unchanged.

**How it was bumped:** the lockfile line directly, not `bundle lock --update json` — the pinned bundler 2.5.22 is not installed on this host and installing it system-wide was not worth the blast radius for a one-line version bump. The lockfile carries no CHECKSUMS block and `json` has no runtime dependencies, so nothing else moves. Worth a `bundle install` on a host that has the pinned bundler before the next TestFlight upload.

Tier 1 dependency bump, unpaired with any other change per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)