### PR TITLE
chore(ios): bump MARKETING_VERSION to 0.8.0

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -15,7 +15,7 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     DEVELOPMENT_TEAM: "9S5FG4LQAF"
-    MARKETING_VERSION: "0.7.0"
+    MARKETING_VERSION: "0.8.0"
     CURRENT_PROJECT_VERSION: "1"
 
 # Local packages = generated bindings (a build precondition via `just ios-gen`,


### PR DESCRIPTION
One-line version bump ahead of tagging v0.8.0. The release lane takes the version from the tag name, so this keeps `project.yml`'s local-build and `workflow_dispatch` fallback in sync — same convention as the v0.7.0 bump (#1351) and v0.6.0 (#1336).

`CURRENT_PROJECT_VERSION` stays at `1`: the workflow injects `BUILD_NUMBER` from `github.run_number`, which is monotonic, so the build number is never taken from here.

0.8.0 rather than 0.7.1: five user-visible features since v0.7.0, and the tempo work changed what the app records.

Tier 1 trivia: gates run (`just check` + `just ios-fmt-check` green), review subagent skipped per CLAUDE.md → Always(5).