### PR TITLE
core(item): create a related exercise already linked to its piece (#1431)

### DIFF
--- a/crates/intrada-core/src/domain/chart.rs
+++ b/crates/intrada-core/src/domain/chart.rs
@@ -664,7 +664,7 @@ fn shells_spec(changes: &[&ChordSymbol], key: &str) -> ScaffoldSpec {
         kind: ScaffoldKind::Shells,
         title: "Shells".to_string(),
         key: key.to_string(),
-        rationale: "3rd + 7th of every chord — the voice-leading skeleton".to_string(),
+        rationale: "3rd + 7th of every chord · the voice-leading skeleton".to_string(),
         content,
         fallback_count,
     }
@@ -789,7 +789,7 @@ fn improv_spec(changes: &[&ChordSymbol], key: &str) -> ScaffoldSpec {
         kind: ScaffoldKind::ConstrainedImprov,
         title: "Constrained improv".to_string(),
         key: key.to_string(),
-        rationale: "Chord tones only, then rhythm — one ladder".to_string(),
+        rationale: "Chord tones only, then rhythm · one ladder".to_string(),
         content,
         fallback_count,
     }

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -96,6 +96,16 @@ pub enum ItemEvent {
         piece_id: String,
         exercise_id: String,
     },
+    /// Create one hand-written exercise already linked to `piece_id`. Single
+    /// event so the shell never has to learn the minted ulid: `Add` alone
+    /// leaves the exercise unlinked and the shell with no id to link it by
+    /// (#1431). Local-first only, like `AddVariant` — the online create path
+    /// reassigns ids server-side, which is the dangling-link trap #1108 marks
+    /// inside `CommitScaffold`.
+    AddLinkedExercise {
+        piece_id: String,
+        input: CreateItem,
+    },
     UnlinkExercise {
         piece_id: String,
         exercise_id: String,
@@ -255,6 +265,67 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
                     crux_core::render::render(),
                 ])
             }
+        }
+        ItemEvent::AddLinkedExercise { piece_id, input } => {
+            if !model.local_first {
+                model.last_error =
+                    Some("Related exercises aren't available online yet".to_string());
+                return crux_core::render::render();
+            }
+
+            if let Err(e) = validation::validate_piece_host(&piece_id, model) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+
+            // Coerced before validation, not after: a piece linked as a related
+            // exercise would break the link invariant `validate_link_exercise`
+            // guards, and the piece-shaped rules must not run on the way past.
+            let input = CreateItem {
+                kind: ItemKind::Exercise,
+                ..input
+            };
+            let input = validation::normalize_create_item(input);
+            if let Err(e) = validation::validate_create_item(&input) {
+                model.last_error = Some(e.to_string());
+                return crux_core::render::render();
+            }
+
+            let now = chrono::Utc::now();
+            let exercise = Item {
+                id: ulid::Ulid::generate().to_string(),
+                title: input.title,
+                kind: input.kind,
+                composer: input.composer,
+                key: input.key,
+                modality: input.modality,
+                tempo: input.tempo,
+                notes: input.notes,
+                tags: input.tags,
+                linked_exercise_ids: vec![],
+                created_at: now,
+                updated_at: now,
+                priority: false,
+                chord_chart: None,
+                variants: vec![],
+            };
+
+            let Some(piece) = model.items.iter_mut().find(|i| i.id == piece_id) else {
+                model.last_error = Some(LibraryError::NotFound { id: piece_id }.to_string());
+                return crux_core::render::render();
+            };
+            piece.linked_exercise_ids.push(exercise.id.clone());
+            piece.updated_at = now;
+            let piece = piece.clone();
+
+            model.items.push(exercise.clone());
+            model.last_error = None;
+            model.record_success();
+
+            Command::all([
+                crate::persistence::save_items(vec![exercise, piece]),
+                crux_core::render::render(),
+            ])
         }
         ItemEvent::Update { id, input } => {
             let input = validation::normalize_update_item(input);
@@ -2422,5 +2493,162 @@ mod tests {
         let piece = model.items.iter().find(|i| i.id == "piece-1").unwrap();
         assert_eq!(piece.linked_exercise_ids, vec!["ex-1".to_string()]);
         assert!(model.last_error.is_none());
+    }
+
+    // ── AddLinkedExercise ──
+
+    fn new_exercise_input(title: &str) -> CreateItem {
+        CreateItem {
+            title: title.to_string(),
+            kind: ItemKind::Exercise,
+            composer: None,
+            key: Some("G".to_string()),
+            modality: None,
+            tempo: None,
+            notes: None,
+            tags: vec![],
+        }
+    }
+
+    #[test]
+    fn add_linked_exercise_creates_it_already_linked_and_persists_one_batch() {
+        let mut model = model_with_piece_and_exercise();
+
+        let mut cmd = send_cmd(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "piece-1".to_string(),
+                input: new_exercise_input("Shell voicings"),
+            },
+        );
+
+        let created = model
+            .items
+            .iter()
+            .find(|i| i.title == "Shell voicings")
+            .expect("the exercise is created");
+        assert_eq!(created.kind, ItemKind::Exercise);
+        assert_eq!(created.key.as_deref(), Some("G"));
+
+        let piece = model.items.iter().find(|i| i.id == "piece-1").unwrap();
+        assert!(
+            piece.linked_exercise_ids.contains(&created.id),
+            "the point of the event: created already linked, with no second step"
+        );
+        assert!(model.last_error.is_none());
+
+        let batch = emits_save_items(&mut cmd).expect("a SaveItems batch is persisted");
+        assert_eq!(batch.len(), 2, "the exercise + the piece, one transaction");
+        assert!(batch.contains(&"piece-1".to_string()));
+        assert!(
+            !emits_http(&mut cmd),
+            "local-first create makes no HTTP (invariant 1)"
+        );
+    }
+
+    #[test]
+    fn add_linked_exercise_forces_the_kind_to_exercise() {
+        let mut model = model_with_piece_and_exercise();
+        let mut input = new_exercise_input("Not a piece");
+        input.kind = ItemKind::Piece;
+
+        send(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "piece-1".to_string(),
+                input,
+            },
+        );
+
+        let created = model
+            .items
+            .iter()
+            .find(|i| i.title == "Not a piece")
+            .expect("the item is created");
+        assert_eq!(
+            created.kind,
+            ItemKind::Exercise,
+            "a piece linked as a related exercise would break the link invariant"
+        );
+        assert!(model.last_error.is_none());
+    }
+
+    #[test]
+    fn add_linked_exercise_rejects_a_non_piece_host() {
+        let mut model = model_with_piece_and_exercise();
+
+        let mut cmd = send_cmd(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "ex-1".to_string(),
+                input: new_exercise_input("Shell voicings"),
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert!(
+            !model.items.iter().any(|i| i.title == "Shell voicings"),
+            "a rejected host creates nothing"
+        );
+        assert!(emits_save_items(&mut cmd).is_none());
+    }
+
+    #[test]
+    fn add_linked_exercise_missing_piece_surfaces_not_found() {
+        let mut model = model_with_piece_and_exercise();
+
+        send(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "nope".to_string(),
+                input: new_exercise_input("Shell voicings"),
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert!(!model.items.iter().any(|i| i.title == "Shell voicings"));
+    }
+
+    #[test]
+    fn add_linked_exercise_rejects_a_blank_title() {
+        let mut model = model_with_piece_and_exercise();
+        let before = model.items.len();
+
+        send(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "piece-1".to_string(),
+                input: new_exercise_input("   "),
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert_eq!(model.items.len(), before, "nothing is created");
+        let piece = model.items.iter().find(|i| i.id == "piece-1").unwrap();
+        assert!(
+            piece.linked_exercise_ids.is_empty(),
+            "and nothing is linked"
+        );
+    }
+
+    #[test]
+    fn add_linked_exercise_online_mode_is_scoped_out_gracefully() {
+        let mut model = model_with_piece_and_exercise();
+        model.local_first = false;
+
+        let mut cmd = send_cmd(
+            &mut model,
+            ItemEvent::AddLinkedExercise {
+                piece_id: "piece-1".to_string(),
+                input: new_exercise_input("Shell voicings"),
+            },
+        );
+
+        assert!(model.last_error.is_some());
+        assert!(
+            !model.items.iter().any(|i| i.title == "Shell voicings"),
+            "online would link against a client ulid the server reassigns (#1108)"
+        );
+        assert!(!emits_http(&mut cmd));
     }
 }

--- a/crates/intrada-core/src/domain/types.rs
+++ b/crates/intrada-core/src/domain/types.rs
@@ -429,6 +429,38 @@ mod tests {
             piece_id: "p1".to_string(),
             ordered_ids: vec!["e1".to_string(), "e2".to_string()],
         });
+        // A nested CreateItem inside an event payload, with the Option-heavy
+        // fields on both their Some and None sides — the #846 shape, pinned
+        // here before any screen sends it (#1431).
+        assert_round_trips(ItemEvent::AddLinkedExercise {
+            piece_id: "p1".to_string(),
+            input: CreateItem {
+                title: "Shell voicings".to_string(),
+                kind: ItemKind::Exercise,
+                composer: None,
+                key: Some("G".to_string()),
+                modality: Some(Modality::Minor),
+                tempo: Some(Tempo {
+                    marking: Some("Andante".to_string()),
+                    bpm: Some(96),
+                }),
+                notes: Some("3rds and 7ths".to_string()),
+                tags: vec!["voicings".to_string()],
+            },
+        });
+        assert_round_trips(ItemEvent::AddLinkedExercise {
+            piece_id: "p1".to_string(),
+            input: CreateItem {
+                title: "Bare".to_string(),
+                kind: ItemKind::Exercise,
+                composer: None,
+                key: None,
+                modality: None,
+                tempo: None,
+                notes: None,
+                tags: vec![],
+            },
+        });
     }
 
     #[test]

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -360,18 +360,10 @@ pub fn validate_rep_consistency(
     Ok(())
 }
 
