### PR TITLE
docs: answer roadmap Q3, a tempo is recorded when it was measured

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,8 +189,24 @@ These are unresolved product questions. Each one likely produces issues
    test-enforced invariants (see CLAUDE.md). #41 closed. What remains is the
    future paid sync tier, deliberately deferred.
 
-3. **Scoring + tempo coupling.** Should every mastery rating require a
-   tempo? Or is tempo optional (only for items with tempo targets)?
+3. **Scoring + tempo coupling (answered 2026-08-27).** The question as
+   written (must every mark carry a tempo, or is tempo optional for items
+   with targets?) was overtaken by the code: tempo capture shipped inside
+   the metronome work (#1398, #1401) and made the stepper appear on every
+   item, always saving, pre-filled from the click's tempo even when the
+   click never sounded. So every mark already carries a tempo and many of
+   those numbers are an untouched default.
+
+   **A tempo is recorded when there is evidence behind it, and never
+   otherwise** (Jon): either the user moved the stepper, or the click was
+   sounding, so the number measures what they actually played to. Tempo is
+   neither required nor optional-by-target; it is recorded when it was
+   measured. This matters for the tempo trend (#1420), which draws the
+   history as a chart, and a chart looks like measurement.
+
+   Costs no new field: `UpdateEntryTempo` already carries `Option<u16>` and
+   `tempo_history` already skips `None`. Keep it that way, because
+   `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob.
 
 4. **Teacher integration timing.** Currently a Layer-5 horizon. Basic
    sharing (routines, item suggestions) could come earlier without AI.

--- a/docs/status.md
+++ b/docs/status.md
@@ -147,15 +147,22 @@ Nothing.
 
 ## Next
 
-- The adopted Stage 4 order ([`research/comparison.md`](research/comparison.md))
-  is clear through step 8. **Step 7, the tempo trend, is still gated** on
-  roadmap Q3 (does a mastery score mean anything without its tempo?), and
-  steps 9 to 11 are the big bets, each a fresh decision gated on lived use.
-  So the honest next move is **not another build**: use the Up next card and
-  the getting-cold signal on the week's lesson tune and file the friction, the
-  way step 2 and step 5 were treated. Two weeks of real use is what tells us
-  whether the staleness thresholds are anywhere near right, and there is no
-  substitute for it.
+- **The tempo trend (#1420) is the next unstarted build.** Step 7 of the
+  adopted Stage 4 order ([`research/comparison.md`](research/comparison.md)),
+  unblocked because roadmap Q3 is now answered (Jon, 2026-08-27): **a tempo is
+  recorded when there is evidence behind it** (the user moved the stepper, or
+  the click was sounding), and never otherwise. The question had been overtaken
+  by #1398 and #1401, which made the stepper always save a click-prefilled
+  default, so `tempo_history` today mixes real measurements with numbers nobody
+  looked at. Costs no schema change; #1420 carries the reasoning and the
+  contract question to pin first. Steps 9 to 11 remain the big bets, each a
+  fresh decision gated on lived use.
+- Running alongside, and not a build: **use** the Up next card and the
+  getting-cold signal on the week's lesson tune and file the friction, the way
+  step 2 and step 5 were treated. Two weeks of real use is what tells us
+  whether the staleness thresholds are anywhere near right (#1419), and there
+  is no substitute for it. A coldness clause on the card's item rows is held
+  back deliberately (#1418).
 - Real use has started (Like Someone in Love, 2026-08-14) and filed its first
   findings: #1390 (add the chord chart and related exercises while creating the
   item, not in a second trip) and a parser friction note on #1387. #1390 is


### PR DESCRIPTION
Docs only, Tier 1. Records roadmap open question 3 as answered, and unblocks step 7 of the adopted order, now scoped on #1420.

## The finding

Q3 asked whether every mastery rating should require a tempo, or whether tempo is optional for items with a declared target. **The code had already answered it and nobody noticed.** Tempo capture shipped inside the metronome work (#1398, #1401):

- `ReflectionSheet` shows the tempo stepper on every item, target or not.
- It always passes a tempo on save. Never nil.
- It pre-fills from `click.bpm`, which is `ClickController.defaultBpm` when the click was never sounded.

So every mark already carries a tempo, and many of those numbers are an untouched default nobody looked at. `ItemPracticeSummary.tempo_history` mixes real measurements with noise and nothing tells them apart.

## The answer (Jon, 2026-08-27)

**A tempo is recorded when there is evidence behind it, and never otherwise:** the user moved the stepper, or the click was sounding so the number measures what they actually played to.

That dissolves the question rather than picking a side. Tempo is neither required nor optional-by-target; it is recorded when it was measured.

It matters because #1420 draws this history as a chart, and a chart looks like measurement in a way a sentence does not. Drawing a line through numbers the user never considered is the borrowed-authority failure #1416 was careful to avoid, and much harder to spot in a chart.

## Cost

None in schema. `SessionEvent::UpdateEntryTempo` already carries `Option<u16>` and `build_practice_summaries` already skips `None`, so `None` already means "not measured" everywhere downstream. Worth keeping that way: `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob, where a new field silently invalidates every stored session (#1345).

Coverage: not applicable, docs only. `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)