### PR TITLE
The tempo trend (#1420), core: record a tempo only when it was measured

### DIFF
--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -126,6 +126,27 @@ pub enum ReflectionField {
     NextTarget,
 }
 
+/// What the shell saw about where an end-of-item tempo came from. Facts only:
+/// whether they amount to evidence is the core's ruling (#1420, roadmap Q3).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct TempoObservation {
+    /// The user set the number themselves rather than accepting the pre-fill.
+    pub user_set: bool,
+    /// The click was sounding when the item ended, so the pre-filled number
+    /// measures what they actually played to.
+    pub click_sounding: bool,
+}
+
+impl TempoObservation {
+    /// A tempo is worth recording when there is evidence behind it, and never
+    /// otherwise. Anything else is a default nobody looked at, and a chart
+    /// drawn through those numbers looks like measurement (#1420).
+    pub fn is_evidenced(&self) -> bool {
+        self.user_set || self.click_sounding
+    }
+}
+
 // ── Transient State Types ──────────────────────────────────────────────
 
 /// State during setlist assembly (Building phase).
@@ -330,6 +351,7 @@ pub enum SessionEvent {
     UpdateEntryTempo {
         entry_id: String,
         tempo: Option<u16>,
+        observed: TempoObservation,
     },
     UpdateSessionNotes {
         notes: Option<String>,
@@ -1488,8 +1510,19 @@ pub fn handle_session_event(event: SessionEvent, model: &mut Model) -> Command<E
             crux_core::render::render()
         }
 
-        SessionEvent::UpdateEntryTempo { entry_id, tempo } => {
+        SessionEvent::UpdateEntryTempo {
+            entry_id,
+            tempo,
+            observed,
+        } => {
             if let Err(_e) = validation::validate_achieved_tempo(&tempo) {
+                return crux_core::render::render();
+            }
+
+            // An unevidenced number is a pre-fill nobody looked at: record
+            // nothing, and clear nothing, so it cannot destroy a real
+            // measurement. Clearing is always honoured.
+            if tempo.is_some() && !observed.is_evidenced() {
                 return crux_core::render::render();
             }
 
@@ -3884,6 +3917,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id,
                 tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -3992,6 +4029,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: "no-such-entry".to_string(),
                 tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4366,6 +4407,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: entry_id.clone(),
                 tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4392,6 +4437,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: entry_id.clone(),
                 tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4401,6 +4450,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: entry_id.clone(),
                 tempo: None,
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4447,6 +4500,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: skipped_entry_id.clone(),
                 tempo: Some(100),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4472,6 +4529,10 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: entry_id.clone(),
                 tempo: Some(0),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
@@ -4485,12 +4546,180 @@ mod tests {
             Event::Session(SessionEvent::UpdateEntryTempo {
                 entry_id: entry_id.clone(),
                 tempo: Some(501),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
             }),
         );
 
         if let SessionStatus::Summary(ref s) = model.session_status {
             assert_eq!(s.entries[0].achieved_tempo, None);
         }
+    }
+
+    // --- Tempo evidence (#1420, roadmap Q3) ---
+
+    fn tempo_entry_id(model: &Model) -> String {
+        match model.session_status {
+            SessionStatus::Summary(ref s) => s.entries[0].id.clone(),
+            _ => panic!("Expected Summary state"),
+        }
+    }
+
+    fn achieved_tempo(model: &Model, entry_id: &str) -> Option<u16> {
+        match model.session_status {
+            SessionStatus::Summary(ref s) => {
+                s.entries
+                    .iter()
+                    .find(|e| e.id == entry_id)
+                    .unwrap()
+                    .achieved_tempo
+            }
+            _ => panic!("Expected Summary state"),
+        }
+    }
+
+    #[test]
+    fn tempo_the_user_set_themselves_is_recorded() {
+        let mut model = model_with_summary();
+        let entry_id = tempo_entry_id(&model);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        assert_eq!(achieved_tempo(&model, &entry_id), Some(120));
+    }
+
+    #[test]
+    fn tempo_played_to_a_sounding_click_is_recorded() {
+        let mut model = model_with_summary();
+        let entry_id = tempo_entry_id(&model);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: false,
+                    click_sounding: true,
+                },
+            }),
+        );
+
+        assert_eq!(achieved_tempo(&model, &entry_id), Some(120));
+    }
+
+    #[test]
+    fn an_untouched_default_is_not_recorded() {
+        let mut model = model_with_summary();
+        let entry_id = tempo_entry_id(&model);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(96),
+                observed: TempoObservation {
+                    user_set: false,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        assert_eq!(
+            achieved_tempo(&model, &entry_id),
+            None,
+            "a pre-fill nobody looked at is not a measurement"
+        );
+    }
+
+    #[test]
+    fn an_untouched_default_does_not_erase_a_measured_tempo() {
+        let mut model = model_with_summary();
+        let entry_id = tempo_entry_id(&model);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(96),
+                observed: TempoObservation {
+                    user_set: false,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        assert_eq!(
+            achieved_tempo(&model, &entry_id),
+            Some(120),
+            "a report that is not a measurement must not destroy one that was"
+        );
+    }
+
+    #[test]
+    fn clearing_the_tempo_needs_no_evidence() {
+        let mut model = model_with_summary();
+        let entry_id = tempo_entry_id(&model);
+
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: None,
+                observed: TempoObservation {
+                    user_set: false,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        assert_eq!(achieved_tempo(&model, &entry_id), None);
+    }
+
+    #[test]
+    fn update_entry_tempo_round_trips_on_ffi_bincode_wire() {
+        crate::domain::types::assert_round_trips(Event::Session(SessionEvent::UpdateEntryTempo {
+            entry_id: "entry-1".to_string(),
+            tempo: Some(132),
+            observed: TempoObservation {
+                user_set: true,
+                click_sounding: true,
+            },
+        }));
     }
 
     // --- format_duration_display Tests ---

--- a/crates/intrada-core/src/domain/session.rs
+++ b/crates/intrada-core/src/domain/session.rs
@@ -140,8 +140,7 @@ pub struct TempoObservation {
 
 impl TempoObservation {
     /// A tempo is worth recording when there is evidence behind it, and never
-    /// otherwise. Anything else is a default nobody looked at, and a chart
-    /// drawn through those numbers looks like measurement (#1420).
+    /// otherwise (design-principles T16, #1420).
     pub fn is_evidenced(&self) -> bool {
         self.user_set || self.click_sounding
     }
@@ -4392,172 +4391,6 @@ mod tests {
 
     // --- UpdateEntryTempo Tests ---
 
-    #[test]
-    fn test_update_entry_tempo_on_completed_entry() {
-        let mut model = model_with_summary();
-
-        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
-            s.entries[0].id.clone()
-        } else {
-            panic!("Expected Summary state");
-        };
-
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: entry_id.clone(),
-                tempo: Some(120),
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        if let SessionStatus::Summary(ref s) = model.session_status {
-            assert_eq!(s.entries[0].achieved_tempo, Some(120));
-        } else {
-            panic!("Expected Summary state");
-        }
-    }
-
-    #[test]
-    fn test_update_entry_tempo_none_clears() {
-        let mut model = model_with_summary();
-
-        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
-            s.entries[0].id.clone()
-        } else {
-            panic!("Expected Summary state");
-        };
-
-        // Set tempo to 120
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: entry_id.clone(),
-                tempo: Some(120),
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        // Clear tempo by setting to None
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: entry_id.clone(),
-                tempo: None,
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        if let SessionStatus::Summary(ref s) = model.session_status {
-            assert_eq!(s.entries[0].achieved_tempo, None);
-        } else {
-            panic!("Expected Summary state");
-        }
-    }
-
-    #[test]
-    fn test_update_entry_tempo_rejected_on_skipped() {
-        // Build a summary with a skipped entry: skip item 1, complete item 2
-        let (mut model, start) = model_with_active_session(2);
-        let t1 = start + chrono::Duration::seconds(10);
-        let t2 = t1 + chrono::Duration::seconds(30);
-
-        // Skip first item
-        update(
-            &mut model,
-            Event::Session(SessionEvent::SkipItem { now: t1 }),
-        );
-        // Finish session (completes second item, transitions to summary)
-        update(
-            &mut model,
-            Event::Session(SessionEvent::FinishSession { now: t2 }),
-        );
-
-        // Find the skipped entry
-        let skipped_entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
-            s.entries
-                .iter()
-                .find(|e| e.status == EntryStatus::Skipped)
-                .expect("Should have a skipped entry")
-                .id
-                .clone()
-        } else {
-            panic!("Expected Summary state");
-        };
-
-        // Try to set tempo on the skipped entry — should be a no-op
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: skipped_entry_id.clone(),
-                tempo: Some(100),
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        if let SessionStatus::Summary(ref s) = model.session_status {
-            let skipped = s.entries.iter().find(|e| e.id == skipped_entry_id).unwrap();
-            assert_eq!(skipped.achieved_tempo, None);
-        }
-    }
-
-    #[test]
-    fn test_update_entry_tempo_rejected_out_of_range() {
-        let mut model = model_with_summary();
-
-        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
-            s.entries[0].id.clone()
-        } else {
-            panic!("Expected Summary state");
-        };
-
-        // Tempo 0 — out of range
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: entry_id.clone(),
-                tempo: Some(0),
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        if let SessionStatus::Summary(ref s) = model.session_status {
-            assert_eq!(s.entries[0].achieved_tempo, None);
-        }
-
-        // Tempo 501 — out of range
-        update(
-            &mut model,
-            Event::Session(SessionEvent::UpdateEntryTempo {
-                entry_id: entry_id.clone(),
-                tempo: Some(501),
-                observed: TempoObservation {
-                    user_set: true,
-                    click_sounding: false,
-                },
-            }),
-        );
-
-        if let SessionStatus::Summary(ref s) = model.session_status {
-            assert_eq!(s.entries[0].achieved_tempo, None);
-        }
-    }
-
     // --- Tempo evidence (#1420, roadmap Q3) ---
 
     fn tempo_entry_id(model: &Model) -> String {
@@ -4570,11 +4403,11 @@ mod tests {
     fn achieved_tempo(model: &Model, entry_id: &str) -> Option<u16> {
         match model.session_status {
             SessionStatus::Summary(ref s) => {
-                s.entries
-                    .iter()
-                    .find(|e| e.id == entry_id)
-                    .unwrap()
-                    .achieved_tempo
+                let entry = s.entries.iter().find(|e| e.id == entry_id).unwrap();
+                // Without this the negative tests would also pass against a
+                // skipped entry, which the handler rejects for another reason.
+                assert_eq!(entry.status, EntryStatus::Completed);
+                entry.achieved_tempo
             }
             _ => panic!("Expected Summary state"),
         }
@@ -4720,6 +4553,143 @@ mod tests {
                 click_sounding: true,
             },
         }));
+    }
+
+    #[test]
+    fn test_update_entry_tempo_none_clears() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Set tempo to 120
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(120),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        // Clear tempo by setting to None
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: None,
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].achieved_tempo, None);
+        } else {
+            panic!("Expected Summary state");
+        }
+    }
+
+    #[test]
+    fn test_update_entry_tempo_rejected_on_skipped() {
+        // Build a summary with a skipped entry: skip item 1, complete item 2
+        let (mut model, start) = model_with_active_session(2);
+        let t1 = start + chrono::Duration::seconds(10);
+        let t2 = t1 + chrono::Duration::seconds(30);
+
+        // Skip first item
+        update(
+            &mut model,
+            Event::Session(SessionEvent::SkipItem { now: t1 }),
+        );
+        // Finish session (completes second item, transitions to summary)
+        update(
+            &mut model,
+            Event::Session(SessionEvent::FinishSession { now: t2 }),
+        );
+
+        // Find the skipped entry
+        let skipped_entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries
+                .iter()
+                .find(|e| e.status == EntryStatus::Skipped)
+                .expect("Should have a skipped entry")
+                .id
+                .clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Try to set tempo on the skipped entry — should be a no-op
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: skipped_entry_id.clone(),
+                tempo: Some(100),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            let skipped = s.entries.iter().find(|e| e.id == skipped_entry_id).unwrap();
+            assert_eq!(skipped.achieved_tempo, None);
+        }
+    }
+
+    #[test]
+    fn test_update_entry_tempo_rejected_out_of_range() {
+        let mut model = model_with_summary();
+
+        let entry_id = if let SessionStatus::Summary(ref s) = model.session_status {
+            s.entries[0].id.clone()
+        } else {
+            panic!("Expected Summary state");
+        };
+
+        // Tempo 0 — out of range
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(0),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].achieved_tempo, None);
+        }
+
+        // Tempo 501 — out of range
+        update(
+            &mut model,
+            Event::Session(SessionEvent::UpdateEntryTempo {
+                entry_id: entry_id.clone(),
+                tempo: Some(501),
+                observed: TempoObservation {
+                    user_set: true,
+                    click_sounding: false,
+                },
+            }),
+        );
+
+        if let SessionStatus::Summary(ref s) = model.session_status {
+            assert_eq!(s.entries[0].achieved_tempo, None);
+        }
     }
 
     // --- format_duration_display Tests ---

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -472,3 +472,50 @@ strip below the fold); a suggestion *line* inside the existing hero with no
 item rows (rejected: the reasons are the honest part, and a piece title with
 no reasons is the app having an opinion it will not show its working for,
 which is the road the coach died on).
