### PR TITLE
ios(picker): break sort ties the way the Library does (#1445)

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -39,6 +39,13 @@ audit backlog and its five-phase build order.
 
 ## Recently landed
 
+- #1445 — **the exercise picker no longer orders exercises differently from the
+  Library**. Sorting by **Last practised** put exercises that have never been
+  practised in one order on the Library screen and another in the **Add
+  exercises** sheet, because the sheet sorts its own candidates and had no rule
+  for what happens when the sort key ties. It now uses the core's: newest
+  first, then id. Same class as the search divergence in #1440, one function
+  below it.
 - #1440 — **search means the same thing in the exercise picker as in the
   Library**. Choosing an exercise for a piece (**Choose one** on the piece)
   opens a sheet whose search only read the exercise's title and its key/tempo

--- a/ios/Intrada/Core/LibraryItemView+Sort.swift
+++ b/ios/Intrada/Core/LibraryItemView+Sort.swift
@@ -1,0 +1,39 @@
+import Foundation
+import SharedTypes
+
+extension Array where Element == LibraryItemView {
+  /// The core's `sort_library_items` (`app.rs`), for a sheet that sorts its own
+  /// candidates: ties fall back to newest first, then id, so the same library
+  /// never comes out in a different order here than on the Library screen
+  /// (#1445).
+  func sortedLikeTheLibrary(by sort: LibrarySort) -> [LibraryItemView] {
+    sorted { a, b in
+      let primary = compareField(a, b, sort.field)
+      if primary != .orderedSame {
+        return sort.direction == .ascending
+          ? primary == .orderedAscending : primary == .orderedDescending
+      }
+      if a.createdAt != b.createdAt { return a.createdAt > b.createdAt }
+      return a.id < b.id
+    }
+  }
+}
+
+private func compareField(
+  _ a: LibraryItemView, _ b: LibraryItemView, _ field: SortField
+) -> ComparisonResult {
+  switch field {
+  case .title:
+    return compare(a.title.lowercased(), b.title.lowercased())
+  case .dateAdded:
+    return compare(a.createdAt, b.createdAt)
+  case .lastPracticed:
+    // Never practised sorts earliest, as `Option`'s own ordering does in the core.
+    return compare(a.practice?.lastPracticedAt ?? "", b.practice?.lastPracticedAt ?? "")
+  }
+}
+
+private func compare(_ a: String, _ b: String) -> ComparisonResult {
+  if a == b { return .orderedSame }
+  return a < b ? .orderedAscending : .orderedDescending
+}

--- a/ios/Intrada/Core/LibraryItemView+Sort.swift
+++ b/ios/Intrada/Core/LibraryItemView+Sort.swift
@@ -2,10 +2,9 @@ import Foundation
 import SharedTypes
 
 extension Array where Element == LibraryItemView {
-  /// The core's `sort_library_items` (`app.rs`), for a sheet that sorts its own
-  /// candidates: ties fall back to newest first, then id, so the same library
-  /// never comes out in a different order here than on the Library screen
-  /// (#1445).
+  /// Mirrors the core's `sort_library_items` (`app.rs`): ties fall back to
+  /// newest first, then id, so a sheet sorting its own candidates cannot order
+  /// the same library differently from the Library screen (#1445).
   func sortedLikeTheLibrary(by sort: LibrarySort) -> [LibraryItemView] {
     sorted { a, b in
       let primary = compareField(a, b, sort.field)
@@ -24,6 +23,7 @@ private func compareField(
 ) -> ComparisonResult {
   switch field {
   case .title:
+    // The core's lowercased compare, not a localised one, so both screens agree.
     return compare(a.title.lowercased(), b.title.lowercased())
   case .dateAdded:
     return compare(a.createdAt, b.createdAt)

--- a/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
+++ b/ios/Intrada/Views/Components/LinkedExercisePickerSheet.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// The filter bar (star / sort / tag / search) drives *shell-local* state over
 /// the passed-in `available` list — the picker curates its own subset rather
 /// than the core's shared Library `ListQuery`, so filtering here never disturbs
-/// the Library screen. Search itself is the core's fields (#1440).
+/// the Library screen. Search and sort themselves are the core's (#1440, #1445).
 struct LinkedExercisePickerSheet: View {
   let available: [LibraryItemView]
   let linkedIds: [String]
@@ -190,22 +190,7 @@ struct LinkedExercisePickerSheet: View {
       }
     }
     items = items.filter { $0.matchesSearch(searchText) }
-    return items.sorted(by: isOrderedBefore)
-  }
-
-  private func isOrderedBefore(_ a: LibraryItemView, _ b: LibraryItemView) -> Bool {
-    let ascending = sort.direction == .ascending
-    switch sort.field {
-    case .title:
-      let result = a.title.localizedCaseInsensitiveCompare(b.title)
-      return ascending ? result == .orderedAscending : result == .orderedDescending
-    case .dateAdded:
-      return ascending ? a.createdAt < b.createdAt : a.createdAt > b.createdAt
-    case .lastPracticed:
-      let la = a.practice?.lastPracticedAt ?? ""
-      let lb = b.practice?.lastPracticedAt ?? ""
-      return ascending ? la < lb : la > lb
-    }
+    return items.sortedLikeTheLibrary(by: sort)
   }
 
   private var list: some View {

--- a/ios/IntradaTests/LibraryItemSortTests.swift
+++ b/ios/IntradaTests/LibraryItemSortTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SharedTypes
+import Testing
+
+@testable import Intrada
+
+/// Ties are the whole point: the core breaks them with newest-first then id,
+/// and a sheet that sorts its own candidates has to do the same or the two
+/// screens disagree (#1445).
+struct LibraryItemSortTests {
+  private static func exercise(
+    id: String, title: String, createdAt: String, lastPractised: String? = nil
+  ) -> LibraryItemView {
+    var item = LibraryItemView.previewExercise
+    item.id = id
+    item.title = title
+    item.createdAt = createdAt
+    item.practice = lastPractised.map { .fixture(lastPracticedAt: $0) }
+    return item
+  }
+
+  // Deliberately in the wrong order for every assertion below, so a comparator
+  // that returns "equal" and leaves the input alone fails.
+  private static var neverPractised: [LibraryItemView] {
+    [
+      exercise(id: "b", title: "Scales", createdAt: "2026-01-01"),
+      exercise(id: "c", title: "Thirds", createdAt: "2026-06-01"),
+      exercise(id: "a", title: "Arpeggios", createdAt: "2026-06-01"),
+    ]
+  }
+
+  @Test("exercises never practised fall back to newest first, then id")
+  func tiesResolveLikeTheCore() {
+    let sorted = Self.neverPractised.sortedLikeTheLibrary(
+      by: LibrarySort(field: .lastPracticed, direction: .ascending))
+    #expect(sorted.map(\.id) == ["a", "c", "b"])
+  }
+
+  @Test("reversing the sort does not reverse the tiebreak")
+  func tiebreakIgnoresDirection() {
+    let sorted = Self.neverPractised.sortedLikeTheLibrary(
+      by: LibrarySort(field: .lastPracticed, direction: .descending))
+    #expect(sorted.map(\.id) == ["a", "c", "b"])
+  }
+
+  @Test("titles sort case-insensitively, ascending and descending")
+  func titleOrdering() {
+    let items = [
+      Self.exercise(id: "a", title: "scales", createdAt: "2026-01-01"),
+      Self.exercise(id: "b", title: "Arpeggios", createdAt: "2026-01-02"),
+    ]
+    #expect(
+      items.sortedLikeTheLibrary(by: LibrarySort(field: .title, direction: .ascending))
+        .map(\.title) == ["Arpeggios", "scales"])
+    #expect(
+      items.sortedLikeTheLibrary(by: LibrarySort(field: .title, direction: .descending))
+        .map(\.title) == ["scales", "Arpeggios"])
+  }
+
+  @Test("a practised exercise sorts after one never practised")
+  func neverPractisedSortsEarliest() {
+    let items = [
+      Self.exercise(id: "a", title: "Scales", createdAt: "2026-01-01", lastPractised: "2026-08-01"),
+      Self.exercise(id: "b", title: "Arpeggios", createdAt: "2026-01-02"),
+    ]
+    #expect(
+      items.sortedLikeTheLibrary(by: LibrarySort(field: .lastPracticed, direction: .ascending))
+        .map(\.id) == ["b", "a"])
+  }
+}

--- a/ios/IntradaTests/LibraryItemSortTests.swift
+++ b/ios/IntradaTests/LibraryItemSortTests.swift
@@ -43,25 +43,27 @@ struct LibraryItemSortTests {
     #expect(sorted.map(\.id) == ["a", "c", "b"])
   }
 
+  // Compared as typed, capital "Scales" wins; only a case-insensitive one doesn't.
   @Test("titles sort case-insensitively, ascending and descending")
   func titleOrdering() {
     let items = [
-      Self.exercise(id: "a", title: "scales", createdAt: "2026-01-01"),
-      Self.exercise(id: "b", title: "Arpeggios", createdAt: "2026-01-02"),
+      Self.exercise(id: "a", title: "Scales", createdAt: "2026-01-01"),
+      Self.exercise(id: "b", title: "arpeggios", createdAt: "2026-01-02"),
     ]
     #expect(
       items.sortedLikeTheLibrary(by: LibrarySort(field: .title, direction: .ascending))
-        .map(\.title) == ["Arpeggios", "scales"])
+        .map(\.title) == ["arpeggios", "Scales"])
     #expect(
       items.sortedLikeTheLibrary(by: LibrarySort(field: .title, direction: .descending))
-        .map(\.title) == ["scales", "Arpeggios"])
+        .map(\.title) == ["Scales", "arpeggios"])
   }
 
