### PR TITLE
core(photo): read a photographed page into title, composer and tempo (#1436)

### DIFF
--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -125,9 +125,15 @@ pub enum Event {
     SessionStoreWritten(PersistenceOutput),
 
     // ── On-device recognition ────────────────────────────────────────
-    /// The shell read the page. `Unsupported` and `Failed` are outcomes the
-    /// confirm surface shows, not errors that mute the banner.
-    PhotoRead(RecognitionOutput),
+    /// The shell read the page. Carries the `photo_id` it was asked to read, so
+    /// a result can only ever land on the read that asked for it — two scans in
+    /// flight would otherwise show one page beside the other's fields.
+    /// `Unsupported` and `Failed` are outcomes the form shows, not errors that
+    /// mute the banner.
+    PhotoRead {
+        photo_id: String,
+        output: RecognitionOutput,
+    },
     /// The user finished with (or backed out of) the recognised draft.
     DiscardPhotoDraft,
 }
@@ -377,15 +383,18 @@ impl Intrada {
             },
 
             // ── On-device recognition ────────────────────────────────
-            Event::PhotoRead(output) => {
-                let crate::model::PhotoRecognition::Reading { photo_id } =
-                    std::mem::take(&mut model.photo_recognition)
-                else {
-                    // Nothing is waiting on this read: the user has already
-                    // moved on, and a late result must not repopulate a sheet
-                    // they have left.
+            Event::PhotoRead { photo_id, output } => {
+                // Anything but "still reading this exact photo" is a result
+                // nothing is waiting on — a scan the user backed out of, or one
+                // superseded by a later scan. Leave the state untouched: the
+                // read that *is* current must survive its predecessor landing.
+                if model.photo_recognition
+                    != (crate::model::PhotoRecognition::Reading {
+                        photo_id: photo_id.clone(),
+                    })
+                {
                     return crux_core::render::render();
-                };
+                }
 
                 model.photo_recognition = match output {
                     RecognitionOutput::Page(page) => crate::model::PhotoRecognition::Ready {

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -25,10 +25,11 @@ use crate::http;
 use crate::model::{
     build_active_session_view, build_blocks, build_summary_view, entry_to_view, session_to_view,
     BuildingSetlistView, ItemPracticeSummary, LibraryItemView, LinkedExerciseView, Model,
-    PieceRefView, ScaffoldPreviewView, ScaffoldSpecView, SessionStatusView, SetSourceStatus,
-    ViewModel,
+    PhotoRecognitionView, PieceRefView, ScaffoldPreviewView, ScaffoldSpecView, SessionStatusView,
+    SetSourceStatus, ViewModel,
 };
 use crate::persistence::{self, PersistenceOperation, PersistenceOutput};
+use crate::recognition::{self, RecognitionOperation, RecognitionOutput};
 
 /// Root Crux application for the music practice library.
 #[derive(Default)]
@@ -122,6 +123,13 @@ pub enum Event {
     SessionsStoreLoaded(PersistenceOutput),
     /// Session write result, kept separate so a failed save reloads sessions (not items).
     SessionStoreWritten(PersistenceOutput),
+
+    // ── On-device recognition ────────────────────────────────────────
+    /// The shell read the page. `Unsupported` and `Failed` are outcomes the
+    /// confirm surface shows, not errors that mute the banner.
+    PhotoRead(RecognitionOutput),
+    /// The user finished with (or backed out of) the recognised draft.
+    DiscardPhotoDraft,
 }
 
 /// Side effects the core requests from shells.
@@ -136,6 +144,9 @@ pub enum Effect {
     App(AppEffect),
     /// Local-first persistence (the core's first effect with typed-data output).
     Persistence(PersistenceOperation),
+    /// On-device page recognition. The shell runs the frameworks and returns
+    /// text with geometry; the core decides what it means (spec decision 4).
+    Recognition(RecognitionOperation),
 }
 
 /// Non-HTTP side-effect operations handled by the shell (localStorage only).
@@ -364,6 +375,36 @@ impl Intrada {
                     persistence::load_sessions()
                 }
             },
+
+            // ── On-device recognition ────────────────────────────────
+            Event::PhotoRead(output) => {
+                let crate::model::PhotoRecognition::Reading { photo_id } =
+                    std::mem::take(&mut model.photo_recognition)
+                else {
+                    // Nothing is waiting on this read: the user has already
+                    // moved on, and a late result must not repopulate a sheet
+                    // they have left.
+                    return crux_core::render::render();
+                };
+
+                model.photo_recognition = match output {
+                    RecognitionOutput::Page(page) => crate::model::PhotoRecognition::Ready {
+                        photo_id,
+                        draft: recognition::read_fields(&page),
+                    },
+                    RecognitionOutput::Unsupported => {
+                        crate::model::PhotoRecognition::Unsupported { photo_id }
+                    }
+                    RecognitionOutput::Failed => {
+                        crate::model::PhotoRecognition::Failed { photo_id }
+                    }
+                };
+                crux_core::render::render()
+            }
+            Event::DiscardPhotoDraft => {
+                model.photo_recognition = crate::model::PhotoRecognition::Idle;
+                crux_core::render::render()
+            }
         }
     }
 
@@ -599,8 +640,52 @@ impl Intrada {
             oauth_redirect_url: model.oauth_redirect_url.clone(),
             last_set_save_request_id: model.last_set_save_request_id.clone(),
             up_next,
+            photo_recognition: photo_recognition_view(&model.photo_recognition),
         }
     }
+}
+
+fn photo_recognition_view(state: &crate::model::PhotoRecognition) -> PhotoRecognitionView {
+    use crate::model::{PhotoRecognition, PhotoRecognitionStatus};
+
+    match state {
+        PhotoRecognition::Idle => PhotoRecognitionView::default(),
+        PhotoRecognition::Reading { photo_id } => PhotoRecognitionView {
+            status: PhotoRecognitionStatus::Reading,
+            photo_id: Some(photo_id.clone()),
+            draft: None,
+            has_low_confidence: false,
+        },
+        PhotoRecognition::Ready { photo_id, draft } => PhotoRecognitionView {
+            status: PhotoRecognitionStatus::Ready,
+            photo_id: Some(photo_id.clone()),
+            has_low_confidence: draft_confidences(draft).any(|c| c < recognition::LOW_CONFIDENCE),
+            draft: Some(draft.clone()),
+        },
+        PhotoRecognition::Unsupported { photo_id } => PhotoRecognitionView {
+            status: PhotoRecognitionStatus::Unsupported,
+            photo_id: Some(photo_id.clone()),
+            draft: None,
+            has_low_confidence: false,
+        },
+        PhotoRecognition::Failed { photo_id } => PhotoRecognitionView {
+            status: PhotoRecognitionStatus::Failed,
+            photo_id: Some(photo_id.clone()),
+            draft: None,
+            has_low_confidence: false,
+        },
+    }
+}
+
+fn draft_confidences(draft: &recognition::PhotoDraft) -> impl Iterator<Item = f32> + '_ {
+    [
+        draft.title.as_ref().map(|f| f.confidence),
+        draft.composer.as_ref().map(|f| f.confidence),
+        draft.tempo.as_ref().map(|f| f.confidence),
+        draft.chart_text.as_ref().map(|f| f.confidence),
+    ]
+    .into_iter()
+    .flatten()
 }
 
 /// Every library item projected for the view, unfiltered and unsorted. Shared

--- a/crates/intrada-core/src/app.rs
+++ b/crates/intrada-core/src/app.rs
@@ -668,7 +668,7 @@ fn photo_recognition_view(state: &crate::model::PhotoRecognition) -> PhotoRecogn
         PhotoRecognition::Ready { photo_id, draft } => PhotoRecognitionView {
             status: PhotoRecognitionStatus::Ready,
             photo_id: Some(photo_id.clone()),
-            has_low_confidence: draft_confidences(draft).any(|c| c < recognition::LOW_CONFIDENCE),
+            has_low_confidence: draft_is_weak(draft),
             draft: Some(draft.clone()),
         },
         PhotoRecognition::Unsupported { photo_id } => PhotoRecognitionView {
@@ -686,15 +686,17 @@ fn photo_recognition_view(state: &crate::model::PhotoRecognition) -> PhotoRecogn
     }
 }
 
-fn draft_confidences(draft: &recognition::PhotoDraft) -> impl Iterator<Item = f32> + '_ {
+/// One field the form will mark as a weak read is enough (key decision 7).
+fn draft_is_weak(draft: &recognition::PhotoDraft) -> bool {
     [
-        draft.title.as_ref().map(|f| f.confidence),
-        draft.composer.as_ref().map(|f| f.confidence),
-        draft.tempo.as_ref().map(|f| f.confidence),
-        draft.chart_text.as_ref().map(|f| f.confidence),
+        draft.title.as_ref().map(|f| f.weak),
+        draft.composer.as_ref().map(|f| f.weak),
+        draft.chart_text.as_ref().map(|f| f.weak),
     ]
     .into_iter()
     .flatten()
+    .chain(draft.tempo.as_ref().map(|f| f.weak))
+    .any(|weak| weak)
 }
 
 /// Every library item projected for the view, unfiltered and unsorted. Shared

--- a/crates/intrada-core/src/domain/item.rs
+++ b/crates/intrada-core/src/domain/item.rs
@@ -172,6 +172,13 @@ pub enum ItemEvent {
     ClearPhoto {
         id: String,
     },
+    /// Read a photo the shell has already written to disk into a draft the
+    /// user confirms. Takes only the `photo_id`, not an item id: on Add there
+    /// is no item to name yet, and the draft is what fills the form
+    /// (#1446, spec open question 4).
+    ReadPhoto {
+        photo_id: String,
+    },
 }
 
 /// Shared by Update / AddTags / RemoveTags.
@@ -251,6 +258,24 @@ fn set_photo(model: &mut Model, id: String, next: Option<String>) -> Command<Eff
     model.record_success();
     Command::all([
         crate::persistence::save_item(item),
+        crux_core::render::render(),
+    ])
+}
+
+/// Kicks off recognition. The bytes are already on disk (phase A writes them
+/// shell-side), so the core only ever names the file.
+fn read_photo(model: &mut Model, photo_id: String) -> Command<Effect, Event> {
+    if let Err(e) = validation::validate_photo_id(&photo_id) {
+        model.last_error = Some(e.to_string());
+        return crux_core::render::render();
+    }
+
+    model.last_error = None;
+    model.photo_recognition = crate::model::PhotoRecognition::Reading {
+        photo_id: photo_id.clone(),
+    };
+    Command::all([
+        crate::recognition::read_page(photo_id),
         crux_core::render::render(),
     ])
 }
@@ -451,6 +476,7 @@ pub fn handle_item_event(event: ItemEvent, model: &mut Model) -> Command<Effect,
         }
         ItemEvent::SetPhoto { id, photo_id } => set_photo(model, id, Some(photo_id)),
         ItemEvent::ClearPhoto { id } => set_photo(model, id, None),
