### PR TITLE
chore(deny): ignore RUSTSEC-2026-0258 (h2 0.3 via libsql, no patch available)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,9 @@ ignore = [
     { id = "RUSTSEC-2026-0098", reason = "transitive via libsql; tracked in #568" },
     { id = "RUSTSEC-2026-0099", reason = "transitive via libsql; tracked in #568" },
     { id = "RUSTSEC-2026-0104", reason = "transitive via libsql; tracked in #568" },
+    # h2 0.3 unbounded empty DATA frames (low-severity DoS), transitive via
+    # libsql 0.9.30 → hyper 0.14. Patched only in h2 0.4.16, no 0.3 release.
+    { id = "RUSTSEC-2026-0258", reason = "transitive via libsql, no h2 0.3 patch; tracked in #568" },
 
     # quick-xml DoS advisories (quadratic duplicate-attr check; unbounded
     # namespace-declaration allocation). Transitive via rust-s3 0.37.2 →


### PR DESCRIPTION
## Summary

cargo-deny has been red on main and every open PR since 2026-08-17: RustSec published RUSTSEC-2026-0258 (h2 accepts unbounded empty DATA frames, low-severity DoS). Our only `h2` is 0.3.27, pinned by libsql 0.9.30 → hyper 0.14; the patch is h2 0.4.16 only, no 0.3 release exists. Nothing to bump, so this ignores it next to the other libsql transitives, tracked in #568 (the libsql 0.10 upgrade clears the lot).

Tier 1 CI unblock. `cargo deny --all-features check advisories` green locally.

Unblocks #1391, #1392 and the dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)