### PR TITLE
docs: per-piece tracking (#1081) was already shipped; tidy the In flight block

### DIFF
--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -98,14 +98,21 @@ Do now (days, not weeks):
 4. **Tempo capture** — the end-of-item tempo stepper pre-fills from the click
    and shows even when the item has no declared target. Small core touch.
    About a day.
-5. **Per-piece tracking (#1081)** — the core derivation (read-only, real
-   bridge tests) then the "By piece" screens. 3–5 days; the first step that
-   needs the Tier-3 spec discipline.
+5. **Per-piece tracking (#1081)** — **already built; nothing to construct.**
+   Verified 2026-08-20: the core derivation landed in #1095 and the "By piece"
+   screens in #1097, both in July, and the issue was never closed, which is
+   step 1's stale-issue pattern a second time. It survived the coach revert intact and
+   works with no network. The Tier-3 spec this step anticipated was not
+   written, because there was no unbuilt work to specify. What it needs is
+   step 2's treatment instead: **use it on the week's lesson tune and file the
+   friction.** The By-piece rows only fill once a piece has related exercises
+   linked and a session groups them, so linking them is part of that use.
 
 Then, each building on the last:
 
 6. **The Up next card (#1082)** — one dismissible suggested session with its
-   reasons in plain words; held to suggest-never-gate. Needs step 5. 2–3 days.
+   reasons in plain words; held to suggest-never-gate. Needed step 5, which is
+   already satisfied, so this is the next unstarted item. 2–3 days.
 7. **The tempo trend** — draw the already-computed tempo history per item;
    blocked on roadmap Q3 (does a mastery score mean anything without its
    tempo?) being answered first.

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,13 +21,34 @@ audit backlog and its five-phase build order.
 
 ## In flight
 
+- Nothing. Step 5 of the adopted order
+  ([`research/comparison.md`](research/comparison.md)) turned out to be built
+  already (below), so step 6, the Up next card (#1082), is the next unstarted
+  item.
+
+## Recently landed
+
+- #1081 — per-piece tracking **was already shipped**, back in July, and the
+  issue was simply never closed. Verified 2026-08-20 against the whole of its
+  stated scope: the core derivation (`build_exercise_contexts`, #1095), the
+  "By piece" rows and the per-this-piece rings on piece detail (#1097), the
+  FFI round-trip guard
+  (`setlist_entry_group_id_round_trips_on_ffi_bincode_wire`), the
+  `testExerciseDetailByPiece` snapshot, and the design mock committed under
+  `specs/track-exercises-per-piece/`. It came through the coach revert intact:
+  `AddToSetlist` still forms blocks, and `group_id` still round-trips the
+  local-first JSON codec, so the feature works with no network. No Tier 3 spec
+  and no core PR were written, because there was nothing left to build. This
+  is the same stale-issue pattern as #1106 in step 1 of the adopted order:
+  built during the coach era, frozen behind the pivot, never closed. **It has
+  not been used in anger**, which is the honest next step for it: the same
+  treatment step 2 gave the chord-chart flow.
+
 - #1404 (#1406) — tempo capture: the end-of-item stepper pre-fills from the
   click's last tempo and shows even when the item declares no target. Step 4
   of the adopted order ([`research/comparison.md`](research/comparison.md)),
   following on from the click (#1398). iOS-only; no core change was needed —
   `UpdateEntryTempo` already accepted an undeclared-target entry.
-
-## Recently landed
 
 - #1398 (#1401) — the metronome click is back in the Focus Player, step 3 of
   the adopted order ([`research/comparison.md`](research/comparison.md)). The


### PR DESCRIPTION
## What this is

Step 5 of the adopted order in [`docs/research/comparison.md`](docs/research/comparison.md) asked for per-piece tracking (#1081) as a Tier 3 build: a spec, then a core PR for the derivation, then a screens PR. It is none of those, because **the whole of #1081 already shipped in July** and the issue was never closed.

So this PR writes down the finding instead of building the feature a second time. No spec, no core change.

## The evidence

Checked against every line of #1081's stated scope:

| #1081 scope | State |
|---|---|
| Derive (exercise x piece) contexts from `group_id` | `build_exercise_contexts`, `app.rs:863` (#1095, `ed5d3e4`) |
| `ExerciseContextView` on the ViewModel | `model.rs:296` |
| "On its own" bucket for standalone practice | `piece: None`, covered by `test_exercise_contexts_grouped_without_piece_is_on_its_own` |
| Rollup v1 = latest score per context | `latest_scored` in the accumulator |
| Tests in both modes | `test_exercise_contexts_identical_in_both_modes` |
| Codec test that entries round-trip `group_id` | `setlist_entry_group_id_round_trips_on_ffi_bincode_wire`, `domain/types.rs:604` |
| Exercise detail "By piece" rows | `LibraryDetailScreen.swift:575` (#1097, `7f75233`) |
| Hero ring is the overall score, captioned | `LibraryDetailScreen.swift:376`, `Eyebrow("Overall")` |
| Piece detail related-exercises card shows per-this-piece score | `LinkedExerciseView.piece_context_score`, under the "Scores shown are for this piece" caption |
| Context pills filtering the history | **Cut deliberately** as design-principles T8: pills are reserved for inputs, not a filter echoing a visible list |
| Design mockups committed | `specs/track-exercises-per-piece/design/exercise-and-piece-detail.html` |

Snapshot coverage exists too (`testExerciseDetailByPiece`).

## It survived the coach revert

Worth stating plainly, since #1344 deleted the coach-pivot builder and left other things shell-dead:

- `AddToSetlist` still pulls a piece's related exercises in and mints a `group_id`, and it has live Swift callers (`AddToSessionSheet.swift:76`, `LibraryDetailScreen.swift:621`). Blocks are still formed by ordinary use.
- `group_id` still round-trips the local-first JSON codec in `LibraryStore.swift` on both encode and decode, so per-piece tracking works with no network.

Neither is like the `Set` (#1348) or session-reflection (#1374) situation. This one is live.

## What actually remains

Not code. The feature shipped in July and then froze behind the coach pivot without ever being used, exactly like the chord-chart flow in step 1 of the adopted order. The honest next step is step 2's treatment: use it on a real lesson tune and file the friction. The By-piece rows only fill once a piece has related exercises linked and a session groups them, so linking them is part of that use.

Step 6, the Up next card (#1082), needed step 5 and is therefore unblocked. It is genuinely unbuilt: no "Up next" surface exists anywhere in the core or the shell.

## Changes

- `docs/status.md` — In flight is empty and says why; #1404 (#1406) moves to Recently landed, where it belonged after `ee89f86`; the #1081 finding is recorded.
- `docs/research/comparison.md` — step 5 annotated as already built, in the style step 1 and step 3 already use; step 6 marked unblocked and next.

## Tier and testing

Tier 1, docs only. `just check` green locally: 807 tests pass, typos and cargo-shear clean. No code changed, so no new tests and no coverage line.

#1081 is closed separately with a pointer to this PR, rather than by this PR, since this PR did not implement it.