+        ItemEvent::ReadPhoto { photo_id } => read_photo(model, photo_id),
         ItemEvent::AddTags { id, tags } => {
             if let Err(e) = validation::validate_tags(&tags) {
                 model.last_error = Some(e.to_string());

--- a/crates/intrada-core/src/lib.rs
+++ b/crates/intrada-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod http;
 pub mod model;
 pub mod persistence;
+pub mod recognition;
 pub(crate) mod staleness;
 pub mod suggestion;
 pub mod validation;
@@ -26,6 +27,10 @@ pub use domain::types::{
 };
 pub use error::LibraryError;
 pub use persistence::{PersistenceOperation, PersistenceOutput};
+pub use recognition::{
+    read_fields, DraftSource, PageReading, PhotoDraft, RecognisedLine, RecognitionOperation,
+    RecognitionOutput, SuggestedFields, TempoDraftField, TextDraftField, LOW_CONFIDENCE,
+};
 
 // Re-export crux_http protocol types so shells can handle HTTP effects
 // without a direct crux_http dependency.
@@ -33,8 +38,9 @@ pub use crux_http::protocol::{HttpHeader, HttpResponse, HttpResult};
 pub use crux_http::{HttpError, HttpRequest};
 pub use model::{
     ActiveSessionView, BuildingSetlistView, ItemPracticeSummary, LibraryItemView, Model,
-    PracticeSessionView, ScoreHistoryEntry, SessionStatusView, SetEntryView, SetSourceStatus,
-    SetView, SetlistEntryView, SummaryView, TempoTrendPoint, TempoTrendView, ViewModel,
+    PhotoRecognition, PhotoRecognitionStatus, PhotoRecognitionView, PracticeSessionView,
+    ScoreHistoryEntry, SessionStatusView, SetEntryView, SetSourceStatus, SetView, SetlistEntryView,
+    SummaryView, TempoTrendPoint, TempoTrendView, ViewModel,
 };
 pub use validation::{
     MAX_ACHIEVED_TEMPO, MAX_BPM, MAX_COMPOSER, MAX_NOTES, MAX_SET_NAME, MAX_TAG, MAX_TEMPO_MARKING,

--- a/crates/intrada-core/src/model.rs
+++ b/crates/intrada-core/src/model.rs
@@ -14,6 +14,7 @@ use crate::domain::session::{
 };
 use crate::domain::set::Set;
 use crate::domain::{LibrarySort, ListQuery};
+use crate::recognition::PhotoDraft;
 use crate::suggestion::SuggestedSession;
 
 /// Internal application state — not exposed to shells.
@@ -84,6 +85,33 @@ pub struct Model {
     /// Bumped by every update that concludes with `last_error` present, so
     /// shells can tell a repeated identical failure from a success (#1056).
     pub error_seq: u64,
+    /// What the last `ReadPhoto` produced. Transient: the confirm surface reads
+    /// it, the user edits it, and `DiscardPhotoDraft` clears it. Never written
+    /// to an item without that confirmation (spec non-goal "no silent write").
+    pub photo_recognition: PhotoRecognition,
+}
+
+/// Model-side recognition state. The view projection is
+/// [`PhotoRecognitionView`].
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum PhotoRecognition {
+    #[default]
+    Idle,
+    Reading {
+        photo_id: String,
+    },
+    Ready {
+        photo_id: String,
+        draft: PhotoDraft,
+    },
+    /// The device has no recognition. Not an error: the photo is still saved
+    /// and the user types the fields.
+    Unsupported {
+        photo_id: String,
+    },
+    Failed {
+        photo_id: String,
+    },
 }
 
 impl Model {
@@ -215,6 +243,34 @@ pub struct ViewModel {
     /// The one suggested session on the Practice tab (#1082). `None` whenever
     /// nothing qualifies: it suggests, it never gates.
     pub up_next: Option<SuggestedSession>,
+    /// What the last photographed page was read into, for the confirm surface.
+    pub photo_recognition: PhotoRecognitionView,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct PhotoRecognitionView {
+    pub status: PhotoRecognitionStatus,
+    /// The photo being read, so the shell can show it beside the fields.
+    pub photo_id: Option<String>,
+    /// Present only under `Ready`.
+    pub draft: Option<PhotoDraft>,
+    /// True when at least one read field is below `recognition::LOW_CONFIDENCE`
+    /// — shown, not hidden (key decision 7). Derived here so the shell does no
+    /// thresholding of its own.
+    pub has_low_confidence: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum PhotoRecognitionStatus {
+    #[default]
+    Idle,
+    Reading,
+    Ready,
+    Unsupported,
+    Failed,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/crates/intrada-core/src/recognition.rs
+++ b/crates/intrada-core/src/recognition.rs
@@ -1,0 +1,925 @@
+//! On-device page recognition — the shell runs Vision (and, from phase C,
+//! Foundation Models); the core decides what any of it means.
+//!
+//! Everything the shell returns is text with geometry. `read_fields` is the
+//! only place a recognised line becomes a title, a composer or a tempo, and it
+//! is a pure function so its tests need no device.
+
+use crux_core::capability::Operation;
+use crux_core::command::Command;
+use serde::{Deserialize, Serialize};
+
+use crate::app::{Effect, Event};
+use crate::domain::types::Tempo;
+use crate::validation::{MAX_BPM, MAX_COMPOSER, MAX_TEMPO_MARKING, MAX_TITLE, MIN_BPM};
+
+// ── The effect contract ─────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum RecognitionOperation {
+    /// Read a page the shell has already written to disk (phase A writes the
+    /// bytes shell-side, so the core only ever names the file).
+    ReadPage { photo_id: String },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum RecognitionOutput {
+    Page(PageReading),
+    /// No recognition available on this device. Not an error: the user types
+    /// the fields, and the photo is still saved.
+    Unsupported,
+    Failed,
+}
+
+impl Operation for RecognitionOperation {
+    type Output = RecognitionOutput;
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct PageReading {
+    /// Recognised lines in reading order, with normalised geometry so the core
+    /// can reason about position without ever seeing the image.
+    pub lines: Vec<RecognisedLine>,
+    /// Populated only where Foundation Models ran (phase C). `None` on most
+    /// devices, and `read_fields` must produce a usable draft regardless.
+    pub suggested: Option<SuggestedFields>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct RecognisedLine {
+    pub text: String,
+    /// Normalised 0..1, origin top-left.
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub confidence: f32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct SuggestedFields {
+    pub title: Option<String>,
+    pub composer: Option<String>,
+    pub tempo_marking: Option<String>,
+    pub bpm: Option<u16>,
+    pub chart_text: Option<String>,
+}
+
+// ── The draft ───────────────────────────────────────────────────────
+
+/// A proposal, exactly as `ScaffoldSpec` is: it becomes an `Item` only when the
+/// user confirms. Every field carries where it came from, so the sheet can show
+/// a low-confidence read differently from a clean one.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct PhotoDraft {
+    pub title: Option<TextDraftField>,
+    pub composer: Option<TextDraftField>,
+    pub tempo: Option<TempoDraftField>,
+    /// Phase D. Always `None` today.
+    pub chart_text: Option<TextDraftField>,
+}
+
+/// The spec pins this as `DraftField<T>`; it is split per payload type because
+/// facet typegen emits no generics across the bridge.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct TextDraftField {
+    pub value: String,
+    pub source: DraftSource,
+    pub confidence: f32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+pub struct TempoDraftField {
+    pub value: Tempo,
+    pub source: DraftSource,
+    pub confidence: f32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "facet_typegen", derive(facet::Facet))]
+#[cfg_attr(feature = "facet_typegen", repr(C))]
+pub enum DraftSource {
+    /// Geometry heuristics in the core. The floor, available everywhere.
+    Recognised,
+    /// The on-device model chose it and it survived the substring clamp.
+    Suggested,
+}
+
+/// Below this a read is shown as uncertain rather than hidden (decision 7).
+pub const LOW_CONFIDENCE: f32 = 0.5;
+
+pub fn read_page(photo_id: String) -> Command<Effect, Event> {
+    Command::request_from_shell(RecognitionOperation::ReadPage { photo_id })
+        .then_send(Event::PhotoRead)
+}
+
+// ── Interpretation ──────────────────────────────────────────────────
+
+/// Tempo markings we will name from a page, longest first so
+/// "Allegro moderato" wins over "Allegro". Canonical spelling is ours, not the
+/// page's: OCR reads `ALLEGRO` and the user should see `Allegro`.
+const TEMPO_MARKINGS: &[&str] = &[
+    "Allegro moderato",
+    "Allegro vivace",
+    "Molto allegro",
+    "Andante moderato",
+    "Adagio ma non troppo",
+    "Larghetto",
+    "Moderato",
+    "Andantino",
+    "Sostenuto",
+    "Allegretto",
+    "Grazioso",
+    "Maestoso",
+    "Marcato",
+    "Adagietto",
+    "Allegro",
+    "Andante",
+    "Moderate",
+    "Adagio",
+    "Largo",
+    "Lento",
+    "Grave",
+    "Vivace",
+    "Presto",
+    "Prestissimo",
+    "Ballad",
+    "Swing",
+    "Bossa",
+    "Latin",
+    "Rubato",
+];
+
+/// Credit prefixes, longest first. The `f32` is how much the match dampens the
+/// line's own OCR confidence: a bare `by` is a weaker claim than `Music by`.
+const CREDIT_PREFIXES: &[(&str, f32)] = &[
+    ("words and music by", 1.0),
+    ("music and lyrics by", 1.0),
+    ("composed by", 1.0),
+    ("music by", 1.0),
+    ("written by", 0.9),
+    ("by", 0.8),
+];
+
+/// A line this high up the page can be the title. Below it we are into the
+/// first stave, where the largest text is a lyric, not a heading.
+const TITLE_BAND: f32 = 0.4;
+
+/// Deterministic. Prefers `suggested` where a field survives the substring
+/// clamp (decision 5), otherwise falls back to geometry heuristics.
+#[must_use]
+pub fn read_fields(page: &PageReading) -> PhotoDraft {
+    let heuristic = heuristic_draft(page);
+    let Some(suggested) = page.suggested.as_ref() else {
+        return heuristic;
+    };
+
+    let haystack = normalise(
+        &page
+            .lines
+            .iter()
+            .map(|l| l.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
+
+    PhotoDraft {
+        title: clamped_text(suggested.title.as_deref(), &haystack, MAX_TITLE).or(heuristic.title),
+        composer: clamped_text(suggested.composer.as_deref(), &haystack, MAX_COMPOSER)
+            .or(heuristic.composer),
+        tempo: clamped_tempo(suggested, &haystack).or(heuristic.tempo),
+        chart_text: clamped_text(suggested.chart_text.as_deref(), &haystack, usize::MAX)
+            .or(heuristic.chart_text),
+    }
+}
+
+/// Decision 5, the whole of it: a suggested value the page does not literally
+/// carry is discarded, so a model cannot invent a composer. Case- and
+/// whitespace-insensitive, because OCR spacing is not the user's problem.
+fn clamped_text(value: Option<&str>, haystack: &str, max: usize) -> Option<TextDraftField> {
+    let value = value?.trim();
+    if value.is_empty() || value.len() > max {
+        return None;
+    }
+    if !haystack.contains(&normalise(value)) {
+        return None;
+    }
+    Some(TextDraftField {
+        value: value.to_string(),
+        source: DraftSource::Suggested,
+        confidence: 1.0,
+    })
+}
+
+fn clamped_tempo(suggested: &SuggestedFields, haystack: &str) -> Option<TempoDraftField> {
+    let marking = clamped_text(
+        suggested.tempo_marking.as_deref(),
+        haystack,
+        MAX_TEMPO_MARKING,
+    )
+    .map(|f| f.value);
+    let bpm = suggested
+        .bpm
+        .filter(|bpm| (MIN_BPM..=MAX_BPM).contains(bpm))
+        .filter(|bpm| haystack.contains(&bpm.to_string()));
+
+    Tempo::from_parts(marking, bpm).map(|value| TempoDraftField {
+        value,
+        source: DraftSource::Suggested,
+        confidence: 1.0,
+    })
+}
+
+fn normalise(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn heuristic_draft(page: &PageReading) -> PhotoDraft {
+    PhotoDraft {
+        title: heuristic_title(&page.lines),
+        composer: heuristic_composer(&page.lines),
+        tempo: heuristic_tempo(&page.lines),
+        chart_text: None,
+    }
+}
+
+/// The largest text in the top band, ignoring anything that has already
+/// explained itself as a credit or a tempo.
+fn heuristic_title(lines: &[RecognisedLine]) -> Option<TextDraftField> {
+    lines
+        .iter()
+        .filter(|l| l.y < TITLE_BAND)
+        .filter(|l| !l.text.trim().is_empty())
+        .filter(|l| credit_prefix(&l.text).is_none())
+        .filter(|l| marking_in(&l.text).is_none() && bpm_in(&l.text).is_none())
+        .filter(|l| l.text.trim().len() <= MAX_TITLE)
+        .max_by(|a, b| a.height.total_cmp(&b.height).then(b.y.total_cmp(&a.y)))
+        .map(|l| TextDraftField {
+            value: l.text.trim().to_string(),
+            source: DraftSource::Recognised,
+            confidence: l.confidence,
+        })
+}
+
+fn heuristic_composer(lines: &[RecognisedLine]) -> Option<TextDraftField> {
+    lines.iter().find_map(|l| {
+        let (rest, damping) = credit_prefix(&l.text)?;
+        let rest = rest.trim();
+        (!rest.is_empty() && rest.len() <= MAX_COMPOSER).then(|| TextDraftField {
+            value: rest.to_string(),
+            source: DraftSource::Recognised,
+            confidence: l.confidence * damping,
+        })
+    })
+}
+
+/// Returns what follows the credit prefix, and how far the prefix dampens
+/// confidence. Matched only at the start of the line.
+fn credit_prefix(text: &str) -> Option<(&str, f32)> {
+    let trimmed = text.trim();
+    let lower = trimmed.to_lowercase();
+    CREDIT_PREFIXES.iter().find_map(|(prefix, damping)| {
+        let rest = lower.strip_prefix(prefix)?;
+        // Must be a word boundary: "Bydgoszcz Suite" is not a credit.
+        if !rest.is_empty() && !rest.starts_with(|c: char| c.is_whitespace() || c == ':') {
+            return None;
+        }
+        let rest = &trimmed[trimmed
+            .char_indices()
+            .nth(prefix.chars().count())
+            .map_or(trimmed.len(), |(at, _)| at)..];
+        Some((rest.trim_start_matches([':', ' ', '\t']), *damping))
+    })
+}
+
+fn heuristic_tempo(lines: &[RecognisedLine]) -> Option<TempoDraftField> {
+    let band: Vec<&RecognisedLine> = lines.iter().filter(|l| l.y < TITLE_BAND).collect();
+
+    let marking = band
+        .iter()
+        .find_map(|l| marking_in(&l.text).map(|m| (m, l.confidence)));
+    let bpm = band
+        .iter()
+        .find_map(|l| bpm_in(&l.text).map(|b| (b, l.confidence)));
+
+    let confidence = match (&marking, &bpm) {
+        (Some((_, a)), Some((_, b))) => a.min(*b),
+        (Some((_, c)), None) | (None, Some((_, c))) => *c,
+        (None, None) => return None,
+    };
+
+    Tempo::from_parts(marking.map(|(m, _)| m), bpm.map(|(b, _)| b)).map(|value| TempoDraftField {
+        value,
+        source: DraftSource::Recognised,
+        confidence,
+    })
+}
+
+fn marking_in(text: &str) -> Option<String> {
+    let lower = text.to_lowercase();
+    TEMPO_MARKINGS.iter().find_map(|marking| {
+        let needle = marking.to_lowercase();
+        lower
+            .match_indices(&needle)
+            .any(|(at, _)| {
+                let before_ok = at == 0
+                    || !lower[..at]
+                        .chars()
+                        .next_back()
+                        .is_some_and(char::is_alphanumeric);
+                let after_ok = !lower[at + needle.len()..]
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_alphanumeric);
+                before_ok && after_ok
+            })
+            .then(|| (*marking).to_string())
+    })
+}
+
+/// Only a number that follows an `=` counts. `♩= 120` OCRs with the glyph
+/// mangled or dropped, but the equals survives; a bare number near the top of a
+/// page is a page number or a bar number at least as often as it is a tempo
+/// (open question 3).
+fn bpm_in(text: &str) -> Option<u16> {
+    let (_, after) = text.rsplit_once('=')?;
+    let digits: String = after
+        .trim_start()
+        .chars()
+        .take_while(char::is_ascii_digit)
+        .collect();
+    digits
+        .parse::<u16>()
+        .ok()
+        .filter(|bpm| (MIN_BPM..=MAX_BPM).contains(bpm))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::item::ItemKind;
+    use crate::domain::types::{assert_round_trips, CreateItem};
+    use crate::validation;
+
+    fn line(text: &str, y: f32, height: f32) -> RecognisedLine {
+        RecognisedLine {
+            text: text.to_string(),
+            x: 0.1,
+            y,
+            width: 0.8,
+            height,
+            confidence: 0.9,
+        }
+    }
+
+    fn page(lines: Vec<RecognisedLine>) -> PageReading {
+        PageReading {
+            lines,
+            suggested: None,
+        }
+    }
+
+    /// A printed first page: title big at the top, credit under it, tempo above
+    /// the first stave, then lyrics well down the page.
+    fn printed_page() -> PageReading {
+        page(vec![
+            line("Autumn Leaves", 0.08, 0.09),
+            line("Music by Joseph Kosma", 0.18, 0.03),
+            line("Moderato  = 120", 0.27, 0.025),
+            line("The falling leaves drift by my window", 0.55, 0.04),
+        ])
+    }
+
+    // ── Title ───────────────────────────────────────────────────────
+
+    #[test]
+    fn title_is_the_largest_text_in_the_top_band() {
+        let draft = read_fields(&printed_page());
+        let title = draft.title.expect("a title");
+        assert_eq!(title.value, "Autumn Leaves");
+        assert_eq!(title.source, DraftSource::Recognised);
+    }
+
+    /// Deleting the top-band filter makes this pass on the lyric instead: the
+    /// biggest text on a lead sheet is often a lyric line halfway down.
+    #[test]
+    fn title_ignores_larger_text_below_the_top_band() {
+        let draft = read_fields(&page(vec![
+            line("Prelude in C", 0.10, 0.04),
+            line("VERSE ONE, SET HUGE", 0.60, 0.20),
+        ]));
+        assert_eq!(draft.title.expect("a title").value, "Prelude in C");
+    }
+
+    /// Deleting the credit filter makes this pass on the credit line.
+    #[test]
+    fn title_is_never_the_credit_line() {
+        let draft = read_fields(&page(vec![
+            line("Music by Erik Satie", 0.10, 0.09),
+            line("Gymnopedie No. 1", 0.20, 0.04),
+        ]));
+        assert_eq!(draft.title.expect("a title").value, "Gymnopedie No. 1");
+    }
+
+    #[test]
+    fn title_carries_the_lines_own_confidence() {
+        let mut lines = vec![line("Blurry Title", 0.08, 0.09)];
+        lines[0].confidence = 0.31;
+        let draft = read_fields(&page(lines));
+        assert_eq!(draft.title.expect("a title").confidence, 0.31);
+    }
+
+    #[test]
+    fn a_page_with_no_text_reads_into_nothing() {
+        let draft = read_fields(&page(vec![]));
+        assert_eq!(draft, PhotoDraft::default());
+    }
+
+    // ── Composer ────────────────────────────────────────────────────
+
+    #[test]
+    fn composer_is_read_from_each_credit_form() {
+        for (text, expected) in [
+            ("Music by Joseph Kosma", "Joseph Kosma"),
+            ("Words and Music by Cole Porter", "Cole Porter"),
+            ("Composed by Clara Schumann", "Clara Schumann"),
+            ("by Thelonious Monk", "Thelonious Monk"),
+            ("Music by: Bill Evans", "Bill Evans"),
+        ] {
+            let draft = read_fields(&page(vec![line(text, 0.2, 0.03)]));
+            assert_eq!(
+                draft.composer.expect("a composer").value,
+                expected,
+                "reading {text:?}"
+            );
+        }
+    }
+
+    /// Deleting the word-boundary check reads "dgoszcz Suite" as a composer.
+    #[test]
+    fn a_word_merely_starting_with_by_is_not_a_credit() {
+        let draft = read_fields(&page(vec![line("Bydgoszcz Suite", 0.1, 0.05)]));
+        assert!(draft.composer.is_none());
+        assert_eq!(draft.title.expect("a title").value, "Bydgoszcz Suite");
+    }
+
+    /// Deleting the damping factor makes both forms equally confident, which
+    /// is the claim being made: a bare `by` is a weaker signal than `Music by`.
+    #[test]
+    fn a_bare_by_is_less_confident_than_an_explicit_credit() {
+        let bare = read_fields(&page(vec![line("by Duke Ellington", 0.2, 0.03)]))
+            .composer
+            .expect("a composer")
+            .confidence;
+        let explicit = read_fields(&page(vec![line("Music by Duke Ellington", 0.2, 0.03)]))
+            .composer
+            .expect("a composer")
+            .confidence;
+        assert!(
+            bare < explicit,
+            "bare {bare} should be less confident than explicit {explicit}"
+        );
+    }
+
+    #[test]
+    fn a_credit_with_no_name_after_it_is_not_a_composer() {
+        let draft = read_fields(&page(vec![line("Music by", 0.2, 0.03)]));
+        assert!(draft.composer.is_none());
+    }
+
+    // ── Tempo ───────────────────────────────────────────────────────
+
+    #[test]
+    fn tempo_reads_the_marking_and_the_bpm_together() {
+        let tempo = read_fields(&printed_page()).tempo.expect("a tempo");
+        assert_eq!(tempo.value.marking.as_deref(), Some("Moderato"));
+        assert_eq!(tempo.value.bpm, Some(120));
+    }
+
+    #[test]
+    fn a_marking_is_named_in_our_spelling_not_the_pages() {
+        let draft = read_fields(&page(vec![line("ALLEGRO", 0.2, 0.03)]));
+        assert_eq!(
+            draft.tempo.expect("a tempo").value.marking.as_deref(),
+            Some("Allegro")
+        );
+    }
+
+    #[test]
+    fn a_longer_marking_wins_over_the_word_inside_it() {
+        let draft = read_fields(&page(vec![line("Allegro moderato", 0.2, 0.03)]));
+        assert_eq!(
+            draft.tempo.expect("a tempo").value.marking.as_deref(),
+            Some("Allegro moderato")
+        );
+    }
+
+    /// Open question 3, answered conservatively. Deleting the `=` requirement
+    /// reads the page number as a tempo.
+    #[test]
+    fn a_bare_number_is_not_a_bpm() {
+        let draft = read_fields(&page(vec![
+            line("Sonata in G", 0.08, 0.09),
+            line("48", 0.02, 0.02),
+        ]));
+        assert!(draft.tempo.is_none());
+    }
+
+    #[test]
+    fn a_bpm_outside_the_accepted_range_is_dropped() {
+        for text in ["= 0", "= 900", "= 40000"] {
+            let draft = read_fields(&page(vec![line(text, 0.2, 0.03)]));
+            assert!(draft.tempo.is_none(), "reading {text:?}");
+        }
+    }
+
+    #[test]
+    fn a_mangled_note_glyph_still_yields_the_bpm() {
+        let draft = read_fields(&page(vec![line("J= 88", 0.2, 0.03)]));
+        assert_eq!(draft.tempo.expect("a tempo").value.bpm, Some(88));
+    }
+
+    #[test]
+    fn tempo_takes_the_weaker_of_its_two_lines_confidences() {
+        let mut lines = vec![line("Andante", 0.15, 0.03), line("= 72", 0.20, 0.03)];
+        lines[0].confidence = 0.8;
+        lines[1].confidence = 0.4;
+        let tempo = read_fields(&page(lines)).tempo.expect("a tempo");
+        assert_eq!(tempo.confidence, 0.4);
+    }
+
+    // ── The substring clamp (key decision 5) ────────────────────────
+
+    fn suggested_page(suggested: SuggestedFields) -> PageReading {
+        PageReading {
+            suggested: Some(suggested),
+            ..printed_page()
+        }
+    }
+
+    fn no_suggestions() -> SuggestedFields {
+        SuggestedFields {
+            title: None,
+            composer: None,
+            tempo_marking: None,
+            bpm: None,
+            chart_text: None,
+        }
+    }
+
+    /// The whole of decision 5: a ~3B model asked to extract will sometimes
+    /// produce a plausible composer that is not on the page. Deleting the
+    /// `haystack.contains` check lets "Cole Porter" through from a Kosma page.
+    #[test]
+    fn a_suggestion_the_page_does_not_carry_is_discarded() {
+        let draft = read_fields(&suggested_page(SuggestedFields {
+            composer: Some("Cole Porter".to_string()),
+            ..no_suggestions()
+        }));
+        let composer = draft.composer.expect("the heuristic composer");
+        assert_eq!(composer.value, "Joseph Kosma");
+        assert_eq!(composer.source, DraftSource::Recognised);
+    }
+
+    #[test]
+    fn a_suggestion_the_page_carries_is_preferred_over_the_heuristic() {
+        let draft = read_fields(&suggested_page(SuggestedFields {
+            composer: Some("Kosma".to_string()),
+            ..no_suggestions()
+        }));
+        let composer = draft.composer.expect("a composer");
+        assert_eq!(composer.value, "Kosma");
+        assert_eq!(composer.source, DraftSource::Suggested);
+    }
+
+    #[test]
+    fn the_clamp_ignores_case_and_ocr_spacing() {
+        let draft = read_fields(&suggested_page(SuggestedFields {
+            title: Some("autumn   leaves".to_string()),
+            ..no_suggestions()
+        }));
+        assert_eq!(draft.title.expect("a title").source, DraftSource::Suggested);
+    }
+
+    #[test]
+    fn a_suggested_bpm_the_page_does_not_print_is_discarded() {
+        let draft = read_fields(&suggested_page(SuggestedFields {
+            bpm: Some(144),
+            ..no_suggestions()
+        }));
+        let tempo = draft.tempo.expect("the heuristic tempo");
+        assert_eq!(tempo.value.bpm, Some(120));
+        assert_eq!(tempo.source, DraftSource::Recognised);
+    }
+
+    #[test]
+    fn suggestions_never_replace_a_field_they_left_empty() {
+        let draft = read_fields(&suggested_page(no_suggestions()));
+        assert_eq!(draft, read_fields(&printed_page()));
+    }
+
+    // ── Against the consumer ────────────────────────────────────────
+
+    /// Pages as a user would photograph them, asserted against what the create
+    /// form actually accepts — not against the heuristics that produced them.
+    #[test]
+    fn every_read_field_is_one_the_create_form_accepts() {
+        let pages: Vec<(&str, PageReading)> = vec![
+            ("printed lead sheet", printed_page()),
+            (
+                "hymnal page",
+                page(vec![
+                    line("Be Thou My Vision", 0.06, 0.07),
+                    line("Words and Music by Traditional Irish", 0.16, 0.025),
+                    line("Andante", 0.24, 0.02),
+                ]),
+            ),
+            (
+                "photocopied study",
+                page(vec![
+                    line("Etude Op. 10 No. 3", 0.09, 0.06),
+                    line("by Frederic Chopin", 0.17, 0.03),
+                    line("Lento ma non troppo  = 100", 0.25, 0.02),
+                ]),
+            ),
+            (
+                "chart with no credit at all",
+                page(vec![
+                    line("Blues in F", 0.07, 0.08),
+                    line("F7 | Bb7 | F7 | F7", 0.30, 0.03),
+                ]),
+            ),
+            (
+                "skewed capture, title not first in reading order",
+                page(vec![
+                    line("Swing", 0.22, 0.02),
+                    line("Music by Count Basie", 0.15, 0.03),
+                    line("One O'Clock Jump", 0.05, 0.08),
+                ]),
+            ),
+        ];
+
+        for (name, page) in pages {
+            let draft = read_fields(&page);
+            let title = draft.title.as_ref().map(|f| f.value.clone());
+            assert!(title.is_some(), "{name}: expected a title");
+
+            let input = CreateItem {
+                title: title.unwrap(),
+                kind: ItemKind::Piece,
+                composer: draft
+                    .composer
+                    .as_ref()
+                    .map(|f| f.value.clone())
+                    .or_else(|| Some("Unknown".to_string())),
+                key: None,
+                modality: None,
+                tempo: draft.tempo.as_ref().map(|f| f.value.clone()),
+                notes: None,
+                tags: vec![],
+            };
+            validation::validate_create_item(&input)
+                .unwrap_or_else(|e| panic!("{name}: the create form rejected the read: {e}"));
+
+            if let Some(tempo) = draft.tempo.as_ref() {
+                validation::validate_tempo(&tempo.value)
+                    .unwrap_or_else(|e| panic!("{name}: tempo rejected: {e}"));
+            }
+        }
+    }
+
+    // ── The bridge wire (#846 class) ────────────────────────────────
+
+    #[test]
+    fn recognition_operation_round_trips_on_ffi_bincode_wire() {
+        assert_round_trips(RecognitionOperation::ReadPage {
+            photo_id: "01JB0000000000000000000000".to_string(),
+        });
+    }
+
+    #[test]
+    fn recognition_output_round_trips_on_ffi_bincode_wire() {
+        assert_round_trips(RecognitionOutput::Page(suggested_page(SuggestedFields {
+            title: Some("Autumn Leaves".to_string()),
+            composer: Some("Kosma".to_string()),
+            tempo_marking: Some("Moderato".to_string()),
+            bpm: Some(120),
+            chart_text: Some("F7 | Bb7".to_string()),
+        })));
+        assert_round_trips(RecognitionOutput::Unsupported);
+        assert_round_trips(RecognitionOutput::Failed);
+    }
+
+    #[test]
+    fn photo_draft_round_trips_on_ffi_bincode_wire() {
+        assert_round_trips(read_fields(&printed_page()));
+        assert_round_trips(PhotoDraft::default());
+    }
+
+    // ── Driving the app ─────────────────────────────────────────────
+
+    mod wiring {
+        use super::*;
+        use crate::app::{Effect, Event, Intrada};
+        use crate::domain::item::ItemEvent;
+        use crate::model::{Model, PhotoRecognition, PhotoRecognitionStatus};
+        use crux_core::App;
+
+        const PHOTO: &str = "01JB0000000000000000000000";
+
+        fn read_photo(model: &mut Model) -> crux_core::Command<Effect, Event> {
+            Intrada.update(
+                Event::Item(ItemEvent::ReadPhoto {
+                    photo_id: PHOTO.to_string(),
+                }),
+                model,
+            )
+        }
+
+        #[test]
+        fn read_photo_requests_recognition_and_marks_the_photo_as_reading() {
+            let mut model = Model::test_default();
+            let mut cmd = read_photo(&mut model);
+
+            assert!(cmd.effects().any(|e| matches!(e, Effect::Recognition(req)
+            if req.operation == RecognitionOperation::ReadPage {
+                photo_id: PHOTO.to_string()
+            })));
+            assert_eq!(
+                model.photo_recognition,
+                PhotoRecognition::Reading {
+                    photo_id: PHOTO.to_string()
+                }
+            );
+        }
+
+        /// Offline-first invariant 1: recognition is on-device, end to end.
+        #[test]
+        fn reading_a_page_issues_no_http() {
+            let mut model = Model::test_default();
+            let mut cmd = read_photo(&mut model);
+            assert!(!cmd.effects().any(|e| matches!(e, Effect::Http(_))));
+        }
+
+        #[test]
+        fn an_unreadable_photo_id_surfaces_an_error_and_requests_nothing() {
+            let mut model = Model::test_default();
+            let mut cmd = Intrada.update(
+                Event::Item(ItemEvent::ReadPhoto {
+                    photo_id: "not-a-ulid".to_string(),
+                }),
+                &mut model,
+            );
+            assert!(model.last_error.is_some());
+            assert_eq!(model.photo_recognition, PhotoRecognition::Idle);
+            assert!(!cmd.effects().any(|e| matches!(e, Effect::Recognition(_))));
+        }
+
+        #[test]
+        fn a_read_page_becomes_the_draft_the_form_is_filled_from() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+
+            let view = Intrada.view(&model).photo_recognition;
+            assert_eq!(view.status, PhotoRecognitionStatus::Ready);
+            assert_eq!(view.photo_id.as_deref(), Some(PHOTO));
+            assert_eq!(
+                view.draft.expect("a draft").title.expect("a title").value,
+                "Autumn Leaves"
+            );
+        }
+
+        /// Key decision 7, projected once in the core so no shell thresholds
+        /// for itself. Deleting the `has_low_confidence` derivation leaves a
+        /// blurry read looking as clean as a sharp one.
+        #[test]
+        fn a_weak_read_is_flagged_low_confidence_in_the_view() {
+            let mut sharp = Model::test_default();
+            let _ = read_photo(&mut sharp);
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut sharp,
+            );
+            assert!(!Intrada.view(&sharp).photo_recognition.has_low_confidence);
+
+            let mut blurry = Model::test_default();
+            let _ = read_photo(&mut blurry);
+            let mut lines = printed_page().lines;
+            lines[0].confidence = 0.2;
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(page(lines))),
+                &mut blurry,
+            );
+            assert!(Intrada.view(&blurry).photo_recognition.has_low_confidence);
+        }
+
+        /// Not an error: the photo is still saved and the user types the
+        /// fields. Surfacing this as a banner would be the wrong story.
+        #[test]
+        fn a_device_without_recognition_is_an_outcome_not_an_error() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(Event::PhotoRead(RecognitionOutput::Unsupported), &mut model);
+
+            assert_eq!(
+                Intrada.view(&model).photo_recognition.status,
+                PhotoRecognitionStatus::Unsupported
+            );
+            assert!(model.last_error.is_none());
+        }
+
+        #[test]
+        fn a_failed_read_is_surfaced_as_failed_not_as_an_empty_draft() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(Event::PhotoRead(RecognitionOutput::Failed), &mut model);
+
+            let view = Intrada.view(&model).photo_recognition;
+            assert_eq!(view.status, PhotoRecognitionStatus::Failed);
+            assert!(view.draft.is_none());
+        }
+
+        /// Deleting the `Reading` guard lets a read the user walked away from
+        /// repopulate the form they have since left.
+        #[test]
+        fn a_late_read_is_dropped_once_the_user_has_moved_on() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(Event::DiscardPhotoDraft, &mut model);
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+            assert_eq!(model.photo_recognition, PhotoRecognition::Idle);
+        }
+
+        #[test]
+        fn discarding_clears_a_draft_the_user_has_finished_with() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+            let _ = Intrada.update(Event::DiscardPhotoDraft, &mut model);
+
+            let view = Intrada.view(&model).photo_recognition;
+            assert_eq!(view.status, PhotoRecognitionStatus::Idle);
+            assert!(view.draft.is_none());
+            assert!(view.photo_id.is_none());
+        }
+
+        /// Nothing recognised is ever written without the user pressing Add
+        /// (spec non-goal "no silent write").
+        #[test]
+        fn reading_a_page_never_writes_an_item() {
+            let mut model = Model::test_default();
+            let mut cmd = read_photo(&mut model);
+            assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
+
+            let mut cmd = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+            assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
+            assert!(model.items.is_empty());
+        }
+
+        #[test]
+        fn the_bridge_events_round_trip_on_ffi_bincode_wire() {
+            assert_round_trips(Event::Item(ItemEvent::ReadPhoto {
+                photo_id: PHOTO.to_string(),
+            }));
+            assert_round_trips(Event::PhotoRead(RecognitionOutput::Unsupported));
+            assert_round_trips(Event::DiscardPhotoDraft);
+        }
+
+        #[test]
+        fn the_view_projection_round_trips_on_ffi_bincode_wire() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(
+                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+            assert_round_trips(Intrada.view(&model).photo_recognition);
+        }
+    }
+}

--- a/crates/intrada-core/src/recognition.rs
+++ b/crates/intrada-core/src/recognition.rs
@@ -95,6 +95,11 @@ pub struct TextDraftField {
     pub value: String,
     pub source: DraftSource,
     pub confidence: f32,
+    /// Whether the form shows this as a weak read. Decided here rather than
+    /// against `confidence` in the shell: where the line between a clean read
+    /// and a doubtful one falls is a domain judgement, and a shell that
+    /// thresholded for itself would be the second place it lives.
+    pub weak: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -103,6 +108,8 @@ pub struct TempoDraftField {
     pub value: Tempo,
     pub source: DraftSource,
     pub confidence: f32,
+    /// See `TextDraftField::weak`.
+    pub weak: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -260,6 +267,7 @@ fn clamped_text(value: Option<&str>, haystack: &str, max: usize) -> Option<TextD
         value: value.to_string(),
         source: DraftSource::Suggested,
         confidence: 1.0,
+        weak: false,
     })
 }
 
@@ -279,6 +287,7 @@ fn clamped_tempo(suggested: &SuggestedFields, haystack: &str) -> Option<TempoDra
         value,
         source: DraftSource::Suggested,
         confidence: 1.0,
+        weak: false,
     })
 }
 
