### PR TITLE
docs: the tempo trend has landed, and step 6 was still calling itself unstarted

### DIFF
--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -111,8 +111,8 @@ Do now (days, not weeks):
 Then, each building on the last:
 
 6. **The Up next card (#1082)** — one dismissible suggested session with its
-   reasons in plain words; held to suggest-never-gate. Needed step 5, which is
-   already satisfied, so this is the next unstarted item. 2–3 days.
+   reasons in plain words; held to suggest-never-gate. **Done 2026-08-27**
+   (#1409, #1414).
 7. **The tempo trend** — draw the already-computed tempo history per item.
    Q3 answered 2026-08-27 and the answer moved the work: the history it would
    have drawn was a mixture of real measurements and untouched defaults, so the
@@ -121,7 +121,10 @@ Then, each building on the last:
    it was measured and never otherwise, so every point in the history is now
    evidenced by construction. **Series done 2026-08-28** (#1423): `tempo_trend`
    replaces `tempo_history`, carrying a slot for every practised session so the
-   gaps have a position. The chart itself is the third PR.
+   gaps have a position. **Chart done 2026-08-28** (#1425, design-principles
+   T17): the line breaks where a session measured no tempo, never drawing a
+   zero and never interpolating across it, and says so plainly where there is
+   less than a trend to show. Step 7 complete.
 8. **The getting-cold signal** — a graded staleness estimate replacing the
    binary 14-day flag, landing as Up next reason lines rather than a surface
    of its own. 1–2 days once step 6 exists. **Done 2026-08-27** (#1416,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -211,7 +211,7 @@ These are unresolved product questions. Each one likely produces issues
    slot for every practised session, so the chart can break its line where
    nothing was measured.
 
-   **Implemented 2026-08-28** (#1420, first of three PRs) as design-principles
+   **Implemented 2026-08-28** (#1420, the first of its three PRs) as design-principles
    **T16**. One correction to the framing above: the untouched pre-fill is not
    always the neutral 96. `ClickController` seeds from the item's own declared
    target, so for an item marked ♩ = 132 the app was recording 132 as achieved. The shell forwards two observed facts (`TempoObservation`) and the

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,20 +21,28 @@ audit backlog and its five-phase build order.
 
 ## In flight
 
-- #1420 — **the tempo trend**, step 7 of the adopted order
-  ([`research/comparison.md`](research/comparison.md)). The first two PRs have
-  landed (below); the **chart** is the last one (#1425): a line across the
-  sessions that measured a tempo, breaking where one did not, on a date axis
-  with `7 of 9 sessions measured` underneath, and a plain line rather than a
-  plot where there is less than a trend to show. Its design rulings are
-  design-principles **T17**, including the one open call: the item's declared
-  target is deliberately not drawn on the plot, because the card sits directly
-  under the Key/Tempo rows and that row already carries it. Mock:
-  [Tempo Trend](https://claude.ai/code/artifact/b0aff8b0-b9e7-45bb-a209-fe8bb866f6fd).
+- No build. #1420, the tempo trend, was the last of the adopted order's numbered
+  steps with anything to construct: steps 1 to 8 are done and steps 9 to 11 are
+  each a fresh decision gated on lived use, not queued work. What *is* running
+  is the real-use thread under **Next** (the week's lesson tune), which is where
+  the next build should come from.
 
 ## Recently landed
 
-- #1420 — the tempo trend's first two PRs. The **evidence contract** (#1422):
+- #1420 — **the tempo trend**, step 7 of the adopted order
+  ([`research/comparison.md`](research/comparison.md)), in three PRs. The
+  **chart** (#1425) draws an item's measured tempo over time on the detail
+  screen: a line across the sessions that measured one, breaking wherever a
+  session measured none, with `7 of 9 sessions measured` underneath and a plain
+  line rather than a plot where there is less than a trend to show. Its rulings
+  are design-principles **T17**, including the two worth knowing: the item's
+  declared target is not drawn on the plot (the card sits directly under the
+  Key/Tempo rows, which already carries it), and the vertical scale never spans
+  less than 8 BPM, so a two-beat drift cannot draw the same climb as a
+  thirty-beat one. Mock:
+  [Tempo Trend](https://claude.ai/code/artifact/b0aff8b0-b9e7-45bb-a209-fe8bb866f6fd).
+
+  Before it, the **evidence contract** (#1422):
   tempo capture (#1398) put the stepper on every item and always saved a number
   pre-filled from the click, so a large share of the recorded tempos were an
   untouched default nobody looked at, and for an item declaring a target that


### PR DESCRIPTION
Follow-up to [#1425](https://github.com/jonyardley/intrada/pull/1425) merging. Docs only.

- **`docs/status.md`** — In flight was describing work that had just landed. #1420 consolidates into one Recently landed entry covering all three PRs, and In flight now says what is true: no build outstanding, with the real-use thread named as where the next one should come from.
- **`docs/research/comparison.md`, step 7** — still ended "the chart itself is the third PR". Now marked done with the T17 pointer.
- **`docs/research/comparison.md`, step 6** — still called the Up next card "the next unstarted item", though [#1082](https://github.com/jonyardley/intrada/issues/1082) closed on 2026-08-27. This one was stale before this PR and is the more useful catch: a stale "next unstarted item" line in the document that `status.md` cites as the authority for the adopted order is exactly how [#1214](https://github.com/jonyardley/intrada/issues/1214) got two independent implementations fifteen hours apart.
- **`docs/roadmap.md`** — "first of three PRs" reads oddly now they have all landed.

`just check` green. Tier 1 (docs only), so no self-review subagent per CLAUDE.md → Workflow/Always(5).