### PR TITLE
docs: record the click as landed

### DIFF
--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -92,6 +92,9 @@ Do now (days, not weeks):
 3. **The click** — bring the deleted metronome engine back into the Focus
    Player (recoverable from `8af4891^`). iOS-only, no schema, Tier 2; pulled
    forward from audit Phase 4 because the hard part already exists. 1–2 days.
+   **Done 2026-08-19** (#1398, #1401): the player's tempo line doubles as the
+   control, the steppers appear only while it sounds, and the ruling is
+   design-principles T14. Still to hear on a device.
 4. **Tempo capture** — the end-of-item tempo stepper pre-fills from the click
    and shows even when the item has no declared target. Small core touch.
    About a day.

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,13 +21,20 @@ audit backlog and its five-phase build order.
 
 ## In flight
 
-- #1398 — the metronome click, back in the Focus Player. Step 3 of the adopted
-  order ([`research/comparison.md`](research/comparison.md)). The engine is
-  recovered from `8af4891^` and trimmed to a plain click; the player's tempo
-  readout becomes the control (design-principles T14). iOS-only: no schema, no
-  bridge, no core change.
+Nothing. Next up is tempo capture, step 4 of the adopted order.
 
 ## Recently landed
+
+- #1398 (#1401) — the metronome click is back in the Focus Player, step 3 of
+  the adopted order ([`research/comparison.md`](research/comparison.md)). The
+  player's tempo line now doubles as the control: one tap sounds a click at the
+  item's target, and the slower/faster steppers appear only while it sounds
+  (design-principles T14). The engine is recovered from `8af4891^` and trimmed
+  to a plain click, keeping the host-time grid, the stranded-clock guard and
+  the interruption handling. iOS-only: no schema, no bridge, no core change.
+  Deferred: background audio (#1399), the design reference (#1400), the tempo
+  constants' home (#1402), accessibility-label tests (#1403). **The click has
+  not been heard on a device yet** — no automated check can hear it.
 
 - Phase 2 (say it right) is **closed**. #1360 (#1383) repurposed the Practice
   hero to the last session plus its one-tap start and moved the header subline
@@ -90,7 +97,7 @@ audit backlog and its five-phase build order.
 - Tempo capture (step 4): the end-of-item stepper pre-fills from the click and
   shows even when the item declares no target. Small core touch.
 - The adopted Stage 4 order ([`research/comparison.md`](research/comparison.md)):
-  use the chord-chart flow on a real tune, then the metronome click, then
+  use the chord-chart flow on a real tune (the metronome click is done), then
   tempo capture, then per-piece tracking (#1081, where the Tier-3 spec
   starts). Real use has started (Like Someone in Love, 2026-08-14) and filed
   its first findings: #1390 (add the chord chart and related exercises while


### PR DESCRIPTION
Post-merge housekeeping for #1401 (the metronome click), per CLAUDE.md
"After completing work".

- `docs/status.md`: #1398 moves from In flight to Recently landed, with the
  four deferred follow-ups named. In flight is now empty.
- `docs/research/comparison.md`: step 3 of the adopted order marked done, the
  way step 1 already was.

Both note that the click has not been heard on a device yet, since no
automated check can hear it.

`in-flight` dropped from #1398; the issue closed itself on merge.

Tier 1, docs only.