@@ -313,6 +322,7 @@ fn heuristic_title(lines: &[RecognisedLine]) -> Option<TextDraftField> {
             value: l.text.trim().to_string(),
             source: DraftSource::Recognised,
             confidence: l.confidence,
+            weak: l.confidence < LOW_CONFIDENCE,
         })
 }
 
@@ -326,10 +336,14 @@ fn heuristic_composer(lines: &[RecognisedLine]) -> Option<TextDraftField> {
             return None;
         }
         let rest = rest.trim();
-        (!rest.is_empty() && rest.len() <= MAX_COMPOSER).then(|| TextDraftField {
-            value: rest.to_string(),
-            source: DraftSource::Recognised,
-            confidence: l.confidence * damping,
+        (!rest.is_empty() && rest.len() <= MAX_COMPOSER).then(|| {
+            let confidence = l.confidence * damping;
+            TextDraftField {
+                value: rest.to_string(),
+                source: DraftSource::Recognised,
+                confidence,
+                weak: confidence < LOW_CONFIDENCE,
+            }
         })
     })
 }
@@ -380,6 +394,7 @@ fn heuristic_tempo(lines: &[RecognisedLine]) -> Option<TempoDraftField> {
         value,
         source: DraftSource::Recognised,
         confidence,
+        weak: confidence < LOW_CONFIDENCE,
     })
 }
 