+  // The never-practised one is older, so the tiebreak alone would put it second.
   @Test("a practised exercise sorts after one never practised")
   func neverPractisedSortsEarliest() {
     let items = [
-      Self.exercise(id: "a", title: "Scales", createdAt: "2026-01-01", lastPractised: "2026-08-01"),
-      Self.exercise(id: "b", title: "Arpeggios", createdAt: "2026-01-02"),
+      Self.exercise(id: "a", title: "Scales", createdAt: "2026-01-02", lastPractised: "2026-08-01"),
+      Self.exercise(id: "b", title: "Arpeggios", createdAt: "2026-01-01"),
     ]
     #expect(
       items.sortedLikeTheLibrary(by: LibrarySort(field: .lastPracticed, direction: .ascending))


### PR DESCRIPTION
Closes #1445.

## What changed

Sort by **Last practised** on the Library screen, then open **Choose one** on a piece and sort **Add exercises** the same way: exercises that have never been practised came out in one order in one place and another in the other.

The core resolves an equal sort key with a tiebreaker — newest first, then id (`app.rs:1102`). The picker sorts its own candidates and had no tiebreaker at all, so ties landed wherever Swift's sort left them. `sortedLikeTheLibrary` mirrors the core's comparator, tiebreaker included, and the picker uses it.

One deliberate consequence: title comparison follows the core's lowercased compare rather than the localised one the picker had, because the point is that the two screens agree. That makes the picker agree with the Library on something the Library gets wrong — accented titles sort after every ASCII one, so an Étude lands after a Waltz. That is a core-side fix, tracked as #1447 rather than papered over here.

Same class as the search divergence in #1440, one function below it. Nothing else in the picker reimplements a core rule.

## Verification

- `just check`, `just ios-fmt-check`, `just ios-test-full` green.
- New table test built around ties, with the fixture ordered against every assertion. Mutation-tested by deleting each branch in turn: removing either half of the tiebreaker fails the two tie tests, removing `.lowercased()` fails the title test, and flattening the last-practised comparison fails the never-practised test.
- Drove the sheet on the simulator to confirm sorting still works; the tie behaviour itself is what the unit tests are for, since the seeded data has no ties.

Coverage: no Rust changed. iOS is in Codecov's ignore list; the gate here is the table test above.