+
+### T16 — A tempo is recorded when it was measured, never as a default
+
+**Status:** DECIDED 2026-08-27 (Jon, roadmap open question 3), implemented in
+jonyardley/intrada#1420. Supersedes the question that log entry originally
+asked.
+
+Tempo capture (**T14**, #1398/#1401) put the stepper on the reflection sheet
+for every item and always saved a number, pre-filled from the click. When the
+click had never sounded that pre-fill was a neutral 96, so a large share of the
+recorded tempos were a default nobody looked at, sitting in the same history as
+real measurements with nothing telling them apart.
+
+**A tempo is worth recording when there is evidence behind it, and never
+otherwise.** Evidence is either of two things: the user moved the stepper, or
+the click was sounding when the item ended, so the pre-filled number measures
+what they actually played to. Anything else is a default, and a default is not
+data.
+
+This dissolves the original question rather than answering it. Tempo is never
+required, and it is not optional-by-item-target either. It is recorded when it
+was measured.
+
+Two rulings come with it:
+
+- **The sheet does not change.** The stepper still appears on every item and
+  still pre-fills, because a musician reaching for it should find it already
+  showing a sensible number. What changed is only whether an untouched number
+  is kept. Nothing on screen tells the user their tempo was not recorded,
+  because nothing was asked of them and there is nothing to report.
+- **The shell reports, the core rules.** Both facts are shell-observable and
+  neither is a judgement, so Swift forwards them untouched and the core decides
+  what counts as evidence. Deciding in the shell would be domain logic in the
+  dumb pipe, and it would put the rule somewhere no core test could reach it.
+
+Why it matters beyond tidiness: the tempo trend draws this history as a chart,
+and a chart looks like measurement. Drawing a line through numbers the user
+never considered is the borrowed authority the getting-cold signal (**#1416**)
+was careful to avoid, and much harder to spot in a chart than in a sentence.
+
+Options considered: requiring a tempo on every mark (rejected: it taxes every
+hand-off for a number most items do not want, and a required field gets
+answered carelessly, which is how you manufacture the same noise deliberately);
+recording only when the item declares a target (rejected: scales and exercises
+declare targets least and want a click most, so it would drop exactly the
+measurements worth having); letting the shell send nil (rejected under the
+second ruling above).

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -481,9 +481,13 @@ asked.
 
 Tempo capture (**T14**, #1398/#1401) put the stepper on the reflection sheet
 for every item and always saved a number, pre-filled from the click. When the
-click had never sounded that pre-fill was a neutral 96, so a large share of the
-recorded tempos were a default nobody looked at, sitting in the same history as
-real measurements with nothing telling them apart.
+click had never sounded, that pre-fill was whatever `ClickController` had
+seeded: the item's own declared target where it has one, and a neutral 96 where
+it does not. So a large share of the recorded tempos were a default nobody
+looked at, sitting in the same history as real measurements with nothing
+telling them apart. **For an item declaring ♩ = 132, that default was 132** —
+the app quietly recording the target as achieved, which is a worse falsehood
+than a stray 96 and the strongest argument for the ruling.
 
 **A tempo is worth recording when there is evidence behind it, and never
 otherwise.** Evidence is either of two things: the user moved the stepper, or
@@ -500,8 +504,14 @@ Two rulings come with it:
 - **The sheet does not change.** The stepper still appears on every item and
   still pre-fills, because a musician reaching for it should find it already
   showing a sensible number. What changed is only whether an untouched number
-  is kept. Nothing on screen tells the user their tempo was not recorded,
-  because nothing was asked of them and there is nothing to report.
+  is kept, and no banner or hint says so: nothing was asked of the user, so
+  there is nothing to report. The one visible consequence is downstream — the
+  session summary's meta row reads `Exercise` rather than `Exercise · 96 bpm`
+  when there was nothing to measure, which is the row telling the truth.
+- **Dialling the click without starting it is not evidence.** The tempo has to
+  have been sounding. Changing a number on a silent row is intent, and intent
+  is not measurement; the musician never played to it. Deliberate, not an
+  oversight.
 - **The shell reports, the core rules.** Both facts are shell-observable and
   neither is a judgement, so Swift forwards them untouched and the core decides
   what counts as evidence. Deciding in the shell would be domain logic in the

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -113,9 +113,13 @@ Then, each building on the last:
 6. **The Up next card (#1082)** — one dismissible suggested session with its
    reasons in plain words; held to suggest-never-gate. Needed step 5, which is
    already satisfied, so this is the next unstarted item. 2–3 days.
-7. **The tempo trend** — draw the already-computed tempo history per item;
-   blocked on roadmap Q3 (does a mastery score mean anything without its
-   tempo?) being answered first.
+7. **The tempo trend** — draw the already-computed tempo history per item.
+   Q3 answered 2026-08-27 and the answer moved the work: the history it would
+   have drawn was a mixture of real measurements and untouched defaults, so the
+   first half of this step is making the recording honest. **Evidence contract
+   done 2026-08-28** (#1420, design-principles T16): a tempo is recorded when
+   it was measured and never otherwise, so every point in `tempo_history` is
+   now evidenced by construction. The chart itself is the second PR.
 8. **The getting-cold signal** — a graded staleness estimate replacing the
    binary 14-day flag, landing as Up next reason lines rather than a surface
    of its own. 1–2 days once step 6 exists. **Done 2026-08-27** (#1416,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,6 +208,13 @@ These are unresolved product questions. Each one likely produces issues
    `tempo_history` already skips `None`. Keep it that way, because
    `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob.
 
+   **Implemented 2026-08-28** (#1420, first of two PRs) as design-principles
+   **T16**. The shell forwards two observed facts (`TempoObservation`) and the
+   core rules on them; no new field, no crash-recovery key bump. Pre-fix
+   history on device is accepted rather than migrated away: there was
+   essentially none, so nulling it would have been destructive work with
+   nothing to show for it.
+
 4. **Teacher integration timing.** Currently a Layer-5 horizon. Basic
    sharing (routines, item suggestions) could come earlier without AI.
    The teacher-assignment capture (#267) addressed the immediate capture

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -209,7 +209,9 @@ These are unresolved product questions. Each one likely produces issues
    `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob.
 
    **Implemented 2026-08-28** (#1420, first of two PRs) as design-principles
-   **T16**. The shell forwards two observed facts (`TempoObservation`) and the
+   **T16**. One correction to the framing above: the untouched pre-fill is not
+   always the neutral 96. `ClickController` seeds from the item's own declared
+   target, so for an item marked ♩ = 132 the app was recording 132 as achieved. The shell forwards two observed facts (`TempoObservation`) and the
    core rules on them; no new field, no crash-recovery key bump. Pre-fix
    history on device is accepted rather than migrated away: there was
    essentially none, so nulling it would have been destructive work with

--- a/docs/status.md
+++ b/docs/status.md
@@ -26,7 +26,8 @@ audit backlog and its five-phase build order.
   then screens. The **evidence contract** is the first PR: tempo capture
   (#1398) put the stepper on every item and always saved a number, pre-filled
   from the click, so a large share of the recorded tempos were an untouched
-  default nobody looked at. A tempo is now recorded only when it was measured
+  default nobody looked at. For an item declaring a target the default was that
+  target, so the app was quietly recording it as achieved. A tempo is now recorded only when it was measured
   (design-principles **T16**, answering roadmap Q3): the shell forwards two
   observed facts and the core rules on whether they amount to evidence. No new
   field, so no crash-recovery key bump. The chart itself is the second PR.

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,7 +21,15 @@ audit backlog and its five-phase build order.
 
 ## In flight
 
-Nothing.
+- #1420 — **the tempo trend**, step 7 of the adopted order
+  ([`research/comparison.md`](research/comparison.md)), shipping core-first
+  then screens. The **evidence contract** is the first PR: tempo capture
+  (#1398) put the stepper on every item and always saved a number, pre-filled
+  from the click, so a large share of the recorded tempos were an untouched
+  default nobody looked at. A tempo is now recorded only when it was measured
+  (design-principles **T16**, answering roadmap Q3): the shell forwards two
+  observed facts and the core rules on whether they amount to evidence. No new
+  field, so no crash-recovery key bump. The chart itself is the second PR.
 
 ## Recently landed
 

--- a/ios/Intrada/Views/Components/AddStepsSheet.swift
+++ b/ios/Intrada/Views/Components/AddStepsSheet.swift
@@ -61,7 +61,7 @@ struct AddStepsSheet: View {
   }
 
   /// Trims and drops blank rows — pulled out as a static func so it's directly
-  /// testable, same as `ReflectionSheet.resolvedAchievedTempo`.
+  /// testable, same as `ReflectionSheet.initialVariantId`.
   static func trimmedLabels(_ labels: [String]) -> [String] {
     labels.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
   }

--- a/ios/Intrada/Views/Screens/FocusPlayerScreen.swift
+++ b/ios/Intrada/Views/Screens/FocusPlayerScreen.swift
@@ -32,10 +32,7 @@ struct FocusPlayerScreen: View {
         itemTitle: target.title, elapsedDisplay: target.elapsedDisplay,
         tempoTarget: target.tempoTargetBpm, startingTempoBpm: target.startingTempoBpm,
         variants: target.variants, currentVariantId: target.currentVariantId,
-        onSave: { score, note, achievedTempo, variantId in
-          handleReflection(
-            target, score: score, note: note, achievedTempo: achievedTempo, variantId: variantId)
-        },
+        onSave: { result in handleReflection(target, result) },
         onSkip: { handleSkipRating() }
       )
       .presentationDetents([.medium, .large])
@@ -236,6 +233,9 @@ struct FocusPlayerScreen: View {
     let elapsedDisplay: String
     let tempoTargetBpm: UInt16?
     let startingTempoBpm: Int
+    /// The click was sounding when the item ended, so `startingTempoBpm`
+    /// measures what they played to rather than being an untouched default.
+    let clickSounding: Bool
     /// The item's step ladder, if any. Empty when the item isn't in the
     /// library (shouldn't happen) or has no steps.
     let variants: [VariantView]
@@ -250,7 +250,9 @@ struct FocusPlayerScreen: View {
     }
     let start = SessionClock.parseRFC3339(active.currentItemStartedAt) ?? Date()
     let elapsed = max(Int((referenceDate ?? Date()).timeIntervalSince(start)), 0)
-    let startingTempoBpm = click.bpm  // read before stop() below
+    // Both read before stop() below.
+    let startingTempoBpm = click.bpm
+    let clickSounding = click.isRunning
     // The item is over; a click ticking through the rating is keeping time for
     // nothing.
     click.stop()
@@ -260,6 +262,7 @@ struct FocusPlayerScreen: View {
       id: entry.id, title: active.currentItemTitle,
       elapsedDisplay: SessionClock.clockDisplay(elapsed),
       tempoTargetBpm: active.currentItemTempoBpm, startingTempoBpm: startingTempoBpm,
+      clickSounding: clickSounding,
       // The entry's own tag (set ahead of time via EntrySettingsSheet) wins
       // over the item's derived "current step" — otherwise a pre-assigned
       // step would be silently overwritten on save.
@@ -271,24 +274,27 @@ struct FocusPlayerScreen: View {
   // then NextItem completes the entry so the score and tempo can land (both
   // need Completed). Errors surface on RootView's banner, so dismiss only on
   // success.
-  private func handleReflection(
-    _ target: ReflectionTarget, score: UInt8?, note: String, achievedTempo: UInt16?,
-    variantId: String?
-  ) {
-    if !note.isEmpty {
+  private func handleReflection(_ target: ReflectionTarget, _ result: ReflectionResult) {
+    if !result.note.isEmpty {
       let before = store.viewModel?.errorSeq
-      store.send(.session(.updateEntryNotes(entryId: target.id, notes: note)))
+      store.send(.session(.updateEntryNotes(entryId: target.id, notes: result.note)))
       if store.viewModel?.errorSeq != before { return }
     }
     store.send(.session(.nextItem(now: SessionClock.nowRFC3339())))
-    if let score {
+    if let score = result.score {
       store.send(.session(.updateEntryScore(entryId: target.id, score: score)))
     }
-    if let achievedTempo {
-      store.send(.session(.updateEntryTempo(entryId: target.id, tempo: achievedTempo)))
-    }
+    // Always sent: the two facts go over as observed and the core rules on
+    // whether they amount to evidence (#1420). Deciding here would be domain
+    // logic in the shell.
+    store.send(
+      .session(
+        .updateEntryTempo(
+          entryId: target.id, tempo: result.achievedTempo,
+          observed: TempoObservation(
+            userSet: result.tempoUserSet, clickSounding: target.clickSounding))))
     if !target.variants.isEmpty {
-      store.send(.session(.setEntryVariant(entryId: target.id, variantId: variantId)))
+      store.send(.session(.setEntryVariant(entryId: target.id, variantId: result.variantId)))
     }
     reflecting = nil
   }

--- a/ios/Intrada/Views/Screens/ReflectionSheet.swift
+++ b/ios/Intrada/Views/Screens/ReflectionSheet.swift
@@ -1,6 +1,22 @@
 import SharedTypes
 import SwiftUI
 
+/// A tempo and whether the user set it, as one value: `bpm` is not writable
+/// except through `set`, so the sheet cannot report a number without also
+/// reporting where it came from (#1420).
+@MainActor
+struct TrackedTempo {
+  private(set) var bpm: Int
+  private(set) var userSet = false
+
+  init(startingBpm: Int) { bpm = TempoStepper.clamp(startingBpm) }
+
+  mutating func set(_ next: Int) {
+    bpm = TempoStepper.clamp(next)
+    userSet = true
+  }
+}
+
 /// What the sheet collected. `tempoUserSet` is an observation, not a
 /// judgement: whether it amounts to evidence is the core's ruling (#1420).
 struct ReflectionResult {
@@ -25,8 +41,7 @@ struct ReflectionSheet: View {
 
   @State private var score: Int = 0
   @State private var note: String = ""
-  @State private var achievedTempo: Int
-  @State private var tempoUserSet = false
+  @State private var achievedTempo: TrackedTempo
   @State private var selectedVariantId: String?
 
   init(
@@ -43,7 +58,7 @@ struct ReflectionSheet: View {
     self.currentVariantId = currentVariantId
     self.onSave = onSave
     self.onSkip = onSkip
-    _achievedTempo = State(initialValue: TempoStepper.clamp(startingTempoBpm))
+    _achievedTempo = State(initialValue: TrackedTempo(startingBpm: startingTempoBpm))
     _selectedVariantId = State(
       initialValue: Self.initialVariantId(currentVariantId: currentVariantId, variants: variants))
   }
@@ -98,8 +113,8 @@ struct ReflectionSheet: View {
           ReflectionResult(
             score: score == 0 ? nil : UInt8(score),
             note: note.trimmingCharacters(in: .whitespacesAndNewlines),
-            achievedTempo: UInt16(achievedTempo),
-            tempoUserSet: tempoUserSet,
+            achievedTempo: UInt16(achievedTempo.bpm),
+            tempoUserSet: achievedTempo.userSet,
             variantId: selectedVariantId))
       } label: {
         Text("Save & continue")
@@ -127,15 +142,9 @@ struct ReflectionSheet: View {
   }
 
   // TempoStepper only writes on an explicit tap or accessibility adjustment,
-  // never on appear, so a write here is the user considering the number —
-  // which is one of the two things that make a tempo worth recording (#1420).
+  // never on appear, so a write here is the user considering the number (#1420).
   private var achievedTempoBinding: Binding<Int> {
-    Binding(
-      get: { achievedTempo },
-      set: {
-        achievedTempo = $0
-        tempoUserSet = true
-      })
+    Binding(get: { achievedTempo.bpm }, set: { achievedTempo.set($0) })
   }
 
   private var selectedVariantIdBinding: Binding<String> {

--- a/ios/Intrada/Views/Screens/ReflectionSheet.swift
+++ b/ios/Intrada/Views/Screens/ReflectionSheet.swift
@@ -1,6 +1,17 @@
 import SharedTypes
 import SwiftUI
 
+/// What the sheet collected. `tempoUserSet` is an observation, not a
+/// judgement: whether it amounts to evidence is the core's ruling (#1420).
+struct ReflectionResult {
+  let score: UInt8?
+  let note: String
+  let achievedTempo: UInt16
+  /// The user moved the stepper rather than accepting the pre-fill.
+  let tempoUserSet: Bool
+  let variantId: String?
+}
+
 struct ReflectionSheet: View {
   let itemTitle: String
   let elapsedDisplay: String
@@ -9,23 +20,20 @@ struct ReflectionSheet: View {
   /// The item's step ladder, if any. Empty hides the step picker entirely.
   let variants: [VariantView]
   let currentVariantId: String?
-  let onSave:
-    (_ score: UInt8?, _ note: String, _ achievedTempo: UInt16?, _ variantId: String?) -> Void
+  let onSave: (ReflectionResult) -> Void
   let onSkip: () -> Void
 
   @State private var score: Int = 0
   @State private var note: String = ""
   @State private var achievedTempo: Int
+  @State private var tempoUserSet = false
   @State private var selectedVariantId: String?
 
   init(
     itemTitle: String, elapsedDisplay: String, tempoTarget: UInt16?,
     startingTempoBpm: Int = ClickController.defaultBpm,
     variants: [VariantView] = [], currentVariantId: String? = nil,
-    onSave:
-      @escaping (
-        _ score: UInt8?, _ note: String, _ achievedTempo: UInt16?, _ variantId: String?
-      ) -> Void,
+    onSave: @escaping (ReflectionResult) -> Void,
     onSkip: @escaping () -> Void
   ) {
     self.itemTitle = itemTitle
@@ -73,7 +81,7 @@ struct ReflectionSheet: View {
 
       eyebrow(tempoTarget.map { "Tempo reached · target ♩ = \($0)" } ?? "Tempo reached")
         .padding(.top, IntradaSpacing.card)
-      TempoStepper(value: $achievedTempo)
+      TempoStepper(value: achievedTempoBinding)
         .padding(.top, IntradaSpacing.controlGap)
 
       eyebrow("Reflection · optional").padding(.top, IntradaSpacing.card)
@@ -87,10 +95,12 @@ struct ReflectionSheet: View {
 
       BrandBarButton {
         onSave(
-          score == 0 ? nil : UInt8(score),
-          note.trimmingCharacters(in: .whitespacesAndNewlines),
-          UInt16(achievedTempo),
-          selectedVariantId)
+          ReflectionResult(
+            score: score == 0 ? nil : UInt8(score),
+            note: note.trimmingCharacters(in: .whitespacesAndNewlines),
+            achievedTempo: UInt16(achievedTempo),
+            tempoUserSet: tempoUserSet,
+            variantId: selectedVariantId))
       } label: {
         Text("Save & continue")
         Image(systemName: "arrow.right")
@@ -114,6 +124,18 @@ struct ReflectionSheet: View {
   private var stepPicker: some View {
     SegmentedPills(
       options: variants.map(\.id), selection: selectedVariantIdBinding, label: chipLabel)
+  }
+
+  // TempoStepper only writes on an explicit tap or accessibility adjustment,
+  // never on appear, so a write here is the user considering the number —
+  // which is one of the two things that make a tempo worth recording (#1420).
+  private var achievedTempoBinding: Binding<Int> {
+    Binding(
+      get: { achievedTempo },
+      set: {
+        achievedTempo = $0
+        tempoUserSet = true
+      })
   }
 
   private var selectedVariantIdBinding: Binding<String> {
@@ -141,7 +163,7 @@ struct ReflectionSheet: View {
       .sheet(isPresented: .constant(true)) {
         ReflectionSheet(
           itemTitle: "Scales · D♭", elapsedDisplay: "7:00", tempoTarget: nil,
-          onSave: { _, _, _, _ in }, onSkip: {}
+          onSave: { _ in }, onSkip: {}
         )
         .presentationDetents([.medium, .large])
       }
@@ -152,7 +174,7 @@ struct ReflectionSheet: View {
       .sheet(isPresented: .constant(true)) {
         ReflectionSheet(
           itemTitle: "Scales · D♭", elapsedDisplay: "7:00", tempoTarget: 96,
-          onSave: { _, _, _, _ in }, onSkip: {}
+          onSave: { _ in }, onSkip: {}
         )
         .presentationDetents([.medium, .large])
       }

--- a/ios/IntradaTests/ScreenSnapshotTests.swift
+++ b/ios/IntradaTests/ScreenSnapshotTests.swift
@@ -364,7 +364,7 @@ final class ScreenSnapshotTests: XCTestCase {
       PaperBackground()
       ReflectionSheet(
         itemTitle: "Scales · D♭", elapsedDisplay: "7:00", tempoTarget: nil,
-        onSave: { _, _, _, _ in }, onSkip: {})
+        onSave: { _ in }, onSkip: {})
     }
     assertSnapshot(of: host(sheet), as: config)
   }
@@ -374,7 +374,7 @@ final class ScreenSnapshotTests: XCTestCase {
       PaperBackground()
       ReflectionSheet(
         itemTitle: "Scales · D♭", elapsedDisplay: "7:00", tempoTarget: 96,
-        onSave: { _, _, _, _ in }, onSkip: {})
+        onSave: { _ in }, onSkip: {})
     }
     assertSnapshot(of: host(sheet), as: config)
   }
@@ -389,7 +389,7 @@ final class ScreenSnapshotTests: XCTestCase {
         currentVariantId: LibraryItemView.previewExerciseWithSteps.variants.first(
           where: \.isCurrent
         )?.id,
-        onSave: { _, _, _, _ in }, onSkip: {})
+        onSave: { _ in }, onSkip: {})
     }
     assertSnapshot(of: host(sheet), as: config)
   }

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -448,11 +448,6 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().error, "clearing the rung round-trips")
   }
 
-  /// Real-bridge wire pin for the tempo evidence contract (#1420): the new
-  /// `TempoObservation` payload has to cross the bincode wire intact, and the
-  /// core's ruling has to hold end to end. A wire break would let an
-  /// unevidenced default through, and the tempo trend would draw it as a
-  /// measurement.
   private func bridgeWithCompletedEntry() throws -> (LiveBridge, String) {
     let bridge = LiveBridge()
     _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
@@ -484,6 +479,10 @@ final class StoreEffectLoopTests: XCTestCase {
     return (bridge, try XCTUnwrap(entries.first?.id))
   }
 
+  /// Real-bridge wire pin for the tempo evidence contract (#1420): the new
+  /// `TempoObservation` payload has to cross the bincode wire intact and the
+  /// core's ruling has to hold end to end. A wire break would let an
+  /// unevidenced default through, and the trend would draw it as a measurement.
   func testRealBridgeRecordsATempoTheUserSetThemselves() throws {
     let (bridge, entryId) = try bridgeWithCompletedEntry()
 

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -448,6 +448,74 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertNil(try bridge.view().error, "clearing the rung round-trips")
   }
 
+  /// Real-bridge wire pin for the tempo evidence contract (#1420): the new
+  /// `TempoObservation` payload has to cross the bincode wire intact, and the
+  /// core's ruling has to hold end to end. A wire break would let an
+  /// unevidenced default through, and the tempo trend would draw it as a
+  /// measurement.
+  private func bridgeWithCompletedEntry() throws -> (LiveBridge, String) {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    _ = try bridge.update(
+      .item(
+        .add(
+          CreateItem(
+            title: "Scales", kind: .exercise, composer: nil, key: nil, modality: nil,
+            tempo: nil, notes: nil, tags: []))))
+    _ = try bridge.update(
+      .item(
+        .add(
+          CreateItem(
+            title: "Arpeggios", kind: .exercise, composer: nil, key: nil, modality: nil,
+            tempo: nil, notes: nil, tags: []))))
+    let ids = try bridge.view().items.map(\.id)
+    XCTAssertEqual(ids.count, 2, "two distinct items: addToSetlist is idempotent by item id")
+
+    _ = try bridge.update(.session(.startBuilding))
+    for id in ids { _ = try bridge.update(.session(.addToSetlist(itemId: id))) }
+    _ = try bridge.update(.session(.startSession(now: "2026-08-28T09:00:00Z")))
+    // Advancing completes the first entry; tempo only lands on a completed one.
+    _ = try bridge.update(.session(.nextItem(now: "2026-08-28T09:10:00Z")))
+
+    let entries = try XCTUnwrap(try bridge.view().activeSession?.entries)
+    XCTAssertEqual(
+      entries.first?.status, .completed,
+      "the negative test must be asserting against a real completed entry")
+    return (bridge, try XCTUnwrap(entries.first?.id))
+  }
+
+  func testRealBridgeRecordsATempoTheUserSetThemselves() throws {
+    let (bridge, entryId) = try bridgeWithCompletedEntry()
+
+    _ = try bridge.update(
+      .session(
+        .updateEntryTempo(
+          entryId: entryId, tempo: 132,
+          observed: TempoObservation(userSet: true, clickSounding: false))))
+
+    let view = try bridge.view()
+    XCTAssertNil(view.error, "the observation must decode on the wire (#846)")
+    XCTAssertEqual(
+      view.activeSession?.entries.first?.achievedTempo, 132,
+      "a tempo the user set themselves is a measurement")
+  }
+
+  func testRealBridgeDoesNotRecordAnUntouchedPreFill() throws {
+    let (bridge, entryId) = try bridgeWithCompletedEntry()
+
+    _ = try bridge.update(
+      .session(
+        .updateEntryTempo(
+          entryId: entryId, tempo: 96,
+          observed: TempoObservation(userSet: false, clickSounding: false))))
+
+    let view = try bridge.view()
+    XCTAssertNil(view.error, "declining to record is a silent success, not an error")
+    XCTAssertNil(
+      view.activeSession?.entries.first?.achievedTempo,
+      "a pre-fill nobody looked at leaves no point for the trend to draw")
+  }
+
   /// but returns a nested `ChordChart` + `ScaffoldPreviewView` across the bincode
   /// wire — a shape a stub bridge can't exercise. A bad chart must surface an
   /// error and never store a partial.
@@ -628,11 +696,19 @@ final class StoreEffectLoopTests: XCTestCase {
       try bridge.view().summary?.entries.first?.notes, "clearing an entry note round-trips")
     // Achieved tempo — the hand-off sheet's TempoStepper write, never previously
     // sent from Swift (#846). Round-trip set + clear through the live bridge.
-    _ = try bridge.update(.session(.updateEntryTempo(entryId: entryId, tempo: 96)))
+    _ = try bridge.update(
+      .session(
+        .updateEntryTempo(
+          entryId: entryId, tempo: 96,
+          observed: TempoObservation(userSet: true, clickSounding: false))))
     XCTAssertEqual(
       try bridge.view().summary?.entries.first?.achievedTempo, 96,
       "the tempo stepper's achieved tempo should round-trip")
-    _ = try bridge.update(.session(.updateEntryTempo(entryId: entryId, tempo: nil)))
+    _ = try bridge.update(
+      .session(
+        .updateEntryTempo(
+          entryId: entryId, tempo: nil,
+          observed: TempoObservation(userSet: true, clickSounding: false))))
     XCTAssertNil(
       try bridge.view().summary?.entries.first?.achievedTempo,
       "clearing an achieved tempo round-trips")

--- a/ios/IntradaTests/TempoStepperTests.swift
+++ b/ios/IntradaTests/TempoStepperTests.swift
@@ -64,6 +64,39 @@ final class ReflectionSheetStepSelectionTests: XCTestCase {
   }
 }
 
+/// The shell half of the tempo evidence contract (#1420): if `userSet` ever
+/// stops tracking the stepper, every tempo becomes unevidenced and the trend
+/// goes silently empty — the #846 failure mode with no other guard on it.
+@MainActor
+final class TrackedTempoTests: XCTestCase {
+  func testAPreFillIsNotUserSet() {
+    XCTAssertFalse(
+      TrackedTempo(startingBpm: 96).userSet,
+      "the sheet opening at a pre-filled number is not the user setting one")
+  }
+
+  func testSettingMarksItUserSet() {
+    var tempo = TrackedTempo(startingBpm: 96)
+    tempo.set(120)
+    XCTAssertEqual(tempo.bpm, 120)
+    XCTAssertTrue(tempo.userSet)
+  }
+
+  func testSettingBackToTheStartingValueStillCounts() {
+    var tempo = TrackedTempo(startingBpm: 96)
+    tempo.set(98)
+    tempo.set(96)
+    XCTAssertTrue(
+      tempo.userSet, "stepping up and back is still the user considering the number")
+  }
+
+  func testAnOutOfRangeStartClampsWithoutCountingAsUserSet() {
+    let tempo = TrackedTempo(startingBpm: 400)
+    XCTAssertEqual(tempo.bpm, TempoStepper.range.upperBound)
+    XCTAssertFalse(tempo.userSet, "clamping is the app tidying up, not the user choosing")
+  }
+}
+
 @MainActor
 final class AddStepsSheetTests: XCTestCase {
   func testEmptyArrayTrimsToEmpty() {


### PR DESCRIPTION
First of two PRs for #1420, step 7 of the adopted order in
[`docs/research/comparison.md`](https://github.com/jonyardley/intrada/blob/main/docs/research/comparison.md).
This one makes the recording honest; the chart is the second PR.

Tier 3 by the domain-sensitivity override: it changes the FFI bridge contract.

## The problem

Tempo capture shipped inside the metronome work (#1398, #1401) and quietly
settled roadmap open question 3 with the wrong answer. `ReflectionSheet` shows
the tempo stepper on every item, always passes a tempo on save, and pre-fills
it from `click.bpm`. When the click never sounded that number is whatever
`ClickController` seeded: **the item's own declared target where it has one**,
and a neutral 96 where it does not.

So every mark already carries a tempo, and a large share of those numbers are
an untouched default nobody looked at. For an item marked ♩ = 132 the app was
recording 132 as achieved, which is a worse falsehood than a stray default. `ItemPracticeSummary.tempo_history` is a
mixture of considered measurements and noise with nothing telling them apart.

Step 7 draws that history as a chart, and a chart looks like measurement.
Drawing a line through numbers the user never considered is the borrowed
authority the getting-cold signal (#1416) was careful to avoid, and much harder
to spot in a chart than in a sentence. Hence the recording gets fixed first.

## The ruling

**A tempo is worth recording when there is evidence behind it, and never
otherwise** (Jon, 2026-08-27; now design-principles **T16**). Evidence is
either of two things:

1. the user moved the stepper, or
2. the click was sounding when the item ended, so the pre-filled number
   measures what they actually played to.

That dissolves the original question rather than answering it. Tempo is never
required and it is not optional-by-item-target either. It is recorded when it
was measured.

## The contract

Pinned on the issue before either side was written
([comment](https://github.com/jonyardley/intrada/issues/1420#issuecomment-5449171587)).

Both facts are shell-observable and neither is a judgement, so the shell
forwards them untouched and the core rules:

```rust
pub struct TempoObservation {
    pub user_set: bool,
    pub click_sounding: bool,
}

UpdateEntryTempo { entry_id: String, tempo: Option<u16>, observed: TempoObservation }

impl TempoObservation {
    pub fn is_evidenced(&self) -> bool { self.user_set || self.click_sounding }
}
```

`is_evidenced` is the only place the rule lives. Deciding in Swift would be
domain logic in the dumb pipe, and it would put the rule somewhere no core test
could reach.

**A struct of two facts, not a three-case enum**, because both can be true at
once (the click was sounding at hand-off and the user then stepped the number).
An enum would make the shell pick a precedence, which is the ruling we are
keeping out of Swift.

### Handler behaviour

| `tempo` | evidenced | result |
|---|---|---|
| `Some(t)` | yes | record `t` |
| `Some(t)` | no | no-op: record nothing, clear nothing |
| `None` | either | clear |

Unevidenced `Some` is a no-op rather than a clear, so a report that is not a
measurement can never destroy one that was. Validation and the `Completed`
status guard are unchanged and still run first.

## What this does not touch

- **No new field on `SetlistEntry`.** `achieved_tempo` is already
  `Option<u16>` and `build_practice_summaries` already skips `None`, so `None`
  already meant "no tempo was measured" everywhere downstream. The
  `ActiveSession` crash-recovery blob's graph is unchanged, so **no
  UserDefaults key bump** (CLAUDE.md → gotchas).
- **No new ViewModel field.** `tempo_history` is already the surface the trend
  reads, and every point in it is now evidenced by construction.
- **No network, no storage op.** A projection over data already in the model,
  so local-first by construction.

## Pre-fix history on device: accepted, not migrated

Tempos recorded between #1398 (2026-08-19) and this PR include unevidenced
defaults, and nothing distinguishes them from real ones. Asked Jon how much
practice had actually gone through the app in that window: essentially none.
So there is no meaningful body of noise to remove, and nulling `achieved_tempo`
across existing sessions would destroy the real measurements among them on the
only copy of the data that exists. Decided deliberately rather than by
omission, per the issue's last section.

## Shell side

The plumbing rides here rather than in the screens PR because the signature
change breaks the Swift build without it, and because it is part of the
contract rather than UI.

- `ReflectionSheet` reports a `ReflectionResult` (replacing a four-argument
  closure that was about to become five) carrying `tempoUserSet`. `TempoStepper`
  only writes on an explicit tap or accessibility adjustment, never on appear,
  so a write is the user considering the number.
- `FocusPlayerScreen` reads `click.isRunning` alongside `click.bpm` before
  `click.stop()` in `presentReflection` and carries it on `ReflectionTarget`. It
  now always sends the event; the core rules.

**The sheet does not change.** The stepper still appears on every item and still
pre-fills, and no banner says a number was not kept, because nothing was asked
of the user. There is one visible consequence downstream: `SessionSummaryScreen`'s
meta row reads `Exercise` rather than `Exercise · 96 bpm` when there was nothing
to measure. That is the row telling the truth, and it is not a new render path
(Skip rating already produces a nil tempo today), which is why no snapshot moved.

## Tests

- The four rows of the ruling in `domain/session.rs`, watched failing first
  (both unevidenced cases recorded 96 before the ruling landed).
- `update_entry_tempo_round_trips_on_ffi_bincode_wire` on the new payload.
- Two live-bridge tests (`StoreEffectLoopTests`) driving a real session so the
  observation crosses the wire and the ruling holds end to end. A stub bridge
  cannot catch a wire break (#846). Both negative tests, Rust and Swift, assert
  their entry is actually `Completed` first, so neither can pass on a
  wrong-shaped session.
- Four tests on `TrackedTempo`, the shell type carrying the `user_set`
  observation. It keeps `bpm` `private(set)` so there is no writable binding
  that bypasses the tracking, which makes the silent-no-op mistake a compile
  error rather than something a test has to catch.

Not covered by any gate: the click-sounding branch end to end, which needs real
audio on a device.

**Coverage:** expect high patch coverage on the Rust side; the change is one
handler branch plus a two-line predicate, both directly tested. `ios/` is in
Codecov's ignore list, so the Swift plumbing will not appear.

## Docs

- **design-principles T16** — the ruling, its two sub-rulings, and the options
  rejected.
- **roadmap Q3** — marked implemented, pointing at T16.
- **comparison.md step 7** — unblocked, and records that the answer moved the
  work: half of step 7 is making the recording honest.
- **status.md** — #1420 in flight.

Closes nothing yet: #1420 stays open for the chart.