@@ -1031,9 +1046,9 @@ mod tests {
             );
         }
 
-        /// Key decision 7, projected once in the core so no shell thresholds
-        /// for itself. Deleting the `has_low_confidence` derivation leaves a
-        /// blurry read looking as clean as a sharp one.
+        /// Key decision 7, decided once in the core so no shell thresholds for
+        /// itself. Deleting the `weak` derivation leaves a blurry read looking
+        /// as clean as a sharp one, per field and for the draft as a whole.
         #[test]
         fn a_weak_read_is_flagged_low_confidence_in_the_view() {
             let mut sharp = Model::test_default();
@@ -1052,7 +1067,18 @@ mod tests {
                 photo_read(RecognitionOutput::Page(page(lines))),
                 &mut blurry,
             );
-            assert!(Intrada.view(&blurry).photo_recognition.has_low_confidence);
+            let view = Intrada.view(&blurry).photo_recognition;
+            assert!(view.has_low_confidence);
+
+            let draft = view.draft.expect("a draft");
+            assert!(
+                draft.title.expect("a title").weak,
+                "the blurry line is title"
+            );
+            assert!(
+                !draft.composer.expect("a composer").weak,
+                "the sharp lines are not dragged down with it"
+            );
         }
 
         /// Not an error: the photo is still saved and the user types the

--- a/crates/intrada-core/src/recognition.rs
+++ b/crates/intrada-core/src/recognition.rs
@@ -762,6 +762,34 @@ mod tests {
     }
 
     #[test]
+    fn a_suggested_tempo_the_page_carries_is_preferred_over_the_heuristic() {
+        let draft = read_fields(&suggested_page(SuggestedFields {
+            tempo_marking: Some("Moderato".to_string()),
+            bpm: Some(120),
+            ..no_suggestions()
+        }));
+        let tempo = draft.tempo.expect("a tempo");
+        assert_eq!(tempo.value.marking.as_deref(), Some("Moderato"));
+        assert_eq!(tempo.value.bpm, Some(120));
+        assert_eq!(tempo.source, DraftSource::Suggested);
+    }
+
+    /// Deleting the length check hands the create form a title it will reject,
+    /// which the table test guards from the other side.
+    #[test]
+    fn a_suggestion_longer_than_the_field_allows_is_discarded() {
+        let long = "La ".repeat(MAX_TITLE);
+        let draft = read_fields(&PageReading {
+            lines: vec![line(&long, 0.08, 0.09)],
+            suggested: Some(SuggestedFields {
+                title: Some(long.clone()),
+                ..no_suggestions()
+            }),
+        });
+        assert!(draft.title.is_none(), "too long for the form either way");
+    }
+
+    #[test]
     fn suggestions_never_replace_a_field_they_left_empty() {
         let draft = read_fields(&suggested_page(no_suggestions()));
         assert_eq!(draft, read_fields(&printed_page()));
@@ -923,6 +951,44 @@ mod tests {
                     photo_id: PHOTO.to_string()
                 }
             );
