### PR TITLE
The tempo trend (#1420), core: a plottable series with gaps where nothing was measured

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -838,14 +838,14 @@ pub(crate) fn build_practice_summaries(
 
             if let Some(score) = entry.score {
                 record.2.push(ScoreHistoryEntry {
-                    session_date: session.started_at.to_rfc3339(),
+                    session_date: session_date.clone(),
                     score,
                     session_id: session.id.clone(),
                 });
             }
 
             record.3.push(TempoTrendPoint {
-                session_date: session.started_at.to_rfc3339(),
+                session_date: session_date.clone(),
                 session_id: session.id.clone(),
                 tempo: entry.achieved_tempo,
             });
@@ -3091,11 +3091,10 @@ mod tests {
         score: Option<u8>,
         tempo: Option<u16>,
     ) -> PracticeSession {
-        let now = started_at;
         PracticeSession {
             id: id.to_string(),
-            started_at: now,
-            completed_at: now,
+            started_at,
+            completed_at: started_at,
             total_duration_secs: 300,
             completion_status: CompletionStatus::Completed,
             session_notes: None,
@@ -3147,11 +3146,15 @@ mod tests {
 
     // ── The tempo trend (#1420) ──
 
-    fn tempo_trend_for(measured: &[Option<u16>]) -> crate::model::TempoTrendView {
+    /// `measured[i]` is the tempo of the i-th session chronologically. The
+    /// sessions are handed over newest first, so a projection that skipped its
+    /// own sort would emit the series backwards.
+    fn summary_for_tempos(measured: &[Option<u16>]) -> ItemPracticeSummary {
         let base = chrono::Utc::now() - chrono::Duration::days(30);
         let sessions: Vec<PracticeSession> = measured
             .iter()
             .enumerate()
+            .rev()
             .map(|(i, tempo)| {
                 make_session_at(
                     &format!("s{i}"),
@@ -3165,7 +3168,10 @@ mod tests {
         build_practice_summaries(&sessions)
             .remove("item-1")
             .expect("summary for item-1")
-            .tempo_trend
+    }
+
+    fn tempo_trend_for(measured: &[Option<u16>]) -> crate::model::TempoTrendView {
+        summary_for_tempos(measured).tempo_trend
     }
 
     #[test]
@@ -3191,6 +3197,12 @@ mod tests {
             trend.points.iter().map(|p| p.tempo).collect::<Vec<_>>(),
             vec![Some(88), None, Some(104)]
         );
+    }
+
+    #[test]
+    fn latest_tempo_is_the_newest_measured_not_the_newest_session() {
+        // Reading the newest slot rather than the newest number would drop it.
+        assert_eq!(summary_for_tempos(&[Some(88), None]).latest_tempo, Some(88));
     }
 
     #[test]

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -809,15 +809,15 @@ pub(crate) fn derive_up_next(
 pub(crate) fn build_practice_summaries(
     sessions: &[PracticeSession],
 ) -> std::collections::HashMap<String, ItemPracticeSummary> {
-    use crate::model::{ScoreHistoryEntry, TempoHistoryEntry};
+    use crate::model::{ScoreHistoryEntry, TempoTrendPoint, TempoTrendView};
     use std::collections::HashMap;
 
-    // (count, secs, score_history, tempo_history, last_practiced_at)
+    // (count, secs, score_history, tempo_points, last_practiced_at)
     type Acc = (
         usize,
         u64,
         Vec<ScoreHistoryEntry>,
-        Vec<TempoHistoryEntry>,
+        Vec<TempoTrendPoint>,
         Option<String>,
     );
 
@@ -844,13 +844,11 @@ pub(crate) fn build_practice_summaries(
                 });
             }
 
-            if let Some(tempo) = entry.achieved_tempo {
-                record.3.push(TempoHistoryEntry {
-                    session_date: session.started_at.to_rfc3339(),
-                    tempo,
-                    session_id: session.id.clone(),
-                });
-            }
+            record.3.push(TempoTrendPoint {
+                session_date: session.started_at.to_rfc3339(),
+                session_id: session.id.clone(),
+                tempo: entry.achieved_tempo,
+            });
         }
     }
 
@@ -858,19 +856,20 @@ pub(crate) fn build_practice_summaries(
         .map(
             |(
                 item_id,
-                (
-                    session_count,
-                    total_secs,
-                    mut score_history,
-                    mut tempo_history,
-                    last_practiced_at,
-                ),
+                (session_count, total_secs, mut score_history, mut tempo_points, last_practiced_at),
             )| {
                 score_history.sort_by(|a, b| b.session_date.cmp(&a.session_date));
                 let latest_score = score_history.first().map(|e| e.score);
 
-                tempo_history.sort_by(|a, b| b.session_date.cmp(&a.session_date));
-                let latest_tempo = tempo_history.first().map(|e| e.tempo);
+                tempo_points.sort_by(|a, b| {
+                    (&a.session_date, &a.session_id).cmp(&(&b.session_date, &b.session_id))
+                });
+                let latest_tempo = tempo_points.iter().rev().find_map(|p| p.tempo);
+                let measured = tempo_points.iter().filter(|p| p.tempo.is_some()).count();
+                let tempo_trend = TempoTrendView {
+                    points: tempo_points,
+                    has_trend: measured >= 2,
+                };
 
                 (
                     item_id,
@@ -880,7 +879,7 @@ pub(crate) fn build_practice_summaries(
                         latest_score,
                         score_history,
                         latest_tempo,
-                        tempo_history,
+                        tempo_trend,
                         last_practiced_at,
                     },
                 )
@@ -2667,18 +2666,15 @@ mod tests {
         let p2_view = vm.items.iter().find(|i| i.id == "p2").unwrap();
 
         // p1 has 2 entries totalling 45 minutes, no scores, no tempo
-        assert_eq!(
-            p1_view.practice,
-            Some(ItemPracticeSummary {
-                session_count: 2,
-                total_minutes: 45,
-                latest_score: None,
-                score_history: vec![],
-                latest_tempo: None,
-                tempo_history: vec![],
-                last_practiced_at: Some(sess1_started.to_rfc3339()),
-            })
-        );
+        let p1 = p1_view.practice.as_ref().expect("p1 practice summary");
+        assert_eq!(p1.session_count, 2);
+        assert_eq!(p1.total_minutes, 45);
+        assert_eq!(p1.latest_score, None);
+        assert_eq!(p1.latest_tempo, None);
+        assert!(p1.score_history.is_empty());
+        assert_eq!(p1.last_practiced_at, Some(sess1_started.to_rfc3339()));
+        assert_eq!(p1.tempo_trend.points.len(), 2);
+        assert!(!p1.tempo_trend.has_trend);
         // p2 has no entries
         assert_eq!(p2_view.practice, None);
     }
@@ -3085,7 +3081,17 @@ mod tests {
         score: Option<u8>,
         tempo: Option<u16>,
     ) -> PracticeSession {
-        let now = chrono::Utc::now();
+        make_session_at(id, item_id, chrono::Utc::now(), score, tempo)
+    }
+
+    fn make_session_at(
+        id: &str,
+        item_id: &str,
+        started_at: chrono::DateTime<chrono::Utc>,
+        score: Option<u8>,
+        tempo: Option<u16>,
+    ) -> PracticeSession {
+        let now = started_at;
         PracticeSession {
             id: id.to_string(),
             started_at: now,
@@ -3137,6 +3143,72 @@ mod tests {
         assert_eq!(summary.total_minutes, 5);
         assert_eq!(summary.latest_score, Some(4));
         assert_eq!(summary.latest_tempo, Some(120));
+    }
+
+    // ── The tempo trend (#1420) ──
+
+    fn tempo_trend_for(measured: &[Option<u16>]) -> crate::model::TempoTrendView {
+        let base = chrono::Utc::now() - chrono::Duration::days(30);
+        let sessions: Vec<PracticeSession> = measured
+            .iter()
+            .enumerate()
+            .map(|(i, tempo)| {
+                make_session_at(
+                    &format!("s{i}"),
+                    "item-1",
+                    base + chrono::Duration::days(i as i64),
+                    None,
+                    *tempo,
+                )
+            })
+            .collect();
+        build_practice_summaries(&sessions)
+            .remove("item-1")
+            .expect("summary for item-1")
+            .tempo_trend
+    }
+
+    #[test]
+    fn tempo_trend_runs_oldest_first_one_point_per_session() {
+        let trend = tempo_trend_for(&[Some(88), Some(96), Some(104)]);
+
+        assert_eq!(
+            trend.points.iter().map(|p| p.tempo).collect::<Vec<_>>(),
+            vec![Some(88), Some(96), Some(104)]
+        );
+        let dates: Vec<&String> = trend.points.iter().map(|p| &p.session_date).collect();
+        assert!(
+            dates.windows(2).all(|w| w[0] < w[1]),
+            "oldest first: {dates:?}"
+        );
+    }
+
+    #[test]
+    fn tempo_trend_leaves_a_gap_where_no_tempo_was_measured() {
+        let trend = tempo_trend_for(&[Some(88), None, Some(104)]);
+
+        assert_eq!(
+            trend.points.iter().map(|p| p.tempo).collect::<Vec<_>>(),
+            vec![Some(88), None, Some(104)]
+        );
+    }
+
+    #[test]
+    fn tempo_trend_has_no_trend_below_two_measured_tempos() {
+        assert!(!tempo_trend_for(&[None, None]).has_trend);
+        assert!(!tempo_trend_for(&[Some(96), None, None]).has_trend);
+    }
+
+    #[test]
+    fn tempo_trend_has_a_trend_at_two_measured_tempos() {
+        assert!(tempo_trend_for(&[Some(96), None, Some(104)]).has_trend);
+    }
+
+    #[test]
+    fn tempo_trend_round_trips_a_gap_on_the_ffi_bincode_wire() {
+        // A `None` inside the points vec is the shape most at risk on the
+        // positional wire, and the gap is the whole point of the chart (#846).
+        crate::domain::types::assert_round_trips(tempo_trend_for(&[Some(88), None, Some(104)]));
     }
 
     #[test]
@@ -3606,7 +3678,9 @@ mod tests {
         assert!(summary.latest_score.is_none());
         assert!(summary.latest_tempo.is_none());
         assert!(summary.score_history.is_empty());
-        assert!(summary.tempo_history.is_empty());
+        assert_eq!(summary.tempo_trend.points.len(), 1);
+        assert!(summary.tempo_trend.points[0].tempo.is_none());
+        assert!(!summary.tempo_trend.has_trend);
     }
 
     #[test]
@@ -3786,11 +3860,8 @@ mod tests {
             crate::model::ItemPracticeSummary {
                 session_count: 1,
                 total_minutes: 1,
-                latest_score: None,
-                score_history: vec![],
-                latest_tempo: None,
-                tempo_history: vec![],
                 last_practiced_at: Some(at.to_rfc3339()),
+                ..crate::model::ItemPracticeSummary::fixture()
             },
         );
     }

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -34,7 +34,7 @@ pub use crux_http::{HttpError, HttpRequest};
 pub use model::{
     ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model,
     PracticeSessionView, ScoreHistoryEntry, SessionStatusView, SetEntryView, SetSourceStatus,
-    SetView, SetlistEntryView, SummaryView, TempoHistoryEntry, ViewModel,
+    SetView, SetlistEntryView, SummaryView, TempoTrendPoint, TempoTrendView, ViewModel,
 };
 pub use validation::{
     MAX_ACHIEVED_TEMPO, MAX_BPM, MAX_COMPOSER, MAX_NOTES, MAX_SET_NAME, MAX_TAG, MAX_TEMPO_MARKING,

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -397,9 +397,7 @@ pub struct ScoreHistoryEntry {
     pub session_id: String,
 }
 
-/// One session's slot in an item's tempo trend, oldest first. `tempo` is `None`
-/// where that session measured none, which the chart draws as a break in the
-/// line rather than a zero or an interpolated point (#1420).
+/// One practised session's slot in a `TempoTrendView`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct TempoTrendPoint {
@@ -408,18 +406,19 @@ pub struct TempoTrendPoint {
     pub tempo: Option<u16>,
 }
 
-/// An item's measured tempo over time, as a plottable series. Every number in
-/// it was measured: the shell reports what it observed and the core rules on
-/// whether that is evidence (design-principles T16, #1422), so an unevidenced
-/// default never reaches a point.
+/// An item's measured tempo over time, as a plottable series. A session that
+/// measured no tempo keeps its slot with `tempo: None`, so the chart breaks the
+/// line there rather than drawing a zero or interpolating across it (#1420).
+/// Every number present was measured, because the evidence contract keeps
+/// unevidenced defaults out of `achieved_tempo` upstream (T16, #1422).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
 pub struct TempoTrendView {
-    /// One point per time this item was practised, oldest first (the reverse of
-    /// `score_history`, which is newest-first for rows rather than a plot).
+    /// Oldest first, the reverse of `score_history`. One point per setlist
+    /// entry, matching `session_count`: an item practised twice in one session
+    /// contributes two points at the same date.
     pub points: Vec<TempoTrendPoint>,
-    /// Two or more measured tempos. Below that there is no direction to read,
-    /// and the screen says so plainly instead of drawing a chart.
+    /// Two or more measured tempos; below that there is no direction to read.
     pub has_trend: bool,
 }
 

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -382,7 +382,7 @@ pub struct ItemPracticeSummary {
     pub latest_score: Option<u8>,
     pub score_history: Vec<ScoreHistoryEntry>,
     pub latest_tempo: Option<u16>,
-    pub tempo_history: Vec<TempoHistoryEntry>,
+    pub tempo_trend: TempoTrendView,
     /// Most recent session date for this item (max `started_at`), independent
     /// of whether a score/tempo was recorded. `None` if never practised.
     /// RFC3339 — sorts chronologically as a string.
@@ -397,12 +397,30 @@ pub struct ScoreHistoryEntry {
     pub session_id: String,
 }
 
+/// One session's slot in an item's tempo trend, oldest first. `tempo` is `None`
+/// where that session measured none, which the chart draws as a break in the
+/// line rather than a zero or an interpolated point (#1420).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
-pub struct TempoHistoryEntry {
+pub struct TempoTrendPoint {
     pub session_date: String,
-    pub tempo: u16,
     pub session_id: String,
+    pub tempo: Option<u16>,
+}
+
+/// An item's measured tempo over time, as a plottable series. Every number in
+/// it was measured: the shell reports what it observed and the core rules on
+/// whether that is evidence (design-principles T16, #1422), so an unevidenced
+/// default never reaches a point.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct TempoTrendView {
+    /// One point per time this item was practised, oldest first (the reverse of
+    /// `score_history`, which is newest-first for rows rather than a plot).
+    pub points: Vec<TempoTrendPoint>,
+    /// Two or more measured tempos. Below that there is no direction to read,
+    /// and the screen says so plainly instead of drawing a chart.
+    pub has_trend: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -618,7 +636,7 @@ impl ItemPracticeSummary {
             latest_score: None,
             score_history: Vec::new(),
             latest_tempo: None,
-            tempo_history: Vec::new(),
+            tempo_trend: TempoTrendView::default(),
             last_practiced_at: None,
         }
     }

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -118,8 +118,10 @@ Then, each building on the last:
    have drawn was a mixture of real measurements and untouched defaults, so the
    first half of this step is making the recording honest. **Evidence contract
    done 2026-08-28** (#1420, design-principles T16): a tempo is recorded when
-   it was measured and never otherwise, so every point in `tempo_history` is
-   now evidenced by construction. The chart itself is the second PR.
+   it was measured and never otherwise, so every point in the history is now
+   evidenced by construction. **Series done 2026-08-28** (#1423): `tempo_trend`
+   replaces `tempo_history`, carrying a slot for every practised session so the
+   gaps have a position. The chart itself is the third PR.
 8. **The getting-cold signal** — a graded staleness estimate replacing the
    binary 14-day flag, landing as Up next reason lines rather than a surface
    of its own. 1–2 days once step 6 exists. **Done 2026-08-27** (#1416,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,10 +205,13 @@ These are unresolved product questions. Each one likely produces issues
    history as a chart, and a chart looks like measurement.
 
    Costs no new field: `UpdateEntryTempo` already carries `Option<u16>` and
-   `tempo_history` already skips `None`. Keep it that way, because
-   `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob.
+   `SetlistEntry.achieved_tempo` already skips `None`. Keep it that way, because
+   `SetlistEntry` sits inside the `ActiveSession` crash-recovery blob. The
+   ViewModel projection is the opposite: `tempo_trend` deliberately carries a
+   slot for every practised session, so the chart can break its line where
+   nothing was measured.
 
-   **Implemented 2026-08-28** (#1420, first of two PRs) as design-principles
+   **Implemented 2026-08-28** (#1420, first of three PRs) as design-principles
    **T16**. One correction to the framing above: the untouched pre-fill is not
    always the neutral 96. `ClickController` seeds from the item's own declared
    target, so for an item marked ♩ = 132 the app was recording 132 as achieved. The shell forwards two observed facts (`TempoObservation`) and the

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,7 +30,14 @@ audit backlog and its five-phase build order.
   target, so the app was quietly recording it as achieved. A tempo is now recorded only when it was measured
   (design-principles **T16**, answering roadmap Q3): the shell forwards two
   observed facts and the core rules on whether they amount to evidence. No new
-  field, so no crash-recovery key bump. The chart itself is the second PR.
+  field, so no crash-recovery key bump.
+
+  The **series** is the second PR: `ItemPracticeSummary.tempo_history` is
+  replaced by `tempo_trend`, one point per practised session oldest first, with
+  `tempo: None` where nothing was measured. The core rules on what counts as a
+  trend (two measured tempos or more) so the screen never has to. The chart
+  drawing that series is the third PR. Mock:
+  [Tempo Trend](https://claude.ai/code/artifact/b0aff8b0-b9e7-45bb-a209-fe8bb866f6fd).
 
 ## Recently landed
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -163,16 +163,13 @@ audit backlog and its five-phase build order.
 
 ## Next
 
-- **The tempo trend (#1420) is the next unstarted build.** Step 7 of the
-  adopted Stage 4 order ([`research/comparison.md`](research/comparison.md)),
-  unblocked because roadmap Q3 is now answered (Jon, 2026-08-27): **a tempo is
-  recorded when there is evidence behind it** (the user moved the stepper, or
-  the click was sounding), and never otherwise. The question had been overtaken
-  by #1398 and #1401, which made the stepper always save a click-prefilled
-  default, so `tempo_history` today mixes real measurements with numbers nobody
-  looked at. Costs no schema change; #1420 carries the reasoning and the
-  contract question to pin first. Steps 9 to 11 remain the big bets, each a
-  fresh decision gated on lived use.
+- **The chart on the detail screen** finishes the tempo trend (#1420): it draws
+  the `tempo_trend` series, breaking the line where a session measured no tempo
+  and saying so plainly where there is less than a trend to show. Mocked as
+  [Tempo Trend](https://claude.ai/code/artifact/b0aff8b0-b9e7-45bb-a209-fe8bb866f6fd);
+  one call open on it, whether the item's declared target draws as a reference
+  line. Needs no core change either way. Steps 9 to 11 remain the big bets,
+  each a fresh decision gated on lived use.
 - Running alongside, and not a build: **use** the Up next card and the
   getting-cold signal on the week's lesson tune and file the friction, the way
   step 2 and step 5 were treated. Two weeks of real use is what tells us

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -3,6 +3,22 @@
   import IntradaCoreFFI
   import SharedTypes
 
+  extension TempoTrendView {
+    /// `tempos[i]` is the i-th session's tempo, `nil` where none was measured.
+    /// Dates end on the newest, so a summary's `lastPracticedAt` and its trend
+    /// agree.
+    static func fixture(_ tempos: [UInt16?]) -> TempoTrendView {
+      let dates = [
+        "2026-06-09T09:00:00Z", "2026-06-12T09:00:00Z", "2026-06-15T09:00:00Z",
+        "2026-06-18T09:00:00Z", "2026-06-21T09:00:00Z", "2026-06-24T09:00:00Z",
+      ].suffix(tempos.count)
+      let points = zip(dates, tempos.enumerated()).map { date, entry in
+        TempoTrendPoint(sessionDate: date, sessionId: "t\(entry.offset)", tempo: entry.element)
+      }
+      return TempoTrendView(points: points, hasTrend: tempos.compactMap { $0 }.count >= 2)
+    }
+  }
+
   extension ItemPracticeSummary {
     /// Preview and snapshot fixture. A new core field costs one edit here rather
     /// than one per call site (CLAUDE.md, Testing).
@@ -456,7 +472,8 @@
             ScoreHistoryEntry(sessionDate: "2026-06-21T09:00:00Z", score: 5, sessionId: "s2"),
             ScoreHistoryEntry(sessionDate: "2026-06-18T09:00:00Z", score: 4, sessionId: "s3"),
           ],
-          latestTempo: 72, lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 72, tempoTrend: .fixture([66, nil, 69, 72]),
+          lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false,
         linkedExercises: [
           // Per-piece scores deliberately differ from the exercises' overall
@@ -465,7 +482,8 @@
             id: "exercise-1", title: "Hanon No. 1", key: "C major", tempo: "♩ = 108",
             practice: ItemPracticeSummary.fixture(
               sessionCount: 8, totalMinutes: 60, latestScore: 7, scoreHistory: [],
-              latestTempo: 108, lastPracticedAt: "2026-06-28T09:00:00Z"),
+              latestTempo: 108, tempoTrend: .fixture([100, 104, 108]),
+              lastPracticedAt: "2026-06-28T09:00:00Z"),
             pieceContextScore: 5),
           LinkedExerciseView(
             id: "exercise-2", title: "Db Major Scale", key: "Db major", tempo: nil,
@@ -495,7 +513,8 @@
             ScoreHistoryEntry(sessionDate: "2026-06-21T09:00:00Z", score: 6, sessionId: "e2"),
             ScoreHistoryEntry(sessionDate: "2026-06-18T09:00:00Z", score: 5, sessionId: "e3"),
           ],
-          latestTempo: 108, lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 108, tempoTrend: .fixture([96, 100, nil, 104, 108]),
+          lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false, linkedExercises: [],
         linkedFromPieces: [
           PieceRefView(id: "piece-1", title: "Clair de Lune", subtitle: "Claude Debussy"),
@@ -517,7 +536,8 @@
           scoreHistory: [
             ScoreHistoryEntry(sessionDate: "2026-06-24T09:00:00Z", score: 7, sessionId: "e1")
           ],
-          latestTempo: 120, lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 120, tempoTrend: .fixture([120]),
+          lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false, linkedExercises: [],
         linkedFromPieces: [
           PieceRefView(id: "piece-1", title: "Strasbourg / St. Denis", subtitle: "Woody Shaw")

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -3,6 +3,25 @@
   import IntradaCoreFFI
   import SharedTypes
 
+  extension ItemPracticeSummary {
+    /// Preview and snapshot fixture. A new core field costs one edit here rather
+    /// than one per call site (CLAUDE.md, Testing).
+    static func fixture(
+      sessionCount: UInt64 = 0,
+      totalMinutes: UInt32 = 0,
+      latestScore: UInt8? = nil,
+      scoreHistory: [ScoreHistoryEntry] = [],
+      latestTempo: UInt16? = nil,
+      tempoTrend: TempoTrendView = TempoTrendView(points: [], hasTrend: false),
+      lastPracticedAt: String? = nil
+    ) -> ItemPracticeSummary {
+      ItemPracticeSummary(
+        sessionCount: sessionCount, totalMinutes: totalMinutes, latestScore: latestScore,
+        scoreHistory: scoreHistory, latestTempo: latestTempo, tempoTrend: tempoTrend,
+        lastPracticedAt: lastPracticedAt)
+    }
+  }
+
   /// A fixed Gregorian/UTC calendar so date-derived UI (the week strip) renders
   /// identically on any host — pair it with `previewReferenceDate` in previews
   /// and pin it via `.environment(\.calendar, PreviewCalendar.utc)` in snapshot hosts.
@@ -281,9 +300,9 @@
 
     private static func scored(_ item: LibraryItemView, _ score: UInt8) -> LibraryItemView {
       var copy = item
-      copy.practice = ItemPracticeSummary(
+      copy.practice = ItemPracticeSummary.fixture(
         sessionCount: 8, totalMinutes: 120, latestScore: score, scoreHistory: [],
-        latestTempo: nil, tempoHistory: [], lastPracticedAt: "2026-05-30T09:00:00Z")
+        latestTempo: nil, lastPracticedAt: "2026-05-30T09:00:00Z")
       return copy
     }
   }
@@ -430,29 +449,29 @@
         tempoBpm: 72,
         notes: "Focus on the rubato in the opening phrase; keep the left hand soft.",
         tags: ["recital", "impressionist"], createdAt: "", updatedAt: "",
-        practice: ItemPracticeSummary(
+        practice: ItemPracticeSummary.fixture(
           sessionCount: 12, totalMinutes: 240, latestScore: 6,
           scoreHistory: [
             ScoreHistoryEntry(sessionDate: "2026-06-24T09:00:00Z", score: 6, sessionId: "s1"),
             ScoreHistoryEntry(sessionDate: "2026-06-21T09:00:00Z", score: 5, sessionId: "s2"),
             ScoreHistoryEntry(sessionDate: "2026-06-18T09:00:00Z", score: 4, sessionId: "s3"),
           ],
-          latestTempo: 72, tempoHistory: [], lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 72, lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false,
         linkedExercises: [
           // Per-piece scores deliberately differ from the exercises' overall
           // `latestScore` (7 / 4), so the snapshot shows the B2 re-source.
           LinkedExerciseView(
             id: "exercise-1", title: "Hanon No. 1", key: "C major", tempo: "♩ = 108",
-            practice: ItemPracticeSummary(
+            practice: ItemPracticeSummary.fixture(
               sessionCount: 8, totalMinutes: 60, latestScore: 7, scoreHistory: [],
-              latestTempo: 108, tempoHistory: [], lastPracticedAt: "2026-06-28T09:00:00Z"),
+              latestTempo: 108, lastPracticedAt: "2026-06-28T09:00:00Z"),
             pieceContextScore: 5),
           LinkedExerciseView(
             id: "exercise-2", title: "Db Major Scale", key: "Db major", tempo: nil,
-            practice: ItemPracticeSummary(
+            practice: ItemPracticeSummary.fixture(
               sessionCount: 3, totalMinutes: 20, latestScore: 4, scoreHistory: [],
-              latestTempo: nil, tempoHistory: [], lastPracticedAt: "2026-06-25T09:00:00Z"),
+              latestTempo: nil, lastPracticedAt: "2026-06-25T09:00:00Z"),
             pieceContextScore: 6),
           LinkedExerciseView(
             id: "exercise-3", title: "Arpeggios in Db", key: nil, tempo: nil,
@@ -469,14 +488,14 @@
         subtitle: "Charles-Louis Hanon",
         key: "C", modality: .major, tempo: "108 BPM", tempoMarking: nil, tempoBpm: 108,
         notes: nil, tags: [], createdAt: "", updatedAt: "",
-        practice: ItemPracticeSummary(
+        practice: ItemPracticeSummary.fixture(
           sessionCount: 9, totalMinutes: 90, latestScore: 7,
           scoreHistory: [
             ScoreHistoryEntry(sessionDate: "2026-06-24T09:00:00Z", score: 7, sessionId: "e1"),
             ScoreHistoryEntry(sessionDate: "2026-06-21T09:00:00Z", score: 6, sessionId: "e2"),
             ScoreHistoryEntry(sessionDate: "2026-06-18T09:00:00Z", score: 5, sessionId: "e3"),
           ],
-          latestTempo: 108, tempoHistory: [], lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 108, lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false, linkedExercises: [],
         linkedFromPieces: [
           PieceRefView(id: "piece-1", title: "Clair de Lune", subtitle: "Claude Debussy"),
@@ -493,12 +512,12 @@
         subtitle: "Bebop vocabulary",
         key: "C", modality: .major, tempo: "120 BPM", tempoMarking: nil, tempoBpm: 120,
         notes: nil, tags: [], createdAt: "", updatedAt: "",
-        practice: ItemPracticeSummary(
+        practice: ItemPracticeSummary.fixture(
           sessionCount: 10, totalMinutes: 120, latestScore: 7,
           scoreHistory: [
             ScoreHistoryEntry(sessionDate: "2026-06-24T09:00:00Z", score: 7, sessionId: "e1")
           ],
-          latestTempo: 120, tempoHistory: [], lastPracticedAt: "2026-06-24T09:00:00Z"),
+          latestTempo: 120, lastPracticedAt: "2026-06-24T09:00:00Z"),
         latestAchievedTempo: nil, priority: false, linkedExercises: [],
         linkedFromPieces: [
           PieceRefView(id: "piece-1", title: "Strasbourg / St. Denis", subtitle: "Woody Shaw")


### PR DESCRIPTION
Second PR of three on [#1420](https://github.com/jonyardley/intrada/issues/1420). The evidence contract landed in [#1422](https://github.com/jonyardley/intrada/pull/1422); this is the series the chart will draw; the chart itself follows.

## What changed

`ItemPracticeSummary.tempo_history` is replaced by `tempo_trend`.

`tempo_history` had no reader outside the preview fixtures, and it could not answer the one question a chart with gaps needs: **which sessions measured no tempo**. It only held the measured ones, so an unmeasured session was indistinguishable from no session at all, and a line drawn through it would silently interpolate across playing nobody measured.

`tempo_trend` holds one point per practised session, oldest first, with `tempo: None` where nothing was measured. The gap now has a position, so the chart can break the line there instead of joining two points across it.

Two rulings live in the core rather than the shell:

- a session with no measured tempo **keeps its slot** in the series;
- `has_trend` is **two or more** measured tempos, because below that there is no direction to read and the screen should say so plainly rather than draw a one-point chart.

Both are domain judgements about what the app is willing to claim, so neither belongs in Swift. What the shell derives from the series (the y-range, the "88 → 116" chip, the "7 of 9 sessions measured" line) is reading the data, not ruling on it.

Every number in the series was measured by construction: [#1422](https://github.com/jonyardley/intrada/pull/1422) keeps unevidenced defaults out of `achieved_tempo` in the first place, so nothing needs filtering here.

## Also here

Both from CLAUDE.md → Testing, "test fixtures for a type with many fields live in one place":

- `make_session_at`, which `make_session` now delegates to. The dated variant was being hand-rolled a third time for these tests.
- `ItemPracticeSummary.fixture` in `PreviewSupport`, which the six preview call sites now use. Adding this PR's field would otherwise have cost six edits; the next one costs zero.

## Tests

Five on the projection, plus one on the wire:

- ordering is oldest first, one point per session
- an unmeasured session is a `None` slot between its neighbours' numbers
- `has_trend` is false at zero and one measured tempo, true at two
- a series carrying a `None` round-trips on the real bincode FFI bridge, which is the shape most at risk on the positional wire ([#846](https://github.com/jonyardley/intrada/issues/846))

Both rulings were mutation-tested: relaxing `has_trend` to `>= 1` fails the threshold test, and reversing the sort fails the ordering and gap tests.

`just check` green (884), `just ios-fmt-check` green, `just ios-test-full` green.

## Not in this PR

The declared-target reference line. Mocked as option B on the [design canvas](https://claude.ai/code/artifact/b0aff8b0-b9e7-45bb-a209-fe8bb866f6fd); it needs no core change either way, and it costs the trend two thirds of its height, so it is a call for Jon on the screens PR rather than something to bake into the series.

Coverage: the projection and both rulings are covered by the five tests above. The only uncovered lines in the diff are the `PreviewSupport` fixture defaults, which are `#if DEBUG` and excluded (`ios/` is an ignored path).

Tier 3 (FFI bridge contract change, domain-sensitivity override).