### PR TITLE
ios(picker): search the same fields the Library searches (#1440)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -29,6 +29,16 @@ audit backlog and its five-phase build order.
 
 ## Recently landed
 
+- #1440 — **search means the same thing in the exercise picker as in the
+  Library**. Choosing an exercise for a piece (**Choose one** on the piece)
+  opens a sheet whose search only read the exercise's title and its key/tempo
+  line, so a composer name, a note or a tag found nothing there while the same
+  words worked everywhere else. It now matches the fields the Library matches.
+  The two add sheets in Build session also put the Library's own filter back
+  when they close, instead of leaving it as the sheet left it. The deeper
+  tidy-up — the two pickers are still built differently, one on the shared
+  query and one on its own state — was weighed and left, since it costs a
+  morning and a musician cannot see it.
 - #1103 — **the related-exercise picker now behaves like the add-to-session
   sheet**. Adding three exercises to a block used to mean opening the sheet
   three times, and a long exercise list had no search in it. The sheet now

--- a/docs/status.md
+++ b/docs/status.md
@@ -33,12 +33,13 @@ audit backlog and its five-phase build order.
   Library**. Choosing an exercise for a piece (**Choose one** on the piece)
   opens a sheet whose search only read the exercise's title and its key/tempo
   line, so a composer name, a note or a tag found nothing there while the same
-  words worked everywhere else. It now matches the fields the Library matches.
+  words worked everywhere else. It now matches the fields the Library matches,
+  and no longer matches the key/tempo line, which the Library never did.
   The two add sheets in Build session also put the Library's own filter back
   when they close, instead of leaving it as the sheet left it. The deeper
-  tidy-up — the two pickers are still built differently, one on the shared
-  query and one on its own state — was weighed and left, since it costs a
-  morning and a musician cannot see it.
+  tidy-up was weighed and left: the two pickers are still built differently,
+  one on the shared query and one on its own state, and unifying them costs a
+  morning for nothing a musician can see.
 - #1103 — **the related-exercise picker now behaves like the add-to-session
   sheet**. Adding three exercises to a block used to mean opening the sheet
   three times, and a long exercise list had no search in it. The sheet now

--- a/ios/Intrada/Core/LibraryItemView+Search.swift
+++ b/ios/Intrada/Core/LibraryItemView+Search.swift
@@ -1,10 +1,8 @@
 import SharedTypes
 
 extension LibraryItemView {
-  /// The shell's copy of the core's free-text match (`apply_query_filter` in
-  /// `app.rs`): title, composer, notes and tags, case-insensitively. A sheet
-  /// that filters its own candidates uses this so search means the same thing
-  /// there as in the Library (#1440).
+  /// The core's free-text fields (`apply_query_filter` in `app.rs`), for a
+  /// sheet that filters its own candidates (#1440).
   func matchesSearch(_ text: String) -> Bool {
     let query = text.trimmingCharacters(in: .whitespaces)
     guard !query.isEmpty else { return true }

--- a/ios/Intrada/Core/LibraryItemView+Search.swift
+++ b/ios/Intrada/Core/LibraryItemView+Search.swift
@@ -1,0 +1,16 @@
+import SharedTypes
+
+extension LibraryItemView {
+  /// The shell's copy of the core's free-text match (`apply_query_filter` in
+  /// `app.rs`): title, composer, notes and tags, case-insensitively. A sheet
+  /// that filters its own candidates uses this so search means the same thing
+  /// there as in the Library (#1440).
+  func matchesSearch(_ text: String) -> Bool {
+    let query = text.trimmingCharacters(in: .whitespaces)
+    guard !query.isEmpty else { return true }
+    if title.localizedCaseInsensitiveContains(query) { return true }
+    if subtitle.localizedCaseInsensitiveContains(query) { return true }
+    if notes?.localizedCaseInsensitiveContains(query) == true { return true }
+    return tags.contains { $0.localizedCaseInsensitiveContains(query) }
+  }
+}

--- a/ios/Intrada/Core/LibraryQueryScope.swift
+++ b/ios/Intrada/Core/LibraryQueryScope.swift
@@ -1,0 +1,33 @@
+import SharedTypes
+import SwiftUI
+
+/// Clears the core's shared library `ListQuery` while a browsing sheet is up,
+/// and puts back whatever the Library had when it goes away (#1440). Sheets
+/// browse the same query the Library screen writes, so without this a filter
+/// left behind on one screen silently narrows the other, and a filter applied
+/// in a sheet follows the musician back out.
+///
+/// It clears rather than narrows: `items` also resolves the pushed detail
+/// screen, so pinning the query to one type pops the screen underneath the
+/// sheet. A sheet that wants one type filters its own candidates.
+private struct LibraryQueryScope: ViewModifier {
+  @Environment(Store.self) private var store
+  @State private var queryBeforeSheet: ListQuery?
+
+  func body(content: Content) -> some View {
+    content
+      .onAppear {
+        queryBeforeSheet = store.viewModel?.activeQuery
+        store.send(.setQuery(nil))
+      }
+      .onDisappear { store.send(.setQuery(queryBeforeSheet)) }
+  }
+}
+
+extension View {
+  /// Opens this sheet on a clean library query and restores the Library's own
+  /// query on dismiss.
+  func libraryQueryScope() -> some View {
+    modifier(LibraryQueryScope())
+  }
+}

--- a/ios/Intrada/Core/LibraryQueryScope.swift
+++ b/ios/Intrada/Core/LibraryQueryScope.swift
@@ -1,32 +1,31 @@
 import SharedTypes
 import SwiftUI
 
-/// Clears the core's shared library `ListQuery` while a browsing sheet is up,
-/// and puts back whatever the Library had when it goes away (#1440). Sheets
-/// browse the same query the Library screen writes, so without this a filter
-/// left behind on one screen silently narrows the other, and a filter applied
-/// in a sheet follows the musician back out.
-///
-/// It clears rather than narrows: `items` also resolves the pushed detail
-/// screen, so pinning the query to one type pops the screen underneath the
-/// sheet. A sheet that wants one type filters its own candidates.
+/// Clears the shared library `ListQuery` while a sheet is up and restores the
+/// Library's own on dismiss (#1440). Clears rather than narrows: `items` also
+/// resolves the pushed detail screen, so pinning it pops that screen.
 private struct LibraryQueryScope: ViewModifier {
   @Environment(Store.self) private var store
   @State private var queryBeforeSheet: ListQuery?
+  @State private var scoped = false
 
   func body(content: Content) -> some View {
     content
+      // A second `onAppear` would capture the already-cleared query to put back.
       .onAppear {
+        guard !scoped else { return }
+        scoped = true
         queryBeforeSheet = store.viewModel?.activeQuery
         store.send(.setQuery(nil))
       }
-      .onDisappear { store.send(.setQuery(queryBeforeSheet)) }
+      .onDisappear {
+        scoped = false
+        store.send(.setQuery(queryBeforeSheet))
+      }
   }
 }
 
 extension View {
-  /// Opens this sheet on a clean library query and restores the Library's own
-  /// query on dismiss.
   func libraryQueryScope() -> some View {
     modifier(LibraryQueryScope())
   }

--- a/ios/Intrada/Views/Components/AddRelatedExerciseSheet.swift
+++ b/ios/Intrada/Views/Components/AddRelatedExerciseSheet.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct AddRelatedExerciseSheet: View {
   let groupId: String
   @Environment(Store.self) private var store
-  @State private var queryBeforeSheet: ListQuery?
 
   private var entries: [SetlistEntryView] { store.viewModel?.buildingSetlist?.entries ?? [] }
 
@@ -33,8 +32,7 @@ struct AddRelatedExerciseSheet: View {
         list
       }
     }
-    .onAppear(perform: scopeQueryToExercises)
-    .onDisappear { store.send(.setQuery(queryBeforeSheet)) }
+    .libraryQueryScope()
   }
 
   @ViewBuilder private var list: some View {
@@ -65,13 +63,6 @@ struct AddRelatedExerciseSheet: View {
       blockEntryByItem[item.id].map { .session(.removeFromSetlist(entryId: $0)) }
       ?? .session(.addExerciseToBlock(groupId: groupId, itemId: item.id))
     store.send(event, onSuccess: .impact)
-  }
-
-  // The shared library query is whatever Library last left behind; its text or
-  // type filter would narrow this sheet with no control here showing why.
-  private func scopeQueryToExercises() {
-    queryBeforeSheet = store.viewModel?.activeQuery
-    store.send(.setQuery(ListQuery(text: nil, itemType: .exercise, key: nil, tags: [])))
   }
 
   private var searchText: String { store.viewModel?.activeQuery?.text ?? "" }

--- a/ios/Intrada/Views/Components/AddToSessionSheet.swift
+++ b/ios/Intrada/Views/Components/AddToSessionSheet.swift
@@ -24,6 +24,7 @@ struct AddToSessionSheet: View {
         library
       }
     }
+    .libraryQueryScope()
   }
 
   @ViewBuilder private var library: some View {

--- a/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
+++ b/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// The filter bar (star / sort / tag / search) drives *shell-local* state over
 /// the passed-in `available` list — the picker curates its own subset rather
 /// than the core's shared Library `ListQuery`, so filtering here never disturbs
-/// the Library screen.
+/// the Library screen. Search still means what it means in the Library:
+/// `matchesSearch` mirrors the core's fields (#1440).
 struct LinkedExercisePickerSheet: View {
   let available: [LibraryItemView]
   let linkedIds: [String]
@@ -189,13 +190,7 @@ struct LinkedExercisePickerSheet: View {
         }
       }
     }
-    let query = searchText.trimmingCharacters(in: .whitespaces)
-    if !query.isEmpty {
-      items = items.filter {
-        $0.title.localizedCaseInsensitiveContains(query)
-          || (metaLine($0)?.localizedCaseInsensitiveContains(query) ?? false)
-      }
-    }
+    items = items.filter { $0.matchesSearch(searchText) }
     return items.sorted(by: isOrderedBefore)
   }
 

--- a/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
+++ b/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
@@ -9,8 +9,7 @@ import SwiftUI
 /// The filter bar (star / sort / tag / search) drives *shell-local* state over
 /// the passed-in `available` list — the picker curates its own subset rather
 /// than the core's shared Library `ListQuery`, so filtering here never disturbs
-/// the Library screen. Search still means what it means in the Library:
-/// `matchesSearch` mirrors the core's fields (#1440).
+/// the Library screen. Search itself is the core's fields (#1440).
 struct LinkedExercisePickerSheet: View {
   let available: [LibraryItemView]
   let linkedIds: [String]

--- a/ios/IntradaTests/LibraryItemSearchTests.swift
+++ b/ios/IntradaTests/LibraryItemSearchTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SharedTypes
+import Testing
+
+@testable import Intrada
+
+/// The picker filters its own candidates, so this is the shell's only guard
+/// that search means there what it means in the Library — the core's
+/// `apply_query_filter` matches title, composer, notes and tags (#1440).
+struct LibraryItemSearchTests {
+  private static func exercise(
+    title: String = "Hanon No. 1", subtitle: String = "Charles-Louis Hanon",
+    notes: String? = "left hand only", tags: [String] = ["warm-up"]
+  ) -> LibraryItemView {
+    LibraryItemView(
+      id: "exercise-1", itemType: .exercise, title: title, subtitle: subtitle,
+      key: "C", modality: .major, tempo: "108 BPM", tempoMarking: nil, tempoBpm: 108,
+      notes: notes, tags: tags, createdAt: "", updatedAt: "", practice: nil,
+      latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
+      exerciseContexts: [], scaffoldPreview: nil, chordChart: nil, variants: [])
+  }
+
+  @Test(
+    "words a musician would type find the exercise",
+    arguments: ["Hanon", "hanon", "Charles-Louis", "warm-up", "left hand", "  Hanon  ", ""])
+  func matchesTheFieldsTheLibraryMatches(text: String) {
+    #expect(Self.exercise().matchesSearch(text))
+  }
+
+  @Test("a word in none of those fields does not match")
+  func missesWhatIsNotThere() {
+    #expect(!Self.exercise().matchesSearch("Debussy"))
+  }
+
+  @Test("key and tempo are not searchable, matching the Library")
+  func doesNotMatchTheMetaLine() {
+    #expect(!Self.exercise(notes: nil, tags: []).matchesSearch("108"))
+  }
+}

--- a/ios/IntradaTests/LibraryItemSearchTests.swift
+++ b/ios/IntradaTests/LibraryItemSearchTests.swift
@@ -7,16 +7,17 @@ import Testing
 /// Each field carries a word none of the others do, so dropping any one branch
 /// of `matchesSearch` fails a case here (#1440).
 struct LibraryItemSearchTests {
+  // Mutates the shared fixture so a new `LibraryItemView` field costs no edit.
   private static func exercise(
     title: String = "Hanon No. 1", subtitle: String = "Charles-Louis",
     notes: String? = "left hand only", tags: [String] = ["warm-up"]
   ) -> LibraryItemView {
-    LibraryItemView(
-      id: "exercise-1", itemType: .exercise, title: title, subtitle: subtitle,
-      key: "C", modality: .major, tempo: "108 BPM", tempoMarking: nil, tempoBpm: 108,
-      notes: notes, tags: tags, createdAt: "", updatedAt: "", practice: nil,
-      latestAchievedTempo: nil, priority: false, linkedExercises: [], linkedFromPieces: [],
-      exerciseContexts: [], scaffoldPreview: nil, chordChart: nil, variants: [])
+    var item = LibraryItemView.previewExercise
+    item.title = title
+    item.subtitle = subtitle
+    item.notes = notes
+    item.tags = tags
+    return item
   }
 
   @Test(

--- a/ios/IntradaTests/LibraryItemSearchTests.swift
+++ b/ios/IntradaTests/LibraryItemSearchTests.swift
@@ -4,12 +4,11 @@ import Testing
 
 @testable import Intrada
 
-/// The picker filters its own candidates, so this is the shell's only guard
-/// that search means there what it means in the Library — the core's
-/// `apply_query_filter` matches title, composer, notes and tags (#1440).
+/// Each field carries a word none of the others do, so dropping any one branch
+/// of `matchesSearch` fails a case here (#1440).
 struct LibraryItemSearchTests {
   private static func exercise(
-    title: String = "Hanon No. 1", subtitle: String = "Charles-Louis Hanon",
+    title: String = "Hanon No. 1", subtitle: String = "Charles-Louis",
     notes: String? = "left hand only", tags: [String] = ["warm-up"]
   ) -> LibraryItemView {
     LibraryItemView(
@@ -22,7 +21,7 @@ struct LibraryItemSearchTests {
 
   @Test(
     "words a musician would type find the exercise",
-    arguments: ["Hanon", "hanon", "Charles-Louis", "warm-up", "left hand", "  Hanon  ", ""])
+    arguments: ["No. 1", "no. 1", "Charles-Louis", "warm-up", "left hand", "  No. 1  ", ""])
   func matchesTheFieldsTheLibraryMatches(text: String) {
     #expect(Self.exercise().matchesSearch(text))
   }


### PR DESCRIPTION
Closes #1440.

## What changed

Two pickers disagreed about what search means. On a piece, **Choose one** opens **Add exercises**, whose search read only the exercise's title and its key/tempo line. The Library's search, and the two sheets in **Build session**, match title, composer, notes and tags. So typing a composer name or a tag in that one sheet found nothing, for no reason a musician could see.

- `LibraryItemView.matchesSearch` puts the core's four fields in one named, tested place, and the picker uses it. It no longer matches the key/tempo line, which the Library never did: typing `108` in that sheet used to find Hanon and now doesn't. That is the point of the change, but it is a loss worth naming.
- The two **Build session** sheets now put the Library's own filter back when they close, via a small `libraryQueryScope` modifier, so filtering inside a sheet no longer follows you out.

## What this deliberately does not do

The issue asked to pick one mechanism for all three pickers. I tried the shared-query route and abandoned it for a concrete reason: `LibraryScreen` resolves a pushed detail screen by looking the item up in the query-filtered list, so a sheet opened from a piece's detail that writes that query pops the screen underneath itself. Typing one character in the picker closed the sheet and the piece.

Jon and I weighed the remaining options against what a musician actually gets. Unifying the plumbing costs either a core change (a second query slot on the bridge) or a morning of shell churn across three working sheets, and changes nothing anyone can see. So this PR fixes the behaviour and leaves the mechanisms alone: the picker still filters locally, the two add sheets still browse the shared query. The screen-popping fragility is real but unreachable today, since nothing shipped writes the query from a detail screen; it is tracked separately.

## Verification

- `just check`, `just ios-fmt-check`, `just ios-test-full` green.
- Driven on the simulator: opened **Choose one** on Nocturne, searched `warm` and got Hanon by its tag, which found nothing before. Confirmed the sheet stays put while searching, and that the **Build session** sheets leave the Library's filter as they found it.
- New table test, mutation-tested by deleting each field branch of `matchesSearch` in turn and confirming a case fails each time. The first version of the test did not do this — its fixture had the same word in title and composer, so the title branch could be deleted with the suite still green. Caught in self-review.

Coverage: no Rust changed. iOS is in Codecov's ignore list; the gate here is the new table test plus the simulator run above.