+        }
+
+        /// The id correlation is only worth anything if the effect's own
+        /// resolution carries it: deleting the capture in `read_page`'s closure
+        /// leaves the event naming a photo the core never asked about.
+        #[test]
+        fn resolving_the_effect_sends_back_the_photo_it_asked_for() {
+            let mut cmd = crate::recognition::read_page(PHOTO.to_string());
+            let mut request = cmd
+                .effects()
+                .find_map(|e| match e {
+                    Effect::Recognition(req) => Some(req),
+                    _ => None,
+                })
+                .expect("a Recognition effect");
+
+            request
+                .resolve(RecognitionOutput::Unsupported)
+                .expect("the shell resolves this once");
+
+            let Some(Event::PhotoRead { photo_id, output }) = cmd.events().next() else {
+                panic!("resolving should send PhotoRead");
+            };
+            assert_eq!(photo_id, PHOTO);
+            assert_eq!(output, RecognitionOutput::Unsupported);
+        }
+
+        /// The screens show a spinner off this, so `Reading` has to reach the
+        /// projection and not only the model.
+        #[test]
+        fn a_read_in_progress_is_visible_in_the_view() {
+            let mut model = Model::test_default();
+            let _ = read_photo(&mut model);
+
+            let view = Intrada.view(&model).photo_recognition;
+            assert_eq!(view.status, PhotoRecognitionStatus::Reading);
+            assert_eq!(view.photo_id.as_deref(), Some(PHOTO));
+            assert!(view.draft.is_none());
         }
 
         /// Offline-first invariant 1: recognition is on-device, end to end.

--- a/crates/intrada-core/src/recognition.rs
+++ b/crates/intrada-core/src/recognition.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::{Effect, Event};
 use crate::domain::types::Tempo;
-use crate::validation::{MAX_BPM, MAX_COMPOSER, MAX_TEMPO_MARKING, MAX_TITLE, MIN_BPM};
+use crate::validation::{MAX_BPM, MAX_COMPOSER, MAX_NOTES, MAX_TEMPO_MARKING, MAX_TITLE};
 
 // ── The effect contract ─────────────────────────────────────────────
 