-pub fn validate_link_exercise(
-    piece_id: &str,
-    exercise_id: &str,
-    model: &Model,
-) -> Result<(), LibraryError> {
-    if piece_id == exercise_id {
-        return Err(LibraryError::Validation {
-            field: "exercise_id".to_string(),
-            message: "A piece cannot be linked to itself".to_string(),
-        });
-    }
-
+/// The host half of `validate_link_exercise`: the id names an item that exists
+/// and is a piece. Shared with `AddLinkedExercise`, where the exercise does not
+/// exist yet and so only this half can run.
+pub fn validate_piece_host(piece_id: &str, model: &Model) -> Result<(), LibraryError> {
     let piece = model
         .items
         .iter()
@@ -386,6 +378,23 @@ pub fn validate_link_exercise(
             message: "Target must be a piece, not an exercise".to_string(),
         });
     }
+
+    Ok(())
+}
+
+pub fn validate_link_exercise(
+    piece_id: &str,
+    exercise_id: &str,
+    model: &Model,
+) -> Result<(), LibraryError> {
+    if piece_id == exercise_id {
+        return Err(LibraryError::Validation {
+            field: "exercise_id".to_string(),
+            message: "A piece cannot be linked to itself".to_string(),
+        });
+    }
+
+    validate_piece_host(piece_id, model)?;
 
     let exercise = model
         .items
@@ -402,7 +411,12 @@ pub fn validate_link_exercise(
         });
     }
 