@@ -118,9 +118,19 @@ pub enum DraftSource {
 /// Below this a read is shown as uncertain rather than hidden (decision 7).
 pub const LOW_CONFIDENCE: f32 = 0.5;
 
+/// `MIN_BPM` is the floor for a tempo the user *typed*. One guessed off a page
+/// can be stricter: nobody prints a five-beats-a-minute marking, so a number
+/// that low is a bar count or a fingering that happened to follow an `=`.
+const MIN_READ_BPM: u16 = 20;
+
 pub fn read_page(photo_id: String) -> Command<Effect, Event> {
-    Command::request_from_shell(RecognitionOperation::ReadPage { photo_id })
-        .then_send(Event::PhotoRead)
+    let read = photo_id.clone();
+    Command::request_from_shell(RecognitionOperation::ReadPage { photo_id }).then_send(
+        move |output| Event::PhotoRead {
+            photo_id: read.clone(),
+            output,
+        },
+    )
 }
 
 // ── Interpretation ──────────────────────────────────────────────────
@@ -128,6 +138,34 @@ pub fn read_page(photo_id: String) -> Command<Effect, Event> {
 /// Tempo markings we will name from a page, longest first so
 /// "Allegro moderato" wins over "Allegro". Canonical spelling is ours, not the
 /// page's: OCR reads `ALLEGRO` and the user should see `Allegro`.
+/// Words that can stand beside a marking without making the line something
+/// other than a tempo instruction: "Medium Swing", "Lento ma non troppo".
+const TEMPO_QUALIFIERS: &[&str] = &[
+    "slow",
+    "slowly",
+    "medium",
+    "med",
+    "fast",
+    "up",
+    "easy",
+    "moderately",
+    "very",
+    "molto",
+    "poco",
+    "ma",
+    "non",
+    "troppo",
+    "e",
+    "con",
+    "quasi",
+    "tempo",
+    "di",
+    "bpm",
+    "feel",
+    "circa",
+    "ca",
+];
+
 const TEMPO_MARKINGS: &[&str] = &[
     "Allegro moderato",
     "Allegro vivace",
@@ -159,6 +197,10 @@ const TEMPO_MARKINGS: &[&str] = &[
     "Latin",
     "Rubato",
 ];
+
+/// A credit that names itself as one, and so needs no damping and no help from
+/// where it sits on the page.
+const EXPLICIT_CREDIT: f32 = 1.0;
 
 /// Credit prefixes, longest first. The `f32` is how much the match dampens the
 /// line's own OCR confidence: a bare `by` is a weaker claim than `Music by`.
@@ -198,7 +240,7 @@ pub fn read_fields(page: &PageReading) -> PhotoDraft {
         composer: clamped_text(suggested.composer.as_deref(), &haystack, MAX_COMPOSER)
             .or(heuristic.composer),
         tempo: clamped_tempo(suggested, &haystack).or(heuristic.tempo),
-        chart_text: clamped_text(suggested.chart_text.as_deref(), &haystack, usize::MAX)
+        chart_text: clamped_text(suggested.chart_text.as_deref(), &haystack, MAX_NOTES)
             .or(heuristic.chart_text),
     }
 }
@@ -230,7 +272,7 @@ fn clamped_tempo(suggested: &SuggestedFields, haystack: &str) -> Option<TempoDra
     .map(|f| f.value);
     let bpm = suggested
         .bpm
-        .filter(|bpm| (MIN_BPM..=MAX_BPM).contains(bpm))
+        .filter(|bpm| (MIN_READ_BPM..=MAX_BPM).contains(bpm))
         .filter(|bpm| haystack.contains(&bpm.to_string()));
 
     Tempo::from_parts(marking, bpm).map(|value| TempoDraftField {
@@ -264,7 +306,7 @@ fn heuristic_title(lines: &[RecognisedLine]) -> Option<TextDraftField> {
         .filter(|l| l.y < TITLE_BAND)
         .filter(|l| !l.text.trim().is_empty())
         .filter(|l| credit_prefix(&l.text).is_none())
-        .filter(|l| marking_in(&l.text).is_none() && bpm_in(&l.text).is_none())
+        .filter(|l| tempo_line(&l.text).is_none())
         .filter(|l| l.text.trim().len() <= MAX_TITLE)
         .max_by(|a, b| a.height.total_cmp(&b.height).then(b.y.total_cmp(&a.y)))
         .map(|l| TextDraftField {
@@ -277,6 +319,12 @@ fn heuristic_title(lines: &[RecognisedLine]) -> Option<TextDraftField> {
 fn heuristic_composer(lines: &[RecognisedLine]) -> Option<TextDraftField> {
     lines.iter().find_map(|l| {
         let (rest, damping) = credit_prefix(&l.text)?;
+        // A bare `by` is ordinary English and appears in lyrics ("By the light
+        // of the silvery moon"), so it only counts where a credit is actually
+        // printed. "Music by" is unambiguous enough to run the whole page.
+        if damping < EXPLICIT_CREDIT && l.y >= TITLE_BAND {
+            return None;
+        }
         let rest = rest.trim();
         (!rest.is_empty() && rest.len() <= MAX_COMPOSER).then(|| TextDraftField {
             value: rest.to_string(),
@@ -290,30 +338,37 @@ fn heuristic_composer(lines: &[RecognisedLine]) -> Option<TextDraftField> {
 /// confidence. Matched only at the start of the line.
 fn credit_prefix(text: &str) -> Option<(&str, f32)> {
     let trimmed = text.trim();
-    let lower = trimmed.to_lowercase();
     CREDIT_PREFIXES.iter().find_map(|(prefix, damping)| {
-        let rest = lower.strip_prefix(prefix)?;
+        // Compared on `trimmed`, not on its lowercase: `to_lowercase` is not
+        // length-preserving, so a byte index taken from one is not an index
+        // into the other.
+        let head = trimmed.get(..prefix.len())?;
+        if !head.eq_ignore_ascii_case(prefix) {
+            return None;
+        }
+        let rest = &trimmed[prefix.len()..];
         // Must be a word boundary: "Bydgoszcz Suite" is not a credit.
         if !rest.is_empty() && !rest.starts_with(|c: char| c.is_whitespace() || c == ':') {
             return None;
         }
-        let rest = &trimmed[trimmed
-            .char_indices()
-            .nth(prefix.chars().count())
-            .map_or(trimmed.len(), |(at, _)| at)..];
+        let rest = &trimmed[prefix.len()..];
         Some((rest.trim_start_matches([':', ' ', '\t']), *damping))
     })
 }
 
 fn heuristic_tempo(lines: &[RecognisedLine]) -> Option<TempoDraftField> {
-    let band: Vec<&RecognisedLine> = lines.iter().filter(|l| l.y < TITLE_BAND).collect();
+    let band: Vec<(&RecognisedLine, TempoRead)> = lines
+        .iter()
+        .filter(|l| l.y < TITLE_BAND)
+        .filter_map(|l| tempo_line(&l.text).map(|read| (l, read)))
+        .collect();
 
     let marking = band
         .iter()
-        .find_map(|l| marking_in(&l.text).map(|m| (m, l.confidence)));
+        .find_map(|(l, read)| read.marking.clone().map(|m| (m, l.confidence)));
     let bpm = band
         .iter()
-        .find_map(|l| bpm_in(&l.text).map(|b| (b, l.confidence)));
+        .find_map(|(l, read)| read.bpm.map(|b| (b, l.confidence)));
 
     let confidence = match (&marking, &bpm) {
         (Some((_, a)), Some((_, b))) => a.min(*b),
@@ -328,26 +383,50 @@ fn heuristic_tempo(lines: &[RecognisedLine]) -> Option<TempoDraftField> {
     })
 }
 
-fn marking_in(text: &str) -> Option<String> {
-    let lower = text.to_lowercase();
-    TEMPO_MARKINGS.iter().find_map(|marking| {
-        let needle = marking.to_lowercase();
-        lower
-            .match_indices(&needle)
-            .any(|(at, _)| {
-                let before_ok = at == 0
-                    || !lower[..at]
-                        .chars()
-                        .next_back()
-                        .is_some_and(char::is_alphanumeric);
-                let after_ok = !lower[at + needle.len()..]
-                    .chars()
-                    .next()
-                    .is_some_and(char::is_alphanumeric);
-                before_ok && after_ok
-            })
-            .then(|| (*marking).to_string())
-    })
+/// What the line says, if it is a tempo instruction and nothing else.
+///
+/// A marking *inside* a longer line belongs to a title — "Allegro Barbaro",
+/// "Swing Low, Sweet Chariot", "Ballad of the Sad Young Men" — and reading it
+/// as a tempo costs the title as well, since a title line is skipped once it
+/// has explained itself as a tempo.
+fn tempo_line(text: &str) -> Option<TempoRead> {
+    let bpm = bpm_in(text);
+    let before_bpm = text.rsplit_once('=').map_or(text, |(before, _)| before);
+    let words: Vec<String> = before_bpm
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|w| !w.is_empty())
+        .map(str::to_lowercase)
+        .collect();
+
+    let mut marking = None;
+    let mut rest: Vec<&str> = words.iter().map(String::as_str).collect();
+    for candidate in TEMPO_MARKINGS {
+        let needle: Vec<String> = candidate
+            .to_lowercase()
+            .split(' ')
+            .map(String::from)
+            .collect();
+        if let Some(at) = rest.windows(needle.len()).position(|w| w == needle) {
+            marking = Some((*candidate).to_string());
+            rest.drain(at..at + needle.len());
+            break;
+        }
+    }
+
+    // A leftover single character is the note glyph Vision mangled out of
+    // `♩=`; anything longer is a word this line is really about.
+    let only_qualifiers = rest
+        .iter()
+        .all(|w| w.chars().count() == 1 || TEMPO_QUALIFIERS.contains(w));
+
+    (only_qualifiers && (marking.is_some() || bpm.is_some())).then_some(TempoRead { marking, bpm })
+}
+
+/// What a tempo-only line says. Both parts are optional because a line can
+/// carry either half on its own: `Andante`, or a bare `= 120`.
+struct TempoRead {
+    marking: Option<String>,
+    bpm: Option<u16>,
 }
 
 /// Only a number that follows an `=` counts. `♩= 120` OCRs with the glyph
@@ -364,7 +443,7 @@ fn bpm_in(text: &str) -> Option<u16> {
     digits
         .parse::<u16>()
         .ok()
-        .filter(|bpm| (MIN_BPM..=MAX_BPM).contains(bpm))
+        .filter(|bpm| (MIN_READ_BPM..=MAX_BPM).contains(bpm))
 }
 
 #[cfg(test)]
@@ -494,6 +573,28 @@ mod tests {
         );
     }
 
+    /// Deleting the band check on a bare `by` reads the lyric as the composer,
+    /// at a confidence high enough that the form would not even mark it as a
+    /// weak read.
+    #[test]
+    fn a_lyric_that_starts_with_by_is_not_a_composer() {
+        let draft = read_fields(&page(vec![
+            line("Moon River", 0.08, 0.09),
+            line("By the light of the silvery moon she waits", 0.72, 0.03),
+        ]));
+        assert!(draft.composer.is_none());
+        assert_eq!(draft.title.expect("a title").value, "Moon River");
+    }
+
+    #[test]
+    fn an_explicit_credit_is_read_wherever_it_is_printed() {
+        let draft = read_fields(&page(vec![
+            line("Moon River", 0.08, 0.09),
+            line("Music by Henry Mancini", 0.88, 0.03),
+        ]));
+        assert_eq!(draft.composer.expect("a composer").value, "Henry Mancini");
+    }
+
     #[test]
     fn a_credit_with_no_name_after_it_is_not_a_composer() {
         let draft = read_fields(&page(vec![line("Music by", 0.2, 0.03)]));
@@ -527,6 +628,39 @@ mod tests {
         );
     }
 
+    /// Deleting the whole-line requirement in `tempo_line` costs both fields at
+    /// once: the tempo is invented, and the title it was invented from is
+    /// skipped as a line that has already explained itself.
+    #[test]
+    fn a_title_containing_a_marking_word_stays_a_title() {
+        for title in [
+            "Swing Low, Sweet Chariot",
+            "Ballad of the Sad Young Men",
+            "Allegro Barbaro",
+            "Latin Jazz Suite",
+        ] {
+            let draft = read_fields(&page(vec![line(title, 0.08, 0.09)]));
+            assert_eq!(draft.title.map(|f| f.value).as_deref(), Some(title));
+            assert!(draft.tempo.is_none(), "{title:?} is not a tempo marking");
+        }
+    }
+
+    #[test]
+    fn a_marking_still_reads_beside_the_words_that_qualify_it() {
+        for (text, expected) in [
+            ("Medium Swing", "Swing"),
+            ("Slow Ballad", "Ballad"),
+            ("Lento ma non troppo", "Lento"),
+        ] {
+            let draft = read_fields(&page(vec![line(text, 0.2, 0.03)]));
+            assert_eq!(
+                draft.tempo.expect("a tempo").value.marking.as_deref(),
+                Some(expected),
+                "reading {text:?}"
+            );
+        }
+    }
+
     /// Open question 3, answered conservatively. Deleting the `=` requirement
     /// reads the page number as a tempo.
     #[test]
@@ -538,9 +672,11 @@ mod tests {
         assert!(draft.tempo.is_none());
     }
 
+    /// Deleting the floor reads a fingering or a bar count that happened to
+    /// follow an `=` as a tempo nobody could play.
     #[test]
     fn a_bpm_outside_the_accepted_range_is_dropped() {
-        for text in ["= 0", "= 900", "= 40000"] {
+        for text in ["= 0", "= 5", "= 900", "= 40000"] {
             let draft = read_fields(&page(vec![line(text, 0.2, 0.03)]));
             assert!(draft.tempo.is_none(), "reading {text:?}");
         }
@@ -663,6 +799,22 @@ mod tests {
                 ]),
             ),
             (
+                "title made of a genre word",
+                page(vec![
+                    line("Swing Low, Sweet Chariot", 0.07, 0.08),
+                    line("Traditional", 0.18, 0.03),
+                    line("Medium Swing", 0.26, 0.02),
+                ]),
+            ),
+            (
+                "lyric that opens with by",
+                page(vec![
+                    line("Moon River", 0.06, 0.09),
+                    line("Music by Henry Mancini", 0.16, 0.03),
+                    line("By the light of the silvery moon she waits", 0.62, 0.04),
+                ]),
+            ),
+            (
                 "skewed capture, title not first in reading order",
                 page(vec![
                     line("Swing", 0.22, 0.02),
@@ -740,6 +892,13 @@ mod tests {
 
         const PHOTO: &str = "01JB0000000000000000000000";
 
+        fn photo_read(output: RecognitionOutput) -> Event {
+            Event::PhotoRead {
+                photo_id: PHOTO.to_string(),
+                output,
+            }
+        }
+
         fn read_photo(model: &mut Model) -> crux_core::Command<Effect, Event> {
             Intrada.update(
                 Event::Item(ItemEvent::ReadPhoto {
@@ -793,7 +952,7 @@ mod tests {
             let mut model = Model::test_default();
             let _ = read_photo(&mut model);
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut model,
             );
 
@@ -814,7 +973,7 @@ mod tests {
             let mut sharp = Model::test_default();
             let _ = read_photo(&mut sharp);
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut sharp,
             );
             assert!(!Intrada.view(&sharp).photo_recognition.has_low_confidence);
@@ -824,7 +983,7 @@ mod tests {
             let mut lines = printed_page().lines;
             lines[0].confidence = 0.2;
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(page(lines))),
+                photo_read(RecognitionOutput::Page(page(lines))),
                 &mut blurry,
             );
             assert!(Intrada.view(&blurry).photo_recognition.has_low_confidence);
@@ -836,7 +995,7 @@ mod tests {
         fn a_device_without_recognition_is_an_outcome_not_an_error() {
             let mut model = Model::test_default();
             let _ = read_photo(&mut model);
-            let _ = Intrada.update(Event::PhotoRead(RecognitionOutput::Unsupported), &mut model);
+            let _ = Intrada.update(photo_read(RecognitionOutput::Unsupported), &mut model);
 
             assert_eq!(
                 Intrada.view(&model).photo_recognition.status,
@@ -849,11 +1008,42 @@ mod tests {
         fn a_failed_read_is_surfaced_as_failed_not_as_an_empty_draft() {
             let mut model = Model::test_default();
             let _ = read_photo(&mut model);
-            let _ = Intrada.update(Event::PhotoRead(RecognitionOutput::Failed), &mut model);
+            let _ = Intrada.update(photo_read(RecognitionOutput::Failed), &mut model);
 
             let view = Intrada.view(&model).photo_recognition;
             assert_eq!(view.status, PhotoRecognitionStatus::Failed);
             assert!(view.draft.is_none());
+        }
+
+        /// Two scans in flight: the first to resolve must not land on the
+        /// second's photo. Deleting the id comparison shows photo B beside the
+        /// fields read off photo A, on the surface the user presses Add from.
+        #[test]
+        fn a_read_never_lands_on_a_photo_it_did_not_come_from() {
+            const OTHER: &str = "01JB0000000000000000000001";
+            let mut model = Model::test_default();
+
+            let _ = read_photo(&mut model);
+            let _ = Intrada.update(
+                Event::Item(ItemEvent::ReadPhoto {
+                    photo_id: OTHER.to_string(),
+                }),
+                &mut model,
+            );
+
+            // The first scan resolves second, as the slower page would.
+            let _ = Intrada.update(
+                photo_read(RecognitionOutput::Page(printed_page())),
+                &mut model,
+            );
+
+            assert_eq!(
+                model.photo_recognition,
+                PhotoRecognition::Reading {
+                    photo_id: OTHER.to_string()
+                },
+                "the current read must survive its predecessor landing"
+            );
         }
 
         /// Deleting the `Reading` guard lets a read the user walked away from
@@ -864,7 +1054,7 @@ mod tests {
             let _ = read_photo(&mut model);
             let _ = Intrada.update(Event::DiscardPhotoDraft, &mut model);
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut model,
             );
             assert_eq!(model.photo_recognition, PhotoRecognition::Idle);
@@ -875,7 +1065,7 @@ mod tests {
             let mut model = Model::test_default();
             let _ = read_photo(&mut model);
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut model,
             );
             let _ = Intrada.update(Event::DiscardPhotoDraft, &mut model);
@@ -895,7 +1085,7 @@ mod tests {
             assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
 
             let mut cmd = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut model,
             );
             assert!(!cmd.effects().any(|e| matches!(e, Effect::Persistence(_))));
@@ -907,7 +1097,7 @@ mod tests {
             assert_round_trips(Event::Item(ItemEvent::ReadPhoto {
                 photo_id: PHOTO.to_string(),
             }));
-            assert_round_trips(Event::PhotoRead(RecognitionOutput::Unsupported));
+            assert_round_trips(photo_read(RecognitionOutput::Unsupported));
             assert_round_trips(Event::DiscardPhotoDraft);
         }
 
@@ -916,7 +1106,7 @@ mod tests {
             let mut model = Model::test_default();
             let _ = read_photo(&mut model);
             let _ = Intrada.update(
-                Event::PhotoRead(RecognitionOutput::Page(printed_page())),
+                photo_read(RecognitionOutput::Page(printed_page())),
                 &mut model,
             );
             assert_round_trips(Intrada.view(&model).photo_recognition);

--- a/crates/intrada-core/src/validation.rs
+++ b/crates/intrada-core/src/validation.rs
@@ -360,9 +360,6 @@ pub fn validate_rep_consistency(
     Ok(())
 }
 
-/// The host half of `validate_link_exercise`: the id names an item that exists
-/// and is a piece. Shared with `AddLinkedExercise`, where the exercise does not
-/// exist yet and so only this half can run.
 /// A photo id becomes a path component in the shell, so a value that is not a
 /// ulid is a traversal out of the app container (`specs/piece-from-photo.md`).
 /// The core is the only layer that can refuse it before it is stored.
@@ -376,6 +373,9 @@ pub fn validate_photo_id(photo_id: &str) -> Result<(), LibraryError> {
     Ok(())
 }
 
+/// The host half of `validate_link_exercise`: the id names an item that exists
+/// and is a piece. Shared with `AddLinkedExercise`, where the exercise does not
+/// exist yet and so only this half can run.
 pub fn validate_piece_host(piece_id: &str, model: &Model) -> Result<(), LibraryError> {
     let piece = model
         .items

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,18 @@ audit backlog and its five-phase build order.
 
 ## In flight
 
+- #1436 — **reading a photographed page into title, composer and tempo**.
+  Phase B of [`specs/piece-from-photo.md`](../specs/piece-from-photo.md), core
+  PR first. It adds the `RecognitionOperation` effect, Vision text recognition
+  in the shell as a dumb pipe, and `read_fields` in the core: the largest text
+  in the top band is the title, a `Music by` line is the composer, a tempo word
+  or a number after an `=` is the tempo. A model suggestion (phase C) is only
+  ever accepted when it appears verbatim on the page, so it can choose but
+  never invent. Nothing is written without the user pressing Add. The screens
+  follow in a second PR now that spec open question 2 is answered:
+  recognition **pre-fills the add form**, it does not open a confirm sheet of
+  its own, which also unblocks #1446.
+
 - #1420, the tempo trend, was the last of the adopted order's numbered
   steps with anything to construct: steps 1 to 8 are done and steps 9 to 11 are
   each a fresh decision gated on lived use, not queued work. What *is* running
@@ -259,6 +271,11 @@ audit backlog and its five-phase build order.
   finding stands: chord symbols on a stave are text so OCR reads them, but
   barlines are graphics, so a lead sheet gives no bar structure and
   `parse_chart` needs bars above all else. That half is a spike (#1438),
-  explicitly not a phase. Design conversation due before #1436's screens —
-  spec open question 2, whether recognition opens its own confirm sheet or
-  pre-fills `ItemFormScaffold`, which #1446 is also waiting on.
+  explicitly not a phase. Spec open question 2 is now answered (Jon,
+  2026-08-29): recognition pre-fills `ItemFormScaffold` on the add path rather
+  than opening a confirm sheet, which is what #1446 was waiting on. What is
+  left for the design conversation before #1436's screens is narrower — how a
+  recognised field is marked, whether a weak read is marked differently again,
+  and whether the mark clears once the user edits it. Open question 3 is
+  answered too: a bpm is only read when it follows an `=`, never from a bare
+  number, which would as often be a page or bar number.

--- a/ios/Intrada/Core/CoreBridge.swift
+++ b/ios/Intrada/Core/CoreBridge.swift
@@ -8,6 +8,7 @@ protocol CoreBridge {
   func update(_ event: Event) throws -> [Request]
   func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request]
   func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request]
+  func resolve(_ id: UInt32, recognitionOutput: RecognitionOutput) throws -> [Request]
   func resolveEmpty(_ id: UInt32) throws -> [Request]
   func view() throws -> ViewModel
 }

--- a/ios/Intrada/Core/LiveBridge.swift
+++ b/ios/Intrada/Core/LiveBridge.swift
@@ -23,6 +23,11 @@ final class LiveBridge: CoreBridge {
     return try Requests.bincodeDeserialize(input: [UInt8](out)).value
   }
 
+  func resolve(_ id: UInt32, recognitionOutput: RecognitionOutput) throws -> [Request] {
+    let out = try core.resolve(id: id, data: Data(try recognitionOutput.bincodeSerialize()))
+    return try Requests.bincodeDeserialize(input: [UInt8](out)).value
+  }
+
   func resolveEmpty(_ id: UInt32) throws -> [Request] {
     let out = try core.resolve(id: id, data: Data())
     return try Requests.bincodeDeserialize(input: [UInt8](out)).value

--- a/ios/Intrada/Core/PageReader.swift
+++ b/ios/Intrada/Core/PageReader.swift
@@ -19,17 +19,13 @@ enum PageReader {
 
   @MainActor
   static func read(photoId: String) async -> RecognitionOutput {
-    guard let source = try? PhotoFileStore.url(for: photoId),
-      let image = UIImage(contentsOfFile: source.path),
-      let cgImage = image.cgImage
-    else {
-      return .failed
-    }
+    guard let source = try? PhotoFileStore.url(for: photoId) else { return .failed }
 
-    // Vision blocks for the best part of a second on a full page, so it runs
-    // off the main actor and only the plain values come back.
+    // Decoding a 2048px JPEG and running Vision over it both block for long
+    // enough to drop frames, so the whole job runs off the main actor and only
+    // the plain values come back.
     guard
-      let lines = await Task.detached(priority: .userInitiated, operation: { recognise(cgImage) })
+      let lines = await Task.detached(priority: .userInitiated, operation: { read(from: source) })
         .value
     else {
       return .failed
@@ -47,6 +43,13 @@ enum PageReader {
         suggested: nil
       )
     )
+  }
+
+  private nonisolated static func read(from source: URL) -> [TextLine]? {
+    guard let image = UIImage(contentsOfFile: source.path), let cgImage = image.cgImage else {
+      return nil
+    }
+    return recognise(cgImage)
   }
 
   private nonisolated static func recognise(_ cgImage: CGImage) -> [TextLine]? {

--- a/ios/Intrada/Core/PageReader.swift
+++ b/ios/Intrada/Core/PageReader.swift
@@ -1,0 +1,84 @@
+import SharedTypes
+import UIKit
+import Vision
+
+/// Runs Vision text recognition over a stored page and hands the core lines
+/// with geometry. Owns no interpretation: what a line *means* is
+/// `recognition::read_fields` in the core (spec decision 4).
+enum PageReader {
+  /// What crosses back from the recognition thread. The generated bridge types
+  /// are not `Sendable`, so they are built on the main actor from this.
+  private struct TextLine: Sendable {
+    let text: String
+    let x: Float
+    let y: Float
+    let width: Float
+    let height: Float
+    let confidence: Float
+  }
+
+  @MainActor
+  static func read(photoId: String) async -> RecognitionOutput {
+    guard let source = try? PhotoFileStore.url(for: photoId),
+      let image = UIImage(contentsOfFile: source.path),
+      let cgImage = image.cgImage
+    else {
+      return .failed
+    }
+
+    // Vision blocks for the best part of a second on a full page, so it runs
+    // off the main actor and only the plain values come back.
+    guard
+      let lines = await Task.detached(priority: .userInitiated, operation: { recognise(cgImage) })
+        .value
+    else {
+      return .failed
+    }
+
+    return .page(
+      PageReading(
+        lines: lines.map {
+          RecognisedLine(
+            text: $0.text, x: $0.x, y: $0.y, width: $0.width, height: $0.height,
+            confidence: $0.confidence)
+        },
+        // Phase C fills this from Foundation Models; the core produces a usable
+        // draft without it on every device we target (spec decision 6).
+        suggested: nil
+      )
+    )
+  }
+
+  private nonisolated static func recognise(_ cgImage: CGImage) -> [TextLine]? {
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    // A title is as often Italian or German as English.
+    request.automaticallyDetectsLanguage = true
+    // A stave is not a paragraph: correcting against a lexicon turns chord
+    // symbols and tempo markings into ordinary words.
+    request.usesLanguageCorrection = false
+
+    do {
+      try VNImageRequestHandler(cgImage: cgImage, options: [:]).perform([request])
+    } catch {
+      report(error, "page-recognition")
+      return nil
+    }
+
+    return (request.results ?? []).compactMap(line(from:))
+  }
+
+  /// Vision normalises to origin bottom-left; the core's contract is top-left.
+  private nonisolated static func line(from observation: VNRecognizedTextObservation) -> TextLine? {
+    guard let candidate = observation.topCandidates(1).first else { return nil }
+    let box = observation.boundingBox
+    return TextLine(
+      text: candidate.string,
+      x: Float(box.origin.x),
+      y: Float(1 - (box.origin.y + box.size.height)),
+      width: Float(box.size.width),
+      height: Float(box.size.height),
+      confidence: candidate.confidence
+    )
+  }
+}

--- a/ios/Intrada/Core/Store.swift
+++ b/ios/Intrada/Core/Store.swift
@@ -57,8 +57,19 @@ final class Store {
       case .persistence(let operation):
         let output = persistenceOutput(for: operation)
         process(guarded { try bridge.resolve(request.id, persistenceOutput: output) } ?? [])
+      case .recognition(let operation):
+        Task { await self.handleRecognition(operation, id: request.id) }
       }
     }
+  }
+
+  private func handleRecognition(_ operation: RecognitionOperation, id: UInt32) async {
+    let output: RecognitionOutput
+    switch operation {
+    case .readPage(let photoId):
+      output = await PageReader.read(photoId: photoId)
+    }
+    process(guarded { try bridge.resolve(id, recognitionOutput: output) } ?? [])
   }
 
   private func refreshView() {

--- a/ios/Intrada/DesignSystem/PreviewSupport.swift
+++ b/ios/Intrada/DesignSystem/PreviewSupport.swift
@@ -110,6 +110,7 @@
     func update(_ event: Event) throws -> [Request] { [] }
     func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request] { [] }
     func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] { [] }
+    func resolve(_ id: UInt32, recognitionOutput: RecognitionOutput) throws -> [Request] { [] }
     func resolveEmpty(_ id: UInt32) throws -> [Request] { [] }
     func view() throws -> ViewModel {
       var viewModel = try ViewModel.bincodeDeserialize(input: [UInt8](core.view()))

--- a/ios/IntradaTests/PageReaderTests.swift
+++ b/ios/IntradaTests/PageReaderTests.swift
@@ -1,0 +1,90 @@
+import SharedTypes
+import Testing
+import UIKit
+
+@testable import Intrada
+
+/// Vision against a page we drew ourselves. The core's heuristics are tested in
+/// Rust with no device; what can only be checked here is that the shell hands
+/// the core the geometry it promised — Vision normalises from the bottom left
+/// and `RecognisedLine` is documented top-left.
+@MainActor
+struct PageReaderTests {
+  private func discard(_ photoId: String) {
+    guard let url = try? PhotoFileStore.url(for: photoId) else { return }
+    try? FileManager.default.removeItem(at: url)
+  }
+
+  /// A title band across the top and a credit line below it, at known heights.
+  private func page(title: String, credit: String) -> UIImage {
+    let size = CGSize(width: 1000, height: 1400)
+    let format = UIGraphicsImageRendererFormat.default()
+    format.scale = 1
+    return UIGraphicsImageRenderer(size: size, format: format).image { context in
+      UIColor.white.setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+      title.draw(
+        at: CGPoint(x: 80, y: 90),
+        withAttributes: [.font: UIFont.systemFont(ofSize: 96), .foregroundColor: UIColor.black])
+      credit.draw(
+        at: CGPoint(x: 80, y: 1180),
+        withAttributes: [.font: UIFont.systemFont(ofSize: 40), .foregroundColor: UIColor.black])
+    }
+  }
+
+  private func lines(from output: RecognitionOutput) throws -> [RecognisedLine] {
+    guard case .page(let reading) = output else {
+      Issue.record("expected a page reading, got \(output)")
+      return []
+    }
+    return reading.lines
+  }
+
+  @Test func readsTheTextOnAPage() async throws {
+    let photoId = Ulid.generate()
+    defer { discard(photoId) }
+    try PhotoFileStore.write(page(title: "Autumn Leaves", credit: "Music by Kosma"), id: photoId)
+
+    let read = try lines(from: await PageReader.read(photoId: photoId))
+
+    #expect(read.contains { $0.text.contains("Autumn") })
+    #expect(read.contains { $0.text.contains("Kosma") })
+  }
+
+  /// The whole reason the shell flips the origin: `read_fields` calls the top
+  /// of the page `y` near 0, and picks the title out of that band. Drop the
+  /// flip and the title reads as the bottom of the page.
+  @Test func geometryIsNormalisedFromTheTopLeft() async throws {
+    let photoId = Ulid.generate()
+    defer { discard(photoId) }
+    try PhotoFileStore.write(page(title: "Autumn Leaves", credit: "Music by Kosma"), id: photoId)
+
+    let read = try lines(from: await PageReader.read(photoId: photoId))
+    let title = try #require(read.first { $0.text.contains("Autumn") })
+    let credit = try #require(read.first { $0.text.contains("Kosma") })
+
+    #expect(title.y < 0.4, "the title sits in the band read_fields looks in")
+    #expect(credit.y > title.y, "the credit is printed below the title")
+  }
+
+  /// The title is set at more than twice the credit's point size, and
+  /// `read_fields` picks the title by exactly this.
+  @Test func lineHeightTracksThePrintedTextSize() async throws {
+    let photoId = Ulid.generate()
+    defer { discard(photoId) }
+    try PhotoFileStore.write(page(title: "Autumn Leaves", credit: "Music by Kosma"), id: photoId)
+
+    let read = try lines(from: await PageReader.read(photoId: photoId))
+    let title = try #require(read.first { $0.text.contains("Autumn") })
+    let credit = try #require(read.first { $0.text.contains("Kosma") })
+
+    #expect(title.height > credit.height)
+  }
+
+  /// Phase A leaves bytes on disk but the core can still name an id nothing was
+  /// written for. That is `Failed`, never an empty page that reads as a blank.
+  @Test func anIdWithNoBytesFails() async {
+    let output = await PageReader.read(photoId: Ulid.generate())
+    #expect(output == .failed)
+  }
+}

--- a/ios/IntradaTests/ScreenSnapshotTests.swift
+++ b/ios/IntradaTests/ScreenSnapshotTests.swift
@@ -11,6 +11,7 @@ private final class StubBridge: CoreBridge {
   func update(_ event: Event) throws -> [Request] { [] }
   func resolve(_ id: UInt32, httpResult: HttpResult) throws -> [Request] { [] }
   func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] { [] }
+  func resolve(_ id: UInt32, recognitionOutput: RecognitionOutput) throws -> [Request] { [] }
   func resolveEmpty(_ id: UInt32) throws -> [Request] { [] }
   func view() throws -> ViewModel {
     try ViewModel.bincodeDeserialize(input: [UInt8](core.view()))

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -495,8 +495,10 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertEqual(
       try XCTUnwrap(draft.title?.confidence), Float(0.93), accuracy: 0.0001,
       "an f32 has to survive the wire, not arrive as a rounded or byte-swapped number")
+    XCTAssertFalse(draft.title?.weak ?? true, "the title was read cleanly")
+    XCTAssertTrue(draft.composer?.weak ?? false, "the credit was read weakly")
     XCTAssertTrue(
-      recognition.hasLowConfidence, "the credit was read weakly and the form must say so")
+      recognition.hasLowConfidence, "and the form must say so for the draft as a whole")
   }
 
   /// The shell mints a photo's id (offline-first invariant 3) and the core

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -454,6 +454,51 @@ final class StoreEffectLoopTests: XCTestCase {
       "an absent Option must decode as absent, not as the previous value")
   }
 
+  /// Every recognition type is new on the bincode wire, and `f32` is a new
+  /// scalar on it. A stub bridge cannot catch a wire break (#846), so this
+  /// drives the whole round trip: the effect out, a `RecognitionOutput` built
+  /// in Swift back in, and the draft the form will read out of the projection.
+  func testRealBridgeReadPhotoFillsTheDraft() throws {
+    let bridge = LiveBridge()
+    _ = try bridge.update(.startApp(apiBaseUrl: "http://localhost:3001", localFirst: true))
+    let photoId = Ulid.generate()
+
+    let requests = try bridge.update(.item(.readPhoto(photoId: photoId)))
+    let request = try XCTUnwrap(
+      requests.first { if case .recognition = $0.effect { return true } else { return false } },
+      "readPhoto should emit a Recognition effect")
+    guard case .recognition(.readPage(let asked)) = request.effect else {
+      return XCTFail("expected readPage, got \(request.effect)")
+    }
+    XCTAssertEqual(asked, photoId, "the core names the file the shell just wrote")
+
+    _ = try bridge.resolve(
+      request.id,
+      recognitionOutput: .page(
+        PageReading(
+          lines: [
+            RecognisedLine(
+              text: "Autumn Leaves", x: 0.1, y: 0.08, width: 0.8, height: 0.09, confidence: 0.93),
+            RecognisedLine(
+              text: "Music by Joseph Kosma", x: 0.1, y: 0.18, width: 0.8, height: 0.03,
+              confidence: 0.4),
+          ],
+          suggested: nil)))
+
+    let recognition = try bridge.view().photoRecognition
+    XCTAssertEqual(recognition.status, .ready)
+    XCTAssertEqual(recognition.photoId, photoId)
+    let draft = try XCTUnwrap(recognition.draft)
+    XCTAssertEqual(draft.title?.value, "Autumn Leaves")
+    XCTAssertEqual(draft.composer?.value, "Joseph Kosma")
+    XCTAssertEqual(draft.title?.source, .recognised)
+    XCTAssertEqual(
+      try XCTUnwrap(draft.title?.confidence), Float(0.93), accuracy: 0.0001,
+      "an f32 has to survive the wire, not arrive as a rounded or byte-swapped number")
+    XCTAssertTrue(
+      recognition.hasLowConfidence, "the credit was read weakly and the form must say so")
+  }
+
   /// The shell mints a photo's id (offline-first invariant 3) and the core
   /// refuses any id that is not a ulid, so `Ulid` and Rust's parser have to
   /// agree.

--- a/ios/IntradaTests/StoreEffectLoopTests.swift
+++ b/ios/IntradaTests/StoreEffectLoopTests.swift
@@ -109,6 +109,22 @@ final class StoreEffectLoopTests: XCTestCase {
     XCTAssertTrue(items.isEmpty, "fresh in-memory store has no rows")
   }
 
+  /// The shell's whole job on this effect: run Vision, hand the core back a
+  /// `RecognitionOutput`, decide nothing. An id with no bytes behind it is
+  /// `Failed`, never a page of no lines (which the core would read as a blank).
+  func testRecognitionResolvesFailedForAPhotoThatIsNotOnDisk() async {
+    let bridge = FakeBridge()
+    bridge.updateHandler = { _ in
+      [Request(id: 11, effect: .recognition(.readPage(photoId: Ulid.generate())))]
+    }
+    let store = Store(bridge: bridge, session: mockSession())
+
+    await whenResolved(bridge) { store.send(.setQuery(nil)) }
+
+    XCTAssertEqual(bridge.recognitionResolved.first?.id, 11)
+    XCTAssertEqual(bridge.recognitionResolved.first?.output, .failed)
+  }
+
   func testPersistenceWriteFailureResolvesFailed() {
     let bridge = FakeBridge()
     bridge.updateHandler = { _ in
@@ -988,6 +1004,7 @@ private final class FakeBridge: CoreBridge {
   private(set) var events: [Event] = []
   private(set) var resolved: [(id: UInt32, result: HttpResult)] = []
   private(set) var persistenceResolved: [(id: UInt32, output: PersistenceOutput)] = []
+  private(set) var recognitionResolved: [(id: UInt32, output: RecognitionOutput)] = []
   private(set) var emptyResolved: [UInt32] = []
   private(set) var viewCallCount = 0
 
@@ -1005,6 +1022,12 @@ private final class FakeBridge: CoreBridge {
 
   func resolve(_ id: UInt32, persistenceOutput: PersistenceOutput) throws -> [Request] {
     persistenceResolved.append((id, persistenceOutput))
+    onResolve?()
+    return []
+  }
+
+  func resolve(_ id: UInt32, recognitionOutput: RecognitionOutput) throws -> [Request] {
+    recognitionResolved.append((id, recognitionOutput))
     onResolve?()
     return []
   }

--- a/specs/piece-from-photo.md
+++ b/specs/piece-from-photo.md
@@ -14,7 +14,7 @@
 > native iOS only.** API/Turso out of scope.
 >
 > Status: **phase A landed** ([#1443] core, [#1449] screens; #1355 closed
-> 2026-08-29). B, C and D are unstarted. The rest is the design as written
+> 2026-08-29); **phase B core in flight** ([#1436]). C and D are unstarted. The rest is the design as written
 > 2026-08-29 from a feasibility review of the iOS on-device stack (appendix).
 
 [#1098]: https://github.com/jonyardley/intrada/issues/1098
@@ -25,6 +25,7 @@
 [#1449]: https://github.com/jonyardley/intrada/pull/1449
 [#1442]: https://github.com/jonyardley/intrada/issues/1442
 [#1446]: https://github.com/jonyardley/intrada/issues/1446
+[#1436]: https://github.com/jonyardley/intrada/issues/1436
 
 ## Problem
 
@@ -118,10 +119,12 @@ in principle and is real research. We are not betting the feature on it.
    iOS 17.0; Foundation Models needs iOS 26 *and* Apple Intelligence hardware.
    Every phase must be fully useful with Vision OCR alone, on every supported
    device. Phase C adds accuracy, never capability.
-7. **The confirm sheet is the feature.** Recognition fills a form the user
+7. **The review surface is the feature.** Recognition fills a form the user
    reviews and edits before saving. Low confidence is shown, not hidden. This
    is the design-principles "spend friction deliberately" call: one screen of
-   friction buys trust in everything behind it.
+   friction buys trust in everything behind it. *Amended 2026-08-29 (open
+   question 2): that form is `ItemFormScaffold` on the add path, not a confirm
+   sheet of its own. The substance is unchanged; only the surface is.*
 8. **Reuse `ChordChartEditSheet`, do not clone it.** Phase D's output is text
    in the existing sheet, with the existing per-token parse errors. Consolidate
    before you template.
@@ -182,14 +185,22 @@ The interpretation is one pure function, and it is where the tests live:
 /// the user confirms. Every field carries where it came from, so the sheet can
 /// show a low-confidence read differently from a clean one.
 pub struct PhotoDraft {
-    pub title: Option<DraftField<String>>,
-    pub composer: Option<DraftField<String>>,
-    pub tempo: Option<DraftField<Tempo>>,
-    pub chart_text: Option<DraftField<String>>,
+    pub title: Option<TextDraftField>,
+    pub composer: Option<TextDraftField>,
+    pub tempo: Option<TempoDraftField>,
+    pub chart_text: Option<TextDraftField>,
 }
 
-pub struct DraftField<T> {
-    pub value: T,
+/// Split per payload type rather than generic: facet typegen emits no
+/// generics across the bridge.
+pub struct TextDraftField {
+    pub value: String,
+    pub source: DraftSource,
+    pub confidence: f32,
+}
+
+pub struct TempoDraftField {
+    pub value: Tempo,
     pub source: DraftSource,
     pub confidence: f32,
 }
@@ -251,7 +262,12 @@ one worth planning against.
   read a file the core assumes is there.
 - **B. Read the page into title, composer and tempo.** The
   `RecognitionOperation` effect, Vision OCR in the shell, `read_fields` and its
-  heuristics in the core, the confirm sheet. 2 to 3 days.
+  heuristics in the core, and the recognised values pre-filling the add form
+  (open question 2). 2 to 3 days. Two departures settled during the core build:
+  `DraftField<T>` is split into `TextDraftField` / `TempoDraftField`, because
+  facet typegen emits no generics across the bridge; and `ReadPhoto` takes only
+  a `photo_id`, never an item id, since on the add path there is no item to
+  name yet.
 - **C. On-device model suggestions.** Foundation Models behind
   `SystemLanguageModel.default.availability` and `if #available(iOS 26)`,
   filling `suggested`, clamped by decision 5. Same sheet, better answers, no
@@ -270,13 +286,26 @@ actually photograph their charts.
 1. **What do people actually photograph?** The whole design assumes a mix of
    printed text charts and Real Book pages. Phase A ships a photo store, which
    means phase A also gives us the answer before D commits to a parser.
-2. **Confirm sheet or pre-filled form?** Whether recognition opens its own
-   review screen or simply pre-fills `ItemFormScaffold` with the recognised
-   values marked as suggestions. Design conversation, before B's screens PR.
-   The second reads as less ceremony and folds neatly into [#1390].
-3. **Tempo from a note glyph.** `♩= 120` is common in print and OCR mangles the
-   glyph often. Whether a bare number near the top is safe to read as bpm, or
-   whether it needs the glyph, is a question for real photographs.
+2. **Confirm sheet or pre-filled form?** ~~Whether recognition opens its own
+   review screen or simply pre-fills `ItemFormScaffold`...~~ **Answered
+   2026-08-29: pre-fill the add form; no confirm sheet.** Recognition gets no
+   new surface. `ItemFormScaffold` receives what was read, the user corrects
+   it, and pressing **Add** is what writes. **Add only, not Edit** — a piece
+   being edited already has real values, and pre-filling over them is a
+   different and worse interaction. The scan entry point sits *above* the form
+   rather than as a row inside it, which is what unblocks [#1446]. Three things
+   stay open for the design conversation before B's screens PR: how a
+   recognised field is marked, whether a low-confidence read is marked
+   differently again, and whether the mark clears once the user edits.
+   `ItemFormScaffold` has no notion of per-field provenance today, so that is
+   where the remaining design work is.
+3. **Tempo from a note glyph.** ~~Whether a bare number near the top is safe
+   to read as bpm...~~ **Answered 2026-08-29 in phase B, conservatively: the
+   number must follow an `=`, and the glyph itself is never required.** The
+   glyph OCRs to junk or vanishes; the equals survives. A bare number near the
+   top of a page is a page number or a bar number at least as often as it is a
+   tempo, so it is not read. Still worth revisiting against real photographs,
+   which is what open question 1 will give us.
 4. **Where the camera lives.** ~~Create form, detail screen, or both.~~
    **Answered 2026-08-29: the detail screen only, in phase A.** A photo row
    inside `ItemFormScaffold` cannot ride the form's own submit — `SetPhoto` was

--- a/specs/piece-from-photo.md
+++ b/specs/piece-from-photo.md
@@ -111,7 +111,11 @@ in principle and is real research. We are not betting the feature on it.
    same shape [#1098] already proposed for inference generally.
 5. **The model may choose, never invent.** Every field the on-device LLM
    suggests must appear as a substring of the OCR lines, or the core discards
-   it and falls back to its own heuristic. A ~3B model asked to extract will
+   it and falls back to its own heuristic. *Pinned in phase B: the match is
+   against all the lines joined, case- and whitespace-insensitively, not
+   per line — a name Vision wrapped across two lines must still be accepted.
+   The cost is that a suggestion may span a line boundary; that is the right
+   trade, but phase C should not assume per-line.* A ~3B model asked to extract will
    sometimes produce a plausible composer that is not on the page; this clamp
    makes that structurally impossible and is a pure function, tested in Rust
    with no device involved.


### PR DESCRIPTION
Phase B of [`specs/piece-from-photo.md`](../blob/main/specs/piece-from-photo.md), **core half**. The screens follow in a second PR. Closes nothing yet; #1436 stays open until the screens land.

## What this does

Photograph a page, and the core reads a title, a composer and a tempo out of it. The shell runs Vision and decides nothing; `read_fields` decides everything and is pure, so its tests need no device.

- **`RecognitionOperation::ReadPage { photo_id }`** resolving `RecognitionOutput` (`Page` / `Unsupported` / `Failed`). `Unsupported` is a normal outcome, not an error: the photo is still saved and the user types the fields.
- **`read_fields(&PageReading) -> PhotoDraft`**, geometry heuristics only. The largest text in the top band is the title; a `Music by` line is the composer; a tempo word or a number following an `=` is the tempo. Every field carries where it came from and how confident the read was.
- **The substring clamp** (key decision 5). A field the on-device model suggests, from phase C onward, is accepted only when it appears verbatim in the OCR text; otherwise it is discarded and the geometry heuristic stands. A model can choose, never invent, and that is structural rather than hoped for.
- **Vision in the shell** as a dumb pipe: recognised text with normalised geometry and confidence, origin flipped to top-left, nothing else.

Nothing recognised is written anywhere. The draft reaches the shell as a view projection; only the user pressing **Add** writes an item.

## Spec open questions answered

**2 — confirm sheet or pre-filled form?** Answered by Jon on the issue: recognition **pre-fills the add form**; no new surface. Folded into the spec here, ahead of the screens PR. This also unblocks #1446. What is left for the design conversation is narrower: how a recognised field is marked, whether a weak read is marked differently again, and whether the mark clears once the user edits it.

**3 — tempo from a note glyph?** Answered conservatively in the implementation: a bpm is read only when it follows an `=`. The glyph OCRs to junk or vanishes; the equals survives. A bare number near the top of a page is a page number or a bar number at least as often as a tempo.

## Departures from the pinned contract

Both are in the spec.

- `DraftField<T>` is split into `TextDraftField` / `TempoDraftField`: facet typegen emits no generics across the bridge.
- `ReadPhoto` takes only a `photo_id`, never an item id. On the add path there is no item to name yet, which follows from open question 2's answer.

## Against the offline-first checklist

- Recognition runs entirely on-device and issues no `Http` — test-enforced (`reading_a_page_issues_no_http`), invariant 1.
- No new persisted table or column, so invariants 2 and 3 are untouched; nothing is written at all on this path (`reading_a_page_never_writes_an_item`).
- Interpretation, the clamp and the state machine are all core, not shell — invariant 4.
- A photo the shell cannot read resolves `Failed`, never a page of no lines, which the core would read as a blank — invariant 5.
- All new code, local-first only — invariant 6.

## Tests

43 Rust tests in `recognition.rs`, four Swift tests driving real Vision over a page drawn in the test, one real-bridge round trip and one Store effect-loop test.

Every load-bearing line was mutation-tested by deleting it (not inverting it): the top-band filter, the credit filter, the substring clamp, the credit word-boundary check, the confidence damping, the tempo confidence minimum, the id correlation, the composer band check and the whole-line tempo rule each take a test down when removed. `bpm_in` was mutation-tested by substituting the naive "first number in the line" a future reader would plausibly write, which takes down three.

`every_read_field_is_one_the_create_form_accepts` is a table test against the consumer: seven pages a user would actually photograph, asserted against `validate_create_item`, not against the heuristics that produced them.

Coverage: expect high patch coverage on `recognition.rs`. Gaps are the Swift under `ios/` (Codecov-ignored) and the `Unsupported` arm, which no device can produce until phase C exists to be unavailable.

## Self-review

Posted as a comment below. Four findings were applied inline; the reviewer reproduced the first against the real app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)