-    if piece.linked_exercise_ids.contains(&exercise_id.to_string()) {
+    let already_linked = model
+        .items
+        .iter()
+        .find(|i| i.id == piece_id)
+        .is_some_and(|p| p.linked_exercise_ids.iter().any(|id| id == exercise_id));
+    if already_linked {
         return Err(LibraryError::Validation {
             field: "exercise_id".to_string(),
             message: "Exercise is already linked to this piece".to_string(),

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -582,3 +582,49 @@ rather than filtered: nothing distinguishes them from the real measurements a
 user made with the click sounding, so any filter would need a cut-off date
 invented for the purpose and would delete genuine measurements alongside the
 noise. It stops growing at #1422 and ages out as real history accumulates.
+
+### T18 — On a piece, the exercise you write outranks the one the app suggests
+
+**Status:** DECIDED 2026-08-28 (jonyardley/intrada#1431), from Jon's second
+round of real use. Spec:
+[`specs/piece-related-exercises.md`](../specs/piece-related-exercises.md).
+Mocked on the
+[design canvas](https://claude.ai/code/artifact/c646b020-6a05-4fe9-9479-73bdbd42528e).
+
+The chord-chart derivation shipped with the loudest affordance on the piece
+page: a full-width brand bar reading **See the curriculum**, one tap from five
+ready-made exercises. Writing your own sat four taps away inside a picker for
+existing ones, and did not even link what it made. The page therefore said the
+app's idea of what to practise mattered more than the musician's.
+
+- **The musician's own exercise is the primary action, and it is the card's
+  only brand bar.** Choosing an existing exercise drops to plain text beneath
+  it. Two brand bars on one screen was the ambiguity that made the page read
+  the wrong way round, and removing the chart card's is most of the fix.
+- **Creating an exercise on a piece saves it already related to that piece.**
+  The primary action is only primary if it completes: a create that leaves you
+  to go and tick your own new exercise in a picker has not done the job. This
+  is what makes the change a core change rather than a layout one.
+- **The derived five are suggestions, offered second, and the word
+  *curriculum* goes.** They keep every mechanic they have. What changes is that
+  the app now proposes rather than prescribes, which is the difference between
+  a suggestion and a syllabus. `Curriculum` becomes `From the chord chart` and
+  `Derived in G minor` becomes `Worked out from these changes`.
+- **The suggestions live in the Related exercises card**, not on the chart
+  card. Everything about exercises for this piece then reads in one place, and
+  the idea does not disappear on a piece with no chart, which is most of the
+  library. The chart-card placement is mocked as `AltOnChartCard` if it is
+  reopened.
+- **The suggestions row is drawn as a control, on `surfaceSunken` with the gold
+  exercise tint.** Drawn as a plain row carrying only a chevron, Jon read the
+  eyebrow above it as the button. A row that creates five library items cannot
+  hang its whole affordance on a chevron, and the gold says what will be
+  produced before it is tapped.
+- **The brand bar belongs to the empty state.** With exercises already in the
+  card the primary action recedes to a plain footer action beside "choose one".
+  One primary action per screen means one obvious *next step*, and once the
+  card is populated, adding another exercise is not it.
+
+**What this does not settle:** whether `Learn the melody` and
+`Constrained improv` are exercises at all (#1389), and the chord chart's own
+display (#1432). Both were deliberately held out.

--- a/specs/piece-related-exercises.md
+++ b/specs/piece-related-exercises.md
@@ -1,0 +1,168 @@
+# Related exercises on a piece: yours first, the chart's second
+
+> Tier 3 by domain sensitivity (one new `Event` crosses the FFI bridge); the
+> surface is otherwise a Tier 2 card redesign. Issue [#1431]. Two PRs: core
+> first (the event and its tests), screens second (the card, the copy and the
+> snapshots). No migration, no schema change, no API change, no new token and
+> no new primitive.
+>
+> Mockups: [`design/`](piece-related-exercises/design/) and the
+> [canvas](https://claude.ai/code/artifact/c646b020-6a05-4fe9-9479-73bdbd42528e).
+
+[#1431]: https://github.com/jonyardley/intrada/issues/1431
+
+## Problem
+
+On a piece with a chord chart, the loudest thing on the screen is the app
+writing five exercises for you. **See the curriculum** is a full-width brand
+bar on the chart card; it opens a sheet of five derived exercises, all
+pre-ticked, and **Add 5** creates them as real linked exercises.
+
+Writing your own is four taps away and hidden inside the wrong flow: the
+**Related exercises** card offers **Add a related exercise**, which opens a
+picker of exercises you already have, and **Create new exercise** is a row
+inside that picker. Worse, the exercise you create there is **not linked** to
+the piece: `LibraryAddScreen` sends `ItemEvent::Add` and returns you to the
+picker, where you must then find and tick the thing you just made.
+
+So the app's own suggestion is one tap and lands linked; yours is four taps and
+does not. Jon's call (2026-08-28): a person creates their own related
+exercises, and the app may pre-populate some examples.
+
+## Approach
+
+Reverse the two, and add the missing link.
+
+1. **The primary action on a piece is creating your own exercise**, as the
+   card's only brand bar, and it saves already related to the piece.
+2. **Choosing an existing exercise stays**, demoted to plain text beneath it.
+3. **The derived five become suggestions**: a quiet row below a hairline inside
+   the same card, not a brand bar on a different one, and the word
+   *curriculum* goes.
+
+The derivation itself is untouched. `derive_scaffold`, `ScaffoldPreviewView`
+and `CommitScaffold` all keep working exactly as they do; only their framing
+and their place on the screen change.
+
+## The contract
+
+One new event, modelled directly on `CommitScaffold`, which already creates
+exercises and links them to a piece atomically in the core:
+
+```rust
+/// Create one hand-written exercise already linked to `piece_id`, in a single
+/// event so the shell never has to learn the new item's id. Local-first only
+/// (invariant 6); mirrors `CommitScaffold`'s create-and-link, for one item the
+/// user typed rather than a batch the core derived.
+AddLinkedExercise {
+    piece_id: String,
+    input: CreateItem,
+},
+```
+
+Handler, in order:
+
+1. `validate_create_item(&input)` after `normalize_create_item`, exactly as
+   `ItemEvent::Add` does. A bad title fails the same way it does today.
+2. The piece must exist and be `ItemKind::Piece`. `validate_link_exercise`
+   already carries that predicate for an existing pair; the new event needs the
+   host half of it before the exercise exists.
+3. `input.kind` is forced to `ItemKind::Exercise`. The form cannot offer a
+   choice here and the core should not trust one.
+4. Mint the ulid, push the item, extend `piece.linked_exercise_ids`, stamp both
+   `updated_at`, then `save_items(vec![exercise, piece])` and `record_success()`.
+
+**Local-first only.** Online returns the same "not available online yet" shape
+`AddVariant` uses. The online create path reassigns ids server-side, so a link
+minted against the client ulid would dangle; that is the same trap already
+marked `FIXME(#1108)` inside `CommitScaffold`, and this event must not walk
+into it a second time.
+
+**No ViewModel change.** The new exercise reaches the screen through
+`LibraryItemView.linked_exercises`, which already projects the piece's links.
+Nothing new needs to cross the wire in that direction.
+
+## Key decisions
+
+**D1 — One event, not a created-id channel.** The alternative was to surface
+the last created item's id on the ViewModel and let the shell fire
+`LinkExercise` after `Add`. Rejected: it puts a two-step transaction in the
+shell, which is the dumb-pipe rule inverted, and it leaves a window where the
+exercise exists unlinked. `CommitScaffold` settled this shape already.
+
+**D2 — The suggestions live in the Related exercises card**, not on the chart
+card. Everything about exercises for this piece then sits in one place, and the
+idea does not vanish on the (much more common) piece with no chart. The
+alternative is on the canvas as `AltOnChartCard` if this is revisited.
+
+**D3 — The suggestions row is a control, not a section.** It sits on
+`surfaceSunken` with the gold exercise tint on its icon and chevron. Drawn as a
+plain row with only a chevron, Jon read the eyebrow above it as the button, and
+it creates five library items, which is too much to hang on a chevron. The gold
+also says what tapping it will produce before it is tapped. See
+[T18](../docs/design-principles.md#t18).
+
+**D4 — The brand bar belongs to the empty state.** Once the card has exercises
+in it, the primary action recedes to a plain footer action alongside "choose
+one". One-primary-action-per-screen is about the screen having one obvious next
+step, and once you have related exercises, adding another is not it.
+
+## Copy
+
+Against [`docs/tone-of-voice.md`](../docs/tone-of-voice.md); no possessives on
+chrome (rule 3), sentence case, no full stops on buttons.
+
+| Where | Today | Becomes |
+|-------|-------|---------|
+| Chart card action | `See the curriculum` | *(removed)* |
+| Sheet title | `Curriculum` | `From the chord chart` |
+| Sheet subhead | `Derived in G minor · 5 exercises` | `Worked out from these changes, in G minor` |
+| Spec flag | `Already linked` | `Already added` |
+| Card primary | *(none)* | `Create an exercise` |
+| Card secondary | `Add a related exercise` | `Choose one from the library` |
+| Suggestions eyebrow | *(none)* | `From the chord chart` |
+| Empty-state help | `Add scales, arpeggios, or any exercise you practise alongside this piece.` | `Scales, arpeggios, and anything else you practise alongside this piece.` |
+| Chart empty help | `Paste the changes to see the exercises they imply.` | `Paste the changes to keep them with the piece.` |
+
+Two `ScaffoldSpec` rationales in `domain/chart.rs` carry an em dash, which the
+tone doc bans outright. They take the house middle dot:
+
+- Shells: `3rd + 7th of every chord · the voice-leading skeleton`
+- Constrained improv: `Chord tones only, then rhythm · one ladder`
+
+## Out of scope
+
+- [#1389] — whether `Learn the melody` and `Constrained improv` should be
+  `ItemKind::Exercise` at all. Renaming the surface does not settle it.
+- [#1390] — the same capture problem on the **create** form rather than the
+  piece page.
+- [#1432] — drawing the chord chart properly, and showing it while practising.
+- [#1363] — many-to-many links and score attribution.
+- The online path for the new event, per invariant 6 and [#1108].
+
+[#1389]: https://github.com/jonyardley/intrada/issues/1389
+[#1390]: https://github.com/jonyardley/intrada/issues/1390
+[#1432]: https://github.com/jonyardley/intrada/issues/1432
+[#1363]: https://github.com/jonyardley/intrada/issues/1363
+[#1108]: https://github.com/jonyardley/intrada/issues/1108
+
+## Open questions
+
+1. **Does the create form return to the piece, or to the new exercise?**
+   Returning to the piece shows the link landing, which is the point of the
+   change. Leaning that way; it is a one-line difference in the screens PR.
+2. **Should `Choose one from the library` keep the full picker** (star, sort,
+   tag, search) now that it is the secondary path, or drop to a plain list?
+   Keeping it; the picker is already built and its filters earn their place on
+   a long library.
+
+## Phasing
+
+**PR 1 (core).** `AddLinkedExercise`, its validation, its handler, and its
+tests: happy path, non-piece host, missing piece, invalid title, kind coerced
+to exercise, online rejection. A real-bridge round-trip for the new event in
+`assert_round_trips` **before** either screen touches it, per the #846 rule.
+Plus the two `chart.rs` rationale strings, which are pure copy.
+
+**PR 2 (screens).** The card rebuilt from the mockup, the sheet's copy, the
+snapshots re-recorded, and the accessibility labels for the new controls.

--- a/specs/piece-related-exercises/design/AltOnChartCard.dc.html
+++ b/specs/piece-related-exercises/design/AltOnChartCard.dc.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 700px; display: flex; flex-direction: column;">
+
+  <div style="padding: 40px 16px 14px; border-bottom: 1px solid #E5DECD;">
+    <div style="width: 11px; height: 18px; margin-bottom: 22px;">
+      <svg viewBox="0 0 11 18" fill="none" stroke="#4C3FA6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1 2 9l7 8"/></svg>
+    </div>
+    <h1 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 30px; line-height: 1.08; margin: 0; letter-spacing: -0.01em;">Autumn Leaves</h1>
+    <p style="font-size: 13px; color: #6E6557; margin: 5px 0 0;">Standard</p>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; display: flex; flex-direction: column;">
+      <div style="padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between;">
+          <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Chord chart</h2>
+          <span style="font-size: 15px; font-weight: 500; color: #4C3FA6;">Edit</span>
+        </div>
+        <div style="font-size: 12px; color: #6E6557;">G minor · 4 bars · 4 changes</div>
+        <div style="font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #9A927F;">A</div>
+        <div style="display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 6px;">
+          <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Cm7</div>
+          <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">F7</div>
+          <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">B♭maj7</div>
+          <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">E♭maj7</div>
+        </div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="padding: 14px 16px; display: flex; align-items: center; gap: 12px;">
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <div style="font-size: 15px;">5 exercises from these changes</div>
+          <div style="font-size: 12px; color: #6E6557;">Worked out in G minor</div>
+        </div>
+        <span style="width: 9px; height: 15px; display: inline-block; flex-shrink: 0;">
+          <svg viewBox="0 0 9 15" fill="none" stroke="#9A927F" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 1.5l6 6-6 6"/></svg>
+        </span>
+      </div>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Related exercises</h2>
+      <div style="font-size: 14px; color: #6E6557; line-height: 1.45;">Scales, arpeggios, and anything else you practise alongside this piece.</div>
+      <div style="display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px; border-radius: 13px; background: linear-gradient(180deg, #6346E5 0%, #4C3FA6 100%); color: #F2EFE8; font-size: 15px; font-weight: 500;">
+        <span style="width: 14px; height: 14px; display: inline-block;">
+          <svg viewBox="0 0 14 14" fill="none" stroke="#F2EFE8" stroke-width="1.8" stroke-linecap="round"><path d="M7 2v10M2 7h10"/></svg>
+        </span>
+        Create an exercise
+      </div>
+      <div style="text-align: center; font-size: 15px; font-weight: 500; color: #4C3FA6;">Choose one from the library</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/Before.dc.html
+++ b/specs/piece-related-exercises/design/Before.dc.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 844px; display: flex; flex-direction: column;">
+
+  <div style="padding: 40px 16px 14px; border-bottom: 1px solid #E5DECD;">
+    <div style="width: 11px; height: 18px; margin-bottom: 22px;">
+      <svg viewBox="0 0 11 18" fill="none" stroke="#4C3FA6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1 2 9l7 8"/></svg>
+    </div>
+    <h1 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 30px; line-height: 1.08; margin: 0; letter-spacing: -0.01em;">Autumn Leaves</h1>
+    <p style="font-size: 13px; color: #6E6557; margin: 5px 0 0;">Standard</p>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+
+    <div style="display: flex;">
+      <span style="display: inline-flex; align-items: center; gap: 5px; padding: 5px 10px; border-radius: 8px; font-size: 12px; font-weight: 600; background: #E7E3F4; color: #4C3FA6;">
+        <span style="width: 12px; height: 12px; display: inline-block;">
+          <svg viewBox="0 0 12 12" fill="none" stroke="#4C3FA6" stroke-width="1.4" stroke-linecap="round"><path d="M4.5 9.2V2.4l5-1v6.4"/><circle cx="3" cy="9.4" r="1.5"/><circle cx="8" cy="8.2" r="1.5"/></svg>
+        </span>
+        Piece
+      </span>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; justify-content: space-between;">
+      <span style="font-size: 15px;">Key</span>
+      <span style="font-size: 15px;">G minor</span>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: baseline; justify-content: space-between;">
+        <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Chord chart</h2>
+        <span style="font-size: 15px; font-weight: 500; color: #4C3FA6;">Edit</span>
+      </div>
+      <div style="font-size: 12px; color: #6E6557;">G minor · 4 bars · 4 changes</div>
+      <div style="font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #9A927F;">A</div>
+      <div style="display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 6px;">
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Cm7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">F7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">B♭maj7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">E♭maj7</div>
+      </div>
+      <div style="display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px; border-radius: 13px; background: linear-gradient(180deg, #6346E5 0%, #4C3FA6 100%); color: #F2EFE8; font-size: 15px; font-weight: 500;">
+        <span style="width: 16px; height: 16px; display: inline-block;">
+          <svg viewBox="0 0 16 16" fill="none" stroke="#F2EFE8" stroke-width="1.3" stroke-linejoin="round"><path d="M8 1.5l1.4 3.6L13 6.5l-3.6 1.4L8 11.5 6.6 7.9 3 6.5l3.6-1.4z"/><path d="M12.8 11l.6 1.5 1.5.6-1.5.6-.6 1.5-.6-1.5-1.5-.6 1.5-.6z"/></svg>
+        </span>
+        See the curriculum
+      </div>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Related exercises</h2>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 12px; padding: 12px 0 4px;">
+        <span style="width: 26px; height: 26px; display: inline-block;">
+          <svg viewBox="0 0 26 26" fill="none" stroke="#9A927F" stroke-width="1.6" stroke-linecap="round"><path d="M10.5 15.5l5-5"/><path d="M13.5 8.5l2-2a3.5 3.5 0 015 5l-2 2"/><path d="M12.5 17.5l-2 2a3.5 3.5 0 01-5-5l2-2"/></svg>
+        </span>
+        <div style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">No related exercises yet</div>
+        <div style="font-size: 14px; color: #6E6557; text-align: center; line-height: 1.45;">Add scales, arpeggios, or any exercise you practise alongside this piece.</div>
+      </div>
+      <div style="display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px; border-radius: 12px; border: 1px dashed #C9C0AC; color: #4C3FA6; font-size: 15px; font-weight: 500;">
+        <span style="width: 14px; height: 14px; display: inline-block;">
+          <svg viewBox="0 0 14 14" fill="none" stroke="#4C3FA6" stroke-width="1.8" stroke-linecap="round"><path d="M7 2v10M2 7h10"/></svg>
+        </span>
+        Add a related exercise
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/Main.dc.html
+++ b/specs/piece-related-exercises/design/Main.dc.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 844px; display: flex; flex-direction: column;">
+
+  <div style="padding: 40px 16px 14px; border-bottom: 1px solid #E5DECD;">
+    <div style="width: 11px; height: 18px; margin-bottom: 22px;">
+      <svg viewBox="0 0 11 18" fill="none" stroke="#4C3FA6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1 2 9l7 8"/></svg>
+    </div>
+    <h1 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 30px; line-height: 1.08; margin: 0; letter-spacing: -0.01em;">Autumn Leaves</h1>
+    <p style="font-size: 13px; color: #6E6557; margin: 5px 0 0;">Standard</p>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+
+    <div style="display: flex;">
+      <span style="display: inline-flex; align-items: center; gap: 5px; padding: 5px 10px; border-radius: 8px; font-size: 12px; font-weight: 600; background: #E7E3F4; color: #4C3FA6;">
+        <span style="width: 12px; height: 12px; display: inline-block;">
+          <svg viewBox="0 0 12 12" fill="none" stroke="#4C3FA6" stroke-width="1.4" stroke-linecap="round"><path d="M4.5 9.2V2.4l5-1v6.4"/><circle cx="3" cy="9.4" r="1.5"/><circle cx="8" cy="8.2" r="1.5"/></svg>
+        </span>
+        Piece
+      </span>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; justify-content: space-between;">
+      <span style="font-size: 15px;">Key</span>
+      <span style="font-size: 15px;">G minor</span>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: baseline; justify-content: space-between;">
+        <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Chord chart</h2>
+        <span style="font-size: 15px; font-weight: 500; color: #4C3FA6;">Edit</span>
+      </div>
+      <div style="font-size: 12px; color: #6E6557;">G minor · 4 bars · 4 changes</div>
+      <div style="font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #9A927F;">A</div>
+      <div style="display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 6px;">
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Cm7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">F7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">B♭maj7</div>
+        <div style="background: #F4F1E8; border: 1px solid #E0D9C8; border-radius: 8px; padding: 8px 4px; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 15px;">E♭maj7</div>
+      </div>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; display: flex; flex-direction: column;">
+      <div style="padding: 16px 16px 0; display: flex; flex-direction: column; gap: 12px;">
+        <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Related exercises</h2>
+        <div style="font-size: 14px; color: #6E6557; line-height: 1.45;">Scales, arpeggios, and anything else you practise alongside this piece.</div>
+        <div style="display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px; border-radius: 13px; background: linear-gradient(180deg, #6346E5 0%, #4C3FA6 100%); color: #F2EFE8; font-size: 15px; font-weight: 500;">
+          <span style="width: 14px; height: 14px; display: inline-block;">
+            <svg viewBox="0 0 14 14" fill="none" stroke="#F2EFE8" stroke-width="1.8" stroke-linecap="round"><path d="M7 2v10M2 7h10"/></svg>
+          </span>
+          Create an exercise
+        </div>
+        <div style="text-align: center; padding-bottom: 4px; font-size: 15px; font-weight: 500; color: #4C3FA6;">Choose one from the library</div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD; margin-top: 16px;"></div>
+
+      <div style="padding: 14px 16px 16px; display: flex; flex-direction: column; gap: 10px;">
+        <div style="font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #9A927F;">From the chord chart</div>
+        <div style="display: flex; align-items: center; gap: 12px; padding: 14px; border-radius: 12px; background: #F0E7D6;">
+          <span style="width: 20px; height: 20px; display: inline-block; flex-shrink: 0;">
+            <svg viewBox="0 0 20 20" fill="none" stroke="#8A6A2E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 2.5l1.7 4.4 4.4 1.7-4.4 1.7L10 14.7 8.3 10.3 3.9 8.6l4.4-1.7z"/><path d="M15.6 14.2l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z"/></svg>
+          </span>
+          <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+            <div style="font-size: 15px; font-weight: 500;">Shells, guide-tone lines and 3 more</div>
+            <div style="font-size: 12px; color: #6E6557;">Worked out from these changes, in G minor</div>
+          </div>
+          <span style="width: 9px; height: 15px; display: inline-block; flex-shrink: 0;">
+            <svg viewBox="0 0 9 15" fill="none" stroke="#8A6A2E" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 1.5l6 6-6 6"/></svg>
+          </span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/NoChart.dc.html
+++ b/specs/piece-related-exercises/design/NoChart.dc.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 700px; display: flex; flex-direction: column;">
+
+  <div style="padding: 40px 16px 14px; border-bottom: 1px solid #E5DECD;">
+    <div style="width: 11px; height: 18px; margin-bottom: 22px;">
+      <svg viewBox="0 0 11 18" fill="none" stroke="#4C3FA6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1 2 9l7 8"/></svg>
+    </div>
+    <h1 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 30px; line-height: 1.08; margin: 0; letter-spacing: -0.01em;">Clair de Lune</h1>
+    <p style="font-size: 13px; color: #6E6557; margin: 5px 0 0;">Claude Debussy</p>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: baseline; justify-content: space-between;">
+        <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Chord chart</h2>
+        <span style="font-size: 15px; font-weight: 500; color: #4C3FA6;">Add</span>
+      </div>
+      <div style="font-size: 14px; color: #6E6557; line-height: 1.45;">Paste the changes to keep them with the piece.</div>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; padding: 16px; display: flex; flex-direction: column; gap: 12px;">
+      <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Related exercises</h2>
+      <div style="font-size: 14px; color: #6E6557; line-height: 1.45;">Scales, arpeggios, and anything else you practise alongside this piece.</div>
+      <div style="display: flex; align-items: center; justify-content: center; gap: 8px; padding: 16px; border-radius: 13px; background: linear-gradient(180deg, #6346E5 0%, #4C3FA6 100%); color: #F2EFE8; font-size: 15px; font-weight: 500;">
+        <span style="width: 14px; height: 14px; display: inline-block;">
+          <svg viewBox="0 0 14 14" fill="none" stroke="#F2EFE8" stroke-width="1.8" stroke-linecap="round"><path d="M7 2v10M2 7h10"/></svg>
+        </span>
+        Create an exercise
+      </div>
+      <div style="text-align: center; font-size: 15px; font-weight: 500; color: #4C3FA6;">Choose one from the library</div>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/Populated.dc.html
+++ b/specs/piece-related-exercises/design/Populated.dc.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 760px; display: flex; flex-direction: column;">
+
+  <div style="padding: 40px 16px 14px; border-bottom: 1px solid #E5DECD;">
+    <div style="width: 11px; height: 18px; margin-bottom: 22px;">
+      <svg viewBox="0 0 11 18" fill="none" stroke="#4C3FA6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 1 2 9l7 8"/></svg>
+    </div>
+    <h1 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 30px; line-height: 1.08; margin: 0; letter-spacing: -0.01em;">Autumn Leaves</h1>
+    <p style="font-size: 13px; color: #6E6557; margin: 5px 0 0;">Standard</p>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; overflow: hidden; display: flex; flex-direction: column;">
+
+      <div style="padding: 16px 16px 12px; display: flex; align-items: center; gap: 10px;">
+        <h2 style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px; margin: 0;">Related exercises</h2>
+        <span style="padding: 3px 7px; border-radius: 999px; background: #F0E7D6; font-size: 12px; font-weight: 600; color: #6E6557;">2</span>
+        <span style="flex-grow: 1;"></span>
+        <span style="font-size: 15px; font-weight: 500; color: #4C3FA6;">Edit</span>
+      </div>
+      <div style="padding: 0 16px 12px; font-size: 12px; color: #6E6557;">Marks shown are for this piece</div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px; border-left: 4px solid #9E7B33;">
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <div style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Hanon No. 1</div>
+          <div style="font-size: 12px; color: #6E6557;">C major · ♩ = 108</div>
+        </div>
+        <span style="width: 44px; height: 44px; display: inline-block; flex-shrink: 0; position: relative;">
+          <svg viewBox="0 0 44 44">
+            <defs><linearGradient id="ringA" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#6346E5"/><stop offset="100%" stop-color="#4C3FA6"/></linearGradient></defs>
+            <circle cx="22" cy="22" r="19" fill="none" stroke="#E2DBC9" stroke-width="4"/>
+            <circle cx="22" cy="22" r="19" fill="none" stroke="url(#ringA)" stroke-width="4" stroke-linecap="round" stroke-dasharray="59.7 119.4" transform="rotate(-90 22 22)"/>
+            <text x="22" y="27" text-anchor="middle" font-family="Source Serif 4, Georgia, serif" font-weight="600" font-size="16" fill="#2B2A26">5</text>
+          </svg>
+        </span>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px; border-left: 4px solid #9E7B33;">
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <div style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Shells</div>
+          <div style="font-size: 12px; color: #6E6557;">G minor</div>
+        </div>
+        <span style="width: 44px; height: 44px; display: inline-block; flex-shrink: 0;">
+          <svg viewBox="0 0 44 44">
+            <circle cx="22" cy="22" r="19" fill="none" stroke="#E2DBC9" stroke-width="4"/>
+            <text x="22" y="27" text-anchor="middle" font-family="Inter, sans-serif" font-size="13" fill="#9A927F">–</text>
+          </svg>
+        </span>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; padding: 4px 8px 8px;">
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; gap: 8px; padding: 12px; color: #4C3FA6; font-size: 15px; font-weight: 500;">
+          <span style="width: 14px; height: 14px; display: inline-block;">
+            <svg viewBox="0 0 14 14" fill="none" stroke="#4C3FA6" stroke-width="1.8" stroke-linecap="round"><path d="M7 2v10M2 7h10"/></svg>
+          </span>
+          Create an exercise
+        </div>
+        <div style="flex-grow: 1; display: flex; align-items: center; justify-content: center; padding: 12px; color: #4C3FA6; font-size: 15px; font-weight: 500;">Choose one</div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="padding: 14px 16px 16px; display: flex; flex-direction: column; gap: 10px;">
+        <div style="font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #9A927F;">From the chord chart</div>
+        <div style="display: flex; align-items: center; gap: 12px; padding: 14px; border-radius: 12px; background: #F0E7D6;">
+          <span style="width: 20px; height: 20px; display: inline-block; flex-shrink: 0;">
+            <svg viewBox="0 0 20 20" fill="none" stroke="#8A6A2E" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 2.5l1.7 4.4 4.4 1.7-4.4 1.7L10 14.7 8.3 10.3 3.9 8.6l4.4-1.7z"/><path d="M15.6 14.2l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7z"/></svg>
+          </span>
+          <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+            <div style="font-size: 15px; font-weight: 500;">Guide-tone lines and 2 more</div>
+            <div style="font-size: 12px; color: #6E6557;">1 of 5 already added</div>
+          </div>
+          <span style="width: 9px; height: 15px; display: inline-block; flex-shrink: 0;">
+            <svg viewBox="0 0 9 15" fill="none" stroke="#8A6A2E" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 1.5l6 6-6 6"/></svg>
+          </span>
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/Suggestions.dc.html
+++ b/specs/piece-related-exercises/design/Suggestions.dc.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Source+Serif+4:wght@600&display=swap">
+  <style>
+    body { margin: 0; font-family: Inter, -apple-system, system-ui, sans-serif; background: linear-gradient(180deg, #F4F1E8 0%, #EBE7D9 100%); color: #2B2A26; -webkit-font-smoothing: antialiased; }
+    a { color: #4C3FA6; } a:hover { color: #392F7C; }
+  </style>
+</helmet>
+<div style="width: 390px; min-height: 700px; display: flex; flex-direction: column;">
+
+  <div style="padding: 10px 0 0; display: flex; justify-content: center;">
+    <div style="width: 36px; height: 5px; border-radius: 999px; background: #D8D0BE;"></div>
+  </div>
+
+  <div style="padding: 14px 16px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid #E5DECD;">
+    <span style="font-size: 15px; color: #4C3FA6; width: 56px;">Cancel</span>
+    <span style="flex-grow: 1; text-align: center; font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">From the chord chart</span>
+    <span style="font-size: 15px; font-weight: 500; color: #4C3FA6; width: 56px; text-align: right;">Add 4</span>
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 12px; padding: 16px;">
+
+    <div style="display: flex; align-items: center; gap: 6px;">
+      <span style="width: 13px; height: 13px; display: inline-block;">
+        <svg viewBox="0 0 13 13" fill="none" stroke="#8A6A2E" stroke-width="1.3" stroke-linecap="round"><circle cx="4.4" cy="8.6" r="2.6"/><path d="M6.4 6.8l4-4M8.6 4.6l1.2 1.2M9.9 3.3l1.2 1.2"/></svg>
+      </span>
+      <span style="font-size: 12px; color: #6E6557;">Worked out from these changes, in G minor</span>
+    </div>
+
+    <div style="background: #FCFAF3; border: 1px solid #E5DECD; border-radius: 12px; overflow: hidden;">
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px; opacity: 0.6;">
+        <div style="width: 4px; height: 34px; border-radius: 999px; background: linear-gradient(180deg, #9E7B33 0%, #8A6A2E 100%); flex-shrink: 0;"></div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <span style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Shells</span>
+            <span style="padding: 2px 6px; border-radius: 999px; background: #F0E7D6; font-size: 10px; letter-spacing: 0.4px; text-transform: uppercase; color: #6E6557;">Already added</span>
+          </div>
+          <div style="font-size: 12px; color: #6E6557;">3rd + 7th of every chord · the voice-leading skeleton</div>
+        </div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px;">
+        <div style="width: 4px; height: 34px; border-radius: 999px; background: linear-gradient(180deg, #9E7B33 0%, #8A6A2E 100%); flex-shrink: 0;"></div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <span style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Learn the melody</span>
+          <div style="font-size: 12px; color: #6E6557;">Hear the tune before you build on it</div>
+        </div>
+        <div style="width: 28px; height: 28px; border-radius: 999px; background: #9E7B33; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+          <span style="width: 14px; height: 14px; display: inline-block;">
+            <svg viewBox="0 0 14 14" fill="none" stroke="#F6EFD8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 7.5l3 3 6-6.5"/></svg>
+          </span>
+        </div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px;">
+        <div style="width: 4px; height: 34px; border-radius: 999px; background: linear-gradient(180deg, #9E7B33 0%, #8A6A2E 100%); flex-shrink: 0;"></div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <span style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Guide-tone lines</span>
+          <div style="font-size: 12px; color: #6E6557;">Connect 3rds to 7ths across each change</div>
+        </div>
+        <div style="width: 28px; height: 28px; border-radius: 999px; background: #9E7B33; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+          <span style="width: 14px; height: 14px; display: inline-block;">
+            <svg viewBox="0 0 14 14" fill="none" stroke="#F6EFD8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 7.5l3 3 6-6.5"/></svg>
+          </span>
+        </div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px;">
+        <div style="width: 4px; height: 34px; border-radius: 999px; background: linear-gradient(180deg, #9E7B33 0%, #8A6A2E 100%); flex-shrink: 0;"></div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+            <span style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Scales to chord tones</span>
+            <span style="padding: 2px 6px; border-radius: 999px; background: #F0E7D6; font-size: 10px; letter-spacing: 0.4px; text-transform: uppercase; color: #8A6A2E;">Fallback</span>
+          </div>
+          <div style="font-size: 12px; color: #6E6557;">Run each chord-scale, landing on a chord tone (ii–V aware)</div>
+        </div>
+        <div style="width: 28px; height: 28px; border-radius: 999px; background: #9E7B33; display: flex; align-items: center; justify-content: center; flex-shrink: 0;">
+          <span style="width: 14px; height: 14px; display: inline-block;">
+            <svg viewBox="0 0 14 14" fill="none" stroke="#F6EFD8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 7.5l3 3 6-6.5"/></svg>
+          </span>
+        </div>
+      </div>
+
+      <div style="height: 1px; background: #E5DECD;"></div>
+
+      <div style="display: flex; align-items: center; gap: 16px; padding: 16px 16px 16px 20px;">
+        <div style="width: 4px; height: 34px; border-radius: 999px; background: linear-gradient(180deg, #9E7B33 0%, #8A6A2E 100%); flex-shrink: 0;"></div>
+        <div style="flex-grow: 1; display: flex; flex-direction: column; gap: 3px;">
+          <span style="font-family: 'Source Serif 4', Georgia, serif; font-weight: 600; font-size: 17px;">Constrained improv</span>
+          <div style="font-size: 12px; color: #6E6557;">Chord tones only, then rhythm · one ladder</div>
+        </div>
+        <div style="width: 28px; height: 28px; border-radius: 999px; border: 2px solid #9E7B33; display: flex; align-items: center; justify-content: center; flex-shrink: 0; box-sizing: border-box;">
+          <span style="width: 12px; height: 12px; display: inline-block;">
+            <svg viewBox="0 0 12 12" fill="none" stroke="#9E7B33" stroke-width="2" stroke-linecap="round"><path d="M6 1.5v9M1.5 6h9"/></svg>
+          </span>
+        </div>
+      </div>
+
+    </div>
+
+    <div style="display: flex; align-items: flex-start; gap: 6px; padding: 0 8px;">
+      <span style="width: 11px; height: 11px; display: inline-block; margin-top: 2px;">
+        <svg viewBox="0 0 11 11" fill="none" stroke="#8A6A2E" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 1.5v4a2 2 0 002 2h5"/><path d="M7 5.5l2 2-2 2"/></svg>
+      </span>
+      <span style="font-size: 10px; color: #9A927F; line-height: 1.5;">Fallback flags a change mapped to its arpeggio, not a scale.</span>
+    </div>
+
+  </div>
+</div>
+</x-dc>
+</body>
+</html>

--- a/specs/piece-related-exercises/design/canvas.json
+++ b/specs/piece-related-exercises/design/canvas.json
@@ -1,0 +1,106 @@
+{
+  "artboards": [
+    {
+      "file": "Before.dc.html",
+      "x": 0,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "Today"
+    },
+    {
+      "file": "Main.dc.html",
+      "x": 470,
+      "y": 0,
+      "w": 390,
+      "h": 844,
+      "title": "Proposed · nothing added yet"
+    },
+    {
+      "file": "Populated.dc.html",
+      "x": 940,
+      "y": 0,
+      "w": 390,
+      "h": 760,
+      "title": "Proposed · two already added"
+    },
+    {
+      "file": "NoChart.dc.html",
+      "x": 0,
+      "y": 1180,
+      "w": 390,
+      "h": 700,
+      "title": "Proposed · piece with no chart"
+    },
+    {
+      "file": "AltOnChartCard.dc.html",
+      "x": 470,
+      "y": 1180,
+      "w": 390,
+      "h": 700,
+      "title": "Alternative · suggestions stay on the chart card"
+    },
+    {
+      "file": "Suggestions.dc.html",
+      "x": 940,
+      "y": 1180,
+      "w": 390,
+      "h": 700,
+      "title": "The sheet, reworded"
+    }
+  ],
+  "annotations": [
+    {
+      "id": "brief",
+      "x": 0,
+      "y": -230,
+      "w": 1330,
+      "text": "Piece page: related exercises (#1431)\n\nJon's two calls, 28 Aug: writing your own exercise becomes the obvious action on a piece, and the five the app works out from the chord chart drop to suggestions rather than a curriculum.\n\nEverything here uses the shipped Paper & Score tokens from Theme.swift. No new tokens, no new primitives."
+    },
+    {
+      "id": "note-today",
+      "x": 0,
+      "y": 900,
+      "w": 390,
+      "text": "TODAY\n\nThe loudest thing on the piece is the app writing five exercises for you: a full-width brand bar. Writing your own is a dashed button in the card below, and it opens a picker of exercises you already have, with Create new exercise as a row inside it.\n\nFour taps to your own exercise, one to the app's."
+    },
+    {
+      "id": "note-main",
+      "x": 470,
+      "y": 900,
+      "w": 390,
+      "text": "PROPOSED\n\nThe brand bar moves to Create an exercise, and it is the only one on the page. Choose one from the library sits under it as plain text.\n\nThe suggestions sit on the sunken surface with the gold exercise tint, so the row reads as a control rather than a section of content, and the colour says up front that these become exercises. The chart card keeps the chart and loses its button."
+    },
+    {
+      "id": "note-populated",
+      "x": 940,
+      "y": 900,
+      "w": 390,
+      "text": "ONCE THERE IS SOMETHING IN IT\n\nThe brand bar recedes to two plain footer actions: the loud CTA belongs to the empty state, where there is one obvious next step.\n\nThe suggestions row now says how many are already in, so the app is not offering you what you have."
+    },
+    {
+      "id": "note-nochart",
+      "x": 0,
+      "y": 1920,
+      "w": 390,
+      "text": "NO CHART ON THE PIECE\n\nMost of the library will look like this. The card is the same minus the suggestions block, so the primary action does not depend on having pasted changes.\n\nThe chart card's empty line drops \"to see the exercises they imply\" with it."
+    },
+    {
+      "id": "note-alt",
+      "x": 470,
+      "y": 1920,
+      "w": 390,
+      "text": "ALTERNATIVE\n\nSuggestions stay on the chord chart card, as a row rather than a brand bar.\n\nFor: the suggestions sit next to the thing they came from. Against: two cards now talk about exercises, and on a piece with no chart the idea vanishes entirely rather than being absent from a place you already know."
+    },
+    {
+      "id": "note-sheet",
+      "x": 940,
+      "y": 1920,
+      "w": 390,
+      "text": "THE SHEET\n\nSame rows and same mechanics. Curriculum becomes From the chord chart, and \"Derived in G minor\" becomes \"Worked out from these changes\".\n\nAlready linked becomes Already added. Two rationales lose an em dash for the house middle dot, which the tone doc has banned all along."
+    }
+  ],
+  "launch": {
+    "view": "canvas"
+  }
+}

--- a/specs/piece-related-exercises/design/support.js
+++ b/specs/piece-related-exercises/design/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();


### PR DESCRIPTION
First of two PRs for [#1431](https://github.com/jonyardley/intrada/issues/1431). This one is core only. The screens follow.

Spec: [`specs/piece-related-exercises.md`](https://github.com/jonyardley/intrada/blob/claude/piece-related-exercises-core/specs/piece-related-exercises.md). Mockups: [`specs/piece-related-exercises/design/`](https://github.com/jonyardley/intrada/tree/claude/piece-related-exercises-core/specs/piece-related-exercises/design) and the [canvas](https://claude.ai/code/artifact/c646b020-6a05-4fe9-9479-73bdbd42528e).

## Why this is a core change and not a layout one

Jon's call was that writing your own related exercise becomes the obvious action on a piece. That only works if the create *completes*. Today it does not: `LibraryAddScreen` sends `ItemEvent::Add`, the core mints the ulid, and the shell never learns it, so the exercise arrives unlinked and you go back to the picker to tick the thing you just made.

## What changed

- **`ItemEvent::AddLinkedExercise { piece_id, input }`** creates the exercise and links it in one event. Modelled on `CommitScaffold`, which already creates and links atomically in the core.
- **Local-first only**, like `AddVariant`. The online create path reassigns ids server-side, so a link minted against the client ulid would dangle. That is the trap `FIXME(#1108)` already marks inside `CommitScaffold`, and there is no reason to walk into it twice.
- **The caller's kind is discarded before validation, not after.** A piece linked as a related exercise breaks the invariant `validate_link_exercise` guards, and the piece-shaped rules should not run on the way past.
- **`validate_piece_host`** is the host half of `validate_link_exercise`, extracted rather than copied. The new event cannot call the whole thing because its exercise does not exist yet.
- Two `ScaffoldSpec` rationales lose an em dash for the house middle dot. Banned by the tone doc, and these strings are on screen.
- Spec, six mockups and design-principles **T18**.

No ViewModel change: the new exercise reaches the screen through `LibraryItemView.linked_exercises`, which already projects the piece's links. No migration, no schema change, no API change.

## Tests

Six behaviour tests, each **mutation-checked by deleting the line it names** rather than inverting it:

| Line deleted | Test that fails |
|---|---|
| `piece.linked_exercise_ids.push(...)` | `creates_it_already_linked_and_persists_one_batch` |
| the kind coercion | `forces_the_kind_to_exercise` |
| the `local_first` guard | `online_mode_is_scoped_out_gracefully` |

Each mutation failed exactly one test, and the other five stayed green.

The event is also **pinned on the bincode wire before any screen sends it**, per the #846 rule, with the nested `CreateItem` exercised on both its `Some` and `None` sides. That nesting is the exact shape #846 was about.

## Tier

Tier 3 by domain sensitivity (a new `Event` crosses the FFI bridge), though the surface is otherwise a Tier 2 card redesign. The spec rides with this, the first implementation phase, per CLAUDE.md.

## Coverage

All new core code is behaviour-tested above. `ios/` is excluded from Codecov and this PR adds no Swift.

## Verification

`just check` green (891 tests, up from 885). `just ios-test` green: the bindings regenerate with `case addLinkedExercise(pieceId:input:)` and the app still builds, though no screen sends it yet.

## Not in this PR

The card itself, the sheet's copy and the snapshots are PR 2. Held out entirely: [#1389](https://github.com/jonyardley/intrada/issues/1389) (whether the derived items are Exercises at all), [#1390](https://github.com/jonyardley/intrada/issues/1390), [#1432](https://github.com/jonyardley/intrada/issues/1432), [#1363](https://github.com/jonyardley/intrada/issues/1363).

Deferred items tracked: none new. The spec's two open questions are decisions for PR 2, recorded in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
